### PR TITLE
fix(compactor): close driver via launchWithCleanup

### DIFF
--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -166,13 +166,6 @@ interface Compactor : AutoCloseable {
 
         override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
 
-            // Child of the owner scope: cancelling that scope stops the loop and its per-job
-            // coroutines, and the driver's resources (child allocator + SegmentMerge temp dir) are
-            // freed when this job completes — leaf-first, after every in-flight compaction buffer's
-            // `.use` has released, so no buffer ever outlives its allocator.
-            private val dbJob = Job(scope.coroutineContext.job)
-            private val loopScope = CoroutineScope(dbJob + dispatcher)
-
             private val trieCatalog = dbState.trieCatalog
             private val liveIndex = dbState.liveIndexOrNull
 
@@ -201,64 +194,70 @@ interface Compactor : AutoCloseable {
             }
 
             init {
-                // Free the driver's resources when the compactor job completes — fires even if the
-                // job is cancelled before the loop is ever scheduled, so the driver never leaks.
-                dbJob.invokeOnCompletion {
-                    driver.close()
-                    LOGGER.debug("compactor closed")
-                }
+                // Cancelling the owner scope stops the loop and its per-job coroutines, then frees
+                // the driver's resources (child allocator + SegmentMerge temp dir) — leaf-first:
+                // `supervisorScope` doesn't return until every in-flight job's `.use` has released
+                // its buffers, so no buffer outlives its allocator, and the cleanup gates the
+                // owner's `cancelAndJoin` (see dev/doc/coroutines.adoc / #5703 for why this is
+                // launchWithCleanup rather than invokeOnCompletion).
+                scope.launchWithCleanup(
+                    dispatcher + CoroutineName("outer loop"),
+                    cleanup = {
+                        driver.close()
+                        LOGGER.debug("compactor closed")
+                    }
+                ) {
+                    // supervisorScope so a failed job doesn't cancel the loop or its sibling jobs.
+                    supervisorScope {
+                        while (true) {
+                            availableJobs =
+                                jobCalculator.availableJobs(trieCatalog)
+                                    .associateBy { JobKey(it.table, it.outputTrieKey.toString()) }
 
-                val jobsScope = CoroutineScope(SupervisorJob(dbJob) + jobsDispatcher)
+                            if (availableJobs.isEmpty() && queuedJobs.isEmpty()) {
+                                LOGGER.trace("sending idle")
+                                compactAllPromise?.complete(Unit)
+                            }
 
-                loopScope.launch(CoroutineName("outer loop")) {
-                    while (true) {
-                        availableJobs =
-                            jobCalculator.availableJobs(trieCatalog)
-                                .associateBy { JobKey(it.table, it.outputTrieKey.toString()) }
+                            availableJobs.keys.forEach { jobKey ->
+                                if (queuedJobs.add(jobKey)) {
+                                    launch(jobsDispatcher + CoroutineName("job: ${jobKey.first} / ${jobKey.second}")) {
+                                        jobsSemaphore.withPermit {
+                                            // check it's still required
+                                            val job = availableJobs[jobKey]
+                                            if (job != null) {
+                                                LOGGER.debug("compacting '${job.table.sym}' ${job.trieKeys} -> ${job.outputTrieKey}")
 
-                        if (availableJobs.isEmpty() && queuedJobs.isEmpty()) {
-                            LOGGER.trace("sending idle")
-                            compactAllPromise?.complete(Unit)
-                        }
+                                                val timer = meterRegistry?.let { Timer.start(it) }
+                                                val triesAdded = driver.executeJob(job)
+                                                jobTimer?.let { timer?.stop(it) }
+                                                driver.publishTries(triesAdded)
 
-                        availableJobs.keys.forEach { jobKey ->
-                            if (queuedJobs.add(jobKey)) {
-                                jobsScope.launch(CoroutineName("job: ${jobKey.first} / ${jobKey.second}")) {
-                                    jobsSemaphore.withPermit {
-                                        // check it's still required
-                                        val job = availableJobs[jobKey]
-                                        if (job != null) {
-                                            LOGGER.debug("compacting '${job.table.sym}' ${job.trieKeys} -> ${job.outputTrieKey}")
-
-                                            val timer = meterRegistry?.let { Timer.start(it) }
-                                            val triesAdded = driver.executeJob(job)
-                                            jobTimer?.let { timer?.stop(it) }
-                                            driver.publishTries(triesAdded)
-
-                                            LOGGER.debug {
-                                                buildString {
-                                                    append("compacted '${job.table.sym}'")
-                                                    append(" -> ")
-                                                    append(
-                                                        triesAdded.tries
-                                                            .joinToString(prefix = "(", postfix = ")") { it.trieKey })
+                                                LOGGER.debug {
+                                                    buildString {
+                                                        append("compacted '${job.table.sym}'")
+                                                        append(" -> ")
+                                                        append(
+                                                            triesAdded.tries
+                                                                .joinToString(prefix = "(", postfix = ")") { it.trieKey })
+                                                    }
                                                 }
                                             }
                                         }
-                                    }
 
-                                    // intentionally outside try/finally - if the job fails, we leave it in queuedJobs
-                                    // so this node doesn't attempt it again
-                                    doneCh.send(jobKey)
+                                        // intentionally outside try/finally - if the job fails, we leave it in queuedJobs
+                                        // so this node doesn't attempt it again
+                                        doneCh.send(jobKey)
+                                    }
                                 }
                             }
-                        }
 
-                        select {
-                            doneCh.onReceive { queuedJobs.remove(it) }
+                            select {
+                                doneCh.onReceive { queuedJobs.remove(it) }
 
-                            wakeupCh.onReceive {
-                                LOGGER.trace("wakey wakey")
+                                wakeupCh.onReceive {
+                                    LOGGER.trace("wakey wakey")
+                                }
                             }
                         }
                     }

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -128,6 +128,8 @@ interface Compactor : AutoCloseable {
 
                                     TriesAdded(Storage.VERSION, bp.epoch, addedTries)
                                 }
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: ClosedByInterruptException) {
                                 throw InterruptedException(e.message)
                             } catch (e: InterruptedException) {

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -134,7 +134,7 @@ class Database(
         runBlocking {
             // One cancel for the whole job tree: the compactor, the source-log subscription and the
             // live leader/follower term all run under `job`, so cancelling and joining it stops them
-            // and runs their `invokeOnCompletion` frees (driver, allocator, replica producer, ext
+            // and waits for their `launchWithCleanup` frees (driver, allocator, replica producer, ext
             // source) before `closeAll` frees the database allocator below.
             job?.cancelAndJoin()
         }
@@ -267,7 +267,7 @@ class Database(
             val job = Job()
 
             // A child of the database `job`, so `close()`'s single `job.cancelAndJoin()` stops the
-            // compactor and frees its driver (via the compactor job's invokeOnCompletion) before the
+            // compactor and frees its driver (via the compactor's `launchWithCleanup`) before the
             // database allocator closes. Also registered with safelyOpening so a failure later in
             // `open` cancels the loop — it runs against the driver, which safelyOpening would
             // otherwise free out from under it.

--- a/core/src/main/kotlin/xtdb/util/CoroutineUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/CoroutineUtil.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Launches a child coroutine that runs [body], then runs [cleanup] under [NonCancellable].
@@ -33,9 +35,10 @@ import kotlinx.coroutines.withContext
  * Rationale and the underlying kotlinx semantics: `dev/doc/coroutines.adoc` / xtdb#5703.
  */
 fun CoroutineScope.launchWithCleanup(
+    context: CoroutineContext = EmptyCoroutineContext,
     cleanup: suspend () -> Unit,
     body: suspend CoroutineScope.() -> Unit = { awaitCancellation() }
-): Job = launch(start = CoroutineStart.ATOMIC) {
+): Job = launch(context, start = CoroutineStart.ATOMIC) {
     try {
         ensureActive()
         body()

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -62,8 +62,8 @@ data class MockDatabase(
     fun close() {
         // The owner stops the GC and compaction processes (the leaves are pure scope-launched
         // processes now); cancelling the scopes they run under is the whole teardown. The compactor
-        // frees its driver's resources via invokeOnCompletion as its job completes. runBlocking only
-        // because this teardown is non-suspend.
+        // frees its driver's resources via launchWithCleanup before the join returns. runBlocking
+        // only because this teardown is non-suspend.
         runBlocking {
             gcScope.coroutineContext.job.cancelAndJoin()
             compactorScope.coroutineContext.job.cancelAndJoin()

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -22,7 +22,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.BlockCatalog.Companion.latestBlock
 import xtdb.compactor.Compactor
 import xtdb.compactor.CompactorDriverConfig
-import xtdb.compactor.CompactorMockDriver
+import xtdb.compactor.CompactorMockDriverFactory
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -103,7 +103,7 @@ class NodeSimulationTest : SimulationTestBase() {
     val garbageLifetime = Duration.ofSeconds(60)
     private lateinit var allocator: BufferAllocator
     private lateinit var sharedBufferPool: MemoryStorage
-    private lateinit var compactorDriver: CompactorMockDriver
+    private lateinit var compactorDriverFactory: CompactorMockDriverFactory
     private lateinit var dbs: List<MockDatabase>
 
     @BeforeEach
@@ -111,7 +111,7 @@ class NodeSimulationTest : SimulationTestBase() {
         setLogLevel.invoke("xtdb".symbol, logLevel)
 
         val jobCalculator = createJobCalculator()
-        compactorDriver = CompactorMockDriver(dispatcher, currentSeed, CompactorDriverConfig())
+        compactorDriverFactory = CompactorMockDriverFactory(dispatcher, currentSeed, CompactorDriverConfig())
         allocator = RootAllocator()
 
         // Create a single shared buffer pool for all systems
@@ -120,7 +120,7 @@ class NodeSimulationTest : SimulationTestBase() {
         dbs = List(numberOfSystems) {
             val trieCatalog = createTrieCatalog()
             val blockCatalog = BlockCatalog("xtdb", sharedBufferPool.latestBlock)
-            val compactor = Compactor.Impl(compactorDriver, null, jobCalculator, false, 2, dispatcher)
+            val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
             val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorScope = CoroutineScope(dispatcher)
@@ -146,13 +146,15 @@ class NodeSimulationTest : SimulationTestBase() {
     @AfterEach
     fun tearDown() {
         dbs.forEach { it.close() }
+        // Stop the drivers' broadcast listeners before freeing the shared pool they write into.
+        runBlocking { compactorDriverFactory.scope.coroutineContext.job.cancelAndJoin() }
         sharedBufferPool.close()
         allocator.close()
     }
 
     private fun addTries(tableRef: TableRef, tries: List<TrieDetails>, timestamp: Instant) {
         tries.forEach {
-            compactorDriver.trieKeyToFileSize[compactorDriver.fileSizeKey(tableRef.tableName, it.trieKey.toString())] = it.dataFileSize
+            compactorDriverFactory.trieKeyToFileSize[compactorDriverFactory.fileSizeKey(tableRef.tableName, it.trieKey.toString())] = it.dataFileSize
         }
         dbs.forEach { db ->
             db.trieCatalog.addTries(tableRef, tries, timestamp)

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -58,7 +58,7 @@ class MockDb(
     val dbState: DatabaseState get() = DatabaseState(name, null, null, trieCatalog, null)
 }
 
-private val LOGGER = CompactorMockDriver::class.logger
+private val LOGGER = CompactorMockDriverFactory::class.logger
 
 enum class TemporalSplitting {
     CURRENT,
@@ -72,7 +72,7 @@ data class CompactorDriverConfig(
     val blocksPerWeek: Long = 140
 )
 
-class CompactorMockDriver(
+class CompactorMockDriverFactory(
     val dispatcher: CoroutineDispatcher,
     val baseSeed: Int,
     config: CompactorDriverConfig
@@ -89,27 +89,36 @@ class CompactorMockDriver(
     val sharedFlow = MutableSharedFlow<AppendMessage>(extraBufferCapacity = Int.MAX_VALUE)
     var nextSystemId = 0
 
+    // Every driver's broadcast-listener coroutine is a child of this scope. The test cancels it
+    // once at teardown (a single top-level bridge), rather than each driver's close() blocking on
+    // its own listener — a runBlocking-in-leaf-close that deadlocks the single-threaded sim
+    // dispatcher when it runs inside the compactor's cleanup fence (#5711). SupervisorJob so one
+    // system's listener failing doesn't cancel the others.
+    val scope = CoroutineScope(dispatcher + SupervisorJob())
+
     override fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers): Driver {
         val systemId = nextSystemId++
-        return ForDatabase(dbStorage, dbState, systemId)
+        return CompactorMockDriver(dbStorage, dbState, systemId)
     }
 
-    inner class ForDatabase(val dbStorage: DatabaseStorage, val dbState: DatabaseState, val systemId: Int) : Driver {
+    private inner class CompactorMockDriver(val dbStorage: DatabaseStorage, val dbState: DatabaseState, val systemId: Int) : Driver {
         val trieCatalog = dbState.trieCatalog
         val bufferPool = dbStorage.bufferPool
 
-        val job = CoroutineScope(dispatcher).launch {
-            sharedFlow.collect { msg ->
-                val trieKeys = msg.triesAdded.tries.map { it.trieKey }
-                LOGGER.debug("[channel msg received] systemId=$systemId received ${trieKeys.size} tries: $trieKeys")
-                yield() // force suspension mid-message processing
-                msg.triesAdded.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
-                    val tableRef = TableRef.parse(dbState.name, tableName)
-                    addTriesToBufferPool(bufferPool, tableRef, tries)
-                    trieCatalog.addTries(tableRef, tries, msg.msgTimestamp)
-                }
+        init {
+            scope.launch {
+                sharedFlow.collect { msg ->
+                    val trieKeys = msg.triesAdded.tries.map { it.trieKey }
+                    LOGGER.debug("[channel msg received] systemId=$systemId received ${trieKeys.size} tries: $trieKeys")
+                    yield() // force suspension mid-message processing
+                    msg.triesAdded.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
+                        val tableRef = TableRef.parse(dbState.name, tableName)
+                        addTriesToBufferPool(bufferPool, tableRef, tries)
+                        trieCatalog.addTries(tableRef, tries, msg.msgTimestamp)
+                    }
 
-                LOGGER.debug("[channel msg processed] systemId=$systemId added ${trieKeys.size} tries to catalog: $trieKeys")
+                    LOGGER.debug("[channel msg processed] systemId=$systemId added ${trieKeys.size} tries to catalog: $trieKeys")
+                }
             }
         }
 
@@ -216,11 +225,8 @@ class CompactorMockDriver(
             LOGGER.debug("[publishTries completed] systemId=$systemId")
         }
 
-        override fun close() {
-            runBlocking {
-                job.cancelAndJoin()
-            }
-        }
+        // No-op: the mock owns no resources — the real driver closes its allocator + SegmentMerge here.
+        override fun close() = Unit
     }
 }
 
@@ -276,14 +282,14 @@ class CompactorSimulationTest : SimulationTestBase() {
     var numberOfSystems: Int = 1
     private lateinit var allocator: BufferAllocator
     private lateinit var sharedBufferPool: BufferPool
-    private lateinit var mockDriver: CompactorMockDriver
+    private lateinit var mockDriverFactory: CompactorMockDriverFactory
     private lateinit var jobCalculator: Compactor.JobCalculator
     private lateinit var dbs: List<MockDb>
 
     @BeforeEach
     fun setUp() {
         setLogLevel.invoke("xtdb.compactor".symbol, logLevel)
-        mockDriver = CompactorMockDriver(dispatcher, currentSeed, driverConfig)
+        mockDriverFactory = CompactorMockDriverFactory(dispatcher, currentSeed, driverConfig)
         jobCalculator = createJobCalculator()
         allocator = RootAllocator()
 
@@ -295,7 +301,7 @@ class CompactorSimulationTest : SimulationTestBase() {
                 name = "xtdb",
                 trieCatalog = createTrieCatalog(),
                 bufferPool = sharedBufferPool,
-                compactor = Compactor.Impl(mockDriver, null, jobCalculator, false, 2, dispatcher),
+                compactor = Compactor.Impl(mockDriverFactory, null, jobCalculator, false, 2, dispatcher),
             )
         }
     }
@@ -303,13 +309,15 @@ class CompactorSimulationTest : SimulationTestBase() {
     @AfterEach
     fun tearDown() {
         driverConfig = CompactorDriverConfig()
+        // Stop the drivers' broadcast listeners before freeing the pool they write into.
+        runBlocking { mockDriverFactory.scope.coroutineContext.job.cancelAndJoin() }
         sharedBufferPool.close()
         allocator.close()
     }
 
     private fun seedTries(tableRef: TableRef, tries: List<TrieDetails>) {
         tries.forEach {
-            mockDriver.trieKeyToFileSize[mockDriver.fileSizeKey(tableRef.tableName, it.trieKey.toString())] = it.dataFileSize
+            mockDriverFactory.trieKeyToFileSize[mockDriverFactory.fileSizeKey(tableRef.tableName, it.trieKey.toString())] = it.dataFileSize
         }
         dbs.forEach { db ->
             addTriesToBufferPool(sharedBufferPool, tableRef, tries)

--- a/dev/doc/coroutines.adoc
+++ b/dev/doc/coroutines.adoc
@@ -28,7 +28,7 @@ scope.launchWithCleanup(
 ----
 
 The helper's kdoc states the lifecycle contract it gives you, and when *not* to use it (resources the coroutine acquires itself belong in the body, under `.use`/`try/finally`, with a plain `launch`).
-In-tree users: `LeaderLogProcessor`, `FollowerLogProcessor`.
+In-tree users: `LeaderLogProcessor`, `FollowerLogProcessor`, `Compactor`.
 
 Most reaches for `Job.invokeOnCompletion` to close resources should be this helper instead — see the gotchas below.
 


### PR DESCRIPTION
Counterpart to #5703 for the compactor; the test commit resolves the fixture instance of #5711.

#5703 moved the log processors' resource cleanup off `Job.invokeOnCompletion` and onto `launchWithCleanup`, because a completion handler races `Database.close()`'s `cancelAndJoin` — the Job's state goes final before the handler runs, so the parent can stop waiting while cleanup is still in flight. The compactor still freed its driver (child allocator + `SegmentMerge` temp dir) from an `invokeOnCompletion` handler, with the same race. This applies the same fix: cleanup moves into the loop coroutine's body via `launchWithCleanup`, so `Database.close` genuinely waits for `driver.close()` before `closeAll` frees the database allocator.

The loop now runs inside `supervisorScope` with the per-job coroutines as its children. That keeps the failure isolation the old `SupervisorJob(dbJob)` sibling scope gave — a crashed job stays in `queuedJobs` and doesn't take down the loop — while also gating the cleanup: `supervisorScope` doesn't return until every in-flight job's `.use` has released its buffers, so the driver and its allocator close strictly after, and strictly before the parent's join returns. A cancel before the loop is ever dispatched still frees the driver — that guarantee now comes from `launchWithCleanup`'s ATOMIC start rather than the old handler.

**Why the test commit is bundled.** Fencing the cleanup into the join exposed a latent deadlock in `CompactorMockDriver` (the sim-test fake): it tore down a `sharedFlow` listener with `runBlocking { cancelAndJoin() }` inside a synchronous `close()`, which — running on the single-threaded sim dispatcher inside the new fence — blocks the only thread that listener needs to observe its own cancellation. Dump-confirmed via the hang watchdog (#5711, instance 1). The production driver owns no coroutine, so this never affected production; it's purely a fixture defect the fence surfaced. The fix makes the mock a proper factory (`CompactorMockDriverFactory`) whose listeners are children of a scope the test cancels at teardown, instead of a blocking per-driver `close()`. The test commit lands first, so every commit is hang-free — per-commit CI or a bisect never stops on the deadlocking intermediate state.

## Changes

1. `test(compactor):` — mock driver becomes a factory owning its listeners' scope; fixes the fixture deadlock (#5711).
2. `fix(compactor):` — driver cleanup via `launchWithCleanup` instead of `invokeOnCompletion`.
3. `fix(compactor):` — don't ERROR-log a compaction job that was merely cancelled.

## Scope

#5712 (single persister channel) was a separate race fix and is not part of this. The broader teardown-hang family — including the production instances in the Kafka and Postgres paths — is tracked in #5711; this PR resolves only the fixture instance.

## Test plan

`NodeSimulationTest` + `CompactorSimulationTest` — 1,613 property iterations green, no hang, no watchdog dump (the exact combination deadlocked at iteration 1 before the fixture fix). Whole-project `./gradlew test` + Kafka `integration-test` on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)