### PR TITLE
build: stamp Scm-Revision into the JAR manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,14 @@ import java.time.Year
 
 evaluationDependsOnChildren()
 
+// Falls back to "unknown" outside a git checkout (e.g. source-tarball builds) so the build still succeeds.
+val gitCommitProvider: Provider<String> =
+    if (!rootDir.resolve(".git").exists()) providers.provider { "unknown" }
+    else providers.exec {
+        commandLine("git", "rev-parse", "HEAD")
+        isIgnoreExitValue = true
+    }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
+
 buildscript {
     dependencies {
         classpath("org.jetbrains.dokka:dokka-base:1.9.10")
@@ -140,6 +148,7 @@ allprojects {
             manifest {
                 attributes(
                     "Implementation-Version" to project.version,
+                    "Scm-Revision" to gitCommitProvider,
                 )
             }
         }


### PR DESCRIPTION
Published JARs currently carry only `Implementation-Version` in `META-INF/MANIFEST.MF`. For releases that's enough — the version maps to a git tag via the POM's `<scm>` section. For snapshots there's no equivalent binding: the timestamped variant `2.x-20260513.101514-1` is a publish-side timestamp, not a SHA, and no tag exists to consult.

`Scm-Revision` makes the binding self-describing — `unzip -p xtdb-core-*.jar META-INF/MANIFEST.MF` shows the commit. Quarkus uses the same spelling; it pairs with the `<scm>` block already declared lower in this file and sits clear of the spec's `Implementation-*` package-versioning attributes.