### PR TITLE
test: hang watchdog — dump coroutines/threads when a test runs long

### DIFF
--- a/build-logic/jlink/build.gradle.kts
+++ b/build-logic/jlink/build.gradle.kts
@@ -26,6 +26,8 @@ val jlinkModules = listOf(
     // clojureRepl
     "jdk.compiler",
     "jdk.javadoc",
+    // DebugProbes dynamic self-attach (test hang watchdog, #5711)
+    "jdk.attach",
 )
 
 val customJreDir = layout.buildDirectory.dir("custom-jre")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -256,6 +256,10 @@ allprojects {
             testRuntimeOnly(libs.junit.jupiter.engine)
             testRuntimeOnly(libs.junit.platform.launcher)
 
+            // dumps coroutines + threads when a test exceeds the hang threshold — see #5711
+            if (proj.path != ":modules:test-watchdog")
+                testRuntimeOnly(project(":modules:test-watchdog"))
+
             testImplementation(libs.testcontainers)
             testImplementation(libs.testcontainers.kafka)
             testImplementation(libs.testcontainers.keycloak)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,7 @@ exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", versio
 
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "kotlin-coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.10.0" }
 mockk = { group = "io.mockk", name = "mockk", version = "1.14.9" }
 kaml = { group = "com.charleskorn.kaml", name = "kaml", version = "0.104.0" }

--- a/modules/test-watchdog/build.gradle.kts
+++ b/modules/test-watchdog/build.gradle.kts
@@ -1,0 +1,21 @@
+// Deliberately NOT `java-library`: the root build's shared test config assumes clojurephant
+// (`devRuntimeOnly` et al), which this pure-Kotlin test-infra module doesn't want. It declares
+// its own minimal test setup instead.
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+dependencies {
+    implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.coroutines.debug)
+    implementation(libs.junit.platform.launcher)
+
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangTracker.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangTracker.kt
@@ -1,0 +1,43 @@
+package xtdb.test.watchdog
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Tracks in-flight tests and reports the ones that have exceeded the hang threshold.
+ *
+ * Pure bookkeeping — the listener owns scheduling and dumping — so the threshold logic is
+ * unit-testable with a fake clock. Times are raw nanos from the caller's clock.
+ */
+class HangTracker(
+    private val timeoutNanos: Long,
+    private val maxReports: Int = 2,
+) {
+    private class Entry(val displayName: String, val startedAt: Long) {
+        var reports = 0
+    }
+
+    private val running = ConcurrentHashMap<String, Entry>()
+
+    fun started(id: String, displayName: String, now: Long) {
+        running[id] = Entry(displayName, now)
+    }
+
+    fun finished(id: String) {
+        running.remove(id)
+    }
+
+    data class Overdue(val displayName: String, val elapsedNanos: Long, val report: Int)
+
+    /**
+     * Tests whose run time has crossed `timeout * (reports + 1)` — each crossing reports once,
+     * up to [maxReports], so a hung test produces two dumps (movement between them distinguishes
+     * "stuck" from "slow") and then goes quiet rather than flooding the log.
+     */
+    fun overdue(now: Long): List<Overdue> =
+        running.values.mapNotNull { e ->
+            val elapsed = now - e.startedAt
+            if (e.reports < maxReports && elapsed >= timeoutNanos * (e.reports + 1))
+                Overdue(e.displayName, elapsed, ++e.reports)
+            else null
+        }
+}

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
@@ -1,0 +1,103 @@
+package xtdb.test.watchdog
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.debug.DebugProbes
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestIdentifier
+import org.junit.platform.launcher.TestPlan
+import java.io.PrintStream
+import java.lang.management.ManagementFactory
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Dumps coroutines and threads to stderr when a test runs past the hang threshold, so a hung
+ * CI job names its stuck coroutine in the log instead of dying silently at the action timeout —
+ * see xtdb#5711.
+ *
+ * Diagnostic only: it never fails or interrupts the test, so a slow-but-progressing test that
+ * trips it costs nothing but log noise. Registered via ServiceLoader
+ * (`META-INF/services/org.junit.platform.launcher.TestExecutionListener`), and this module rides
+ * every project's testRuntimeOnly classpath, so every `Test` task gets it with no per-project
+ * config.
+ *
+ * System properties: `xtdb.test.hang-watchdog.enabled` (default `true`),
+ * `xtdb.test.hang-watchdog.timeout-seconds` (default 360 — comfortably past any legitimate
+ * single test, comfortably before CI's 15-minute action timeout).
+ */
+class HangWatchdog : TestExecutionListener {
+
+    private val enabled = System.getProperty("xtdb.test.hang-watchdog.enabled", "true").toBoolean()
+    private val timeoutSeconds = System.getProperty("xtdb.test.hang-watchdog.timeout-seconds", "360").toLong()
+
+    private val tracker = HangTracker(TimeUnit.SECONDS.toNanos(timeoutSeconds))
+
+    // Gradle can execute several TestPlans in one worker JVM; install/schedule only once and let
+    // the daemon scheduler live for the JVM's lifetime rather than tracking plan finish.
+    private val active = AtomicBoolean(false)
+
+    @Volatile
+    private var probesInstalled = false
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun testPlanExecutionStarted(testPlan: TestPlan) {
+        if (!enabled || !active.compareAndSet(false, true)) return
+
+        try {
+            // creation stack traces capture a throwable per coroutine launch — far too expensive
+            // for the sim tests, and the dump's suspension stacks are what we need.
+            DebugProbes.enableCreationStackTraces = false
+            DebugProbes.install()
+            probesInstalled = true
+        } catch (e: Throwable) {
+            // e.g. a JRE without jdk.attach — degrade to thread dumps rather than failing the run
+            System.err.println("[hang-watchdog] DebugProbes unavailable ($e); will dump threads only")
+        }
+
+        Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "xtdb-test-hang-watchdog").apply { isDaemon = true }
+        }.scheduleWithFixedDelay(::scan, 30, 30, TimeUnit.SECONDS)
+    }
+
+    override fun executionStarted(id: TestIdentifier) {
+        if (enabled && id.isTest) tracker.started(id.uniqueId, id.displayName, System.nanoTime())
+    }
+
+    override fun executionFinished(id: TestIdentifier, result: TestExecutionResult) {
+        if (enabled && id.isTest) tracker.finished(id.uniqueId)
+    }
+
+    private fun scan() {
+        tracker.overdue(System.nanoTime()).forEach(::dump)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun dump(o: HangTracker.Overdue) {
+        val out: PrintStream = System.err
+        out.println("=== [hang-watchdog] '${o.displayName}' still running after ${TimeUnit.NANOSECONDS.toSeconds(o.elapsedNanos)}s (report ${o.report}) ===")
+
+        if (probesInstalled) {
+            try {
+                DebugProbes.dumpCoroutines(out)
+            } catch (e: Throwable) {
+                out.println("[hang-watchdog] coroutine dump failed: $e")
+            }
+        }
+
+        out.println("--- [hang-watchdog] thread dump ---")
+        // ThreadInfo.toString truncates stacks, so format by hand.
+        for (ti in ManagementFactory.getThreadMXBean().dumpAllThreads(true, true)) {
+            out.println(buildString {
+                append("\"${ti.threadName}\" #${ti.threadId} ${ti.threadState}")
+                ti.lockName?.let { append(" on $it") }
+                ti.lockOwnerName?.let { append(" owned by \"$it\" #${ti.lockOwnerId}") }
+            })
+            ti.stackTrace.forEach { out.println("\tat $it") }
+            out.println()
+        }
+        out.println("=== [hang-watchdog] end of dump for '${o.displayName}' ===")
+        out.flush()
+    }
+}

--- a/modules/test-watchdog/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/modules/test-watchdog/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+xtdb.test.watchdog.HangWatchdog

--- a/modules/test-watchdog/src/test/kotlin/xtdb/test/watchdog/HangTrackerTest.kt
+++ b/modules/test-watchdog/src/test/kotlin/xtdb/test/watchdog/HangTrackerTest.kt
@@ -1,0 +1,47 @@
+package xtdb.test.watchdog
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class HangTrackerTest {
+
+    private val timeout = TimeUnit.SECONDS.toNanos(360)
+    private val tracker = HangTracker(timeout)
+
+    @Test
+    fun `not overdue before the threshold`() {
+        tracker.started("t1", "test one", now = 0)
+        assertTrue(tracker.overdue(timeout - 1).isEmpty())
+    }
+
+    @Test
+    fun `reports once at the threshold, again at double, then goes quiet`() {
+        tracker.started("t1", "test one", now = 0)
+
+        val first = tracker.overdue(timeout)
+        assertEquals(listOf("test one" to 1), first.map { it.displayName to it.report })
+
+        assertTrue(tracker.overdue(timeout + 1).isEmpty(), "no re-report before the next threshold")
+
+        val second = tracker.overdue(timeout * 2)
+        assertEquals(listOf("test one" to 2), second.map { it.displayName to it.report })
+
+        assertTrue(tracker.overdue(timeout * 10).isEmpty(), "capped at two reports")
+    }
+
+    @Test
+    fun `finished tests are never reported`() {
+        tracker.started("t1", "test one", now = 0)
+        tracker.finished("t1")
+        assertTrue(tracker.overdue(timeout * 2).isEmpty())
+    }
+
+    @Test
+    fun `only the overdue test among several is reported`() {
+        tracker.started("t1", "slow", now = 0)
+        tracker.started("t2", "fresh", now = timeout)
+        assertEquals(listOf("slow"), tracker.overdue(timeout).map { it.displayName })
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,9 @@ project(":modules:google-cloud").name = "xtdb-google-cloud"
 include("modules:bench", "modules:datasets")
 project(":modules:datasets").name = "xtdb-datasets"
 
+// test infra, not published
+include("modules:test-watchdog")
+
 include("monitoring")
 if (file("monitoring/docker-image").isDirectory) {
     include("monitoring:docker-image")


### PR DESCRIPTION
Part of #5711. The close-path hangs die silently: the test stops logging, the CI action times out 15 minutes later, and the log names neither the test nor the stuck coroutine. Six occurrences have each cost an investigation, and the in-memory shape remains unattributed — so the diagnostic lands ahead of further speculative fixes.

A JUnit Platform `TestExecutionListener` (new `modules/test-watchdog`, ServiceLoader-registered, on every `Test` task's runtime classpath via the root's shared test config) tracks in-flight tests. When one passes the threshold — default 6 minutes: above any legitimate single test, below the action timeout — it prints kotlinx `DebugProbes.dumpCoroutines()` plus a full thread dump to stderr, which Gradle captures into the test-results XML. It reports at the threshold and again at 2×, so movement between the dumps distinguishes stuck from slow, then goes quiet.

Design notes: dump-only — it never fails or interrupts a test, so a slow-but-progressing test costs log noise, not a failure. Coroutine creation stack traces are disabled (a throwable per launch is far too hot for the sims). `jdk.attach` joins the jlink module list — DebugProbes installs by dynamic self-attach, which the custom test JRE otherwise lacks; if install fails anyway, the watchdog degrades to thread dumps rather than failing the run. The module is deliberately not `java-library`, since the root's shared test-config block assumes clojurephant.

Test plan: unit tests for the threshold/reporting logic (fake clock); end-to-end verification with a deliberately hanging scratch test (since deleted) — reports fired at threshold and 2×, the sleeping coroutine appeared in the dump as `BlockingCoroutine{Active}`; `:xtdb-api:test` green on the rebuilt custom JRE with probes installing cleanly and zero watchdog noise on a healthy run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)