### PR TITLE
feat(kafka-connect-source): external source via Kafka Connect

### DIFF
--- a/docker/aws/build.gradle.kts
+++ b/docker/aws/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":modules:xtdb-kafka"))
     implementation(project(":modules:xtdb-aws"))
     implementation(project(":modules:xtdb-postgres-source"))
+    implementation(project(":modules:xtdb-kafka-connect-source"))
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))

--- a/docker/azure/build.gradle.kts
+++ b/docker/azure/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":modules:xtdb-kafka"))
     implementation(project(":modules:xtdb-azure"))
     implementation(project(":modules:xtdb-postgres-source"))
+    implementation(project(":modules:xtdb-kafka-connect-source"))
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))

--- a/docker/google-cloud/build.gradle.kts
+++ b/docker/google-cloud/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":modules:xtdb-kafka"))
     implementation(project(":modules:xtdb-google-cloud"))
     implementation(project(":modules:xtdb-postgres-source"))
+    implementation(project(":modules:xtdb-kafka-connect-source"))
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,7 +158,12 @@ guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 # Kafka
 kafka-clients = { group = "org.apache.kafka", name = "kafka-clients", version.ref = "kafka" }
 kafka-connect-api = { group = "org.apache.kafka", name = "connect-api", version.ref = "kafka" }
+kafka-connect-json = { group = "org.apache.kafka", name = "connect-json", version.ref = "kafka" }
+kafka-connect-transforms = { group = "org.apache.kafka", name = "connect-transforms", version.ref = "kafka" }
 kafka-avro-serializer = { group = "io.confluent", name = "kafka-avro-serializer", version.ref = "confluent" }
+kafka-connect-avro-converter = { group = "io.confluent", name = "kafka-connect-avro-converter", version.ref = "confluent" }
+kafka-json-schema-serializer = { group = "io.confluent", name = "kafka-json-schema-serializer", version.ref = "confluent" }
+kafka-connect-json-schema-converter = { group = "io.confluent", name = "kafka-connect-json-schema-converter", version.ref = "confluent" }
 
 # Dev/test dependencies
 jovial = { group = "dev.clojurephant", name = "jovial", version = "0.4.3" }

--- a/modules/kafka-connect-source/build.gradle.kts
+++ b/modules/kafka-connect-source/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    `java-library`
+    alias(libs.plugins.clojurephant)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.protobuf)
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+dependencies {
+    api(project(":xtdb-api"))
+    api(project(":xtdb-core"))
+    api(project(":modules:xtdb-kafka"))
+
+    api(kotlin("stdlib"))
+    api(libs.kotlinx.serialization.json)
+    api(libs.protobuf.kotlin)
+
+    implementation(libs.kafka.clients)
+    api(libs.kafka.connect.api)
+    api(libs.kafka.connect.json)
+    api(libs.kafka.connect.transforms)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.kafka)
+    testImplementation(libs.kafka.connect.avro.converter)
+    testImplementation(libs.kafka.json.schema.serializer)
+    testImplementation(libs.kafka.connect.json.schema.converter)
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.asProvider().get()}"
+    }
+
+    generateProtoTasks {
+        all().forEach {
+            it.builtins {
+                create("kotlin")
+            }
+        }
+    }
+}

--- a/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/DocsIndexer.kt
+++ b/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/DocsIndexer.kt
@@ -1,0 +1,211 @@
+package xtdb.kafkaconnectsource
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import org.apache.kafka.connect.data.Date as ConnectDate
+import org.apache.kafka.connect.data.Decimal
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.data.Time as ConnectTime
+import org.apache.kafka.connect.data.Timestamp as ConnectTimestamp
+import org.apache.kafka.connect.sink.SinkRecord
+import xtdb.error.Fault
+import xtdb.error.Incorrect
+import xtdb.indexer.OpenTx
+import xtdb.indexer.TxIndexer
+import xtdb.indexer.TxIndexer.TxResult
+import xtdb.kafkaconnectsource.proto.DocsIndexerConfig
+import xtdb.kafkaconnectsource.proto.docsIndexerConfig
+import xtdb.kafkaconnectsource.proto.kafkaConnectSourceToken
+import xtdb.table.TableRef
+import xtdb.util.asIid
+import java.math.BigDecimal
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import com.google.protobuf.Any as ProtoAny
+
+private const val PROTO_TAG_PREFIX = "proto.xtdb.com"
+
+/**
+ * One [SinkRecord] = one XT transaction. The value [Struct] (or [Map]/primitive for schemaless converters)
+ * is walked against its [Schema] and written as a doc. Tombstones (null value) become deletes.
+ *
+ * Connect's logical types map through to native XT types:
+ *   Decimal      → BigDecimal
+ *   Timestamp    → Instant
+ *   Date         → LocalDate (UTC)
+ *   Time         → LocalTime (UTC)
+ */
+class DocsIndexer(
+    private val table: TableRef,
+) : RecordIndexer {
+
+    @Serializable
+    @SerialName("!Docs")
+    data class Factory(
+        val table: String,
+    ) : RecordIndexer.Factory {
+
+        override fun open(dbName: String): RecordIndexer =
+            DocsIndexer(TableRef.parse(dbName, table))
+
+        override fun toProto(): ProtoAny =
+            ProtoAny.pack(docsIndexerConfig { table = this@Factory.table }, PROTO_TAG_PREFIX)
+
+        class Registration : RecordIndexer.Registration {
+            override val protoTag: String
+                get() = "$PROTO_TAG_PREFIX/xtdb.kafkaconnectsource.proto.DocsIndexerConfig"
+
+            override fun fromProto(msg: ProtoAny): RecordIndexer.Factory {
+                val config = msg.unpack(DocsIndexerConfig::class.java)
+                return Factory(table = config.table)
+            }
+
+            override fun registerSerde(builder: PolymorphicModuleBuilder<RecordIndexer.Factory>) {
+                builder.subclass(Factory::class)
+            }
+        }
+    }
+
+    override suspend fun indexRecords(records: List<SinkRecord>, txIndexer: TxIndexer) {
+        for (rec in records) {
+            val token = kafkaConnectSourceToken { offset = rec.kafkaOffset() }.toByteArray()
+            val systemTime = rec.timestamp()?.let { Instant.ofEpochMilli(it) }
+
+            txIndexer.indexTx(token, systemTime = systemTime) { openTx ->
+                try {
+                    writeRecord(openTx, rec)
+                    TxResult.Committed()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    val coords = coordsFor(rec)
+                    TxResult.Aborted(wrapWithCoords(e, rec, coords), userMetadata = coords)
+                }
+            }
+        }
+    }
+
+    private fun coordsFor(rec: SinkRecord): Map<String, Any?> =
+        mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset())
+
+    private fun wrapWithCoords(cause: Throwable, rec: SinkRecord, coords: Map<String, Any?>): Throwable =
+        Fault(
+            "!Docs indexer failed at ${rec.topic()}-${rec.kafkaPartition()} offset ${rec.kafkaOffset()}: ${cause.message}",
+            "xtdb.kafka-connect-source/docs-indexer-failed",
+            coords,
+            cause = cause,
+        )
+
+    private fun writeRecord(openTx: OpenTx, rec: SinkRecord) {
+        val openTxTable = openTx.table(table)
+        val value = rec.value()
+
+        if (value == null) {
+            val id = rec.key() ?: throw Incorrect(
+                "tombstone has no key — can't resolve _id",
+                "xtdb.kafka-connect-source/docs-no-id-on-tombstone",
+                mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset()),
+            )
+            openTxTable.logDelete(
+                ByteBuffer.wrap(unwrapKeyForId(id).asIid),
+                openTx.systemFrom,
+                Long.MAX_VALUE,
+            )
+            return
+        }
+
+        val converted = convertValue(value, rec.valueSchema())
+        @Suppress("UNCHECKED_CAST")
+        val docMap = (converted as? Map<String, Any?>)?.toMutableMap()
+            ?: throw Incorrect(
+                "expected Struct or Map at top level, got ${value::class.simpleName}",
+                "xtdb.kafka-connect-source/docs-non-struct-value",
+                mapOf(
+                    "topic" to rec.topic(),
+                    "partition" to rec.kafkaPartition(),
+                    "offset" to rec.kafkaOffset(),
+                    "valueType" to value::class.simpleName,
+                ),
+            )
+
+        val id = docMap["_id"] ?: rec.key()?.let { unwrapKeyForId(it) }?.also { docMap["_id"] = it }
+            ?: throw Incorrect(
+                "no _id on doc and no record key — can't resolve _id",
+                "xtdb.kafka-connect-source/docs-no-id",
+                mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset()),
+            )
+
+        openTxTable.logPut(
+            ByteBuffer.wrap(id.asIid),
+            openTx.systemFrom,
+            Long.MAX_VALUE,
+        ) { openTxTable.docWriter.writeObject(docMap) }
+    }
+}
+
+// Connect's StringConverter produces String keys; AvroConverter et al may yield a Struct
+// with one field — in that case unwrap. ByteArrayConverter passes bytes through and asIid
+// handles those directly.
+private fun unwrapKeyForId(key: Any): Any =
+    if (key is Struct && key.schema()?.fields()?.size == 1)
+        key.get(key.schema().fields()[0])
+    else key
+
+
+// -- Value walk ------------------------------------------------------------------------------------
+//
+// Schema-first dispatch, matching Kafka Connect's own pattern (cf. JsonConverter.convertToJson):
+//   1. null
+//   2. logical-type check via schema.name() (overrides the primitive interpretation)
+//   3. schema.type() switch
+//   4. schemaless fallback dispatching on the JVM class
+//
+// Connect's Date/Time logical types are a `java.util.Date` pinned to 1970-01-01 UTC (see
+// Time.toLogical / Date.toLogical in connect-api). The explicit `ZoneOffset.UTC` below is
+// load-bearing — without it `toLocalDate()` / `toLocalTime()` use the JVM default zone and can
+// shift the answer across a date or hour boundary.
+
+@Suppress("UNCHECKED_CAST")
+internal fun convertValue(v: Any?, schema: Schema?): Any? {
+    if (v == null) return null
+
+    if (schema != null) {
+        when (schema.name()) {
+            Decimal.LOGICAL_NAME -> return v as BigDecimal
+            ConnectTimestamp.LOGICAL_NAME -> return (v as java.util.Date).toInstant()
+            ConnectDate.LOGICAL_NAME -> return (v as java.util.Date).toInstant().atZone(ZoneOffset.UTC).toLocalDate()
+            ConnectTime.LOGICAL_NAME -> return (v as java.util.Date).toInstant().atZone(ZoneOffset.UTC).toLocalTime()
+        }
+        return when (schema.type()) {
+            Schema.Type.STRUCT -> structToMap(v as Struct)
+            Schema.Type.ARRAY -> (v as List<Any?>).map { convertValue(it, schema.valueSchema()) }
+            Schema.Type.MAP -> (v as Map<Any?, Any?>).entries
+                .associateTo(mutableMapOf<String, Any?>()) { (k, vv) -> k.toString() to convertValue(vv, schema.valueSchema()) }
+            Schema.Type.BYTES -> when (v) {
+                is ByteBuffer -> ByteArray(v.remaining()).also { v.duplicate().get(it) }
+                is ByteArray -> v
+                else -> v
+            }
+            else -> v
+        }
+    }
+
+    // Schemaless: dispatch on JVM class as a fallback.
+    return when (v) {
+        is Struct -> structToMap(v)
+        is List<*> -> v.map { convertValue(it, null) }
+        is Map<*, *> -> v.entries.associateTo(mutableMapOf<String, Any?>()) { (k, vv) -> k.toString() to convertValue(vv, null) }
+        is ByteBuffer -> ByteArray(v.remaining()).also { v.duplicate().get(it) }
+        else -> v
+    }
+}
+
+private fun structToMap(s: Struct): MutableMap<String, Any?> =
+    s.schema().fields().associateTo(mutableMapOf()) { f -> f.name() to convertValue(s.get(f), f.schema()) }

--- a/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/KafkaConnectSource.kt
+++ b/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/KafkaConnectSource.kt
@@ -1,0 +1,380 @@
+package xtdb.kafkaconnectsource
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runInterruptible
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.subclass
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.InterruptException
+import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.connect.data.SchemaAndValue
+import org.apache.kafka.connect.header.ConnectHeaders
+import org.apache.kafka.connect.sink.SinkRecord
+import org.apache.kafka.connect.storage.Converter
+import org.apache.kafka.connect.storage.HeaderConverter
+import org.apache.kafka.connect.storage.SimpleHeaderConverter
+import org.apache.kafka.connect.transforms.Transformation
+import org.apache.kafka.connect.transforms.predicates.Predicate
+import io.micrometer.core.instrument.MeterRegistry
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
+import xtdb.api.log.KafkaCluster
+import xtdb.database.ExternalSource
+import xtdb.database.ExternalSourceToken
+import xtdb.database.proto.DatabaseConfig
+import xtdb.error.Incorrect
+import xtdb.indexer.TxIndexer
+import xtdb.kafkaconnectsource.proto.KafkaConnectSourceConfig
+import xtdb.kafkaconnectsource.proto.KafkaConnectSourceToken
+import xtdb.kafkaconnectsource.proto.kafkaConnectSourceConfig
+import xtdb.util.error
+import xtdb.util.info
+import xtdb.util.logger
+import xtdb.util.warn
+import java.time.Duration
+import com.google.protobuf.Any as ProtoAny
+
+private val LOG = KafkaConnectSource::class.logger
+
+private const val PROTO_TAG_PREFIX = "proto.xtdb.com"
+private val POLL_DURATION: Duration = Duration.ofSeconds(1)
+
+// Resume token is our offset; Kafka must not commit its own.
+private val HARDCODED_CONSUMER_CONFIG: Map<String, String> = mapOf(
+    "enable.auto.commit" to "false",
+    "key.deserializer" to ByteArrayDeserializer::class.java.name,
+    "value.deserializer" to ByteArrayDeserializer::class.java.name,
+)
+
+// We always seek explicitly (seekToBeginning when no token; seek(offset+1) otherwise).
+// `auto.offset.reset=none` makes it a hard failure if the explicit seek ever fails to happen,
+// rather than silently sliding to earliest/latest.
+private val DEFAULT_CONSUMER_CONFIG: Map<String, String> = mapOf(
+    "auto.offset.reset" to "none",
+)
+
+class KafkaConnectSource(
+    private val dbName: String,
+    private val cluster: KafkaCluster,
+    private val topic: String,
+    private val connectConfig: Map<String, String>,
+    private val indexer: RecordIndexer,
+) : ExternalSource {
+
+    @Serializable
+    @SerialName("!KafkaConnect")
+    data class Factory(
+        val remote: RemoteAlias,
+        val topic: String,
+        val connectConfig: Map<String, String> = emptyMap(),
+        val indexer: RecordIndexer.Factory,
+    ) : ExternalSource.Factory {
+
+        override fun open(
+            dbName: String,
+            remotes: Map<RemoteAlias, Remote>,
+            meterRegistry: MeterRegistry?,
+        ): ExternalSource {
+            val raw = remotes[remote]
+                ?: throw Incorrect(
+                    "no remote configured with alias '$remote' — add a '!Kafka' entry under 'remotes:' in node config",
+                    errorCode = "xtdb.kafka-connect-source/missing-remote",
+                    data = mapOf("alias" to remote),
+                )
+
+            val actualType = raw::class.simpleName ?: raw::class.qualifiedName ?: "unknown"
+
+            val cluster = raw as? KafkaCluster
+                ?: throw Incorrect(
+                    "remote '$remote' is a $actualType, expected a !Kafka remote",
+                    errorCode = "xtdb.kafka-connect-source/wrong-remote-type",
+                    data = mapOf("alias" to remote, "actualType" to actualType),
+                )
+
+            return KafkaConnectSource(dbName, cluster, topic, connectConfig, indexer.open(dbName))
+        }
+
+        override fun writeTo(dbConfig: DatabaseConfig.Builder) {
+            dbConfig.externalSource = ProtoAny.pack(kafkaConnectSourceConfig {
+                remote = this@Factory.remote
+                topic = this@Factory.topic
+                connectConfig.putAll(this@Factory.connectConfig)
+                indexer = this@Factory.indexer.toProto()
+            }, PROTO_TAG_PREFIX)
+        }
+
+        class Registration : ExternalSource.Registration {
+            override val protoTag: String
+                get() = "$PROTO_TAG_PREFIX/xtdb.kafkaconnectsource.proto.KafkaConnectSourceConfig"
+
+            override fun fromProto(msg: ProtoAny): ExternalSource.Factory {
+                val config = msg.unpack(KafkaConnectSourceConfig::class.java)
+                return Factory(
+                    remote = config.remote,
+                    topic = config.topic,
+                    connectConfig = config.connectConfigMap,
+                    indexer = RecordIndexer.Factory.fromProto(config.indexer),
+                )
+            }
+
+            override fun registerSerde(builder: PolymorphicModuleBuilder<ExternalSource.Factory>) {
+                builder.subclass(Factory::class)
+            }
+
+            override val serializersModule: SerializersModule = RecordIndexer.Factory.serializersModule
+        }
+    }
+
+    override suspend fun onPartitionAssigned(
+        partition: Int,
+        afterToken: ExternalSourceToken?,
+        txIndexer: TxIndexer,
+    ) {
+        LOG.info("[$dbName] Partition $partition assigned (topic=$topic)")
+
+        val keyConverter = openConverter(connectConfig, isKey = true)
+        val valueConverter = openConverter(connectConfig, isKey = false)
+        val headerConverter = SimpleHeaderConverter().also { it.configure(emptyMap<String, Any>()) }
+        val transformChain = openTransforms(connectConfig)
+
+        val mergedConsumerConfig: Map<String, Any> =
+            DEFAULT_CONSUMER_CONFIG + cluster.kafkaConfigMap + filteredConsumerConfig(connectConfig) + HARDCODED_CONSUMER_CONFIG
+
+        val consumer = KafkaConsumer<ByteArray?, ByteArray?>(mergedConsumerConfig)
+
+        try {
+            val tp = TopicPartition(topic, partition)
+            consumer.assign(listOf(tp))
+
+            if (afterToken != null) {
+                val offset = KafkaConnectSourceToken.parseFrom(afterToken).offset + 1
+                LOG.info("[$dbName] Resuming from offset $offset on $topic-$partition")
+                consumer.seek(tp, offset)
+            } else {
+                LOG.info("[$dbName] No token — seeking to beginning of $topic-$partition")
+                consumer.seekToBeginning(listOf(tp))
+            }
+
+            while (currentCoroutineContext().isActive) {
+                val records = try {
+                    runInterruptible(Dispatchers.IO) { consumer.poll(POLL_DURATION) }
+                } catch (_: WakeupException) {
+                    break
+                } catch (_: InterruptException) {
+                    break
+                }
+
+                if (records.isEmpty) continue
+
+                // Halt-on-failure: converter / transform exceptions propagate up. Mirrors
+                // Kafka Connect's `errors.tolerance=none` default. If we wanted DLQ-style
+                // skip-and-continue (`errors.tolerance=all`), we'd need to interleave aborted
+                // txs with indexer commits in offset order to keep the resume token correct.
+                val sinkRecords = records.records(tp).mapNotNull { rec ->
+                    val sinkRec = buildSinkRecord(rec, keyConverter, valueConverter, headerConverter)
+                    transformChain.apply(sinkRec)
+                }
+
+                if (sinkRecords.isNotEmpty()) {
+                    indexer.indexRecords(sinkRecords, txIndexer)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LOG.error(e, "[$dbName] External source failed")
+            throw e
+        } finally {
+            runCatching { transformChain.close() }
+                .onFailure { LOG.warn(it, "[$dbName] Transform-chain close failed") }
+            runCatching { keyConverter.close() }
+                .onFailure { LOG.warn(it, "[$dbName] Key-converter close failed") }
+            runCatching { valueConverter.close() }
+                .onFailure { LOG.warn(it, "[$dbName] Value-converter close failed") }
+            runCatching { headerConverter.close() }
+                .onFailure { LOG.warn(it, "[$dbName] Header-converter close failed") }
+            runCatching { consumer.close() }
+                .onFailure { LOG.error(it, "[$dbName] Consumer close failed") }
+        }
+    }
+
+    private fun buildSinkRecord(
+        rec: ConsumerRecord<ByteArray?, ByteArray?>,
+        keyConverter: Converter,
+        valueConverter: Converter,
+        headerConverter: HeaderConverter,
+    ): SinkRecord {
+        val key: SchemaAndValue = keyConverter.toConnectData(rec.topic(), rec.key())
+        val value: SchemaAndValue = valueConverter.toConnectData(rec.topic(), rec.value())
+        val headers = convertHeaders(rec.headers(), rec.topic(), headerConverter)
+        return SinkRecord(
+            rec.topic(), rec.partition(),
+            key.schema(), key.value(),
+            value.schema(), value.value(),
+            rec.offset(), rec.timestamp(), rec.timestampType(),
+            headers,
+        )
+    }
+
+    private fun convertHeaders(
+        kafkaHeaders: Headers,
+        topic: String,
+        headerConverter: HeaderConverter,
+    ): ConnectHeaders {
+        val connectHeaders = ConnectHeaders()
+        for (header in kafkaHeaders) {
+            val sv = headerConverter.toConnectHeader(topic, header.key(), header.value())
+            connectHeaders.add(header.key(), sv)
+        }
+        return connectHeaders
+    }
+
+    override fun close() {
+        LOG.info("[$dbName] Closing external source")
+        runCatching { indexer.close() }
+            .onFailure { LOG.error(it, "[$dbName] Indexer close failed") }
+    }
+}
+
+// -- Converter / Transform loaders -----------------------------------------------------------------------
+
+private fun openConverter(connectConfig: Map<String, String>, isKey: Boolean): Converter {
+    val role = if (isKey) "key.converter" else "value.converter"
+    val className = connectConfig[role]
+        ?: throw Incorrect(
+            "missing '$role' in connectConfig",
+            "xtdb.kafka-connect-source/missing-converter",
+            mapOf("role" to role),
+        )
+    val nested = connectConfig
+        .filterKeys { it.startsWith("$role.") }
+        .mapKeys { (k, _) -> k.removePrefix("$role.") }
+
+    // NOTE: different from KC. KC's `Plugins.newConverter` uses an isolated classpath for
+    // dependency isolation between plugins.
+    val cls = try {
+        Class.forName(className).asSubclass(Converter::class.java)
+    } catch (e: Exception) {
+        throw Incorrect(
+            "couldn't load $role class '$className': ${e.message}",
+            "xtdb.kafka-connect-source/converter-class-not-found",
+            mapOf("role" to role, "className" to className),
+            cause = e,
+        )
+    }
+    return cls.getDeclaredConstructor().newInstance().apply { configure(nested, isKey) }
+}
+
+// Strip converter/transforms keys before handing the consumer its own config — Kafka logs
+// noisy warnings otherwise.
+private fun filteredConsumerConfig(connectConfig: Map<String, String>): Map<String, String> =
+    connectConfig.filterKeys {
+        !it.startsWith("key.converter") &&
+            !it.startsWith("value.converter") &&
+            !it.startsWith("transforms") &&
+            !it.startsWith("predicates")
+    }
+
+internal class TransformChain(
+    private val transforms: List<Pair<Transformation<SinkRecord>, Predicate<SinkRecord>?>>,
+) : AutoCloseable {
+    fun apply(initial: SinkRecord): SinkRecord? {
+        var rec: SinkRecord? = initial
+        for ((transform, predicate) in transforms) {
+            val current = rec ?: return null
+            if (predicate == null || predicate.test(current)) {
+                rec = transform.apply(current)
+            }
+        }
+        return rec
+    }
+
+    override fun close() {
+        for ((transform, predicate) in transforms) {
+            runCatching { transform.close() }
+            runCatching { predicate?.close() }
+        }
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun openTransforms(connectConfig: Map<String, String>): TransformChain {
+    val raw = connectConfig["transforms"]?.trim().orEmpty()
+    val aliases = if (raw.isEmpty()) emptyList()
+        else raw.split(",").map { it.trim() }
+    if (aliases.any { it.isEmpty() }) {
+        throw Incorrect(
+            "empty alias in 'transforms' — check for stray commas",
+            "xtdb.kafka-connect-source/empty-transform-alias",
+            mapOf("transforms" to raw),
+        )
+    }
+
+    val chain = aliases.map { alias ->
+        val typeKey = "transforms.$alias.type"
+        val type = connectConfig[typeKey]
+            ?: throw Incorrect(
+                "missing '$typeKey' for transform alias '$alias'",
+                "xtdb.kafka-connect-source/missing-transform-type",
+                mapOf("alias" to alias),
+            )
+        val predicateAlias = connectConfig["transforms.$alias.predicate"]
+        val negate = connectConfig["transforms.$alias.negate"]?.toBoolean() == true
+
+        val transformConfig = connectConfig
+            .filterKeys { it.startsWith("transforms.$alias.") }
+            .filterKeys { !it.endsWith(".type") && !it.endsWith(".predicate") && !it.endsWith(".negate") }
+            .mapKeys { (k, _) -> k.removePrefix("transforms.$alias.") }
+
+        val transform = (Class.forName(type) as Class<Transformation<SinkRecord>>)
+            .getDeclaredConstructor().newInstance()
+            .apply { configure(transformConfig) }
+
+        val predicate = predicateAlias?.let { openPredicate(connectConfig, it, negate) }
+
+        transform to predicate
+    }
+    return TransformChain(chain)
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun openPredicate(
+    connectConfig: Map<String, String>,
+    alias: String,
+    negate: Boolean,
+): Predicate<SinkRecord> {
+    val type = connectConfig["predicates.$alias.type"]
+        ?: throw Incorrect(
+            "missing 'predicates.$alias.type'",
+            "xtdb.kafka-connect-source/missing-predicate-type",
+            mapOf("alias" to alias),
+        )
+    val predicateConfig = connectConfig
+        .filterKeys { it.startsWith("predicates.$alias.") && !it.endsWith(".type") }
+        .mapKeys { (k, _) -> k.removePrefix("predicates.$alias.") }
+
+    val base = (Class.forName(type) as Class<Predicate<SinkRecord>>)
+        .getDeclaredConstructor().newInstance()
+        .apply { configure(predicateConfig) }
+
+    return if (negate) NegatedPredicate(base) else base
+}
+
+private class NegatedPredicate<R : org.apache.kafka.connect.connector.ConnectRecord<R>>(
+    private val inner: Predicate<R>,
+) : Predicate<R> {
+    override fun config() = inner.config()
+    override fun test(record: R): Boolean = !inner.test(record)
+    override fun close() = inner.close()
+    override fun configure(configs: MutableMap<String, *>?) = inner.configure(configs)
+}

--- a/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/RecordIndexer.kt
+++ b/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/RecordIndexer.kt
@@ -1,0 +1,61 @@
+package xtdb.kafkaconnectsource
+
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import org.apache.kafka.connect.sink.SinkRecord
+import xtdb.indexer.TxIndexer
+import java.util.ServiceLoader
+import com.google.protobuf.Any as ProtoAny
+
+/**
+ * Indexes a batch of [SinkRecord]s into XT transactions.
+ *
+ * [SinkRecord]s have already been through the configured key/value [org.apache.kafka.connect.storage.Converter]s
+ * and any configured [org.apache.kafka.connect.transforms.Transformation] chain by the time they reach an indexer —
+ * `value()` is a Connect [org.apache.kafka.connect.data.Struct] (or primitive / `Map` for schemaless converters),
+ * with `valueSchema()` describing its shape.
+ *
+ * The same SPI shape is what Kafka Connect's `SinkTask.put(records)` delivers — by design, so the indexer
+ * works identically under [KafkaConnectSource] (XTDB owns the consumer) and under a future KC sink connector
+ * (KC's runtime owns the consumer).
+ */
+interface RecordIndexer : AutoCloseable {
+
+    suspend fun indexRecords(records: List<SinkRecord>, txIndexer: TxIndexer)
+
+    override fun close() = Unit
+
+    interface Factory {
+        fun toProto(): ProtoAny
+        fun open(dbName: String): RecordIndexer
+
+        companion object {
+            private val registrations = ServiceLoader.load(Registration::class.java).toList()
+            private val registrationsByTag = registrations.associateBy { it.protoTag }
+
+            val serializersModule = SerializersModule {
+                for (reg in registrations)
+                    include(reg.serializersModule)
+
+                polymorphic(Factory::class) {
+                    for (reg in registrations)
+                        reg.registerSerde(this)
+                }
+            }
+
+            fun fromProto(any: ProtoAny): Factory {
+                val reg = registrationsByTag[any.typeUrl]
+                    ?: error("unknown record indexer: ${any.typeUrl}")
+                return reg.fromProto(any)
+            }
+        }
+    }
+
+    interface Registration {
+        val protoTag: String
+        fun fromProto(msg: ProtoAny): Factory
+        fun registerSerde(builder: PolymorphicModuleBuilder<Factory>)
+        val serializersModule: SerializersModule get() = SerializersModule {}
+    }
+}

--- a/modules/kafka-connect-source/src/main/proto/kafka_connect_source.proto
+++ b/modules/kafka-connect-source/src/main/proto/kafka_connect_source.proto
@@ -1,0 +1,30 @@
+edition = "2023";
+
+package xtdb.kafkaconnectsource.proto;
+
+import "google/protobuf/any.proto";
+
+option java_multiple_files = true;
+
+message KafkaConnectSourceConfig {
+    string remote = 1;
+    string topic = 2;
+
+    // Flat KC-style config: key.converter / value.converter / value.converter.*
+    // / transforms / transforms.<alias>.* / consumer.override.* etc.
+    map<string, string> connect_config = 3;
+
+    // Carried as Any so the proto stays decoupled from specific indexer config shapes —
+    // mirrors how DatabaseConfig.external_source carries the outer ExternalSource factory.
+    google.protobuf.Any indexer = 4;
+}
+
+message KafkaConnectSourceToken {
+    int64 offset = 1;
+}
+
+message DocsIndexerConfig {
+    // Target table — qualified ('public.orders') or unqualified ('orders'),
+    // unqualified names default to the 'public' schema.
+    string table = 1;
+}

--- a/modules/kafka-connect-source/src/main/resources/META-INF/services/xtdb.database.ExternalSource$Registration
+++ b/modules/kafka-connect-source/src/main/resources/META-INF/services/xtdb.database.ExternalSource$Registration
@@ -1,0 +1,1 @@
+xtdb.kafkaconnectsource.KafkaConnectSource$Factory$Registration

--- a/modules/kafka-connect-source/src/main/resources/META-INF/services/xtdb.kafkaconnectsource.RecordIndexer$Registration
+++ b/modules/kafka-connect-source/src/main/resources/META-INF/services/xtdb.kafkaconnectsource.RecordIndexer$Registration
@@ -1,0 +1,1 @@
+xtdb.kafkaconnectsource.DocsIndexer$Factory$Registration

--- a/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/DocsIndexerTest.kt
+++ b/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/DocsIndexerTest.kt
@@ -1,0 +1,64 @@
+package xtdb.kafkaconnectsource
+
+import org.apache.kafka.connect.data.Date as ConnectDate
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Time as ConnectTime
+import org.apache.kafka.connect.data.Timestamp as ConnectTimestamp
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.Date
+import java.util.TimeZone
+
+private const val MS_PER_DAY = 86_400_000L
+
+class DocsIndexerTest {
+
+    /** Runs [block] with the JVM default zone temporarily overridden to UTC-8 (LA). */
+    private inline fun <R> withNonUtcDefaultZone(block: () -> R): R {
+        val original = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+        try {
+            return block()
+        } finally {
+            TimeZone.setDefault(original)
+        }
+    }
+
+    @Test
+    fun `Date logical type does not shift under non-UTC JVM default zone`() = withNonUtcDefaultZone {
+        // Connect encodes Date as `Date(epochDay * 86_400_000)` — pinned to 00:00 UTC on the target
+        // calendar day. Naive `toInstant().toLocalDate()` in a non-UTC default zone would shift
+        // back a day, because midnight-UTC reads as the previous day west of Greenwich.
+        val schema = SchemaBuilder.int32().name(ConnectDate.LOGICAL_NAME).build()
+        val expected = LocalDate.of(2024, 6, 8)
+        val connectValue = Date(expected.toEpochDay() * MS_PER_DAY)
+
+        assertEquals(expected, convertValue(connectValue, schema))
+    }
+
+    @Test
+    fun `Time logical type does not shift under non-UTC JVM default zone`() = withNonUtcDefaultZone {
+        // Connect encodes Time as `Date(millis_of_day)` — pinned to 1970-01-01 UTC + the time of day.
+        // Naive `toInstant().toLocalTime()` in a non-UTC default zone would subtract the offset.
+        val schema = SchemaBuilder.int32().name(ConnectTime.LOGICAL_NAME).build()
+        val expected = LocalTime.of(12, 34, 56)
+        val millisOfDay = expected.toNanoOfDay() / 1_000_000L
+        val connectValue = Date(millisOfDay)
+
+        assertEquals(expected, convertValue(connectValue, schema))
+    }
+
+    @Test
+    fun `Timestamp logical type round-trips an Instant`() {
+        // Timestamps are already TZ-anchored (millis-since-epoch), so JVM zone shouldn't matter.
+        // Belt-and-braces test that the conversion does what we claim.
+        val schema = SchemaBuilder.int64().name(ConnectTimestamp.LOGICAL_NAME).build()
+        val expected = Instant.parse("2024-06-08T12:34:56.789Z")
+        val connectValue = Date.from(expected)
+
+        assertEquals(expected, convertValue(connectValue, schema))
+    }
+}

--- a/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceFactoryTest.kt
+++ b/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceFactoryTest.kt
@@ -1,0 +1,98 @@
+package xtdb.kafkaconnectsource
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import xtdb.database.Database
+
+class KafkaConnectSourceFactoryTest {
+
+    private fun protoRoundTrip(factory: KafkaConnectSource.Factory): KafkaConnectSource.Factory {
+        val dbConfig = Database.Config().externalSource(factory)
+        val restored = Database.Config.fromProto(dbConfig.serializedConfig)
+        return restored.externalSource as KafkaConnectSource.Factory
+    }
+
+    @Test
+    fun `proto round-trips factory`() {
+        val original = KafkaConnectSource.Factory(
+            remote = "my-kafka",
+            topic = "orders",
+            connectConfig = mapOf(
+                "key.converter" to "org.apache.kafka.connect.storage.StringConverter",
+                "value.converter" to "io.confluent.connect.avro.AvroConverter",
+                "value.converter.schema.registry.url" to "http://schema-registry:8081",
+                "transforms" to "unwrap",
+                "transforms.unwrap.type" to "org.apache.kafka.connect.transforms.ExtractField\$Value",
+                "transforms.unwrap.field" to "payload",
+            ),
+            indexer = DocsIndexer.Factory(table = "orders"),
+        )
+
+        val restored = protoRoundTrip(original)
+
+        assertEquals("my-kafka", restored.remote)
+        assertEquals("orders", restored.topic)
+        assertEquals("io.confluent.connect.avro.AvroConverter", restored.connectConfig["value.converter"])
+        assertEquals("http://schema-registry:8081", restored.connectConfig["value.converter.schema.registry.url"])
+        assertEquals("unwrap", restored.connectConfig["transforms"])
+        val docs = restored.indexer as DocsIndexer.Factory
+        assertEquals("orders", docs.table)
+    }
+
+    @Test
+    fun `YAML round-trips !KafkaConnect with !Docs indexer`() {
+        val yaml = """
+            externalSource: !KafkaConnect
+              remote: my-kafka
+              topic: orders
+              connectConfig:
+                key.converter: org.apache.kafka.connect.storage.StringConverter
+                value.converter: org.apache.kafka.connect.json.JsonConverter
+                value.converter.schemas.enable: "false"
+              indexer: !Docs
+                table: orders
+        """.trimIndent()
+
+        val config = Database.Config.fromYaml(yaml)
+        val factory = config.externalSource as KafkaConnectSource.Factory
+
+        assertEquals("my-kafka", factory.remote)
+        assertEquals("orders", factory.topic)
+        assertEquals("org.apache.kafka.connect.json.JsonConverter", factory.connectConfig["value.converter"])
+        assertEquals("false", factory.connectConfig["value.converter.schemas.enable"])
+        val docs = factory.indexer as DocsIndexer.Factory
+        assertEquals("orders", docs.table)
+    }
+
+    @Test
+    fun `connectConfig defaults to empty map`() {
+        val yaml = """
+            externalSource: !KafkaConnect
+              remote: k
+              topic: t
+              indexer: !Docs
+                table: orders
+        """.trimIndent()
+
+        val factory = Database.Config.fromYaml(yaml).externalSource as KafkaConnectSource.Factory
+
+        assertTrue(factory.connectConfig.isEmpty())
+    }
+
+    @Test
+    fun `qualified table name parses to schema + table`() {
+        val yaml = """
+            externalSource: !KafkaConnect
+              remote: k
+              topic: t
+              indexer: !Docs
+                table: analytics.events
+        """.trimIndent()
+
+        val factory = Database.Config.fromYaml(yaml).externalSource as KafkaConnectSource.Factory
+        val docs = factory.indexer as DocsIndexer.Factory
+
+        assertEquals("analytics.events", docs.table)
+    }
+}

--- a/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceIntegrationTest.kt
+++ b/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceIntegrationTest.kt
@@ -1,0 +1,1080 @@
+package xtdb.kafkaconnectsource
+
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.test.runTest
+import org.apache.avro.Schema as AvroSchema
+import org.apache.avro.generic.GenericData
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.lifecycle.Startables
+import xtdb.api.Xtdb
+import xtdb.api.log.KafkaCluster
+import java.util.UUID
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("integration")
+class KafkaConnectSourceIntegrationTest {
+
+    companion object {
+        private val network: Network = Network.newNetwork()
+
+        private val kafka = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+
+        private val schemaRegistry: GenericContainer<*> = GenericContainer("confluentinc/cp-schema-registry:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("schema-registry")
+            .withExposedPorts(8081)
+            .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+            .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081")
+            .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9093")
+            .waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+            .dependsOn(kafka)
+
+        private val schemaRegistryUrl: String
+            get() = "http://${schemaRegistry.host}:${schemaRegistry.firstMappedPort}"
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            Startables.deepStart(kafka, schemaRegistry).join()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            schemaRegistry.stop()
+            kafka.stop()
+            network.close()
+        }
+    }
+
+    private fun createTopic(topic: String) {
+        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use { admin ->
+            admin.createTopics(listOf(NewTopic(topic, 1, 1.toShort()))).all().get()
+        }
+    }
+
+    private fun openNode(sourceTopic: String): Xtdb = Xtdb.openNode {
+        server { port = 0 }; flightSql = null
+        logCluster("kafka", KafkaCluster.ClusterFactory(kafka.bootstrapServers))
+        log(KafkaCluster.LogFactory("kafka", sourceTopic))
+    }
+
+    private fun attach(node: Xtdb, dbName: String, yaml: String) {
+        node.getConnection().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("ATTACH DATABASE $dbName WITH \$\$\n$yaml\n\$\$")
+            }
+        }
+    }
+
+    private fun produceBytes(topic: String, key: String?, value: ByteArray?) {
+        val producerProps = mapOf(
+            "bootstrap.servers" to kafka.bootstrapServers,
+            "key.serializer" to StringSerializer::class.java.name,
+            "value.serializer" to ByteArraySerializer::class.java.name,
+        )
+        KafkaProducer<String?, ByteArray?>(producerProps).use { producer ->
+            producer.send(ProducerRecord(topic, key, value)).get()
+        }
+    }
+
+    private fun produceAvro(topic: String, key: String?, value: GenericData.Record?) {
+        val producerProps = mapOf(
+            "bootstrap.servers" to kafka.bootstrapServers,
+            "key.serializer" to StringSerializer::class.java.name,
+            "value.serializer" to "io.confluent.kafka.serializers.KafkaAvroSerializer",
+            "schema.registry.url" to schemaRegistryUrl,
+        )
+        KafkaProducer<String?, GenericData.Record?>(producerProps).use { producer ->
+            producer.send(ProducerRecord(topic, key, value)).get()
+        }
+    }
+
+    private fun xtQueryDb(node: Xtdb, dbName: String, sql: String): List<Map<String, Any?>> =
+        node.createConnectionBuilder().database(dbName).build().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery(sql).use { rs ->
+                    val md = rs.metaData
+                    val cols = (1..md.columnCount).map { md.getColumnName(it) }
+                    buildList {
+                        while (rs.next()) add(cols.associateWith { rs.getObject(it) })
+                    }
+                }
+            }
+        }
+
+    private suspend fun awaitCondition(description: String, timeout: Duration = 30.seconds, check: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (System.currentTimeMillis() < deadline) {
+            if (runCatching(check).getOrDefault(false)) return
+            runInterruptible { Thread.sleep(200) }
+        }
+        throw AssertionError("Timed out waiting for: $description")
+    }
+
+    @Test
+    fun `JsonConverter happy path snapshot + streaming`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        produceBytes(sourceTopic, "k1", """{"name":"Alice","age":30}""".toByteArray())
+        produceBytes(sourceTopic, "k2", """{"_id":"explicit","name":"Bob"}""".toByteArray())
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("both records appear") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events").size == 2
+            }
+
+            val k1 = xtQueryDb(node, "events", "SELECT _id, name, age FROM public.events WHERE _id = 'k1'")
+            assertEquals(1, k1.size)
+            assertEquals("Alice", k1[0]["name"])
+
+            val k2 = xtQueryDb(node, "events", "SELECT _id, name FROM public.events WHERE _id = 'explicit'")
+            assertEquals(1, k2.size)
+            assertEquals("Bob", k2[0]["name"])
+
+            produceBytes(sourceTopic, "k3", """{"name":"Charlie"}""".toByteArray())
+            awaitCondition("streamed record appears") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'k3'").isNotEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `null value tombstone deletes the row (JsonConverter)`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        produceBytes(sourceTopic, "k1", """{"name":"Alice"}""".toByteArray())
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("Alice ingested") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'k1'").isNotEmpty()
+            }
+
+            produceBytes(sourceTopic, "k1", null)
+            awaitCondition("Alice deleted") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'k1'").isEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `resume from token after restart`() = runTest(timeout = 180.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        val xtLog = "xt-log-${UUID.randomUUID()}"
+        val replicaTopic = "test-replica-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        val attachYaml = """
+            log: !Kafka
+              cluster: kafka
+              topic: $replicaTopic
+            externalSource: !KafkaConnect
+              remote: kafka
+              topic: $sourceTopic
+              connectConfig:
+                key.converter: org.apache.kafka.connect.storage.StringConverter
+                value.converter: org.apache.kafka.connect.json.JsonConverter
+                value.converter.schemas.enable: "false"
+              indexer: !Docs
+                table: events
+        """.trimIndent()
+
+        produceBytes(sourceTopic, "a", """{"name":"Alice"}""".toByteArray())
+
+        openNode(xtLog).use { node ->
+            attach(node, "events", attachYaml)
+
+            awaitCondition("Alice appears") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'a'").isNotEmpty()
+            }
+
+            produceBytes(sourceTopic, "b", """{"name":"Bob"}""".toByteArray())
+            awaitCondition("Bob appears") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'b'").isNotEmpty()
+            }
+        }
+
+        produceBytes(sourceTopic, "c", """{"name":"Charlie"}""".toByteArray())
+
+        openNode(xtLog).use { node ->
+            awaitCondition("Charlie appears after restart", timeout = 60.seconds) {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'c'").isNotEmpty()
+            }
+
+            val rows = xtQueryDb(node, "events", "SELECT _id, name FROM public.events ORDER BY _id")
+            assertEquals(3, rows.size, "All three rows present — no duplication, no loss")
+            assertEquals("Alice", rows[0]["name"])
+            assertEquals("Bob", rows[1]["name"])
+            assertEquals("Charlie", rows[2]["name"])
+        }
+    }
+
+    @Test
+    fun `deserialization failure halts the source`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        // Prime the topic with a good record so we can confirm the source is healthy
+        // before we feed it a bad one.
+        produceBytes(sourceTopic, "first", """{"name":"First"}""".toByteArray())
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("first record ingested — source is healthy") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'first'").isNotEmpty()
+            }
+
+            // Now a bad record followed by a good one. Under halt-on-decode-failure, the
+            // source dies on the bad record; the trailing good record is never indexed.
+            produceBytes(sourceTopic, "bad", "{not-json".toByteArray())
+            produceBytes(sourceTopic, "second", """{"name":"Second"}""".toByteArray())
+
+            // Give the source time to crash on the bad record. Brittle, but no API for
+            // observing "source died".
+            runInterruptible { Thread.sleep(5_000) }
+
+            val second = xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'second'")
+            assertTrue(second.isEmpty(), "second shouldn't appear — source halts at the bad record under halt-on-decode-failure")
+
+            // No DLQ-style aborted tx — halt-on-failure means decode errors propagate
+            // rather than getting recorded as aborted txs.
+            val aborted = xtQueryDb(node, "events", "SELECT _id FROM xt.txs WHERE committed = false")
+            assertTrue(aborted.isEmpty(), "no aborted txs under halt-on-decode-failure, got: $aborted")
+        }
+    }
+
+    @Test
+    fun `SMT chain applies ExtractField to unwrap envelope`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        produceBytes(
+            sourceTopic, "k1",
+            """{"op":"c","payload":{"_id":"alice","name":"Alice","age":30}}""".toByteArray(),
+        )
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                    transforms: unwrap
+                    transforms.unwrap.type: org.apache.kafka.connect.transforms.ExtractField${'$'}Value
+                    transforms.unwrap.field: payload
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("unwrapped record appears") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'alice'").isNotEmpty()
+            }
+
+            val rows = xtQueryDb(node, "events", "SELECT _id, name, age FROM public.events WHERE _id = 'alice'")
+            assertEquals("Alice", rows[0]["name"])
+            assertTrue(
+                xtQueryDb(node, "events", "SELECT op FROM public.events WHERE _id = 'alice' AND op IS NOT NULL").isEmpty(),
+                "envelope's op field should not be on the unwrapped doc",
+            )
+        }
+    }
+
+    @Test
+    fun `SMT chain runs transforms in declaration order`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        // Envelope-shaped: { meta, payload: { _id, name, email } }
+        // Chain: unwrap (ExtractField -> payload) THEN mask (MaskField -> email).
+        // Order matters: mask must run on the unwrapped payload, not the outer envelope.
+        produceBytes(
+            sourceTopic, "k1",
+            """{"meta":{"op":"c"},"payload":{"_id":"alice","name":"Alice","email":"a@example.com"}}""".toByteArray(),
+        )
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                    transforms: unwrap,mask
+                    transforms.unwrap.type: org.apache.kafka.connect.transforms.ExtractField${'$'}Value
+                    transforms.unwrap.field: payload
+                    transforms.mask.type: org.apache.kafka.connect.transforms.MaskField${'$'}Value
+                    transforms.mask.fields: email
+                    transforms.mask.replacement: REDACTED
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("record appears with both transforms applied") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'alice'").isNotEmpty()
+            }
+
+            val rows = xtQueryDb(node, "events", "SELECT _id, name, email FROM public.events WHERE _id = 'alice'")
+            assertEquals("Alice", rows[0]["name"], "name should pass through")
+            assertEquals("REDACTED", rows[0]["email"], "email should be masked by the second transform")
+        }
+    }
+
+    @Test
+    fun `predicate with negate skips tombstones from a transform that would crash on null`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        // Two records, distinct keys, so we can observe each independently:
+        //   - alice: regular record — predicate.test=false on this, negate→true, mask APPLIES,
+        //                             email should land masked.
+        //   - bob:   tombstone     — predicate.test=true on this, negate→false, mask SKIPPED,
+        //                             record reaches indexer unmolested (no aborted tx, no row
+        //                             since there's nothing to delete).
+        produceBytes(sourceTopic, "alice", """{"_id":"alice","email":"a@example.com"}""".toByteArray())
+        produceBytes(sourceTopic, "bob", null)
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                    transforms: mask
+                    transforms.mask.type: org.apache.kafka.connect.transforms.MaskField${'$'}Value
+                    transforms.mask.fields: email
+                    transforms.mask.replacement: REDACTED
+                    transforms.mask.predicate: notTombstone
+                    transforms.mask.negate: "true"
+                    predicates: notTombstone
+                    predicates.notTombstone.type: org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("Alice ingested with masked email") {
+                val rows = xtQueryDb(node, "events", "SELECT email FROM public.events WHERE _id = 'alice'")
+                rows.isNotEmpty() && rows[0]["email"] == "REDACTED"
+            }
+
+            // Without the predicate, MaskField would crash on the tombstone's null value
+            // and we'd see an aborted tx for that record.
+            val aborted = xtQueryDb(node, "events", "SELECT committed FROM xt.txs WHERE committed = false")
+            assertTrue(aborted.isEmpty(), "no aborted txs — tombstone should bypass MaskField via the predicate, got: $aborted")
+        }
+    }
+
+    // Helpers that paper over JDBC's "could be any of these" behaviour for date / time / timestamp.
+    private fun toInstant(v: Any?): java.time.Instant = when (v) {
+        is java.time.Instant -> v
+        is java.time.ZonedDateTime -> v.toInstant()
+        is java.time.OffsetDateTime -> v.toInstant()
+        is java.sql.Timestamp -> v.toInstant()
+        else -> error("unexpected timestamp type: ${v?.javaClass}")
+    }
+
+    private fun toLocalDate(v: Any?): java.time.LocalDate = when (v) {
+        is java.time.LocalDate -> v
+        is java.sql.Date -> v.toLocalDate()
+        is String -> java.time.LocalDate.parse(v)
+        else -> error("unexpected date type: ${v?.javaClass}")
+    }
+
+    private fun toLocalTime(v: Any?): java.time.LocalTime = when (v) {
+        is java.time.LocalTime -> v
+        is java.sql.Time -> v.toLocalTime()
+        is String -> java.time.LocalTime.parse(v)
+        else -> error("unexpected time type: ${v?.javaClass}")
+    }
+
+    /** JDBC returns arrays as `java.sql.Array` (PostgreSQL's `PgArray`); unwrap to a plain List. */
+    private fun toList(v: Any?): List<Any?> = when (v) {
+        is List<*> -> v
+        is java.sql.Array -> (v.array as Array<*>).toList()
+        else -> error("unexpected array type: ${v?.javaClass}")
+    }
+
+    @Test
+    fun `JsonConverter roundtrips all JSON types`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        // JSON's native types: string, integer, number (double), boolean, null, array, object.
+        produceBytes(
+            sourceTopic, "all-types",
+            """
+            {
+              "_id": "all-types",
+              "string_val": "hello",
+              "int_val": 42,
+              "long_val": 9999999999,
+              "double_val": 3.14,
+              "bool_val": true,
+              "null_val": null,
+              "array_val": [1, 2, 3],
+              "nested_val": {"role": "admin", "level": 5}
+            }
+            """.trimIndent().toByteArray(),
+        )
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("record appears") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'all-types'").isNotEmpty()
+            }
+
+            val row = xtQueryDb(
+                node, "events",
+                "SELECT _id, string_val, int_val, long_val, double_val, bool_val, null_val, array_val, nested_val " +
+                    "FROM public.events WHERE _id = 'all-types'",
+            )[0]
+
+            assertEquals("hello", row["string_val"])
+            assertEquals(42L, (row["int_val"] as Number).toLong())
+            assertEquals(9999999999L, (row["long_val"] as Number).toLong())
+            assertEquals(3.14, (row["double_val"] as Number).toDouble(), 0.0001)
+            assertEquals(true, row["bool_val"])
+            assertEquals(null, row["null_val"])
+
+            assertEquals(listOf(1L, 2L, 3L), toList(row["array_val"]).map { (it as Number).toLong() })
+
+            @Suppress("UNCHECKED_CAST")
+            val nested = row["nested_val"] as Map<String, Any?>
+            assertEquals("admin", nested["role"])
+            assertEquals(5L, (nested["level"] as Number).toLong())
+        }
+    }
+
+    @Test
+    fun `JsonSchemaConverter with Schema Registry roundtrips all JSON Schema types`() = runTest(timeout = 180.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        // The schema covers two paths through the converter:
+        //   1. Native JSON Schema types (string / integer / number / boolean / array / object).
+        //   2. Connect logical types via `title` — `type: integer` + `title` set to the Connect
+        //      logical-type name is JsonSchemaConverter's supported way to ingest typed
+        //      Timestamp/Date/Time. (Plain `format: date-time` etc. without `title` is metadata
+        //      only and arrives as a string — see the `*_str` fields below for that path.)
+        val schemaStr = """
+            {
+              "${'$'}schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "_id":           { "type": "string" },
+                "string_val":    { "type": "string" },
+                "int_val":       { "type": "integer" },
+                "double_val":    { "type": "number" },
+                "bool_val":      { "type": "boolean" },
+                "array_val":     { "type": "array", "items": { "type": "integer" } },
+                "nested_val":    {
+                  "type": "object",
+                  "properties": {
+                    "inner": { "type": "string" }
+                  }
+                },
+                "timestamp_str": { "type": "string", "format": "date-time" },
+                "date_str":      { "type": "string", "format": "date" },
+                "time_str":      { "type": "string", "format": "time" },
+                "timestamp_val": { "type": "integer", "title": "org.apache.kafka.connect.data.Timestamp" },
+                "date_val":      { "type": "integer", "title": "org.apache.kafka.connect.data.Date" },
+                "time_val":      { "type": "integer", "title": "org.apache.kafka.connect.data.Time" }
+              }
+            }
+        """.trimIndent()
+
+        val mapper = com.fasterxml.jackson.databind.ObjectMapper()
+
+        // `*_str` fields: documents the format-metadata-only behaviour (arrives as strings).
+        val timestampStr = "2024-06-08T12:34:56.789Z"
+        val dateStr = "2024-06-08"
+        // JSON Schema's `time` format requires a zone designator (RFC 3339 full-time).
+        val timeStr = "12:34:56Z"
+
+        // `*_val` fields: typed temporals via `title` + integer. Producer emits Connect's wire
+        // encoding for each logical type: Timestamp → millis since epoch, Date → days since epoch,
+        // Time → millis since midnight.
+        val expectedTs = java.time.Instant.parse("2024-06-08T12:34:56.789Z")
+        val expectedDate = java.time.LocalDate.of(2024, 6, 8)
+        val expectedTime = java.time.LocalTime.of(12, 34, 56)
+        val tsMillis = expectedTs.toEpochMilli()
+        val daysSinceEpoch = expectedDate.toEpochDay()
+        val millisOfDay = expectedTime.toNanoOfDay() / 1_000_000L
+
+        val payloadJson = mapper.readTree("""
+            {
+              "_id": "all-types",
+              "string_val": "hello",
+              "int_val": 42,
+              "double_val": 3.14,
+              "bool_val": true,
+              "array_val": [1, 2, 3],
+              "nested_val": {"inner": "deep"},
+              "timestamp_str": "$timestampStr",
+              "date_str": "$dateStr",
+              "time_str": "$timeStr",
+              "timestamp_val": $tsMillis,
+              "date_val": $daysSinceEpoch,
+              "time_val": $millisOfDay
+            }
+        """.trimIndent())
+
+        val jsonSchema = io.confluent.kafka.schemaregistry.json.JsonSchema(schemaStr)
+        val envelope = io.confluent.kafka.schemaregistry.json.JsonSchemaUtils.toObject(payloadJson, jsonSchema)
+
+        val producerProps = mapOf(
+            "bootstrap.servers" to kafka.bootstrapServers,
+            "key.serializer" to StringSerializer::class.java.name,
+            "value.serializer" to "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
+            "schema.registry.url" to schemaRegistryUrl,
+            "auto.register.schemas" to "true",
+        )
+        KafkaProducer<String?, Any?>(producerProps).use { producer ->
+            producer.send(ProducerRecord(sourceTopic, "all-types", envelope)).get()
+        }
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: io.confluent.connect.json.JsonSchemaConverter
+                    value.converter.schema.registry.url: $schemaRegistryUrl
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("record appears", timeout = 60.seconds) {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'all-types'").isNotEmpty()
+            }
+
+            val row = xtQueryDb(
+                node, "events",
+                "SELECT _id, string_val, int_val, double_val, bool_val, array_val, nested_val, " +
+                    "timestamp_str, date_str, time_str, " +
+                    "timestamp_val, date_val, time_val " +
+                    "FROM public.events WHERE _id = 'all-types'",
+            )[0]
+
+            assertEquals("hello", row["string_val"])
+            assertEquals(42L, (row["int_val"] as Number).toLong())
+            assertEquals(3.14, (row["double_val"] as Number).toDouble(), 0.0001)
+            assertEquals(true, row["bool_val"])
+
+            assertEquals(listOf(1L, 2L, 3L), toList(row["array_val"]).map { (it as Number).toLong() })
+
+            @Suppress("UNCHECKED_CAST")
+            val nested = row["nested_val"] as Map<String, Any?>
+            assertEquals("deep", nested["inner"])
+
+            // `*_str` fields — JSON Schema's `format` keyword (date-time / date / time) is metadata
+            // only. Confluent's JsonSchemaConverter doesn't promote it to a Connect logical type;
+            // the values arrive as strings and XT stores them as strings. If you need typed temporals
+            // and can't change the producer, drop in a `TimestampConverter` SMT.
+            assertEquals(timestampStr, row["timestamp_str"])
+            assertEquals(dateStr, row["date_str"])
+            assertEquals(timeStr, row["time_str"])
+
+            // `*_val` fields — typed temporals via `title` + integer. The field is `type: integer`
+            // with `title` pointing at the Connect logical-type name, and the producer emits Connect's
+            // integer wire encoding. JsonSchemaConverter promotes to a Connect logical type and the
+            // values come back as typed temporals.
+            assertEquals(expectedTs, toInstant(row["timestamp_val"]))
+            assertEquals(expectedDate, toLocalDate(row["date_val"]))
+            assertEquals(expectedTime, toLocalTime(row["time_val"]))
+        }
+    }
+
+    @Test
+    fun `null value tombstone deletes the row (JsonSchemaConverter)`() = runTest(timeout = 180.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        val schemaStr = """
+            {
+              "${'$'}schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "_id":  { "type": "string" },
+                "name": { "type": "string" }
+              }
+            }
+        """.trimIndent()
+
+        val mapper = com.fasterxml.jackson.databind.ObjectMapper()
+        val jsonSchema = io.confluent.kafka.schemaregistry.json.JsonSchema(schemaStr)
+        val envelope = io.confluent.kafka.schemaregistry.json.JsonSchemaUtils.toObject(
+            mapper.readTree("""{"_id":"k1","name":"Alice"}"""),
+            jsonSchema,
+        )
+
+        val producerProps = mapOf(
+            "bootstrap.servers" to kafka.bootstrapServers,
+            "key.serializer" to StringSerializer::class.java.name,
+            "value.serializer" to "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
+            "schema.registry.url" to schemaRegistryUrl,
+            "auto.register.schemas" to "true",
+        )
+        KafkaProducer<String?, Any?>(producerProps).use { producer ->
+            producer.send(ProducerRecord(sourceTopic, "k1", envelope)).get()
+        }
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: io.confluent.connect.json.JsonSchemaConverter
+                    value.converter.schema.registry.url: $schemaRegistryUrl
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("Alice ingested", timeout = 60.seconds) {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'k1'").isNotEmpty()
+            }
+
+            // Tombstones are just null value bytes — same wire shape regardless of format.
+            produceBytes(sourceTopic, "k1", null)
+            awaitCondition("Alice deleted") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'k1'").isEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `null value tombstone deletes the row (AvroConverter)`() = runTest(timeout = 180.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        val avroSchema = AvroSchema.Parser().parse("""
+            {
+              "type":"record","name":"Person","namespace":"xtdb.test",
+              "fields":[
+                {"name":"_id","type":"string"},
+                {"name":"name","type":"string"}
+              ]
+            }
+        """.trimIndent())
+
+        val rec = GenericData.Record(avroSchema).apply {
+            put("_id", "k1")
+            put("name", "Alice")
+        }
+        produceAvro(sourceTopic, "k1", rec)
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: io.confluent.connect.avro.AvroConverter
+                    value.converter.schema.registry.url: $schemaRegistryUrl
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("Alice ingested", timeout = 60.seconds) {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'k1'").isNotEmpty()
+            }
+
+            produceBytes(sourceTopic, "k1", null)
+            awaitCondition("Alice deleted") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'k1'").isEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `AvroConverter recursively converts logical types inside nested compound shapes`() = runTest(timeout = 180.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        // Logical types at various depths:
+        //   - Struct → Struct → Decimal + Timestamp
+        //   - Struct → Array<Timestamp>
+        //   - Struct → Map<String, Struct<Decimal>>
+        // The schema-driven walk has to propagate logical-type recognition through every level.
+        val schemaJson = """
+            {
+              "type": "record", "name": "OrderEnvelope", "namespace": "xtdb.test",
+              "fields": [
+                {"name": "_id", "type": "string"},
+                {"name": "header", "type": {
+                  "type": "record", "name": "Header",
+                  "fields": [
+                    {"name": "placed_at", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+                    {"name": "totals", "type": {
+                      "type": "record", "name": "Totals",
+                      "fields": [
+                        {"name": "subtotal", "type": {"type": "bytes", "logicalType": "decimal",
+                                                     "precision": 12, "scale": 2}}
+                      ]
+                    }}
+                  ]
+                }},
+                {"name": "delivery_attempts", "type": {
+                  "type": "array",
+                  "items": {"type": "long", "logicalType": "timestamp-millis"}
+                }},
+                {"name": "lines_by_sku", "type": {
+                  "type": "map",
+                  "values": {
+                    "type": "record", "name": "Line",
+                    "fields": [
+                      {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal",
+                                                  "precision": 12, "scale": 2}}
+                    ]
+                  }
+                }}
+              ]
+            }
+        """.trimIndent()
+        val avroSchema = AvroSchema.Parser().parse(schemaJson)
+
+        val placedAt = java.time.Instant.parse("2024-06-08T12:34:56.789Z")
+        val attempt1 = java.time.Instant.parse("2024-06-08T14:00:00Z")
+        val attempt2 = java.time.Instant.parse("2024-06-09T10:00:00Z")
+        val subtotal = java.math.BigDecimal("999.99")
+        val lineA = java.math.BigDecimal("100.00")
+        val lineB = java.math.BigDecimal("250.50")
+
+        val decimalConv = org.apache.avro.Conversions.DecimalConversion()
+        fun decimalBytes(value: java.math.BigDecimal, fieldName: String, parent: AvroSchema): java.nio.ByteBuffer {
+            val fieldSchema = parent.getField(fieldName).schema()
+            return decimalConv.toBytes(value, fieldSchema, fieldSchema.logicalType)
+        }
+
+        val totalsSchema = avroSchema.getField("header").schema().getField("totals").schema()
+        val totalsRec = GenericData.Record(totalsSchema).apply {
+            put("subtotal", decimalBytes(subtotal, "subtotal", totalsSchema))
+        }
+
+        val headerSchema = avroSchema.getField("header").schema()
+        val headerRec = GenericData.Record(headerSchema).apply {
+            put("placed_at", placedAt.toEpochMilli())
+            put("totals", totalsRec)
+        }
+
+        val lineSchema = avroSchema.getField("lines_by_sku").schema().valueType
+        fun lineRec(amt: java.math.BigDecimal) = GenericData.Record(lineSchema).apply {
+            put("amount", decimalBytes(amt, "amount", lineSchema))
+        }
+
+        val envelope = GenericData.Record(avroSchema).apply {
+            put("_id", "nested")
+            put("header", headerRec)
+            put("delivery_attempts", listOf(attempt1.toEpochMilli(), attempt2.toEpochMilli()))
+            put("lines_by_sku", mapOf("SKU-A" to lineRec(lineA), "SKU-B" to lineRec(lineB)))
+        }
+
+        produceAvro(sourceTopic, "nested", envelope)
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: io.confluent.connect.avro.AvroConverter
+                    value.converter.schema.registry.url: $schemaRegistryUrl
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("record appears", timeout = 60.seconds) {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'nested'").isNotEmpty()
+            }
+
+            val row = xtQueryDb(
+                node, "events",
+                "SELECT _id, header, delivery_attempts, lines_by_sku FROM public.events WHERE _id = 'nested'",
+            )[0]
+
+            // header.placed_at: Timestamp two structs deep.
+            // header.totals.subtotal: Decimal three structs deep.
+            @Suppress("UNCHECKED_CAST")
+            val header = row["header"] as Map<String, Any?>
+            assertEquals(placedAt, toInstant(header["placed_at"]))
+
+            @Suppress("UNCHECKED_CAST")
+            val totals = header["totals"] as Map<String, Any?>
+            assertEquals(subtotal, totals["subtotal"])
+
+            // delivery_attempts: Array<Timestamp> — every element should be an Instant, not a Long.
+            val attempts = toList(row["delivery_attempts"])
+            assertEquals(2, attempts.size)
+            assertEquals(attempt1, toInstant(attempts[0]))
+            assertEquals(attempt2, toInstant(attempts[1]))
+
+            // lines_by_sku: Map<String, Struct<Decimal>> — Decimal at array-of-struct depth.
+            @Suppress("UNCHECKED_CAST")
+            val lines = row["lines_by_sku"] as Map<String, Any?>
+            @Suppress("UNCHECKED_CAST")
+            val lineARow = lines["SKU-A"] as Map<String, Any?>
+            @Suppress("UNCHECKED_CAST")
+            val lineBRow = lines["SKU-B"] as Map<String, Any?>
+            assertEquals(lineA, lineARow["amount"])
+            assertEquals(lineB, lineBRow["amount"])
+        }
+    }
+
+    @Test
+    fun `AvroConverter with Schema Registry roundtrips all Avro types`() = runTest(timeout = 180.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        // Avro's full type universe — primitives, compound (record/enum/array/map/union),
+        // bytes, plus the logical types we map (decimal/date/time-millis/timestamp-millis).
+        val schemaJson = """
+            {
+              "type": "record",
+              "name": "AllTypes",
+              "namespace": "xtdb.test",
+              "fields": [
+                {"name": "_id",          "type": "string"},
+                {"name": "bool_val",     "type": "boolean"},
+                {"name": "int_val",      "type": "int"},
+                {"name": "long_val",     "type": "long"},
+                {"name": "float_val",    "type": "float"},
+                {"name": "double_val",   "type": "double"},
+                {"name": "string_val",   "type": "string"},
+                {"name": "bytes_val",    "type": "bytes"},
+                {"name": "nullable_val", "type": ["null", "string"], "default": null},
+                {"name": "enum_val", "type": {"type": "enum", "name": "Color",
+                                              "symbols": ["RED", "GREEN", "BLUE"]}},
+                {"name": "array_val",    "type": {"type": "array", "items": "int"}},
+                {"name": "map_val",      "type": {"type": "map", "values": "string"}},
+                {"name": "nested_val",   "type": {
+                    "type": "record", "name": "Nested",
+                    "fields": [{"name": "inner", "type": "string"}]
+                }},
+                {"name": "decimal_val",  "type": {"type": "bytes", "logicalType": "decimal",
+                                                  "precision": 10, "scale": 2}},
+                {"name": "date_val",     "type": {"type": "int",  "logicalType": "date"}},
+                {"name": "time_val",     "type": {"type": "int",  "logicalType": "time-millis"}},
+                {"name": "timestamp_val","type": {"type": "long", "logicalType": "timestamp-millis"}}
+              ]
+            }
+        """.trimIndent()
+        val avroSchema = AvroSchema.Parser().parse(schemaJson)
+
+        val decimal = java.math.BigDecimal("123.45")
+        val decimalBytes = org.apache.avro.Conversions.DecimalConversion().toBytes(
+            decimal,
+            avroSchema.getField("decimal_val").schema(),
+            avroSchema.getField("decimal_val").schema().logicalType,
+        )
+
+        val expectedDate = java.time.LocalDate.of(2024, 6, 8)
+        val expectedTime = java.time.LocalTime.of(12, 34, 56)
+        val expectedTs = java.time.Instant.parse("2024-06-08T12:34:56.789Z")
+
+        val daysSinceEpoch = expectedDate.toEpochDay().toInt()
+        val millisOfDay = ((expectedTime.toNanoOfDay() / 1_000_000L).toInt())
+        val tsMillis = expectedTs.toEpochMilli()
+
+        val enumSchema = avroSchema.getField("enum_val").schema()
+        val nestedSchema = avroSchema.getField("nested_val").schema()
+
+        val rec = GenericData.Record(avroSchema).apply {
+            put("_id", "all-types")
+            put("bool_val", true)
+            put("int_val", 42)
+            put("long_val", 9999999999L)
+            put("float_val", 3.14f)
+            put("double_val", 2.71828)
+            put("string_val", "hello")
+            put("bytes_val", java.nio.ByteBuffer.wrap(byteArrayOf(0x01, 0x02, 0x03)))
+            put("nullable_val", "maybe")
+            put("enum_val", GenericData.EnumSymbol(enumSchema, "GREEN"))
+            put("array_val", listOf(1, 2, 3))
+            put("map_val", mapOf("k1" to "v1", "k2" to "v2"))
+            put("nested_val", GenericData.Record(nestedSchema).apply { put("inner", "deep") })
+            put("decimal_val", decimalBytes)
+            put("date_val", daysSinceEpoch)
+            put("time_val", millisOfDay)
+            put("timestamp_val", tsMillis)
+        }
+
+        produceAvro(sourceTopic, "all-types", rec)
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: io.confluent.connect.avro.AvroConverter
+                    value.converter.schema.registry.url: $schemaRegistryUrl
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("record appears", timeout = 60.seconds) {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'all-types'").isNotEmpty()
+            }
+
+            val row = xtQueryDb(
+                node, "events",
+                "SELECT _id, bool_val, int_val, long_val, float_val, double_val, string_val, bytes_val, " +
+                    "nullable_val, enum_val, array_val, map_val, nested_val, " +
+                    "decimal_val, date_val, time_val, timestamp_val " +
+                    "FROM public.events WHERE _id = 'all-types'",
+            )[0]
+
+            assertEquals(true, row["bool_val"])
+            assertEquals(42L, (row["int_val"] as Number).toLong())
+            assertEquals(9999999999L, (row["long_val"] as Number).toLong())
+            assertEquals(3.14, (row["float_val"] as Number).toDouble(), 0.001)
+            assertEquals(2.71828, (row["double_val"] as Number).toDouble(), 0.00001)
+            assertEquals("hello", row["string_val"])
+
+            val bytes = row["bytes_val"]
+            assertNotNull(bytes)
+            val byteArr: ByteArray = when (bytes) {
+                is ByteArray -> bytes
+                is java.nio.ByteBuffer -> ByteArray(bytes.remaining()).also { bytes.duplicate().get(it) }
+                else -> error("unexpected bytes type: ${bytes!!::class}")
+            }
+            assertEquals(listOf<Byte>(0x01, 0x02, 0x03), byteArr.toList())
+
+            assertEquals("maybe", row["nullable_val"])
+            assertEquals("GREEN", row["enum_val"])
+
+            assertEquals(listOf(1L, 2L, 3L), toList(row["array_val"]).map { (it as Number).toLong() })
+
+            @Suppress("UNCHECKED_CAST")
+            val map = row["map_val"] as Map<String, Any?>
+            assertEquals(mapOf("k1" to "v1", "k2" to "v2"), map)
+
+            @Suppress("UNCHECKED_CAST")
+            val nested = row["nested_val"] as Map<String, Any?>
+            assertEquals("deep", nested["inner"])
+
+            // Logical types
+            assertEquals(decimal, row["decimal_val"])
+            assertEquals(expectedDate, toLocalDate(row["date_val"]))
+            assertEquals(expectedTime, toLocalTime(row["time_val"]))
+            assertEquals(expectedTs, toInstant(row["timestamp_val"]))
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,9 +14,10 @@ if (file("lang/test-harness").isDirectory) {
 
 include("docker:standalone", "docker:aws", "docker:azure", "docker:google-cloud")
 
-include("modules:kafka", "modules:kafka-connect", "modules:postgres-source", "modules:aws", "modules:azure", "modules:google-cloud")
+include("modules:kafka", "modules:kafka-connect", "modules:kafka-connect-source", "modules:postgres-source", "modules:aws", "modules:azure", "modules:google-cloud")
 project(":modules:kafka").name = "xtdb-kafka"
 project(":modules:kafka-connect").name = "xtdb-kafka-connect"
+project(":modules:kafka-connect-source").name = "xtdb-kafka-connect-source"
 project(":modules:postgres-source").name = "xtdb-postgres-source"
 project(":modules:aws").name = "xtdb-aws"
 project(":modules:azure").name = "xtdb-azure"


### PR DESCRIPTION
Resolves #5562.

## Summary

Adds `!KafkaConnect` as a second external-source flavour for XT databases fed by a Kafka topic. The framework owns subscription, partition assignment, polling and resume-token lifecycle; bytes flow through a Kafka Connect `Converter` + `Transformation` chain to produce `SinkRecord`s, which a pluggable `RecordIndexer` writes to XT. The reference `!Docs` indexer (one record = one tx, value-as-doc, key-as-`_id` fallback) walks the resulting `Struct` against its `Schema` and emits Connect's logical types as their natural XT counterparts: `Decimal → BigDecimal`, `Timestamp → Instant`, `Date → LocalDate`, `Time → LocalTime`.

## Context / Motivation

`!Postgres` is the only external source today. Kafka topics are the next-most-common shape operators want to consume from, and a Connect-shaped pipeline gives us standardised handling across formats (Avro, JSON, JSON Schema, plus anything else with a `Converter`), free SMT chain support that mirrors how operators already shape data in their KC pipelines, and a SPI shape (`SinkRecord`) that lines up with what KC sink connectors consume — the same shape full KC compatibility would want anyway.

The alternative shape — `KafkaConsumer<K, V>` + raw `Deserializer`s — would put every indexer on the hook for format-specific JVM types (`Map` for JSON, `GenericRecord` for Avro, `JsonNode` for JSON Schema) and lose schema information at the indexer boundary. Connect already solved that problem; we re-use the solution.

## Usage

Node config — register the Kafka cluster as a remote in the YAML:

```yaml
remotes:
  my-kafka: !Kafka
    bootstrapServers: kafka.prod.internal:9092
```

Then attach a database against it at runtime, via SQL on a connected client:

```sql
ATTACH DATABASE orders WITH $$
  log: !Kafka
    cluster: my-kafka
    topic: orders-replica
  externalSource: !KafkaConnect
    remote: my-kafka
    topic: orders
    connectConfig:
      key.converter: org.apache.kafka.connect.storage.StringConverter
      value.converter: io.confluent.connect.avro.AvroConverter
      value.converter.schema.registry.url: http://schema-registry:8081

      # SMT chain (optional, same shape as KC):
      transforms: unwrap,maskEmail
      transforms.unwrap.type: org.apache.kafka.connect.transforms.ExtractField$Value
      transforms.unwrap.field: payload

      # Predicates gate transforms — only mask when the PII header is present:
      transforms.maskEmail.type: org.apache.kafka.connect.transforms.MaskField$Value
      transforms.maskEmail.fields: email
      transforms.maskEmail.predicate: hasPii
      predicates: hasPii
      predicates.hasPii.type: org.apache.kafka.connect.transforms.predicates.HasHeaderKey
      predicates.hasPii.name: PII
    indexer: !Docs
      table: orders
$$;
```

`connectConfig` accepts the same keys you'd pass to a KC sink connector: `key.converter`, `value.converter`, `value.converter.<prop>`, `transforms`, `transforms.<alias>.<prop>`, plus the predicate triplet (`predicates`, `predicates.<alias>.type`, `predicates.<alias>.<prop>`) and the `transforms.<alias>.predicate` / `transforms.<alias>.negate` keys that gate a transform on a predicate.

Three Confluent-supported formats are bundled into the published `aws`, `azure`, and `google-cloud` Docker images:

- `org.apache.kafka.connect.json.JsonConverter` — schemaless JSON, no SR.
- `io.confluent.connect.avro.AvroConverter` — Avro + Confluent SR.
- `io.confluent.connect.json.JsonSchemaConverter` — JSON Schema + Confluent SR.

The `standalone` image is *not* wired up — see the `build(docker)` commit body for why.

## Implementation notes

**Connect data model end-to-end.** `KafkaConnectSource` configures the consumer with `ByteArrayDeserializer` for both key and value, runs each record's bytes through the configured `Converter`s to produce a `SchemaAndValue`, and assembles a `SinkRecord`. The SMT chain (built from `transforms.*` config) operates on the `SinkRecord` exactly as it does inside a KC sink task. The indexer SPI receives a `List<SinkRecord>` and decides commit cadence.

**Schema-first walk in `DocsIndexer.convertValue`.** Matches the order Connect's own `JsonConverter.convertToJson` dispatches: null → `schema.name()` for logical-type promotion → `schema.type()` → schemaless fallback dispatching on JVM class. The schema is the primary source of truth because most Connect values can't self-describe — a `java.util.Date` could be a `Date`, `Time`, or `Timestamp` logical type, only `schema.name()` disambiguates.

**UTC for Date and Time.** Connect encodes `Date` as `Date(epochDay * 86_400_000)` and `Time` as `Date(millis_of_day)`, both anchored at the UTC epoch. Decoding requires re-interpretation in UTC — anywhere else and the calendar reading shifts by the JVM's local offset (a node running in Pacific time would read `2024-06-08` Date values as `2024-06-07`). `DocsIndexerTest` forces the JVM default zone to America/Los_Angeles for the assertion to prove this isn't accidentally satisfied by a UTC CI runner.

**ProtoAny for the indexer factory.** `RecordIndexer.Factory` mirrors `ExternalSource.Factory` — config flows through `google.protobuf.Any` to support cross-node ATTACH DATABASE. Considered a tag-plus-bytes shape parallel to 3763caa42's `ExternalSourceToken = ByteArray` refactor, but tokens are opaque per-source-instance (no polymorphism) while indexer configs are polymorphic across registered factories (need a discriminator). ProtoAny's `typeUrl` is doing real work. Third-party indexer authors take the protobuf dep — same trade-off `PostgresSource` accepted internally.

**Halt-on-decode-failure.** Matches KC's default (`errors.tolerance=none`): any converter / SMT / indexer exception propagates up, the source coroutine dies, the leader fails over, the consumer re-reads from the last good token. KC's `errors.tolerance=all` (DLQ) mode requires offset-ordered commits — see Dead ends.

## Dead ends

**DLQ-via-aborted-tx.** Earlier iterations carried a DLQ path: a failed decode wrote an aborted XT tx with the bad record's topic/partition/offset coords and advanced the resume token, then continued. Looked clean but had a subtle race — the aborted-tx commit advanced the token *before* the indexer's per-record commits, so on a mid-batch indexer crash the good records earlier in the batch were lost on restart (their token had been overwritten). KC handles this in `errors.tolerance=all` mode by reordering commits so good records always commit before any abort that supersedes them; doing that properly here is out of scope. Halt-on-failure for now, DLQ as a follow-up.

**Bespoke `MapJsonDeserializer`.** An earlier iteration shipped a custom test deserializer to bridge raw Kafka deserializers' output into `!Docs`'s expected `Map`. Survey of the ecosystem (Kafka Connect's `Converter` + `SchemaAndValue`, Pinot's `StreamMessageDecoder`, Druid's `inputFormat`, Materialize / RisingWave's `FORMAT ENCODE`, ClickHouse's `kafka_format`) showed all of them converge on per-format decoders producing a uniform schema-aware shape. Switched the source to KC's `Converter` directly; the bespoke deserializer went away.

## Out of scope, deferred

- Multi-partition consumption (Stage 3 constraint from #5330 — single-partition only).
- Multi-topic / topic patterns — one source = one topic.
- The `errors.tolerance=all` DLQ flow with offset-ordered commits.
- Additional reference indexers beyond `!Docs` (e.g. CDC-shaped record mapping for Debezium envelopes).
- Pluggable `_id` source.
- `standalone` Docker image wiring — would transitively pull `xtdb-kafka` log support into the playground image; separate decision.

## Changes

Two commits, intended reading order:

1. `feat(kafka-connect-source): external source via Kafka Connect data model` — the module itself: SPI, source, indexer, factory + integration tests.
2. `build(docker): bundle xtdb-kafka-connect-source in the cloud images` — wire the module into the `aws`, `azure`, `google-cloud` published images so operators can use `!KafkaConnect` without rebuilding.

## Test plan

7 unit tests (`./gradlew :modules:xtdb-kafka-connect-source:test`):

- `KafkaConnectSourceFactoryTest` (4) — YAML + proto roundtrip for `!KafkaConnect` + `!Docs`.
- `DocsIndexerTest` (3) — UTC convention for Connect `Date` / `Time` / `Timestamp` under a non-UTC default JVM zone.

13 integration tests (`./gradlew :modules:xtdb-kafka-connect-source:integration-test`, requires Docker for Kafka + Schema Registry containers):

- `JsonConverter` happy path, tombstone delete, all JSON types.
- `JsonSchemaConverter` with Schema Registry: tombstone delete, all JSON Schema types including the `title`-keyed path for typed temporals.
- `AvroConverter` with Schema Registry: tombstone delete, all Avro types, recursive logical-type promotion through nested compound shapes.
- Resume from token after node restart.
- Halt-on-decode-failure (consumer dies; good records before the bad one stay committed, source doesn't recover until restart).

All 20 tests pass on the branch.