### PR TITLE
fix(flight-sql): advertise transaction support in GetSqlInfo

### DIFF
--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -25,6 +25,8 @@ import org.apache.arrow.vector.VectorLoader
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.VectorUnloader
 import org.apache.arrow.vector.complex.DenseUnionVector
+import org.apache.arrow.vector.holders.NullableIntHolder
+import org.apache.arrow.vector.holders.NullableVarCharHolder
 import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
 import org.apache.arrow.adbc.core.BulkIngestMode
@@ -666,25 +668,56 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         singleBatchStream(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA, listener) { root ->
             val infoNameVec = root.getVector("info_name") as UInt4Vector
             val valueVec = root.getVector("value") as DenseUnionVector
-            val stringVec = valueVec.getVarCharVector(0)
 
             var idx = 0
+
             fun addString(code: Int, value: String) {
                 if (requestedCodes.isNotEmpty() && code !in requestedCodes) return
                 infoNameVec.setSafe(idx, code)
-                valueVec.setTypeId(idx, 0)
-                valueVec.offsetBuffer.setInt(idx.toLong() * DenseUnionVector.OFFSET_WIDTH, idx)
-                stringVec.setSafe(idx, value.toByteArray())
+                // setTypeId selects the union leg for this row; setSafe(holder) then appends to that
+                // leg's child vector and writes the row's child-local offset. This is the Arrow-blessed
+                // way to build a DenseUnionVector — it keeps each child's valueCount and the offset
+                // buffer consistent, which a strict (C++/Go) consumer requires.
+                valueVec.setTypeId(idx, STRING_LEG)
+                NullableVarCharHolder().also { h ->
+                    val bytes = value.toByteArray()
+                    h.isSet = 1
+                    h.buffer = allocator.buffer(bytes.size.toLong()).also { it.setBytes(0, bytes) }
+                    h.start = 0
+                    h.end = bytes.size
+                    valueVec.setSafe(idx, h)
+                    h.buffer.close()
+                }
                 idx++
             }
 
-            // FlightSQL SqlInfo codes
-            addString(0, "XTDB")     // FLIGHT_SQL_SERVER_NAME
-            addString(1, "dev")      // FLIGHT_SQL_SERVER_VERSION
+            fun addInt32(code: Int, value: Int) {
+                if (requestedCodes.isNotEmpty() && code !in requestedCodes) return
+                infoNameVec.setSafe(idx, code)
+                valueVec.setTypeId(idx, INT32_BITMASK_LEG)
+                NullableIntHolder().also { h -> h.isSet = 1; h.value = value; valueVec.setSafe(idx, h) }
+                idx++
+            }
+
+            addString(SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE, "XTDB")
+            addString(SqlInfo.FLIGHT_SQL_SERVER_VERSION_VALUE, "dev")
+            // The ADBC Go driver (underlying the Python adbc_driver_flightsql package) reads this code
+            // at connect; without it set_autocommit(False) raises NOT_IMPLEMENTED. The value is the
+            // SqlSupportedTransaction enum — TRANSACTION means begin/commit/rollback are supported.
+            addInt32(
+                SqlInfo.FLIGHT_SQL_SERVER_TRANSACTION_VALUE,
+                SqlSupportedTransaction.SQL_SUPPORTED_TRANSACTION_TRANSACTION_VALUE
+            )
 
             valueVec.valueCount = idx
             root.rowCount = idx
         }
+    }
+
+    private companion object {
+        // GET_SQL_INFO `value` dense-union leg type ids (FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA).
+        const val STRING_LEG: Byte = 0
+        const val INT32_BITMASK_LEG: Byte = 3
     }
 
     override fun getFlightInfoCatalogs(

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -29,14 +29,18 @@ import org.apache.arrow.flight.client.ClientCookieMiddleware
 import org.apache.arrow.flight.sql.FlightSqlClient
 import org.apache.arrow.flight.sql.FlightSqlClient.ExecuteIngestOptions
 import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest
+import org.apache.arrow.flight.sql.impl.FlightSql.SqlInfo
+import org.apache.arrow.flight.sql.impl.FlightSql.SqlSupportedTransaction
 import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions
 import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions.TableExistsOption
 import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementIngest.TableDefinitionOptions.TableNotExistOption
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.UInt4Vector
 import org.apache.arrow.vector.VarBinaryVector
 import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.complex.DenseUnionVector
 import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.ipc.ReadChannel
 import org.apache.arrow.vector.ipc.message.MessageSerializer
@@ -210,6 +214,46 @@ class FlightSqlAdbcTest {
     fun `test FlightSQL getSqlInfo`() {
         val rows = fsqlClient.getSqlInfo(intArrayOf(), *emptyCallOpts).readRows()
         assertTrue(rows.isNotEmpty(), "Expected at least one info row")
+    }
+
+    @Test
+    fun `test FlightSQL getSqlInfo advertises transaction support`() {
+        // The ADBC Go driver (underlying the Python adbc_driver_flightsql package) requests
+        // FLIGHT_SQL_SERVER_TRANSACTION at connect; if it's absent set_autocommit(False) raises
+        // NOT_IMPLEMENTED.
+        // Value 1 = SqlSupportedTransaction.TRANSACTION (begin/commit/rollback supported).
+        //
+        // We read the `value` DenseUnionVector with *standard* Arrow accessors off the post-IPC stream
+        // root — the way the Go/Python consumer reads it — rather than through XTDB's lenient Relation
+        // reader, and we request it in a mixed batch alongside the string-valued codes so a botched
+        // dense-union offset for the int32 leg would surface as a null here.
+        val code = SqlInfo.FLIGHT_SQL_SERVER_TRANSACTION_VALUE
+        val info = fsqlClient.getSqlInfo(
+            intArrayOf(SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE, SqlInfo.FLIGHT_SQL_SERVER_VERSION_VALUE, code),
+            *emptyCallOpts
+        )
+        fsqlClient.getStream(info.endpoints.first().ticket, *emptyCallOpts).use { stream ->
+            assertTrue(stream.next(), "expected a GET_SQL_INFO batch")
+            val root = stream.root
+
+            val infoNameVec = root.getVector("info_name") as UInt4Vector
+            val valueVec = root.getVector("value") as DenseUnionVector
+
+            val rowIdx = (0 until root.rowCount).singleOrNull { infoNameVec.get(it) == code }
+                ?: fail("GET_SQL_INFO must advertise FLIGHT_SQL_SERVER_TRANSACTION (code $code)")
+
+            // type id 3 = int32_bitmask leg of the GET_SQL_INFO value union
+            assertEquals(3, valueVec.getTypeId(rowIdx), "code $code must be tagged with the int32 leg")
+
+            val int32Vec = valueVec.getIntVector(3)
+            val legOffset = valueVec.getOffset(rowIdx)
+            assertFalse(int32Vec.isNull(legOffset), "code $code's int32 value must be non-null on the wire")
+            assertEquals(
+                SqlSupportedTransaction.SQL_SUPPORTED_TRANSACTION_TRANSACTION_VALUE,
+                int32Vec.get(legOffset),
+                "code $code must carry SqlSupportedTransaction.TRANSACTION"
+            )
+        }
     }
 
     private val asString = object : NoOpSessionOptionValueVisitor<String?>() {


### PR DESCRIPTION
## Problem

XTDB's Flight SQL server didn't advertise `FLIGHT_SQL_SERVER_TRANSACTION` (SqlInfo code `8`) in its `GetSqlInfo` response — `getStreamSqlInfo` only emitted codes `0` (`FLIGHT_SQL_SERVER_NAME`) and `1` (`FLIGHT_SQL_SERVER_VERSION`).

The Apache Arrow ADBC **Go** driver (which underlies the Python `adbc_driver_flightsql` package) requests code `8` at connect and caches the result; if it's absent, `set_autocommit(False)` raises `NOT_IMPLEMENTED`.
So a Python/Go client can't begin a transaction over the wire — even though XTDB's server-side transaction machinery already exists (begin/commit/rollback actions plus dedicated per-session transaction connections, from #5666).

## Fix

`getStreamSqlInfo` now advertises `FLIGHT_SQL_SERVER_TRANSACTION` (code `8`) with value `SQL_SUPPORTED_TRANSACTION_TRANSACTION` (`1` — begin/commit/rollback supported), using the generated `SqlInfo` / `SqlSupportedTransaction` proto enums rather than magic numbers.

The `value` column is a dense union; the int32 leg is written through Arrow's holder-based `setTypeId` + `setSafe` path, which keeps each leg's child `valueCount` and the offset buffer consistent for strict (Go / C++) consumers.

Complements #5666: that PR built the transaction machinery; this advertises it so non-JVM ADBC clients can reach it.

## Test

`test FlightSQL getSqlInfo advertises transaction support` in `FlightSqlAdbcTest` requests code `8` in a mixed batch alongside the string-valued codes and reads the result's `value` `DenseUnionVector` with **standard Arrow accessors** — the way the Go/Python consumer reads it, with no XTDB-specific unwrap.
It asserts the row exists, is tagged with the int32 leg, and decodes non-null to `TRANSACTION`.
Verified red before the fix and green after; the `FlightSqlAdbcTest`, `InProcessAdbcTest`, and `AdbcTest` suites stay green with no reflection or boxed-math warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
