### PR TITLE
fix(indexer): single persister task channel, not selectUnbiased

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.Counter
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
-import kotlinx.coroutines.selects.selectUnbiased
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.Metrics.withSpan
 import xtdb.NodeBase
@@ -137,12 +136,13 @@ class LeaderLogProcessor(
         }
     }
 
-    private val sourceLogCh =
-        Channel<SourceLogTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
-    private val extSourceCh =
-        Channel<ExtSourceTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
-    private val gcCh =
-        Channel<GcTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
+    // One channel for all task sources, received with plain `receive` — NOT per-source channels
+    // under `selectUnbiased`: `onUndeliveredElement` is only reliable for plain send/receive, and
+    // a task lost in a select/cancellation race leaves its submitter awaiting `onComplete`
+    // forever — from the shared log-consumer loop, that deadlocks `Database.close` (#5711).
+    // FIFO across sources also keeps one producer from starving the others.
+    private val taskCh =
+        Channel<PersisterTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
 
     private suspend fun handleSourceLogRecord(task: SourceLogTask.Record) {
         val record = task.record
@@ -251,11 +251,7 @@ class LeaderLogProcessor(
     }
 
     private suspend fun submit(task: PersisterTask) {
-        when (task) {
-            is SourceLogTask -> sourceLogCh.send(task)
-            is ExtSourceTask -> extSourceCh.send(task)
-            is GcTask -> gcCh.send(task)
-        }
+        taskCh.send(task)
         task.onComplete.await()
     }
 
@@ -303,17 +299,12 @@ class LeaderLogProcessor(
     ) {
         // supervisorScope so an ext-source crash doesn't kill the persister.
         supervisorScope {
-            // Persister: unbiased select across source-log records, external-source resolved
-            // txs, and GC trie deletions — so a slow producer on one channel can't starve the
-            // others.
+            // Persister: source-log records, external-source resolved txs, and GC trie
+            // deletions, one queue — see the `taskCh` declaration for why it's a single channel.
             launch {
                 try {
                     while (true) {
-                        val task: PersisterTask = selectUnbiased {
-                            sourceLogCh.onReceive { it }
-                            extSourceCh.onReceive { it }
-                            gcCh.onReceive { it }
-                        }
+                        val task: PersisterTask = taskCh.receive()
                         try {
                             when (task) {
                                 is SourceLogTask.Record -> handleSourceLogRecord(task)
@@ -339,9 +330,7 @@ class LeaderLogProcessor(
                     }
                 } catch (_: Throwable) {
                 } finally {
-                    sourceLogCh.close()
-                    extSourceCh.close()
-                    gcCh.close()
+                    taskCh.close()
                 }
             }
 


### PR DESCRIPTION
Part of #5711 — the issue carries the full deadlock analysis and the CI-timeline evidence; this PR lands the first (and for now only) remediation.

The persister received tasks via `selectUnbiased` over three per-source rendezvous channels, with `onUndeliveredElement` as the loss-protection for cancellation races. That protection is only reliable for plain send/receive — a task handed off in a select/cancellation race is owned by nobody: the persister's catch-chain never sees it and `onUndeliveredElement` never fires, so the task's `onComplete` is never resolved and its submitter awaits forever. When the submitter is the shared log-consumer loop (outside the database job tree, so unreachable by `Database.close`'s cancel), that await stops the loop polling and deadlocks close until the CI action timeout.

The fix collapses the three channels into one `Channel<PersisterTask>` received with plain `receive()`, making the lost-handoff state unrepresentable. A single FIFO queue preserves the cross-source fairness the unbiased select was approximating — no task source can starve another. All failure-path behaviour is otherwise unchanged: a closed/cancelled channel lands in the same catch/finally the select did.

Deliberately one fix at a time: this is the only candidate that explains all three observed hang shapes (including the in-memory-log hangs, where the other suspect — uninterruptible blocking Kafka producer calls — cannot apply). #5711 stays open to watch CI for recurrence; the producer-side `runInterruptible` wrap is queued there if needed.

Test plan: `xtdb.indexer.*` + `xtdb.database.*` unit tests, `LogProcessorSimTest`/`NodeSimulationTest` property runs, and the Clojure `xtdb.indexer-test`/`xtdb.api-test` suites — all green. The real verification is CI integration runs over the coming days, per the issue.

Generated with [Claude Code](https://claude.com/claude-code)