### PR TITLE
tidy(database): relocate LogProcessor to DatabasePartition (#5557)

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -63,7 +63,6 @@ class Database(
     val partitions: Map<Int, DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
     private val job: Job? = null,
-    private val processor: LogProcessor? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
 ) : IQuerySource.QueryDatabase, AutoCloseable {
 
@@ -181,7 +180,7 @@ class Database(
      * Intended for tests and manual admin pokes; bypasses the `enabled` flag.
      */
     fun gcAll() {
-        processor?.gcAll()
+        partitions.values.forEach { it.logProcessor?.gcAll() }
     }
 
     companion object {
@@ -282,12 +281,11 @@ class Database(
                 if (readOnly) Compactor.NOOP.openForDatabase(compactorScope, allocator, storage, state, watchers)
                 else compactor.openForDatabase(compactorScope, allocator, storage, state, watchers)
 
-            var processor: LogProcessor? = null
             val scope = CoroutineScope(job + CoroutineExceptionHandler { _, e ->
                 watchers.notifyError(e)
             })
 
-            if (indexerConfig.enabled) {
+            val logProcessor = if (indexerConfig.enabled) {
                 val blockUploader = BlockUploader(storage, state, compactorForDb, dbCatalog, base.meterRegistry)
                 val hasExternalSource = dbConfig.externalSource != null
 
@@ -334,13 +332,8 @@ class Database(
                     )
                 }
 
-                val lp = LogProcessor(procFactory, storage, state, watchers, blockUploader, scope, base.meterRegistry)
-                processor = lp
-
-                if (!readOnly) {
-                    scope.launch { storage.sourceLog.openGroupSubscription(lp) }
-                }
-            }
+                LogProcessor(procFactory, storage, state, watchers, blockUploader, scope, base.meterRegistry)
+            } else null
 
             val meterRegistry = base.meterRegistry
             val gauges = meterRegistry?.let { reg ->
@@ -370,9 +363,10 @@ class Database(
                 state = state,
                 watchers = watchers,
                 compactorOrNull = compactorForDb,
+                logProcessor = logProcessor,
             )
 
-            Database(
+            val db = Database(
                 allocator = allocator,
                 config = dbConfig,
                 storage = storage,
@@ -380,9 +374,23 @@ class Database(
                 partitions = mapOf(0 to partition),
                 meterRegistry = meterRegistry,
                 job = job,
-                processor = processor,
                 registeredGauges = gauges,
             )
+
+            if (indexerConfig.enabled && !readOnly) {
+                val listener = object : Log.SubscriptionListener<SourceMessage> {
+                    override suspend fun onPartitionsAssigned(partitions: Collection<Int>) =
+                        partitions.singleOrNull()
+                            ?.let { db.partitions[it]?.logProcessor?.onPartitionsAssigned(listOf(it)) }
+
+                    override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
+                        for (idx in partitions) db.partitions[idx]?.logProcessor?.onPartitionsRevoked(listOf(idx))
+                    }
+                }
+                scope.launch { storage.sourceLog.openGroupSubscription(listener) }
+            }
+
+            db
         }
     }
 

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -5,6 +5,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.indexer.LiveIndex
+import xtdb.indexer.LogProcessor
 import xtdb.indexer.Snapshot
 import xtdb.trie.TrieCatalog
 
@@ -13,6 +14,7 @@ class DatabasePartition(
     val state: DatabaseState,
     val watchers: Watchers,
     val compactorOrNull: Compactor.ForDatabase? = null,
+    val logProcessor: LogProcessor? = null,
 ) : AutoCloseable {
 
     val blockCatalog: BlockCatalog get() = state.blockCatalog

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -126,8 +126,6 @@ class LogProcessor(
     }
 
     override suspend fun onPartitionsAssigned(partitions: Collection<Int>): Log.TailSpec<SourceMessage>? {
-        if (partitions != listOf(0)) return null
-
         return when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("[$dbName] partitions assigned: $partitions — already leader, no transition needed")
@@ -188,8 +186,6 @@ class LogProcessor(
     }
 
     override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
-        if (partitions != listOf(0)) return
-
         when (val oldSys = sys) {
             is LeaderSystem -> {
                 LOG.info("[$dbName] partitions revoked: $partitions — was leader, transitioning to follower")


### PR DESCRIPTION
Continuing the per-partition aggregate from units 1-3. `LogProcessor` was the last per-partition-shaped piece still hanging off `Database`: the partition gate (`partitions != listOf(0)`) lived inside `LogProcessor`, and `gcAll` fanned into a single processor field.

The subscription listener role moves up a level to accommodate routing. `Database.open` constructs an inline `Log.SubscriptionListener<SourceMessage>` that closes over the constructed database and dispatches per-partition rebalance events to the corresponding partition's `LogProcessor`. The listener lives only in `open`'s lexical scope — the log layer sees a two-method protocol object instead of the whole `Database` surface — and the database type itself stays out of the subscription protocol. At single-partition — the only representable shape today — the router receives `[0]` and delegates to partition 0; behaviour is bit-identical. The multi-partition switch lands at unit 9 once `partitions > 1` is actually representable.

The `logProcessor` field on `DatabasePartition` is a routing handle for `gcAll` and the inline listener's dispatch, not a lifecycle owner — each LP's term is a child of `Database.job`, so `close()`'s single `job.cancelAndJoin()` already reaps it.

Listener interface shape (`Collection<Int>` vs `Int`) doesn't change here — the routing is identical either way at N=1. Singularisation lands in unit 5 alongside the rest of the `Log<M>` widening; the inline-listener body will collapse to two one-liners at that point.

The `procFactory` stays in `Database.open` for now — it captures a mix of per-partition (`state`, `watchers`, `blockUploader`, `compactorForDb`) and shared (`storage`, `dbCatalog`) references. Splitting it across N partition factories is a unit-5+ concern, when `Database.Config.partitions` becomes a knob.

Refs #5557.