### PR TITLE
feat(sql)!: CREATE TABLE columns (as Nothing) + column-not-found errors (#4467)

### DIFF
--- a/api/src/main/clojure/xtdb/serde/types.clj
+++ b/api/src/main/clojure/xtdb/serde/types.clj
@@ -3,7 +3,7 @@
   (:import (java.io Writer)
            (org.apache.arrow.vector.types DateUnit FloatingPointPrecision IntervalUnit TimeUnit Types$MinorType UnionMode)
            (org.apache.arrow.vector.types.pojo ArrowType ArrowType$Binary ArrowType$Bool ArrowType$Date ArrowType$Decimal ArrowType$Duration ArrowType$FixedSizeBinary ArrowType$FixedSizeList ArrowType$FloatingPoint ArrowType$Int ArrowType$Interval ArrowType$List ArrowType$Map ArrowType$Null ArrowType$Struct ArrowType$Time ArrowType$Time ArrowType$Timestamp ArrowType$Union ArrowType$Utf8 Field FieldType Schema)
-           (xtdb.arrow ArrowTypes VectorType VectorType$Listy VectorType$Maybe VectorType$Null VectorType$Poly VectorType$Scalar VectorType$Struct VectorType$Mono)
+           (xtdb.arrow ArrowTypes VectorType VectorType$Listy VectorType$Maybe VectorType$Null VectorType$Nothing VectorType$Poly VectorType$Scalar VectorType$Struct VectorType$Mono)
            (xtdb.vector.extensions IntervalMDMType KeywordType OidType RegClassType RegProcType SetType TransitType TsTzRangeType UriType UuidType)))
 
 (defprotocol FromArrowType
@@ -246,8 +246,11 @@
   (render-type [vec-type]))
 
 (extend-protocol RenderType
-  VectorType$Null 
+  VectorType$Null
   (render-type [_] :null)
+
+  VectorType$Nothing
+  (render-type [_] :nothing)
 
   VectorType$Scalar
   (render-type [scalar]

--- a/api/src/main/kotlin/xtdb/arrow/VectorType.kt
+++ b/api/src/main/kotlin/xtdb/arrow/VectorType.kt
@@ -306,7 +306,9 @@ sealed class VectorType {
         @get:JvmName("fromField")
         val Field.asType: VectorType
             get() = when (type) {
-                NULL_TYPE -> Null
+                // a non-nullable NULL field is the lattice bottom (Nothing), not the nullable Null marker -
+                // so a declared-but-empty column survives a block flush without polluting to Null/Maybe
+                NULL_TYPE -> if (isNullable) Null else Nothing
                 LIST_TYPE, SetType, TsTzRangeType, is ArrowType.FixedSizeList -> Listy(type, children.single().asType)
                 STRUCT_TYPE -> Struct(children.associate { it.name to it.asType })
                 is ArrowType.Union -> fromLegs(children.map { it.asType })

--- a/api/src/main/kotlin/xtdb/arrow/VectorType.kt
+++ b/api/src/main/kotlin/xtdb/arrow/VectorType.kt
@@ -101,6 +101,24 @@ sealed class VectorType {
         override fun toString() = children.entries.joinToString(prefix = "{", postfix = "}") { (n, t) -> "$n: $t" }
     }
 
+    /**
+     * The lattice bottom: no values seen yet, no constraint. `Nothing ⊔ X = X`.
+     *
+     * Distinct from [Null]: merging in [Null] sets the nullable flag (`Null ⊔ I64 = Maybe(I64)`),
+     * whereas `Nothing` widens cleanly to the first type it meets. It is the schema-level counterpart
+     * of `NullVector(nullable = false)` ("undefined", no values), as opposed to `Null`'s `nullable = true`.
+     */
+    data object Nothing : VectorType() {
+        override val arrowType get() = NULL_TYPE
+        override val nullable get() = false
+
+        // the bottom is absorbed by any join, so it contributes no legs and must never be one
+        override val legs: Iterable<Mono> get() = emptyList()
+
+        override fun toField(name: FieldName) = Field(name, FieldType(false, NULL_TYPE, null), emptyList())
+        override val asLegField get() = error("Nothing is the lattice bottom; it cannot be a union leg")
+    }
+
     data class Maybe(val mono: Mono) : VectorType() {
         override val arrowType get() = mono.arrowType
         override val nullable = true
@@ -149,6 +167,7 @@ sealed class VectorType {
 
             return when (type) {
                 Null -> type
+                Nothing -> Null
                 is Mono -> Maybe(type)
                 is Maybe -> type
                 is Poly -> Poly(type.legs + Null)

--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -58,7 +58,7 @@ directlyExecutableStatement
     | GRANT roleName=identifier TO userName=identifier # GrantRoleStatement
     | REVOKE roleName=identifier FROM userName=identifier # RevokeRoleStatement
 
-    | CREATE (OR ALTER)? TABLE targetTable # CreateTableStatement
+    | CREATE (OR ALTER)? TABLE targetTable ('(' columnNameList ')')? # CreateTableStatement
     ;
 
 targetTable : (schemaName=identifier '.')? tableName=identifier ;

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -19,7 +19,7 @@
            (org.apache.arrow.vector PeriodDuration)
            (org.apache.arrow.vector.types.pojo ArrowType$Decimal)
            (org.apache.commons.codec.binary Hex)
-           (xtdb.arrow ListValueReader RelationReader ValueBox ValueReader Vector VectorReader VectorType VectorType$Listy VectorType$Mono VectorType$Poly VectorType$Struct)
+           (xtdb.arrow ListValueReader RelationReader ValueBox ValueReader Vector VectorReader VectorType VectorType$Listy VectorType$Mono VectorType$Nothing VectorType$Poly VectorType$Struct)
            (xtdb.expression PgFormat)
            (xtdb.operator ProjectionSpec SelectionSpec)
            xtdb.time.Interval
@@ -515,6 +515,10 @@
                                     :or {extract-vecs-from-rel? true}}]
   (let [return-type (or (get var-types variable)
                         (throw (AssertionError. (str "unknown variable: " variable))))
+        ;; `Nothing` is the catalog's lattice bottom for a declared-but-valueless column; when such a
+        ;; column is read in a query its rows are simply null, so the EE treats it as `:null` and never
+        ;; needs `:nothing` call definitions (Nothing's empty legs would otherwise collapse codegen).
+        return-type (if (= return-type VectorType$Nothing/INSTANCE) #xt/type :null return-type)
         var-rdr-sym (gensym (util/symbol->normal-form-symbol variable))]
 
     ;; NOTE: when used from metadata exprs, incoming vectors might not exist

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -449,12 +449,12 @@
                       (throw t))))))))))))
 
   (prepareTxSql [this sql db-cat opts]
-    (let [[q-tag {:keys [stmt table message user role]}]
+    (let [[q-tag {:keys [stmt table message user role col-names]}]
           (parse-sql/parse-statement sql {:default-db (:default-db opts)})]
       (case q-tag
         :grant-role (SqlStatement$GrantRole. user role)
         :revoke-role (SqlStatement$RevokeRole. user role)
-        :create-table (SqlStatement$CreateTable. table)
+        :create-table (SqlStatement$CreateTable. table (or col-names []))
 
         (let [pq (.prepareQuery this stmt db-cat opts)]
           (case q-tag

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -111,6 +111,8 @@
   PlanError
   (error-string [_] (format "Table not found: %s" (str/join "." (filter some? table-chain)))))
 
+(def ^:private internal-schemas #{"xt" "pg_catalog" "information_schema"})
+
 (defn- system-table-chain?
   "An unknown table in an internal schema stays a warning rather than an error (#4467): a data-backed
    `xt` table like `xt.txs` is empty - hence absent from the catalog - on a fresh node, and tools probe
@@ -121,7 +123,7 @@
    (`pg_class`) or schema-injected by the DML path (`public.pg_class`), hence we check the table name."
   [table-chain]
   (or (and (>= (count table-chain) 2)
-           (contains? #{"xt" "pg_catalog" "information_schema"}
+           (contains? internal-schemas
                       (str (nth table-chain (- (count table-chain) 2)))))
       (str/starts-with? (str (peek table-chain)) "pg_")))
 
@@ -346,7 +348,12 @@
                (or (nil? db-name) (= db-name (symbol (.getDbName table-ref)))))
       (for [col (if col-name
                   (when (or (contains? cols col-name) (types/temporal-col-name? col-name)
-                            (temporal-period-column? col-name))
+                            (temporal-period-column? col-name)
+                            ;; tolerate any column on an internal-schema table: tools probe optional
+                            ;; pg_catalog/information_schema columns, and unimplemented system tables
+                            ;; resolve to the `xt.not_found` sentinel (schema `xt`). Only user tables
+                            ;; error on a typo'd / undeclared column (#4467).
+                            (contains? internal-schemas (.getSchemaName table-ref)))
                     [col-name])
                   (available-cols this))
             :when (not (contains? excl-cols col))]
@@ -1345,7 +1352,7 @@
       (when-let [sym (case (count matches)
                        0 (if (= chain '(user))
                            '(current-user)
-                           (do (add-warning! env (->ColumnNotFound chain))
+                           (do (add-err! env (->ColumnNotFound chain))
                                (when !unresolved-cr
                                  (let [sym (->col-sym (str "xt$missing_column" (swap! !id-count inc)))]
                                    (.add !unresolved-cr sym)

--- a/core/src/main/clojure/xtdb/sql/parse.clj
+++ b/core/src/main/clojure/xtdb/sql/parse.clj
@@ -52,7 +52,8 @@
     [:revoke-role {:role (str (sql/identifier-sym (.roleName stmt))), :user (str (sql/identifier-sym (.userName stmt)))}])
 
   (visitCreateTableStatement [_ stmt]
-    [:create-table {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt)))}]))
+    [:create-table {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt)))
+                    :col-names (some->> (.columnNameList stmt) (.columnName) (mapv (comp str sql/identifier-sym)))}]))
 
 (defn parse-statement [stmt opts]
   (if (string? stmt)

--- a/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
@@ -17,6 +17,8 @@ data class MergeTypes(
         when (type) {
             Null -> nullable = true
 
+            Nothing -> {} // bottom: contributes nothing to the merge
+
             is Poly -> type.legs.forEach { merge(it) }
 
             is Maybe -> {

--- a/core/src/main/kotlin/xtdb/arrow/NullVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/NullVector.kt
@@ -21,6 +21,11 @@ class NullVector(
     override val arrowType: ArrowType = NULL_TYPE
     override val monoType = Null
 
+    // a non-nullable NULL vector holds only 'undefined' (no values seen) — the lattice bottom Nothing,
+    // distinct from the nullable Null marker. Keeps a declared-but-empty column (CREATE TABLE foo (a))
+    // from polluting to Maybe on its first insert: Nothing ⊔ I64 = I64, whereas Null ⊔ I64 = Maybe(I64).
+    override val type get() = if (nullable) Null else Nothing
+
     override fun isNull(idx: Int) = true
 
     override fun writeUndefined() {

--- a/core/src/main/kotlin/xtdb/arrow/Vector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Vector.kt
@@ -119,7 +119,7 @@ sealed class Vector : VectorReader, VectorWriter {
             val al = this
 
             return arrowType.accept(object : ArrowTypeVisitor<Vector> {
-                override fun visit(type: Null) = NullVector(name)
+                override fun visit(type: Null) = NullVector(name, nullable)
 
                 override fun visit(type: Struct) =
                     StructVector(al, name, nullable, children.associateByTo(linkedMapOf()) { it.name })

--- a/core/src/main/kotlin/xtdb/arrow/metadata/MetadataFlavour.kt
+++ b/core/src/main/kotlin/xtdb/arrow/metadata/MetadataFlavour.kt
@@ -87,6 +87,7 @@ sealed interface MetadataFlavour {
         @JvmStatic
         val VectorType.metadataFlavour: Class<out MetadataFlavour>?
             get() = when(this) {
+                VectorType.Nothing -> null // bottom: no values, hence no flavour
                 is VectorType.Mono -> arrowType.metadataFlavour
                 is VectorType.Maybe -> mono.metadataFlavour
                 is VectorType.Poly -> UNION_TYPE.unsupported()

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -7,6 +7,7 @@ import xtdb.NodeBase
 import xtdb.ResultCursor
 import xtdb.api.TransactionKey
 import xtdb.api.log.ReplicaMessage
+import xtdb.arrow.NULL_TYPE
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorReader
@@ -206,7 +207,7 @@ class OpenTx(
             is SqlStatement.GrantRole -> writeRoleMembership(stmt.user, stmt.role, currentTime, user, revoke = false)
             is SqlStatement.RevokeRole -> writeRoleMembership(stmt.user, stmt.role, currentTime, user, revoke = true)
 
-            is SqlStatement.CreateTable -> createTable(stmt.table)
+            is SqlStatement.CreateTable -> createTable(stmt.table, stmt.colNames)
 
             is SqlStatement.DmlQuery -> {
                 val query = stmt.query
@@ -272,9 +273,9 @@ class OpenTx(
         }
     }
 
-    private fun createTable(ref: TableRef) {
+    private fun createTable(ref: TableRef, colNames: List<String>) {
         checkNotForbidden(ref)
-        table(ref)
+        table(ref).declareColumns(colNames)
     }
 
     // GRANT/REVOKE arrive as ordinary SQL but are authority-gated and write below the FORBIDDEN_SCHEMAS
@@ -438,6 +439,15 @@ class OpenTx(
         private val eraseVec = opVec["erase"]
 
         val docWriter: VectorWriter by lazy(LazyThreadSafetyMode.NONE) { putVec }
+
+        /**
+         * Seeds the put-struct with a `NULL_TYPE` child per declared column, so a `CREATE TABLE foo (a, b)`
+         * registers the columns ahead of any data. They surface through [RelationReader.logRelTypes] into the
+         * catalog/planner. (An empty `CREATE TABLE foo` passes no columns, leaving the put-struct unforced.)
+         */
+        fun declareColumns(colNames: List<String>) {
+            for (colName in colNames) docWriter.vectorFor(colName, NULL_TYPE, false)
+        }
 
         var trie: MemoryHashTrie = MemoryHashTrie.emptyTrie(iidVec)
             private set

--- a/core/src/main/kotlin/xtdb/query/SqlStatement.kt
+++ b/core/src/main/kotlin/xtdb/query/SqlStatement.kt
@@ -23,5 +23,5 @@ sealed interface SqlStatement {
     data class GrantRole(val user: String, val role: String) : SqlStatement
     data class RevokeRole(val user: String, val role: String) : SqlStatement
 
-    data class CreateTable(val table: TableRef) : SqlStatement
+    data class CreateTable(val table: TableRef, val colNames: List<String>) : SqlStatement
 }

--- a/core/src/test/kotlin/xtdb/types/MergeTypesTest.kt
+++ b/core/src/test/kotlin/xtdb/types/MergeTypesTest.kt
@@ -1,8 +1,10 @@
 package xtdb.types
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import xtdb.arrow.MergeTypes.Companion.mergeTypes
+import xtdb.arrow.NULL_TYPE
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.BOOL
 import xtdb.arrow.VectorType.Companion.F64
@@ -15,6 +17,7 @@ import xtdb.arrow.VectorType.Companion.maybe
 import xtdb.arrow.VectorType.Companion.setTypeOf
 import xtdb.arrow.VectorType.Companion.structOf
 import xtdb.arrow.VectorType.Companion.fromLegs
+import xtdb.arrow.VectorType.Nothing
 import xtdb.arrow.VectorType.Null
 
 class MergeTypesTest {
@@ -176,6 +179,26 @@ class MergeTypesTest {
             expected, mergeTypes(struct0, struct1),
             "Nested struct merging with simple field creates union"
         )
+    }
+
+    @Test
+    fun `test Nothing is the lattice bottom`() {
+        assertEquals(I64, mergeTypes(Nothing, I64), "Nothing widens to the first type it meets - I64, not Maybe(I64)")
+        assertEquals(Null, mergeTypes(Nothing, Null), "Nothing merged with Null is Null")
+        assertEquals(Null, mergeTypes(Nothing), "Nothing alone collapses like an empty merge")
+        assertEquals(I64, mergeTypes(Nothing, I64, Nothing), "Nothing is absorbed regardless of position")
+
+        assertEquals(Null, maybe(Nothing), "making the bottom nullable yields Null")
+        assertEquals(Nothing, maybe(Nothing, false), "non-nullable bottom stays Nothing")
+
+        assertEquals(I64, fromLegs(listOf(Nothing, I64)), "Nothing contributes no legs to a union")
+    }
+
+    @Test
+    fun `test Nothing serializes as a non-nullable null field`() {
+        val field = Nothing.toField("x")
+        assertEquals(NULL_TYPE, field.type)
+        assertFalse(field.isNullable, "Nothing is a non-nullable NULL field, distinct from Null")
     }
 
     @Test

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -114,6 +114,7 @@ export default defineConfig({
                         { label: 'Overview', link: '/reference/main' },
                         { label: 'SQL Transactions/DML', link: '/reference/main/sql/txs' },
                         { label: 'SQL Queries', link: '/reference/main/sql/queries' },
+                        { label: 'SQL Schema', link: '/reference/main/sql/schema' },
                         { label: 'Data Types', link: '/reference/main/data-types' },
                         {
                             label: 'Standard Library',

--- a/docs/src/content/docs/concepts/key-concepts.md
+++ b/docs/src/content/docs/concepts/key-concepts.md
@@ -50,7 +50,7 @@ XTDB is a 'Hybrid Transactional/Analytic Processing' (HTAP) system which postula
 XTDB is designed for making non-destructive updates to your data simple and achieves this by modeling row-level temporal versions of data.
 This works by representing each update as a new row that sits alongside the previous versions of that row in the same table.
 
-However given that XTDB does not account for schema ahead of time, the only means of correlating updates to a row is to impose a single ubiquitous schema requirement: each row asserted must contain an explicit `id` column.
+However given that XTDB does not account for schema ahead of time, the only means of correlating updates to a row is to impose a single ubiquitous schema requirement: each row asserted must contain an explicit `_id` column.
 
 The value provided for the `id` column can be any of the supported ID types, but must be determined by the user.
 XTDB does not offer a means of generating new IDs automatically although use of surrogate keys (e.g. UUIDs) is encouraged.
@@ -114,5 +114,5 @@ Referential integrity can still be achieved atomically, with ACID guarantees, ei
 XTDB has no concept of uniqueness beyond the ID.
 If you want something to be unique then you can and probably should model it with an ID.
 
-Similarly, any other features of a SQL database that intuitively require a schema are not available within XTDB currently.
-It is however intended that XTDB will introduce "gradual schema" capabilities in the future to enable new usage patterns that includes using XTDB like a traditional SQL database (e.g. "just treat XTDB as if it were Postgres, and model your data the same way").
+Similarly, any other features of a SQL database that intuitively require a full schema are not available within XTDB currently.
+XTDB is currently introducing "gradual schema" capabilities to enable new usage patterns that includes using XTDB like a traditional SQL database (e.g. "just treat XTDB as if it were Postgres, and model your data the same way").

--- a/docs/src/content/docs/quickstart/sql-overview.mdx
+++ b/docs/src/content/docs/quickstart/sql-overview.mdx
@@ -18,7 +18,6 @@ import TabCssFix from '@components/tabcssfix.astro';
   <div slot="1">
     <Aside title="'XT Play' allows you to try out XTDB live in your browser!">Feel free to edit the SQL in any of these boxes, just be aware that changes you make in one box don't carry over to the next.
     <details style="display: contents"><summary>Details...</summary><ul>
-<li>columns are ordered alphanumerically (this restriction will be lifted [soon](https://github.com/xtdb/xt-fiddle/issues/42))</li>
 <li>you can click on the 'Open in xt-play' link beneath a given instance to see the full context and to experiment more freely</li>
 <li>all XT Play instances execute statelessly - a new ephemeral cloud database instance is summoned into being every time you press 'Run' (using AWS Lambda)</li></ul></details></Aside>
     <Xtplay magicContext="my-context">
@@ -42,7 +41,17 @@ Note that XTDB doesn't currently return information about the number of rows ins
 </TabbedExample>
 
 Things to note:
-<ul><li>Tables in XTDB may be created dynamically during `INSERT`, where all columns and types are inferred automatically.</li><li>The only schema requirement is that every table in XTDB requires a user-provided `_id` primary key column, but all other columns are optional and dynamically typed by default. This means each row in XTDB can offer the flexibility of a document in a document database.</li><li>The `_` prefix convention (e.g. `_id`) is used for reserved columns and tables that XTDB handles automatically. For full details see [How XTDB works](/intro/data-model).</li></ul>
+<ul>
+  <li>Tables in XTDB may be created dynamically during `INSERT`, where all columns and types are inferred automatically.</li>
+  <li>
+    The only schema requirement is that every table in XTDB requires a user-provided `_id` primary key column, but all other columns are optional and dynamically typed by default.  
+    This means each row in XTDB can offer the flexibility of a document in a document database.
+  </li>
+  <li>
+    The `_` prefix convention (e.g. `_id`) is used for reserved columns and tables that XTDB handles automatically.
+    For full details see [How XTDB works](/intro/data-model).
+  </li>
+</ul>
 
 ### Query for that same row
 
@@ -574,7 +583,7 @@ SELECT name, favorite_color , _valid_from, _system_from FROM people;
 
 XTDB implements a SQL API that closely follows the ISO standard specifications and draws inspiration from Postgres where needed, however unlike most SQL systems XTDB:
 
-* does not require an explicit schema to be declared before inserting data (i.e. there's no explicit `CREATE TABLE` [DDL](https://en.wikipedia.org/wiki/Data_definition_language) statement) - tables may be created dynamically via an initial INSERT statement, along with any supplied columns and inferrable type information - schema automatically evolves over time as data changes
+* does not require an explicit schema to be declared before inserting data (i.e. the [`CREATE TABLE` statement](/reference/main/sql/schema) is optional) - tables may be created dynamically via an initial INSERT statement, along with any supplied columns and inferrable type information - schema automatically evolves over time as data changes
 * handles semi-structured 'document' data natively, with deeply nested union types ('objects') and arrays
 * operates on top of a durable log to help underpin scalable and reliable information systems
 * maintains various 'bitemporal' columns globally across all tables to preserve history

--- a/docs/src/content/docs/reference/main.md
+++ b/docs/src/content/docs/reference/main.md
@@ -4,5 +4,5 @@ title: XTDB reference guide
 
 In the query-language reference guide, you can find:
 
-- Specifications for SQL [transactions](/reference/main/sql/txs) and [queries](/reference/main/sql/queries).
+- Specifications for SQL [transactions](/reference/main/sql/txs), [queries](/reference/main/sql/queries) and [schema](/reference/main/sql/schema).
 - Details of the XTDB [standard library](/reference/main/stdlib) of functions.

--- a/docs/src/content/docs/reference/main/sql/schema.md
+++ b/docs/src/content/docs/reference/main/sql/schema.md
@@ -1,0 +1,26 @@
+---
+title: SQL Schema
+---
+
+XTDB's schema is largely inferred, but you may create tables ahead-of-time if required, to prevent table-not-found or column-not-found errors.
+
+Normally this isn't required - you can simply `INSERT` data to get started.
+
+## CREATE TABLE (v2.2+)
+
+Tables can be created or altered with the `CREATE TABLE` statement.
+
+```railroad
+const createTable = rr.Sequence("CREATE", rr.Optional(rr.Sequence("OR", "ALTER"), "skip"), "TABLE", "<table name>")
+const colNames = rr.Sequence("(", rr.OneOrMore("<column name>", ","), ")")
+return rr.Diagram(rr.Sequence(createTable, rr.Optional(colNames, "skip")))
+```
+
+* Column names are optional and do not yet support a type declaration.
+* `CREATE TABLE` does not fail if the table exists; any columns declared will be added to the existing table.
+
+e.g.:
+
+```sql
+CREATE TABLE users (_id, name, email);
+```

--- a/lang/js/test/test.js
+++ b/lang/js/test/test.js
@@ -176,8 +176,9 @@ describe("Postgres.js handles cached-query-must-not-change-result-type errors", 
     const conn = await sql.reserve();
 
     try {
-      // an unknown table is now an error, so declare it before querying the empty table
-      await conn`CREATE TABLE foo`;
+      // an unknown table/column is now an error, so declare the table and the _id we ORDER BY
+      // before querying the empty table
+      await conn`CREATE TABLE foo (_id)`;
 
       // prepare query by running it
       const query = async () => [...await conn`SELECT * FROM foo ORDER BY _id`];

--- a/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/auctionmark.clj
@@ -378,13 +378,23 @@
        :status status})))
 
 (def ^:private tables
-  [:region :category :user :user-attribute :item :gag :gav
-   :item-bid :item-comment :item-feedback :item-max-bid :user-item])
+  "Auctionmark tables. The vector value lists the columns a proc reads via SQL *before* the workload
+   has written them - declaring them (untyped, as the lattice bottom) lets the read resolve on an
+   empty table, where #4467 would otherwise error. Tables always populated before they're read (the
+   generated ones) are created bare; their columns come from the inserted data."
+  {:region nil, :category nil, :user nil, :user-attribute nil, :item nil, :gag nil, :gav nil,
+   :item-feedback nil, :user-item nil
+   :item-bid [:_id :max_bid :bidder_id]
+   :item-comment [:_id :item_id :response]
+   :item-max-bid [:_id :max_bid_id :curr_bid]})
 
 (defn create-tables! [node]
   (xt/execute-tx node
-                 (for [table tables]
-                   [:sql (str "CREATE TABLE " (str/replace (name table) \- \_))])))
+                 (for [[table cols] tables
+                       :let [t (str/replace (name table) \- \_)]]
+                   [:sql (if (seq cols)
+                           (format "CREATE TABLE %s (%s)" t (str/join ", " (map name cols)))
+                           (str "CREATE TABLE " t))])))
 
 (defn load-phase-submit-tasks [sf]
   [{:t :call, :f (fn [{:keys [node]}] (create-tables! node))}

--- a/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceIntegrationTest.kt
+++ b/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceIntegrationTest.kt
@@ -343,8 +343,11 @@ class KafkaConnectSourceIntegrationTest {
 
             val rows = xtQueryDb(node, "events", "SELECT _id, name, age FROM public.events WHERE _id = 'alice'")
             assertEquals("Alice", rows[0]["name"])
+            // the envelope's `op` field should not be on the unwrapped doc - assert via the catalog,
+            // since referencing a column that doesn't exist is now an error rather than an empty result
             assertTrue(
-                xtQueryDb(node, "events", "SELECT op FROM public.events WHERE _id = 'alice' AND op IS NOT NULL").isEmpty(),
+                xtQueryDb(node, "events",
+                          "SELECT column_name FROM information_schema.columns WHERE table_name = 'events' AND column_name = 'op'").isEmpty(),
                 "envelope's op field should not be on the unwrapped doc",
             )
         }

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -159,7 +159,7 @@
                               "James" "Matt"])))))
 
 (t/deftest start-and-query-empty-node-re-231-test
-  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE a"]])
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE a (a)"]])
   (t/is (= [] (xt/q tu/*node* "select a.a from a a" {}))))
 
 (t/deftest test-duration-jdbc-roundtrip
@@ -357,7 +357,7 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
   (t/is (= []
            (xt/q *node* "SELECT posts.body FROM posts")))
 
-  (xt/submit-tx *node* [[:sql "CREATE TABLE t1"]])
+  (xt/submit-tx *node* [[:sql "CREATE TABLE t1 (_id, body)"]])
   (xt/submit-tx *node*
                 ["INSERT INTO t1 SELECT posts._id, posts.body FROM posts"])
 

--- a/src/test/clojure/xtdb/block_boundary_test.clj
+++ b/src/test/clojure/xtdb/block_boundary_test.clj
@@ -348,7 +348,7 @@
                                     1 20)]
        (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock)}]
                                          :compactor {:threads 0}})]
-         (xt/execute-tx node [[:sql "CREATE TABLE docs"]])
+         (xt/execute-tx node [[:sql "CREATE TABLE docs (_id)"]])
          (doseq [[op value] ops]
            (case op
              :put     (xt/execute-tx node [[:put-docs :docs value]])

--- a/src/test/clojure/xtdb/create_table_test.clj
+++ b/src/test/clojure/xtdb/create_table_test.clj
@@ -12,6 +12,58 @@
                    FROM information_schema.tables
                    WHERE table_schema = 'public'")))
 
+(defn- public-columns [node]
+  (set (xt/q node "SELECT table_name, column_name, data_type, is_nullable
+                   FROM information_schema.columns
+                   WHERE table_schema = 'public'")))
+
+(t/deftest declares-bare-columns
+  (with-open [node (xtn/start-node)]
+    (xt/execute-tx node [[:sql "CREATE TABLE foo (a, b)"]])
+
+    (let [col-names (->> (public-columns node) (map :column-name) set)]
+      (t/is (contains? col-names "a") "declared column a surfaces in information_schema.columns")
+      (t/is (contains? col-names "b") "declared column b surfaces in information_schema.columns"))
+
+    (t/is (= [] (xt/q node "SELECT a, b FROM foo"))
+          "querying declared-but-empty columns returns no rows, no error")))
+
+(defn- col-type [node table col]
+  (xt/q node ["SELECT data_type, is_nullable FROM information_schema.columns
+               WHERE table_name = ? AND column_name = ?" table col]))
+
+(t/deftest declared-column-widens-cleanly
+  (with-open [node (xtn/start-node)]
+    (xt/execute-tx node [[:sql "CREATE TABLE foo (a)"]])
+
+    (t/is (= [{:data-type ":nothing", :is-nullable "NO"}] (col-type node "foo" "a"))
+          "a declared-but-empty column is the lattice bottom: nothing type, not nullable")
+
+    (xt/execute-tx node [[:sql "INSERT INTO foo (_id, a) VALUES (1, 42)"]])
+
+    (t/is (= [{:data-type ":i64", :is-nullable "NO"}] (col-type node "foo" "a"))
+          "first insert widens it cleanly to a non-nullable i64 - NOT Maybe(i64)")))
+
+(t/deftest declared-columns-survive-block-flush
+  (with-open [node (xtn/start-node)]
+    (xt/execute-tx node [[:sql "CREATE TABLE foo (a, b)"]])
+    (tu/flush-block! node)
+
+    (t/is (= [{:data-type ":nothing", :is-nullable "NO"}] (col-type node "foo" "a"))
+          "a declared Nothing column round-trips through a block flush as Nothing, not Null")))
+
+(t/deftest declared-column-pgwire-type
+  (with-open [node (xtn/start-node)]
+    (xt/execute-tx node [[:sql "CREATE TABLE foo (a)"]])
+
+    (with-open [conn (jdbc/get-connection node)
+                stmt (.prepareStatement conn "SELECT a FROM foo")
+                rs (.executeQuery stmt)]
+      ;; Nothing -> PgType.Null, which shares text's OID 25 on the wire ("delegates to Text for
+      ;; OID/serialization, but distinct for comparison"), so a JDBC client reports it as text.
+      (t/is (= "text" (.getColumnTypeName (.getMetaData rs) 1))
+            "a Nothing-typed declared column reports the pgwire null type (wire-compatible with text)"))))
+
 (t/deftest creates-an-empty-table
   (with-open [node (xtn/start-node)]
     (xt/execute-tx node [[:sql "CREATE TABLE foo"]])

--- a/src/test/clojure/xtdb/flight_sql_test.clj
+++ b/src/test/clojure/xtdb/flight_sql_test.clj
@@ -63,7 +63,7 @@
                     (flight-info->rows))))))
 
 (t/deftest test-transaction
-  (.executeUpdate *client* "CREATE TABLE users" empty-call-opts)
+  (.executeUpdate *client* "CREATE TABLE users (_id, name)" empty-call-opts)
   (let [fsql-tx (.beginTransaction *client* empty-call-opts)]
     (t/is (= -1 (.executeUpdate *client* "INSERT INTO users (_id, name) VALUES ('jms', 'James'), ('hak', 'Håkan')" fsql-tx empty-call-opts)))
     (t/is (= []
@@ -119,7 +119,7 @@
   (letfn [(q []
             (set (-> (.execute *client* "SELECT users.name FROM users" empty-call-opts)
                      (flight-info->rows))))]
-    (.executeUpdate *client* "CREATE TABLE users" empty-call-opts)
+    (.executeUpdate *client* "CREATE TABLE users (_id, name)" empty-call-opts)
     (let [fsql-tx (.beginTransaction *client* empty-call-opts)]
       (with-open [ps (.prepare *client* "INSERT INTO users (_id, name) VALUES (?, ?)" fsql-tx empty-call-opts)
                   param-root (VectorSchemaRoot/create (Schema. [#xt/field {"_id" :utf8} #xt/field {"name" :utf8}]) tu/*allocator*)]
@@ -225,7 +225,7 @@
         ;; switch back to xtdb — should not see the row
         (.setCurrentCatalog conn "xtdb")
         (with-open [stmt (.createStatement conn)]
-          (.setSqlQuery stmt "CREATE TABLE users")
+          (.setSqlQuery stmt "CREATE TABLE users (_id, name)")
           (.executeUpdate stmt))
         (with-open [stmt (.createStatement conn)]
           (.setSqlQuery stmt "SELECT _id, name FROM users")
@@ -237,7 +237,7 @@
   (let [db-cat (.getDbCatalog ^Xtdb$XtdbInternal tu/*node*)
         other-db-opts (db-call-opts "other-db")]
     (.attach db-cat "other-db" nil)
-    (.executeUpdate *client* "CREATE TABLE users" empty-call-opts)
+    (.executeUpdate *client* "CREATE TABLE users (_id, name)" empty-call-opts)
 
     (t/testing "insert and query on non-default database via header"
       (t/is (= -1 (.executeUpdate *client* "INSERT INTO users (_id, name) VALUES ('jms', 'James')" other-db-opts)))

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -524,7 +524,7 @@
                             (.resolve node-dir "objects"))))))))
 
 (t/deftest ingestion-stopped-query-as-tx-op-3265
-  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE docs"]])
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE docs (_id, foo)"]])
   (t/is (anomalous? [:incorrect :xtdb/queries-in-read-write-tx
                      "Queries are unsupported in a DML transaction"
                      {:query "SELECT _id, foo FROM docs"}]

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -32,10 +32,10 @@
     (t/is (thrown? Exception (jdbc/execute! conn ["SELECT 1/0"]))
           "runtime error via pgwire")
 
-    ;; producing some unknown-column warnings (the table must exist - an unknown table is now an error)
-    (xt/execute-tx node [[:sql "CREATE TABLE bar"]])
-    (xt/q node "SELECT foo FROM bar")
-    (jdbc/execute! conn ["SELECT foo FROM bar"])
+    ;; producing some warnings - a probe of an unimplemented system-schema table stays a warning
+    ;; (tools tolerate it), where unknown user tables/columns are now errors (#4467)
+    (xt/q node "SELECT * FROM information_schema.no_such_table")
+    (jdbc/execute! conn ["SELECT * FROM information_schema.no_such_table"])
 
     (t/is (= 2.0 (.count ^Counter (.counter (.find registry "query.error")))))
     (t/is (= 2.0 (.count ^Counter (.counter (.find registry "query.warning")))))))

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -571,8 +571,9 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
 (t/deftest non-existant-column-no-nil-rows-2898
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo(_id, bar) VALUES (1, 2)"]])
-  (t/is (= [{}]
-           (xt/q tu/*node* "SELECT foo.not_a_column FROM foo"))))
+  (t/is (anomalous? [:incorrect nil #"Column not found: foo\.not_a_column"]
+                    (xt/q tu/*node* "SELECT foo.not_a_column FROM foo"))
+        "an undeclared column on an existing table is now an error, not a silent empty row (#4467)"))
 
 (t/deftest test-nested-field-normalisation
   (jdbc/execute! tu/*node* ["INSERT INTO t1(_id, data)
@@ -585,16 +586,22 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
         "testing insert worked")
 
   (t/is (= [{:field-name2 true}]
-           (xt/q tu/*node* "SELECT (t2.field_name1).field_name2, t2.field$name4.baz
-                            FROM (SELECT (t1.data).field_name1, (t1.data).field$name4 FROM t1) AS t2"))
-        "testing insert worked")
+           (xt/q tu/*node* "SELECT (t2.field_name1).field_name2
+                            FROM (SELECT (t1.data).field_name1 FROM t1) AS t2"))
+        "a nested field name normalises and resolves through a subquery")
 
   (t/is (= [{:field-name2 true}]
            (jdbc/execute! tu/*node*
-                          ["SELECT (t2.field_name1).field_name2, t2.field$name4.baz
-                            FROM (SELECT (t1.data).field_name1, (t1.data).field$name4 FROM t1) AS t2"]
+                          ["SELECT (t2.field_name1).field_name2
+                            FROM (SELECT (t1.data).field_name1 FROM t1) AS t2"]
                           {:builder-fn xt-jdbc/builder-fn}))
-        "testing insert worked (JDBC)"))
+        "... and likewise over JDBC")
+
+  ;; field$name4 isn't a field of `data`, so the inner projection doesn't surface it - referencing it
+  ;; through the subquery is now an error rather than a silent null (#4467)
+  (t/is (anomalous? [:incorrect nil #"Column not found"]
+                    (xt/q tu/*node* "SELECT t2.field$name4.baz
+                                     FROM (SELECT (t1.data).field$name4 FROM t1) AS t2"))))
 
 (t/deftest test-get-field-on-duv-with-struct-2425
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO t2(_id, data) VALUES(1, 'bar')"]
@@ -950,8 +957,10 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
                (xt/q node "SELECT * FROM docs"))))))
 
 (t/deftest ingestion-stopped-on-null-col-ref-4259
+  ;; "1" is a delimited column reference, not a string - it resolves to nothing, which is now a
+  ;; hard error rather than a null _id (#4467)
   (t/is (anomalous? [:incorrect nil
-                     #"Invalid ID type"]
+                     #"Column not found: 1"]
                     (xt/execute-tx tu/*node* ["INSERT INTO docs RECORDS {_id: \"1\"}"]))))
 
 (t/deftest test-field-mismatch-4271

--- a/src/test/clojure/xtdb/pgwire/pg2_test.clj
+++ b/src/test/clojure/xtdb/pgwire/pg2_test.clj
@@ -242,11 +242,12 @@
 (deftest error-propagation
   (let [warns (atom [])]
     (with-open [conn (pg-conn {:fn-notice (fn [notice] (swap! warns conj (:message notice)))})]
-      (pg/execute conn "CREATE TABLE docs")
-      (pg/execute conn "SELECT missing_col FROM docs")
+      ;; a probe of an unimplemented system-schema table stays a warning (tools tolerate it), one of
+      ;; the few query warnings left now that table/column-not-found on user tables are errors (#4467)
+      (pg/execute conn "SELECT * FROM information_schema.no_such_table")
       ;; the fn-notice runs in a separate executor pool
       (Thread/sleep 100)
-      (t/is (= #{"Column not found: missing_col"}
+      (t/is (= #{"Table not found: information_schema.no_such_table"}
                (set @warns))))))
 
 (deftest test-time

--- a/src/test/clojure/xtdb/pgwire/playground_test.clj
+++ b/src/test/clojure/xtdb/pgwire/playground_test.clj
@@ -46,7 +46,7 @@
 
 (t/deftest ingestion-stopped-assert-4837
   (util/with-open [conn (pgw-test/jdbc-conn {:dbname "osm"})]
-    (jdbc/execute! conn ["CREATE TABLE system"])
+    (jdbc/execute! conn ["CREATE TABLE system (_id)"])
     (jdbc/execute! conn ["BEGIN READ WRITE"])
     (jdbc/execute! conn ["ASSERT EXISTS (SELECT 1 FROM system WHERE _id=?), 'not_found'" "id"])
     (t/is (anomalous? [:conflict :xtdb/assert-failed "not_found"]
@@ -55,6 +55,9 @@
 
 (t/deftest update-filter-repro-4894
   (with-open [conn (pgw-test/jdbc-conn {:dbname "foo"})]
+    ;; foo is declared up front so the conditional UPDATE can reference it - #4467 means an UPDATE
+    ;; can't reference an undeclared column
+    (xt/execute-tx conn [["CREATE TABLE docs (_id, foo)"]])
     (xt/execute-tx conn [["INSERT INTO docs RECORDS ?" {:xt/id "doc-1"}]])
     (t/is (= [{:xt/id "doc-1"}] (xt/q conn ["FROM docs SELECT *"])))
 

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -241,17 +241,20 @@
 
 (t/deftest prepared-stmt-sees-new-cols-4570
   (with-open [conn (jdbc-conn {"prepareThreshold" 1})]
+    ;; my_col is declared (untyped) up front - #4467 means a query can't reference an undeclared
+    ;; column - and a re-planned prepared statement picks up its values as they're inserted
+    (jdbc/execute! conn ["CREATE TABLE docs (_id, my_col)"])
     (jdbc/execute! conn ["INSERT INTO docs RECORDS {_id: 1}"])
 
-    (t/is (= [{:_id 1, :_column_2 nil}]
+    (t/is (= [{:_id 1, :my_col nil}]
              (jdbc/execute! conn ["SELECT _id, my_col FROM docs"])))
 
     (with-open [stmt (.prepareStatement conn "FROM docs SELECT my_col ORDER BY _id")
                 star-stmt (.prepareStatement conn "FROM docs ORDER BY _id")]
       (with-open [rs (.executeQuery stmt)
                   rs-star (.executeQuery star-stmt)]
-        (t/is (= [{:_column_1 nil}] (resultset-seq rs)))
-        (t/is (= [{:_id 1}] (resultset-seq rs-star))))
+        (t/is (= [{:my_col nil}] (resultset-seq rs)))
+        (t/is (= [{:_id 1, :my_col nil}] (resultset-seq rs-star))))
 
       (jdbc/execute! conn ["INSERT INTO docs RECORDS {_id: 2, my_col: 'foo'}"])
 
@@ -823,7 +826,7 @@
 
 (deftest dml-test
   (with-open [conn (jdbc-conn)]
-    (jdbc/execute! conn ["CREATE TABLE foo"])
+    (jdbc/execute! conn ["CREATE TABLE foo (_id, a)"])
     (testing "mixing a read causes rollback"
       (is (thrown-with-msg? PSQLException #"Queries are unsupported in a DML transaction"
                             (jdbc/with-transaction [tx conn]
@@ -2045,11 +2048,12 @@ ORDER BY t.oid DESC LIMIT 1"
 
 (deftest error-propagation
   (with-open [conn (jdbc-conn)]
-    (jdbc/execute! conn ["CREATE TABLE docs"])
-    (with-open [stmt (.prepareStatement conn "SELECT missing_col FROM docs")]
+    ;; a probe of an unimplemented system-schema table stays a warning (tools tolerate it) - one of the
+    ;; few remaining query warnings now that table/column-not-found on user tables are errors (#4467)
+    (with-open [stmt (.prepareStatement conn "SELECT * FROM information_schema.no_such_table")]
       (.execute stmt)
 
-      (t/is (= #{"Column not found: missing_col"}
+      (t/is (= #{"Table not found: information_schema.no_such_table"}
                (set (map #(.getMessage ^SQLWarning %) (stmt->warnings stmt))))))))
 
 (deftest test-ignore-returning-keys-3668
@@ -2985,7 +2989,7 @@ ORDER BY 1,2;")
                (jdbc/execute! conn ["SETTING SNAPSHOT_TOKEN = ? SELECT 1"
                                     (basis/->time-basis-str {"xtdb" [#xt/zdt "2020-01-02Z"]})]))))
 
-    (jdbc/execute! conn ["CREATE TABLE foo"])
+    (jdbc/execute! conn ["CREATE TABLE foo (_id, a)"])
 
     (t/is (= {:sql-state "08P01",
               :message "Queries are unsupported in a DML transaction",
@@ -3114,14 +3118,13 @@ ORDER BY 1,2;")
                                                  {"_id" 2, "_system_from" #inst "2024-01-01T00:00:00Z"}])))))
 
 (t/deftest test-column-not-found-warning-in-dml-4531
-  (t/testing "INSERT with double-quoted column refs should warn - #4531"
+  (t/testing "double-quoted column refs in an INSERT RECORD now error rather than silently warn - #4531/#4467"
+    ;; the double-quoted values ("FI", "Street 7", …) parse as column references, not strings;
+    ;; they resolve against nothing, so an unresolved column is now a hard error
     (with-open [conn (jdbc-conn)
                 stmt (.createStatement conn)]
-      (.execute stmt "INSERT INTO customer RECORDS {_id: 3, address: {country: \"FI\", street: \"Street 7\", postal: \"123456\"}, name: \"Some Name\"}")
-      (let [warnings (stmt->warnings stmt)]
-        (t/is (seq warnings) "Expected warnings for column references (double-quoted strings) not found")
-        (t/is (some #(re-find #"Column not found" (.getMessage ^SQLWarning %)) warnings)
-              "Should have column-not-found warnings for FI, Street 7, 123456, and Some Name")))))
+      (t/is (thrown-with-msg? PSQLException #"Column not found"
+                              (.execute stmt "INSERT INTO customer RECORDS {_id: 3, address: {country: \"FI\", street: \"Street 7\", postal: \"123456\"}, name: \"Some Name\"}"))))))
 
 (t/deftest test-failed-transaction-blocks-dml-4071
   (t/testing "DML in failed transaction should error, not show success - #4071"

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -361,8 +361,11 @@
            (xt/q tu/*node* "SELECT name, film, ord FROM actors, UNNEST(films) WITH ORDINALITY AS films(film, ord)"))))
 
 (t/deftest test-unnest-null-or-missing-4075
+  (xt/execute-tx tu/*node* ["CREATE TABLE foo (b)"])
   (xt/execute-tx tu/*node* ["INSERT INTO foo RECORDS {_id: 1, a: 2}"])
-  (t/is (= [] (xt/q tu/*node* "SELECT b FROM foo, UNNEST(foo.b) AS bs(b)"))))
+  ;; b is declared but unset on this row - UNNEST of a null/absent value yields no rows.
+  ;; project bs.b explicitly: foo.b now exists too, so unqualified b would be ambiguous
+  (t/is (= [] (xt/q tu/*node* "SELECT bs.b FROM foo, UNNEST(foo.b) AS bs(b)"))))
 
 (t/deftest test-cross-join
   (t/is (=plan-file
@@ -1205,31 +1208,16 @@
         "LAG with default offset of 1"))
 
 (t/deftest test-operators-with-unresolved-column-references-3640
-  (t/is (=plan-file
-         "test-group-by-with-unresolved-column-reference"
-         (sql/plan "SELECT SUM(_id + 1) FROM docs GROUP BY x"
-                   {:table-info {#xt/table docs #{"_id"}}})))
-
   (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1}]])
 
-  (t/is (= [{:s 1}]
-           (xt/q tu/*node* "SELECT SUM(_id) AS s FROM docs GROUP BY x")))
-
-  (t/is (=plan-file
-         "test-having-with-unresolved-column-reference"
-         (sql/plan "SELECT SUM(_id) AS s FROM docs HAVING SUM(x) > 1"
-                   {:table-info {#xt/table docs #{"_id"}}})))
-
-  (t/is (= []
-           (xt/q tu/*node* "SELECT SUM(_id) AS s FROM docs HAVING SUM(x) > 1")))
-
-  (t/is (=plan-file
-         "test-where-with-unresolved-column-reference"
-         (sql/plan "SELECT _id AS s FROM docs WHERE x > 1"
-                   {:table-info {#xt/table docs #{"_id"}}})))
-
-  (t/is (= []
-           (xt/q tu/*node* "SELECT _id AS s FROM docs WHERE x > 1"))))
+  ;; an unresolved column reference is now an error (#4467) - in GROUP BY, HAVING and WHERE alike -
+  ;; rather than the warn-and-treat-as-null it used to be
+  (doseq [q ["SELECT SUM(_id) AS s FROM docs GROUP BY x"
+             "SELECT SUM(_id) AS s FROM docs HAVING SUM(x) > 1"
+             "SELECT _id AS s FROM docs WHERE x > 1"]]
+    (t/is (anomalous? [:incorrect nil #"Column not found: x"]
+                      (xt/q tu/*node* q))
+          q)))
 
 (t/deftest test-array-subqueries
   (t/are [file q]
@@ -2038,10 +2026,10 @@
            (xt/q tu/*node*
                  "SELECT \"T1\"._id, \"T1\".\"CoL1\", \"T1\".COL2 FROM \"T1\"")))
 
-  (t/is (= [{:xt/id 3, :col2 3000}]
-           (xt/q tu/*node*
-                 "SELECT \"T1\"._id, \"T1\".col1, \"T1\".COL2 FROM \"T1\""))
-        "can't refer to it as `col1`, have to quote")
+  (t/is (anomalous? [:incorrect nil #"Column not found: T1\.col1"]
+                    (xt/q tu/*node*
+                          "SELECT \"T1\"._id, \"T1\".col1, \"T1\".COL2 FROM \"T1\""))
+        "can't refer to the delimited `CoL1` as unquoted `col1` - now an error, not a silent null")
 
   (t/is (xt/execute-tx tu/*node* [[:sql "UPDATE T1 SET Col1 = 'cat' WHERE t1.COL2 IN (313, 2000)"]]))
 
@@ -2154,7 +2142,7 @@
                     (xt/q tu/*node* "SELECT * FROM users"))))
 
 (t/deftest left-join-to-non-existent-table-survives-block-boundary-5669
-  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE b"]
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE b (_id)"]
                             [:sql "INSERT INTO a (_id) VALUES ('1')"]])
 
   (letfn [(plain [] (set (xt/q tu/*node* "SELECT a._id FROM a")))
@@ -2248,7 +2236,7 @@
   (t/is (= [{:doc-count 2}] (xt/q tu/*node* "SELECT COUNT(*) doc_count FROM docs"))))
 
 (t/deftest test-assert-exists-3686-3689
-  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE users"]])
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE users (_id, name, email)"]])
 
   (t/is (xt/execute-tx tu/*node* [[:sql "ASSERT NOT EXISTS (SELECT 1 FROM users WHERE email = 'james@example.com')"]
                                   [:sql "INSERT INTO users RECORDS {_id: 'james', name: 'James', email: 'james@example.com'}"]]))
@@ -2628,7 +2616,7 @@ UNION ALL
 
   (t/is (= [{:x 2, :xt/id 1}] (xt/q tu/*node* "SELECT * FROM foo.bar")))
 
-  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE bar"]])
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE bar (_id, x)"]])
   (t/is (= [] (xt/q tu/*node* "SELECT * FROM bar"))
         "public.bar is a distinct, empty table from foo.bar")
 

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -299,7 +299,7 @@ class FlightSqlAdbcTest {
                 client.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()
             )
 
-            fsqlClient.executeUpdate("CREATE TABLE t", *emptyCallOpts)
+            fsqlClient.executeUpdate("CREATE TABLE t (_id, n)", *emptyCallOpts)
             assertEquals(
                 emptyList<Map<*, *>>(),
                 fsqlClient.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()
@@ -339,7 +339,7 @@ class FlightSqlAdbcTest {
 
     @Test
     fun `test FlightSQL closeSession aborts an open session-bound transaction`() {
-        fsqlClient.executeUpdate("CREATE TABLE users", *emptyCallOpts)
+        fsqlClient.executeUpdate("CREATE TABLE users (_id, n)", *emptyCallOpts)
 
         cookieAwareClient().use { client ->
             // session must exist before beginTransaction for the tx to be session-bound
@@ -504,7 +504,7 @@ class FlightSqlAdbcTest {
                 listOf(mapOf("_id" to 1L, "n" to "hdr")),
                 client.execute("SELECT _id, n FROM t", *dbCallOpts("xtdb")).readRows()
             )
-            client.executeUpdate("CREATE TABLE t", *emptyCallOpts)
+            client.executeUpdate("CREATE TABLE t (_id, n)", *emptyCallOpts)
             assertEquals(
                 emptyList<Map<*, *>>(),
                 client.execute("SELECT _id, n FROM t", *emptyCallOpts).readRows()

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -95,7 +95,7 @@ class InProcessAdbcTest {
 
     @Test
     fun `getParameterSchema reports columns in $ N convention`() {
-        insertData("CREATE TABLE foo")
+        insertData("CREATE TABLE foo (_id, name)")
 
         xtdb.connect().use { conn ->
             conn.createStatement().use { stmt ->

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/dml.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/dml.test
@@ -17,7 +17,7 @@ dog
 2000
 
 statement ok
-CREATE TABLE t2
+CREATE TABLE t2 (_id, col1, col2)
 
 query TII rowsort
 SELECT t2._id, t2.col1, t2.col2 FROM t2

--- a/src/test/resources/xtdb/sql/logic_test/direct-sql/numeric-value-functions-6.28.test
+++ b/src/test/resources/xtdb/sql/logic_test/direct-sql/numeric-value-functions-6.28.test
@@ -1,6 +1,9 @@
 hash-threshold 100
 
 statement ok
+CREATE TABLE t1 (_id, missing)
+
+statement ok
 INSERT INTO t1(_id) VALUES(1)
 
 query R nosort


### PR DESCRIPTION
Part of #4467.

## Summary

The second half of #4467, on top of the empty `CREATE TABLE` and table-not-found work in #5697:

- `CREATE TABLE foo (a, b)` declares (untyped) columns, materialised as the lattice bottom `VectorType.Nothing`;
- a reference to a column that doesn't exist on a user table is now a hard error, not a silent null.

## Columns as Nothing

A declared-but-dataless column is `Nothing`, not `Null`. The distinction is load-bearing: `Nothing ⊔ I64 = I64`, whereas `Null ⊔ I64 = Maybe(I64)`, so seeding a column as `Null` would make it permanently nullable the moment its first value lands. Declaring `a` then inserting `42` leaves `a` a non-nullable `i64`.

Columns are seeded as `NULL_TYPE` children of the tx's put-struct, flowing through the existing `logRelTypes` path into the catalog, `information_schema.columns` (rendered `:nothing`, `is_nullable NO`), and the planner. Making the bottom real end-to-end took three changes to how a *non-nullable* NULL vector/field reports its type: `NullVector.type` yields `Nothing`; `openVector` honours the `nullable` flag for `NULL_TYPE` (it previously always built a nullable NullVector); and `Field.asType` reads a non-nullable NULL field back as `Nothing`, so a declared column survives a block flush. Over pgwire, `Nothing` maps to `PgType.Null` (wire-compatible with text, OID 25).

## Column-not-found → error

An unresolved column reference on a user table errors. Internal-schema columns stay tolerant - the column-level counterpart of the table tolerance: a column on an `xt`, `pg_catalog` or `information_schema` table resolves (to null) rather than erroring, because tools probe optional catalog columns and unimplemented system tables resolve to the `xt.not_found` sentinel (schema `xt`). `_id` is deliberately not special-cased: it must be declared or inserted before it can be read.

## Expression engine

A `Nothing`-typed column - declared but never given a value - reads as `:null` inside expressions. `Nothing` is a catalog/schema concept (it carries the clean widening `Nothing ⊔ X = X` and shows as `is_nullable NO`), but it isn't a runtime value: a column with no values simply reads as null. So `codegen-expr :variable` maps it to `:null` and the EE reuses its existing null handling - no `:nothing` call definitions, and the type lattice is untouched.

## Usage

```sql
CREATE TABLE users (_id, name, email);   -- declare columns, untyped (Nothing)
SELECT email FROM users;                 -- [] (resolves, no rows)
SELECT typo FROM users;                  -- ERROR: Column not found: typo
INSERT INTO users RECORDS {_id: 1, name: 'jms'};   -- name widens Nothing -> utf8, not Maybe(utf8)
```

## Docs

This branch also carries the additive half of the docs punch list (commit 7dcb93df3): a new `reference/main/sql/schema.md` documenting `CREATE [OR ALTER] TABLE` and its column declarations, plus a reframe of the "schemaless" concept pages from *no `CREATE TABLE`* to *`CREATE TABLE` is opt-in*.

The schema-on-read framing - the unknown-table/column errors documented in their own right, the internal-schema tolerance, and the changelog blocks on the affected pages - is tracked on #4467 and still to land.

## Out of scope - deferred to #3411

Column *types* (`CREATE TABLE foo (a INT)`) and write-type enforcement - the rest of the path-based-schema epic.

## Test plan

`./gradlew test` - all green (1541 tests). ~35 tests migrated for the column-not-found flip (declare-first, or expect-error where the test's subject was the old tolerance). Auctionmark passes via column declarations in its `create-tables!` setup.