### PR TITLE
fix(kafka-connect-source): halt the source on an un-indexable record

### DIFF
--- a/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/DocsIndexer.kt
+++ b/modules/kafka-connect-source/src/main/kotlin/xtdb/kafkaconnectsource/DocsIndexer.kt
@@ -12,7 +12,7 @@ import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.data.Time as ConnectTime
 import org.apache.kafka.connect.data.Timestamp as ConnectTimestamp
 import org.apache.kafka.connect.sink.SinkRecord
-import xtdb.error.Fault
+import xtdb.error.Anomaly.Companion.toAnomaly
 import xtdb.error.Incorrect
 import xtdb.indexer.OpenTx
 import xtdb.indexer.TxIndexer
@@ -73,8 +73,7 @@ class DocsIndexer(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Throwable) {
-                    val coords = coordsFor(rec)
-                    TxResult.Aborted(wrapWithCoords(e, rec, coords), userMetadata = coords)
+                    throw e.toAnomaly(coordsFor(rec))
                 }
             }
         }
@@ -82,14 +81,6 @@ class DocsIndexer(
 
     private fun coordsFor(rec: SinkRecord): Map<String, Any?> =
         mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset())
-
-    private fun wrapWithCoords(cause: Throwable, rec: SinkRecord, coords: Map<String, Any?>): Throwable =
-        Fault(
-            "!Docs indexer failed at ${rec.topic()}-${rec.kafkaPartition()} offset ${rec.kafkaOffset()}: ${cause.message}",
-            "xtdb.kafka-connect-source/docs-indexer-failed",
-            coords,
-            cause = cause,
-        )
 
     private fun writeRecord(openTx: OpenTx, rec: SinkRecord) {
         val openTxTable = openTx.table(table)

--- a/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceIntegrationTest.kt
+++ b/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/KafkaConnectSourceIntegrationTest.kt
@@ -310,6 +310,49 @@ class KafkaConnectSourceIntegrationTest {
     }
 
     @Test
+    fun `indexer failure halts the source`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        produceBytes(sourceTopic, "first", """{"name":"First"}""".toByteArray())
+
+        openNode("xt-log-${UUID.randomUUID()}").use { node ->
+            attach(node, "events", """
+                log: !Kafka
+                  cluster: kafka
+                  topic: test-replica-${UUID.randomUUID()}
+                externalSource: !KafkaConnect
+                  remote: kafka
+                  topic: $sourceTopic
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                    value.converter.schemas.enable: "false"
+                  indexer: !Docs
+                    table: events
+            """.trimIndent())
+
+            awaitCondition("first record ingested — source is healthy") {
+                xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'first'").isNotEmpty()
+            }
+
+            produceBytes(sourceTopic, null, """{"name":"no-id"}""".toByteArray())
+            produceBytes(sourceTopic, "second", """{"name":"Second"}""".toByteArray())
+
+            val cat = (node as Xtdb.XtdbInternal).dbCatalog
+            awaitCondition("source halts with an ingestion error") {
+                cat["events"]?.ingestionError != null
+            }
+
+            val second = xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'second'")
+            assertTrue(second.isEmpty(), "second shouldn't appear — source halts at the un-indexable record under halt-on-failure")
+
+            val aborted = xtQueryDb(node, "events", "SELECT _id FROM xt.txs WHERE committed = false")
+            assertTrue(aborted.isEmpty(), "no aborted txs under halt-on-failure, got: $aborted")
+        }
+    }
+
+    @Test
     fun `SMT chain applies ExtractField to unwrap envelope`() = runTest(timeout = 120.seconds) {
         val sourceTopic = "events-${UUID.randomUUID()}"
         createTopic(sourceTopic)


### PR DESCRIPTION
Refs #5696 — realigns the connector with the halt-on-failure policy that PR set.

## Summary

The connector is meant to halt on any failure (Kafka Connect's `errors.tolerance=none` default). The converter and SMT paths do; the `!Docs` indexer didn't — a record that decoded cleanly but couldn't be written was recorded as an aborted `xt.txs` row and skipped, advancing the resume token past it.

## Root cause

The per-record `catch (e: Throwable)` in `DocsIndexer.indexRecords` returned `TxResult.Aborted` instead of letting the exception propagate. It's a leftover from an earlier DLQ-via-aborted-tx iteration that #5696 abandoned — the indexer `catch` was never updated to match the chosen halt policy.

Skip-and-continue is the exact failure mode #5696 rejected DLQ for: an aborted-tx commit advances the resume token around the indexer's per-record commits, so a mid-batch failure can drop earlier good records on restart — silent data loss.

## The change

The per-record `catch` rethrows (as it already does for `CancellationException`), so a bad record halts the source and surfaces via `ingestionError`, with the resume token left on the last good record. The error keeps its original anomaly category — a malformed record (no `_id`, a non-`Struct` value, a tombstone with no key) stays a caller-fault `Incorrect`; only a genuinely unexpected failure becomes a `Fault` — via `Throwable.toAnomaly`.

## Behaviour change

Observable for the existing rejection cases: a pipeline that was silently dropping such records will now stop on them.

## Test plan

The indexer error path had no coverage — `DocsIndexerTest` only exercised the `convertValue` helper — which is why the divergence went unnoticed. The new integration test feeds a record that decodes cleanly but fails in the indexer (no `_id`, null key), then asserts the source halts: a following good record never lands and no aborted tx is written. It waits on the database's `ingestionError` (the signal the postgres-source tests already use) rather than a fixed sleep, so it's deterministic.