### PR TITLE
fix(util): launchWithCleanup cleanup survives cancel-before-dispatch

### DIFF
--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -302,7 +302,7 @@ class Database(
                     )
 
                     // The leader term owns its replica producer and ext source; both are freed by
-                    // LeaderLogProcessor's `invokeOnCompletion` when `termScope` is cancelled.
+                    // LeaderLogProcessor's `launchWithCleanup` cleanup when `termScope` is cancelled.
                     override fun openLeader(
                         termScope: CoroutineScope,
                         replicaProducer: Log.AtomicProducer<ReplicaMessage>,

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -73,7 +73,7 @@ class LogProcessor(
     // The running term: the role-specific subsystem and the SupervisorJob its processor runs under (a
     // child of the database scope). `sys` holds it as one atomically-swapped value — a job-less term
     // is unrepresentable. Cancelling the job tears the term down; structured concurrency joins the
-    // term's coroutines and each processor frees what it opened via its own `invokeOnCompletion`.
+    // term's coroutines and each processor frees what it opened via its own `launchWithCleanup`.
     private sealed class SubSystem(private val job: Job) {
         suspend fun cancelAndJoin() = job.cancelAndJoin()
     }

--- a/core/src/main/kotlin/xtdb/util/CoroutineUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/CoroutineUtil.kt
@@ -1,35 +1,43 @@
 package xtdb.util
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
  * Launches a child coroutine that runs [body], then runs [cleanup] under [NonCancellable].
  *
- * The cleanup is part of the launched Job's lifecycle: the Job doesn't reach a final state
- * until cleanup has returned, so a parent's `cancelAndJoin` waits for it. That's the
- * property [kotlinx.coroutines.Job.invokeOnCompletion] doesn't give you — see
- * `dev/doc/coroutines.adoc` / xtdb#5703.
+ * Guarantees:
+ * - [cleanup] runs exactly once, after the body — whether the body returned, threw, was
+ *   cancelled mid-flight, or was cancelled before it started (the coroutine starts
+ *   [CoroutineStart.ATOMIC]; the [ensureActive] keeps default-start semantics for the body).
+ * - The Job doesn't reach a final state until cleanup has returned, so a parent's
+ *   `cancelAndJoin` waits for it — the property [Job.invokeOnCompletion] doesn't give you.
  *
- * Cleanup runs after the body whether the body returned normally, threw, or was cancelled.
- * [NonCancellable] keeps cleanup running through cancellation requests that arrive while it
- * is in flight.
+ * Intended for cleanup of resources that exist before the launch. If the body acquires its
+ * own resources, use `.use`/`try/finally` inside a plain [launch] instead.
  *
- * If [cleanup] throws, the Job ends `CompletedExceptionally` and the exception surfaces via
- * the scope's [kotlinx.coroutines.CoroutineExceptionHandler].
+ * Workers the body launches are children of the hosting Job, not of the body statement —
+ * fence them with `supervisorScope`/`coroutineScope`, or they race the cleanup.
  *
- * [body] defaults to [awaitCancellation] for the "exists only to run cleanup on cancel"
- * shape; pass a body for "do work, then clean up after."
+ * If [cleanup] throws, the Job completes exceptionally and the exception surfaces via the
+ * scope's [kotlinx.coroutines.CoroutineExceptionHandler].
+ *
+ * [body] defaults to [awaitCancellation] for the "exists only to run cleanup on cancel" shape.
+ *
+ * Rationale and the underlying kotlinx semantics: `dev/doc/coroutines.adoc` / xtdb#5703.
  */
 fun CoroutineScope.launchWithCleanup(
     cleanup: suspend () -> Unit,
     body: suspend CoroutineScope.() -> Unit = { awaitCancellation() }
-): Job = launch {
+): Job = launch(start = CoroutineStart.ATOMIC) {
     try {
+        ensureActive()
         body()
     } finally {
         withContext(NonCancellable) { cleanup() }

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -87,7 +87,7 @@ class ExternalSourceTest {
 
     // The leader is launched into `backgroundScope`, which runTest cancels at the end of the test —
     // that cancel is the teardown: it stops the persister and ext-source loop and, once they've
-    // joined, the leader's `invokeOnCompletion` frees its allocator and replica producer.
+    // joined, the leader's `launchWithCleanup` cleanup frees its allocator and replica producer.
     private fun TestScope.leaderProc(
         sourceLog: InMemoryLog<SourceMessage> = InMemoryLog(InstantSource.system(), 0),
         replicaLog: InMemoryLog<ReplicaMessage> = InMemoryLog(InstantSource.system(), 0),

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -96,7 +96,7 @@ class LogProcessorSimTest : SimulationTestBase() {
      * driver against a stale `TxIndexer` reference) is what keeps the leader's allocator
      * accounting clean across rebalances: `indexTx` allocates an `OpenTx` from the
      * leader's allocator; if the leader term's scope were cancelled while that `OpenTx` is
-     * still live, the leader's `invokeOnCompletion` `allocator.close()` would throw on the
+     * still live, the leader's cleanup `allocator.close()` would throw on the
      * outstanding allocation. Holding the call inside `onPartitionAssigned` ties its lifetime
      * to the leader's scope — cancelling that scope propagates cancellation through `indexTx`'s
      * inner catch, which closes the `OpenTx` before the allocator does.

--- a/dev/doc/coroutines.adoc
+++ b/dev/doc/coroutines.adoc
@@ -27,12 +27,42 @@ scope.launchWithCleanup(
 }
 ----
 
-The helper's kdoc states the lifecycle property it gives you.
+The helper's kdoc states the lifecycle contract it gives you, and when *not* to use it (resources the coroutine acquires itself belong in the body, under `.use`/`try/finally`, with a plain `launch`).
 In-tree users: `LeaderLogProcessor`, `FollowerLogProcessor`.
 
-Most reaches for `Job.invokeOnCompletion` to close resources should be this helper instead — see the gotcha below.
+Most reaches for `Job.invokeOnCompletion` to close resources should be this helper instead — see the gotchas below.
+
+When the body hosts further workers (its own `launch`es), wrap them in `supervisorScope`/`coroutineScope` rather than launching them as plain siblings: the scope builder doesn't return until every child has completed, so the `finally` — and with it the cleanup — runs strictly after the workers have released what they hold.
+Unfenced workers would be children of the hosting Job, not of the body statement — the cleanup would race them.
+
+.Considered, deferred — wrapping the body in `coroutineScope`
+[NOTE]
+====
+The fencing obligation above could be made structural instead of documented, by the helper wrapping the body itself:
+
+[source,kotlin]
+----
+try {
+    ensureActive()
+    coroutineScope(body)   // body's launches attach to the block's own Job
+} finally {
+    withContext(NonCancellable) { cleanup() }
+}
+----
+
+`coroutineScope` doesn't return until every child completes, so "cleanup runs after all body-launched workers" holds by construction — the unfenced state stops being representable.
+A body wanting failure isolation between its workers writes `supervisorScope` inside, as `LeaderLogProcessor` already does; the extra Job per scope builder is not a factor (one allocation, started undispatched, no thread hop).
+
+Deferred until more worker-hosting callers exist, to confirm the fencing default from observed usage rather than one caller's shape.
+====
 
 == Gotchas
+
+=== A cancel before first dispatch skips the coroutine body entirely
+
+With `CoroutineStart.DEFAULT`, a coroutine cancelled before its first dispatch never executes its block — including any `try/finally` inside it.
+Cleanup hung on a `finally` therefore silently doesn't run if the scope is cancelled in the window between `launch` returning and the dispatcher first running the coroutine — leaking anything acquired before the launch (allocators, drivers) that the cleanup was meant to free.
+`launchWithCleanup` starts its coroutine with `CoroutineStart.ATOMIC` (stable since kotlinx-coroutines 1.9) to close this window, but only so the `try/finally` is entered: an `ensureActive()` ahead of the body keeps default-start semantics for the body itself, so user code still doesn't run when cancellation has already landed.
 
 === `invokeOnCompletion` is not a fence over `cancelAndJoin`
 


### PR DESCRIPTION
Follow-up to #5703 (builds on the model from #5676).

The job-owned lifecycle model needs two properties of service cleanup. It must run even when the job is cancelled before its body ever executes — #5676 chose `invokeOnCompletion` for precisely this, since a body `finally` is skipped in that window. And it must complete before a parent's `cancelAndJoin` returns — #5703 showed `invokeOnCompletion` doesn't give this, because handlers fire after the Job's state goes final. Neither primitive delivers both. #5703's move to a body `finally` fixed the join fence but silently traded away the first property: `Database.open`'s failure path `cancelAndJoin`s the freshly-created scope, possibly before the processor's coroutine has dispatched, leaving LP/FLP's child allocator open and the database allocator's close throwing on it.

`CoroutineStart.ATOMIC` closes that window: the `try/finally` is entered even when cancellation precedes first dispatch. ATOMIC alone would also force the body to run to its first suspension point mid-teardown, so an `ensureActive()` ahead of the body keeps default-start semantics for user code — ATOMIC is used purely to make the `finally` reachable. The resources cleanup frees are constructor-time (allocators, producers, sources), so there is always something to free in that window.

The kdoc now states the helper's contract: it is for resources that pre-exist the launch (body-acquired resources belong under `.use`/`try/finally` in a plain `launch`), and body-launched workers must be fenced with `supervisorScope`/`coroutineScope` or they race the cleanup. `dev/doc/coroutines.adoc` gains the cancelled-before-dispatch gotcha and records a considered-but-deferred design — the helper wrapping its body in `coroutineScope` to make the fencing structural — parked until more worker-hosting callers exist to pick the default from evidence.

No caller changes: LP and FLP work unchanged. Verified against the `xtdb.indexer.*` and `xtdb.database.*` unit tests, the `LogProcessorSimTest` property run, and the Clojure read-only-node tests.

Also carries a comment-only tidy commit updating references left pointing at `invokeOnCompletion` by 427964b04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)