### PR TITLE
fix(indexer): Database.close waits for LP/FLP cleanup (resolves #5703)

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -5,7 +5,6 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import org.apache.arrow.memory.BufferAllocator
@@ -26,6 +25,7 @@ import xtdb.table.TableRef
 import xtdb.util.StringUtil.asLexHex
 import xtdb.util.debug
 import xtdb.util.error
+import xtdb.util.launchWithCleanup
 import xtdb.util.logger
 import xtdb.util.trace
 
@@ -276,12 +276,12 @@ class FollowerLogProcessor @JvmOverloads constructor(
         replicaState.value = ReplicaState.Failed(latestReplicaMsgId, e)
     }
 
-    // Launched last, so every field the tail touches is initialised before the loop's first record;
-    // `tailAll` suspends immediately on subscribe. A cancel (role transition / shutdown) stops the
-    // tail and, once it has joined, the completion handler frees this processor's child allocator.
-    // `allocator` is `this@…`-qualified: bare `allocator` in an init lambda binds the ctor param.
+    // Launched last so every field the tail touches is initialised before the first record.
+    // See dev/doc/coroutines.adoc / #5703 for why this uses launchWithCleanup rather than
+    // invokeOnCompletion. `allocator` is `this@…`-qualified: bare `allocator` in a launch lambda
+    // binds the ctor param.
     init {
-        val tailJob = scope.launch {
+        scope.launchWithCleanup(cleanup = { this@FollowerLogProcessor.allocator.close() }) {
             try {
                 replicaLog.tailAll(afterReplicaMsgId, this@FollowerLogProcessor)
             } catch (e: CancellationException) {
@@ -290,6 +290,5 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 notifyError(e); throw e
             }
         }
-        tailJob.invokeOnCompletion { this@FollowerLogProcessor.allocator.close() }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -250,48 +250,6 @@ class LeaderLogProcessor(
         trieCatalog.deleteTries(task.tableName, task.trieKeys)
     }
 
-    // Unbiased select across the three sources so a slow producer on one channel can't starve
-    // the others. The three sources are: source-log records, external-source resolved txs, and
-    // GC trie deletions.
-    private val persisterJob: Job = scope.launch {
-        try {
-            while (true) {
-                val task: PersisterTask = selectUnbiased {
-                    sourceLogCh.onReceive { it }
-                    extSourceCh.onReceive { it }
-                    gcCh.onReceive { it }
-                }
-                try {
-                    when (task) {
-                        is SourceLogTask.Record -> handleSourceLogRecord(task)
-                        is SourceLogTask.ResolvedTx -> handleResolvedTx(task.resolvedTx, task.srcMsgId)
-                        is ExtSourceTask.ResolvedTx -> handleResolvedTx(task.resolvedTx, srcMsgId = null)
-                        is GcTask.TriesDeleted -> handleTriesDeleted(task)
-                    }
-                    task.onComplete.complete(Unit)
-                } catch (e: CancellationException) {
-                    task.onComplete.cancel(e)
-                    throw e
-                } catch (e: InterruptedException) {
-                    task.onComplete.completeExceptionally(e)
-                    throw e
-                } catch (e: Interrupted) {
-                    task.onComplete.completeExceptionally(e)
-                    throw e
-                } catch (e: Throwable) {
-                    watchers.notifyError(e)
-                    task.onComplete.completeExceptionally(e)
-                    throw e
-                }
-            }
-        } catch (_: Throwable) {
-        } finally {
-            sourceLogCh.close()
-            extSourceCh.close()
-            gcCh.close()
-        }
-    }
-
     private suspend fun submit(task: PersisterTask) {
         when (task) {
             is SourceLogTask -> sourceLogCh.send(task)
@@ -334,27 +292,70 @@ class LeaderLogProcessor(
 
     private val txErrorCounter: Counter? = nodeBase.meterRegistry?.let { Counter.builder("tx.error").register(it) }
 
-    private val extJob = extSource?.let { source ->
-        scope.launch {
-            try {
-                source.onPartitionAssigned(partition, watchers.externalSourceToken, this@LeaderLogProcessor)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                watchers.notifyError(e)
-            }
-        }
-    }
-
-    init {
-        // Cleanup rides the job tree, not an explicit teardown call: once the leader term's scope is
-        // cancelled and its coroutines (persister, ext source, GCs) have joined, free what this term
-        // opened — leaf-first. `allocator` must be `this@…`-qualified: bare `allocator` in an init
-        // lambda binds the ctor param (the parent), not this child field.
-        scope.coroutineContext.job.invokeOnCompletion {
+    // Hosts persister + the optional ext-source loop + cleanup. See dev/doc/coroutines.adoc /
+    // #5703 for why this uses launchWithCleanup rather than invokeOnCompletion.
+    private val termJob: Job = scope.launchWithCleanup(
+        cleanup = {
             extSource?.close()
             replicaProducer.close()
             this@LeaderLogProcessor.allocator.close()
+        }
+    ) {
+        // supervisorScope so an ext-source crash doesn't kill the persister.
+        supervisorScope {
+            // Persister: unbiased select across source-log records, external-source resolved
+            // txs, and GC trie deletions — so a slow producer on one channel can't starve the
+            // others.
+            launch {
+                try {
+                    while (true) {
+                        val task: PersisterTask = selectUnbiased {
+                            sourceLogCh.onReceive { it }
+                            extSourceCh.onReceive { it }
+                            gcCh.onReceive { it }
+                        }
+                        try {
+                            when (task) {
+                                is SourceLogTask.Record -> handleSourceLogRecord(task)
+                                is SourceLogTask.ResolvedTx -> handleResolvedTx(task.resolvedTx, task.srcMsgId)
+                                is ExtSourceTask.ResolvedTx -> handleResolvedTx(task.resolvedTx, srcMsgId = null)
+                                is GcTask.TriesDeleted -> handleTriesDeleted(task)
+                            }
+                            task.onComplete.complete(Unit)
+                        } catch (e: CancellationException) {
+                            task.onComplete.cancel(e)
+                            throw e
+                        } catch (e: InterruptedException) {
+                            task.onComplete.completeExceptionally(e)
+                            throw e
+                        } catch (e: Interrupted) {
+                            task.onComplete.completeExceptionally(e)
+                            throw e
+                        } catch (e: Throwable) {
+                            watchers.notifyError(e)
+                            task.onComplete.completeExceptionally(e)
+                            throw e
+                        }
+                    }
+                } catch (_: Throwable) {
+                } finally {
+                    sourceLogCh.close()
+                    extSourceCh.close()
+                    gcCh.close()
+                }
+            }
+
+            extSource?.let { source ->
+                launch {
+                    try {
+                        source.onPartitionAssigned(partition, watchers.externalSourceToken, this@LeaderLogProcessor)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        watchers.notifyError(e)
+                    }
+                }
+            }
         }
     }
 

--- a/core/src/main/kotlin/xtdb/util/CoroutineUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/CoroutineUtil.kt
@@ -1,0 +1,37 @@
+package xtdb.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Launches a child coroutine that runs [body], then runs [cleanup] under [NonCancellable].
+ *
+ * The cleanup is part of the launched Job's lifecycle: the Job doesn't reach a final state
+ * until cleanup has returned, so a parent's `cancelAndJoin` waits for it. That's the
+ * property [kotlinx.coroutines.Job.invokeOnCompletion] doesn't give you — see
+ * `dev/doc/coroutines.adoc` / xtdb#5703.
+ *
+ * Cleanup runs after the body whether the body returned normally, threw, or was cancelled.
+ * [NonCancellable] keeps cleanup running through cancellation requests that arrive while it
+ * is in flight.
+ *
+ * If [cleanup] throws, the Job ends `CompletedExceptionally` and the exception surfaces via
+ * the scope's [kotlinx.coroutines.CoroutineExceptionHandler].
+ *
+ * [body] defaults to [awaitCancellation] for the "exists only to run cleanup on cancel"
+ * shape; pass a body for "do work, then clean up after."
+ */
+fun CoroutineScope.launchWithCleanup(
+    cleanup: suspend () -> Unit,
+    body: suspend CoroutineScope.() -> Unit = { awaitCancellation() }
+): Job = launch {
+    try {
+        body()
+    } finally {
+        withContext(NonCancellable) { cleanup() }
+    }
+}

--- a/dev/doc/coroutines.adoc
+++ b/dev/doc/coroutines.adoc
@@ -1,0 +1,70 @@
+= Coroutines in XTDB
+
+:written: 2026-06-11
+
+Notes on coroutine patterns and gotchas specific to this codebase, supplementing the link:https://kotlinlang.org/docs/coroutines-overview.html[official Kotlin docs].
+We are on kotlinx-coroutines `1.10.2`; source links point there.
+
+== Patterns
+
+=== `launchWithCleanup` for cleanup that gates parent close
+
+For "do work, then close some things, and make sure a parent's `cancelAndJoin` waits for the close," use `xtdb.util.launchWithCleanup`.
+
+[source,kotlin]
+----
+scope.launchWithCleanup(
+    cleanup = {
+        extSource?.close()
+        replicaProducer.close()
+        allocator.close()
+    }
+) {
+    supervisorScope {
+        launch { runPersister() }
+        launch { runExt() }
+    }
+}
+----
+
+The helper's kdoc states the lifecycle property it gives you.
+In-tree users: `LeaderLogProcessor`, `FollowerLogProcessor`.
+
+Most reaches for `Job.invokeOnCompletion` to close resources should be this helper instead — see the gotcha below.
+
+== Gotchas
+
+=== `invokeOnCompletion` is not a fence over `cancelAndJoin`
+
+A `Job`'s state CASes to its final state *before* its `invokeOnCompletion` handlers iterate.
+Observers of the job's state — `join`, `isCompleted`, `invokeOnCompletion(invokeImmediately=false)` — see the job as "done" the moment the CAS lands, while handlers are still running on whatever thread triggered finalisation.
+
+In particular, a parent waiting on a child via `tryWaitForChild` short-circuits on a child whose state is already final:
+
+[source,kotlin]
+----
+private tailrec fun tryWaitForChild(state: Finishing, child: ChildHandleNode, ...): Boolean {
+    val handle = child.childJob.invokeOnCompletion(
+        invokeImmediately = false,
+        handler = ChildCompletion(this, state, child, ...)
+    )
+    if (handle !== NonDisposableHandle) return true   // <1>
+    val nextChild = child.nextChild() ?: return false  // <2>
+    return tryWaitForChild(state, nextChild, ...)
+}
+----
+<1> Child still incomplete — register the wait handler, return.
+<2> Child already final — the parent skips it without registering a wait.
+
+So if your `invokeOnCompletion` handler does any non-trivial work — slow I/O, multiple `.close()` calls — that work can race the parent's `cancelAndJoin` returning and whatever happens next.
+For cleanup that needs to gate a parent's close, put it in the coroutine body's `try/finally` instead (or use `launchWithCleanup`).
+
+Background: this was the root cause of link:https://github.com/xtdb/xtdb/issues/5703[#5703].
+
+== Source pointers
+
+* link:https://github.com/Kotlin/kotlinx.coroutines/blob/1.10.2/kotlinx-coroutines-core/common/src/JobSupport.kt[`JobSupport.kt`] — `Job` state machine.
+  Functions worth knowing: `finalizeFinishingState`, `completeStateFinalization`, `tryWaitForChild`, `continueCompleting`, `notifyCompletion`, `cancelImpl`.
+* link:https://github.com/Kotlin/kotlinx.coroutines/blob/1.10.2/kotlinx-coroutines-core/common/src/CompletionHandler.common.kt[`CompletionHandler.common.kt`] — `JobNode` hierarchy (`ChildHandleNode`, `ChildCompletion`, `ResumeOnCompletion`).
+* link:https://kotlinlang.org/docs/cancellation-and-timeouts.html[Kotlin: Cancellation and timeouts] — official guide.
+* link:https://elizarov.medium.com/structured-concurrency-722d765aa952[Structured concurrency] (Elizarov) — design intent behind parent/child Job relationships.


### PR DESCRIPTION
Resolves #5703.

`Database.close()` was returning before `LeaderLogProcessor` and `FollowerLogProcessor` had finished closing their resources. The cleanup was hung off `Job.invokeOnCompletion` handlers, and a parent's `cancelAndJoin` observes the child's *state*, which CASes to final before its handlers iterate — so `closeAll(allocator)` ran concurrently with the closes, and `allocator.close()` then tripped `BaseAllocator.assertOpen()`. The issue body walks through the kotlinx mechanism in full.

## Fix

Move LP and FLP cleanup out of `invokeOnCompletion` and into the launched coroutine's body, behind a new helper `xtdb.util.launchWithCleanup` that codifies the pattern:

```kotlin
scope.launchWithCleanup(
    cleanup = {
        extSource?.close()
        replicaProducer.close()
        allocator.close()
    }
) {
    supervisorScope {
        launch { /* persister */ }
        extSource?.let { launch { /* ext */ } }
    }
}
```

The helper wraps body+cleanup as `try { body() } finally { withContext(NonCancellable) { cleanup() } }`, so the launched Job's state can't go final until cleanup has completed — a parent's `cancelAndJoin` therefore genuinely waits.

LP needed to collapse its two init-launched workers (`persisterJob`, `extJob`) into a single hosting `termJob`, with `supervisorScope` preserving sibling-isolation. FLP just passes its existing tail-loop body to the helper.

## Out of scope

`Compactor.kt:206` (`dbJob.invokeOnCompletion { driver.close() }`) is the same anti-pattern; tracked as #5707. Its fix needs a similar restructure but has to thread through the per-job coroutines that use the shared driver — left for a follow-up to keep this PR focused.

## Test plan

- [x] `:xtdb-core:test --tests 'xtdb.indexer.*'` passes locally
- [x] `:modules:xtdb-kafka-connect-source:integration-test` passes locally with 0 occurrences of `IllegalStateException: Attempting operation on allocator when allocator is closed`. Pre-fix runs on `main` show 11–25 occurrences per run.
- [x] `:modules:xtdb-postgres-source:integration-test` passes locally with 0 occurrences.
- [ ] CI green on this branch's commit.

## Dev doc

`dev/doc/coroutines.adoc` is added — a short reference covering the patterns and gotchas around `invokeOnCompletion` / `cancelAndJoin`, supplementing the official Kotlin docs.
