### PR TITLE
feat(postgres-source): pluggable indexer SPI with !DirectMirror default

### DIFF
--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/DirectMirror.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/DirectMirror.kt
@@ -1,0 +1,104 @@
+package xtdb.postgres
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import xtdb.error.Incorrect
+import xtdb.indexer.OpenTx
+import xtdb.postgres.proto.DirectMirrorConfig
+import xtdb.postgres.proto.directMirrorConfig
+import xtdb.table.TableRef
+import xtdb.time.InstantUtil.asMicros
+import xtdb.util.asIid
+import java.nio.ByteBuffer
+import java.time.ZonedDateTime
+import com.google.protobuf.Any as ProtoAny
+
+private const val PROTO_TAG_PREFIX = "proto.xtdb.com"
+
+/**
+ * The default [PgIndexer]: mirrors the upstream into XT as-is. A row from `public.users` lands in
+ * the `users` table; `_id` is taken from the row, with explicit `_valid_from`/`_valid_to` columns
+ * honoured when present.
+ */
+class DirectMirror(private val dbName: String) : PgIndexer {
+    private fun explicitValidTimeMicros(name: String, value: Any?): Long? = when (value) {
+        null -> null
+        is ZonedDateTime -> value.toInstant().asMicros
+        else -> throw Incorrect(
+            "'$name' must be a TIMESTAMPTZ column",
+            errorCode = "xtdb.postgres/invalid-explicit-valid-time",
+            data = mapOf("column" to name, "type" to (value::class.qualifiedName ?: value::class.simpleName)),
+        )
+    }
+
+    private fun writeOp(openTx: OpenTx, dbName: String, op: RowOp) {
+        val openTxTable = openTx.table(TableRef(dbName, op.schema, op.table))
+
+        when (op) {
+            is RowOp.Put -> {
+                val docMap = op.row.toMutableMap()
+
+                val id = docMap["_id"]
+                ?: throw Incorrect("Missing '_id' in row from ${op.schema}.${op.table}")
+
+                val explicitValidFrom = explicitValidTimeMicros("_valid_from", docMap.remove("_valid_from"))
+                val explicitValidTo = explicitValidTimeMicros("_valid_to", docMap.remove("_valid_to"))
+
+                if (explicitValidTo != null && explicitValidFrom == null)
+                throw Incorrect("'_valid_to' requires '_valid_from'")
+
+                openTxTable.logPut(
+                    ByteBuffer.wrap(id.asIid),
+                    explicitValidFrom ?: openTx.systemFrom,
+                    explicitValidTo ?: Long.MAX_VALUE,
+                ) { openTxTable.docWriter.writeObject(docMap) }
+            }
+
+            is RowOp.Delete -> {
+                val id = op.row["_id"]
+                ?: throw Incorrect("Missing '_id' in delete on ${op.schema}.${op.table}")
+
+                openTxTable.logDelete(
+                    ByteBuffer.wrap(id.asIid),
+                    openTx.systemFrom,
+                    Long.MAX_VALUE,
+                )
+            }
+        }
+    }
+
+    override fun indexTx(tx: PostgresDriver.Transaction, openTx: OpenTx) {
+        for (op in tx.ops) writeOp(openTx, dbName, op)
+    }
+
+    @Serializable
+    @SerialName("!DirectMirror")
+    class Factory : PgIndexer.Factory {
+
+        override fun open(dbName: String): PgIndexer = DirectMirror(dbName)
+
+        override fun equals(other: Any?) = other is Factory
+        override fun hashCode() = javaClass.hashCode()
+
+        class Registration : PgIndexer.Registration<Factory> {
+            override val protoTag: String
+                get() = "$PROTO_TAG_PREFIX/xtdb.postgres.proto.DirectMirrorConfig"
+
+            override val factoryClass get() = Factory::class.java
+
+            override fun toProto(factory: Factory): ProtoAny =
+                ProtoAny.pack(directMirrorConfig { }, PROTO_TAG_PREFIX)
+
+            override fun fromProto(msg: ProtoAny): PgIndexer.Factory {
+                msg.unpack(DirectMirrorConfig::class.java)
+                return Factory()
+            }
+
+            override fun registerSerde(builder: PolymorphicModuleBuilder<PgIndexer.Factory>) {
+                builder.subclass(Factory::class)
+            }
+        }
+    }
+}

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgIndexer.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgIndexer.kt
@@ -1,0 +1,77 @@
+package xtdb.postgres
+
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import xtdb.error.Unsupported
+import xtdb.indexer.OpenTx
+import java.util.ServiceLoader
+import com.google.protobuf.Any as ProtoAny
+
+/**
+ * Writes a source [PostgresDriver.Transaction] into XT via the supplied [OpenTx].
+ *
+ * The source owns the token, system-time and failure model — the indexer runs *inside* a
+ * token-managed [OpenTx] and just decides what to write. Snapshot and streaming both arrive as a
+ * [PostgresDriver.Transaction]; the snapshot path synthesises one per batch so there is a single
+ * entry point.
+ *
+ * Each op carries its source `schema`/`table` ([RowOp]), so an indexer can re-route tables, derive
+ * `_id`, drop or mask columns, or filter ops entirely. The reference [DirectMirror] mirrors the
+ * upstream as-is and has no privileged access — it uses the same [OpenTx] surface as any indexer.
+ */
+interface PgIndexer : AutoCloseable {
+
+    fun indexTx(tx: PostgresDriver.Transaction, openTx: OpenTx)
+
+    override fun close() = Unit
+
+    interface Factory {
+        fun open(dbName: String): PgIndexer
+
+        companion object {
+            private val registrations = ServiceLoader.load(Registration::class.java).toList()
+            private val registrationsByTag = registrations.associateBy { it.protoTag }
+            private val registrationsByClass = registrations.associateBy { it.factoryClass }
+
+            val serializersModule = SerializersModule {
+                for (reg in registrations)
+                    include(reg.serializersModule)
+
+                polymorphic(Factory::class) {
+                    for (reg in registrations)
+                        reg.registerSerde(this)
+                }
+            }
+
+            fun fromProto(any: ProtoAny): Factory {
+                val reg = registrationsByTag[any.typeUrl]
+                    ?: error("unknown pg indexer: ${any.typeUrl}")
+                return reg.fromProto(any)
+            }
+
+            // A factory is persistable iff a Registration claims its class. A programmatically-supplied
+            // indexer with no Registration is a legal Factory, but can't travel as a serialised secondary.
+            @Suppress("UNCHECKED_CAST")
+            fun toProto(factory: Factory): ProtoAny {
+                val reg = registrationsByClass[factory.javaClass] as Registration<Factory>?
+                    ?: throw Unsupported(
+                        "pg indexer ${factory.javaClass.name} can't be persisted as a secondary database — " +
+                            "it has no Registration",
+                        "xtdb.postgres/indexer-not-serializable",
+                        mapOf("indexer" to factory.javaClass.name),
+                    )
+                return reg.toProto(factory)
+            }
+        }
+    }
+
+    interface Registration<F : Factory> {
+        val protoTag: String
+        val factoryClass: Class<F>
+        fun toProto(factory: F): ProtoAny
+        fun fromProto(msg: ProtoAny): Factory
+        fun registerSerde(builder: PolymorphicModuleBuilder<Factory>)
+        val serializersModule: SerializersModule get() = SerializersModule {}
+    }
+}

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.subclass
 import org.postgresql.replication.LogSequenceNumber
 import org.postgresql.util.PSQLException
@@ -16,7 +17,6 @@ import xtdb.indexer.TxIndexer
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
 import xtdb.database.ExternalSource
-import xtdb.indexer.OpenTx
 import xtdb.indexer.TxIndexer.TxResult
 import xtdb.database.ExternalSourceToken
 import xtdb.error.Fault
@@ -25,12 +25,8 @@ import xtdb.postgres.proto.PostgresSourceConfig
 import xtdb.postgres.proto.PostgresSourceToken
 import xtdb.postgres.proto.postgresSourceConfig
 import xtdb.postgres.proto.postgresSourceToken
-import xtdb.table.TableRef
-import xtdb.time.InstantUtil.asMicros
 import xtdb.util.*
-import java.nio.ByteBuffer
 import java.time.Instant
-import java.time.ZonedDateTime
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import com.google.protobuf.Any as ProtoAny
@@ -43,6 +39,7 @@ class PostgresSource(
     private val dbName: String,
     private val driver: PostgresDriver,
     private val slotName: String,
+    private val indexer: PgIndexer,
     meterRegistry: MeterRegistry? = null,
 ) : ExternalSource {
 
@@ -121,6 +118,7 @@ class PostgresSource(
         val remote: RemoteAlias,
         val slotName: String,
         val publicationName: String,
+        val indexer: PgIndexer.Factory = DirectMirror.Factory(),
     ) : ExternalSource.Factory {
 
         override fun open(
@@ -149,7 +147,7 @@ class PostgresSource(
                 slotName, publicationName,
             )
 
-            return PostgresSource(dbName, driver, slotName, meterRegistry)
+            return PostgresSource(dbName, driver, slotName, indexer.open(dbName), meterRegistry)
         }
 
         class Registration : ExternalSource.Registration<Factory> {
@@ -162,6 +160,7 @@ class PostgresSource(
                     remote = factory.remote
                     slotName = factory.slotName
                     publicationName = factory.publicationName
+                    indexer = PgIndexer.Factory.toProto(factory.indexer)
                 }, PROTO_TAG_PREFIX)
 
             override fun fromProto(msg: ProtoAny): Factory {
@@ -170,12 +169,17 @@ class PostgresSource(
                     remote = config.remote,
                     slotName = config.slotName,
                     publicationName = config.publicationName,
+                    // absent on configs persisted before pluggable indexers landed
+                    indexer = if (config.hasIndexer()) PgIndexer.Factory.fromProto(config.indexer)
+                              else DirectMirror.Factory(),
                 )
             }
 
             override fun registerSerde(builder: PolymorphicModuleBuilder<ExternalSource.Factory>) {
                 builder.subclass(Factory::class)
             }
+
+            override val serializersModule: SerializersModule = PgIndexer.Factory.serializersModule
         }
     }
 
@@ -258,9 +262,9 @@ class PostgresSource(
                     }.toByteArray()
 
                     txIndexer.indexTx(token) { openTx ->
-                        for (op in batch) {
-                            writeOp(openTx, dbName, op)
-                        }
+                        // snapshot has no upstream commit time — use the tx's system-time
+                        val snapshotTx = PostgresDriver.Transaction(snapshot.slotLsn, openTx.txKey.systemTime, batch)
+                        indexer.indexTx(snapshotTx, openTx)
                         TxResult.Committed()
                     }
                 }
@@ -292,9 +296,7 @@ class PostgresSource(
                         }.toByteArray()
 
                         txIndexer.indexTx(token, systemTime = tx.commitTime) { openTx ->
-                            for (op in tx.ops) {
-                                writeOp(openTx, dbName, op)
-                            }
+                            indexer.indexTx(tx, openTx)
                             TxResult.Committed()
                         }
 
@@ -315,56 +317,7 @@ class PostgresSource(
 
     override fun close() {
         LOG.info("[$dbName] Closing external source")
+        runCatching { indexer.close() }
         driver.close()
-    }
-}
-
-private fun explicitValidTimeMicros(name: String, value: Any?): Long? = when (value) {
-    null -> null
-    is ZonedDateTime -> value.toInstant().asMicros
-    else -> throw Incorrect(
-        "'$name' must be a TIMESTAMPTZ column",
-        errorCode = "xtdb.postgres/invalid-explicit-valid-time",
-        data = mapOf("column" to name, "type" to (value::class.qualifiedName ?: value::class.simpleName)),
-    )
-}
-
-private fun writeOp(
-    openTx: OpenTx,
-    dbName: String,
-    op: RowOp,
-) {
-    val openTxTable = openTx.table(TableRef(dbName, op.schema, op.table))
-
-    when (op) {
-        is RowOp.Put -> {
-            val docMap = op.row.toMutableMap()
-
-            val id = docMap["_id"]
-                ?: throw Incorrect("Missing '_id' in row from ${op.schema}.${op.table}")
-
-            val explicitValidFrom = explicitValidTimeMicros("_valid_from", docMap.remove("_valid_from"))
-            val explicitValidTo = explicitValidTimeMicros("_valid_to", docMap.remove("_valid_to"))
-
-            if (explicitValidTo != null && explicitValidFrom == null)
-                throw Incorrect("'_valid_to' requires '_valid_from'")
-
-            openTxTable.logPut(
-                ByteBuffer.wrap(id.asIid),
-                explicitValidFrom ?: openTx.systemFrom,
-                explicitValidTo ?: Long.MAX_VALUE,
-            ) { openTxTable.docWriter.writeObject(docMap) }
-        }
-
-        is RowOp.Delete -> {
-            val id = op.row["_id"]
-                ?: throw Incorrect("Missing '_id' in delete on ${op.schema}.${op.table}")
-
-            openTxTable.logDelete(
-                ByteBuffer.wrap(id.asIid),
-                openTx.systemFrom,
-                Long.MAX_VALUE,
-            )
-        }
     }
 }

--- a/modules/postgres-source/src/main/proto/postgres_source.proto
+++ b/modules/postgres-source/src/main/proto/postgres_source.proto
@@ -2,12 +2,22 @@ edition = "2023";
 
 package xtdb.postgres.proto;
 
+import "google/protobuf/any.proto";
+
 option java_multiple_files = true;
 
 message PostgresSourceConfig {
     string remote = 1;
     string slot_name = 2;
     string publication_name = 3;
+
+    // Carried as Any so the proto stays decoupled from specific indexer config shapes —
+    // mirrors KafkaConnectSourceConfig.indexer and DatabaseConfig.external_source.
+    // Absent on configs persisted before pluggable indexers landed — decoded as !DirectMirror.
+    google.protobuf.Any indexer = 4;
+}
+
+message DirectMirrorConfig {
 }
 
 message PostgresSourceToken {

--- a/modules/postgres-source/src/main/resources/META-INF/services/xtdb.postgres.PgIndexer$Registration
+++ b/modules/postgres-source/src/main/resources/META-INF/services/xtdb.postgres.PgIndexer$Registration
@@ -1,0 +1,1 @@
+xtdb.postgres.DirectMirror$Factory$Registration

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
@@ -29,6 +29,27 @@ class PostgresSourceFactoryTest {
     }
 
     @Test
+    fun `indexer defaults to DirectMirror`() {
+        val factory = PostgresSource.Factory(remote = "pg", slotName = "s", publicationName = "p")
+        assertTrue(factory.indexer is DirectMirror.Factory)
+
+        assertTrue(protoRoundTrip(factory).indexer is DirectMirror.Factory, "survives proto round-trip")
+    }
+
+    @Test
+    fun `config persisted before pluggable indexers decodes to DirectMirror`() {
+        // an older PostgresSourceConfig carries no `indexer` field; the absent Any must decode as the default
+        val legacy = xtdb.postgres.proto.postgresSourceConfig {
+            remote = "pg"; slotName = "s"; publicationName = "p"
+        }
+        val any = com.google.protobuf.Any.pack(legacy, "proto.xtdb.com")
+
+        val factory = PostgresSource.Factory.Registration().fromProto(any)
+
+        assertTrue(factory.indexer is DirectMirror.Factory)
+    }
+
+    @Test
     fun `YAML round-trips factory as external source`() {
         val yaml = """
             externalSource: !Postgres

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIndexerTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIndexerTest.kt
@@ -1,0 +1,89 @@
+package xtdb.postgres
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import xtdb.api.Xtdb
+import java.nio.file.Files
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end proof of the pluggable-indexer seam: a genuinely-registered, test-only [PgIndexer]
+ * ([TestRerouteIndexer], `!TestReroute`) selected through ATTACH YAML re-routes rows to a different
+ * table and drops a column on the way through. Exercises the whole new pathway — YAML deserialize,
+ * proto persist/restore, `open`, and `indexTx(tx, openTx)` — against a real Postgres source.
+ */
+@Tag("integration")
+class PostgresSourceIndexerTest : PostgresSourceTestBase() {
+
+    private fun attachCdcWithReroute(
+        node: Xtdb,
+        cdcLog: java.nio.file.Path,
+        cdcStorage: java.nio.file.Path,
+        slot: String,
+        pub: String,
+        target: String,
+        dropColumn: String,
+    ) {
+        node.createConnectionBuilder().build().use { c ->
+            c.createStatement().use { s ->
+                s.execute(
+                    """
+                    ATTACH DATABASE cdc WITH $$
+                        storage: !Local
+                          path: $cdcStorage
+                        log: !Local
+                          path: $cdcLog
+                        externalSource: !Postgres
+                          remote: pg
+                          slotName: $slot
+                          publicationName: $pub
+                          indexer: !TestReroute
+                            target: $target
+                            dropColumn: $dropColumn
+                    $$""".trimIndent()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `custom indexer reroutes table and drops column`() = runTest(timeout = 120.seconds) {
+        val slot = unique("reroute_slot")
+        val pub = unique("reroute_pub")
+        val tmp = Files.createTempDirectory("pg-reroute")
+
+        pgExecute(
+            "CREATE TABLE widgets (_id int PRIMARY KEY, name text, secret text)",
+            "CREATE PUBLICATION $pub FOR TABLE widgets",
+        )
+
+        val node = openNode(tmp.resolve("log"), tmp.resolve("storage"))
+        try {
+            attachCdcWithReroute(
+                node, tmp.resolve("cdc-log"), tmp.resolve("cdc-storage"),
+                slot, pub, target = "gadgets", dropColumn = "secret",
+            )
+            awaitStreaming(node)
+
+            commitTx("INSERT INTO widgets (_id, name, secret) VALUES (?, ?, ?)") { ps ->
+                ps.setInt(1, 1); ps.setString(2, "anvil"); ps.setString(3, "classified")
+            }
+
+            // the row lands in the rerouted `gadgets` table (proving reroute), with `secret` absent
+            // from the projection (proving the drop) — `name` survives
+            val gadgets = await(
+                done = { rows: List<Map<String, Any?>> -> rows.isNotEmpty() },
+            ) { xtQuery(node, "SELECT * FROM gadgets") }
+
+            assertEquals(1, gadgets.size)
+            assertEquals("anvil", gadgets[0]["name"])
+            assertFalse(gadgets[0].containsKey("secret"), "dropped column must not appear")
+        } finally {
+            node.close()
+            dropSlot(slot)
+        }
+    }
+}

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/TestRerouteIndexer.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/TestRerouteIndexer.kt
@@ -1,0 +1,74 @@
+package xtdb.postgres
+
+import com.google.protobuf.Struct
+import com.google.protobuf.Value
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import kotlinx.serialization.modules.subclass
+import xtdb.indexer.OpenTx
+import com.google.protobuf.Any as ProtoAny
+
+/**
+ * A genuinely-registered, test-only [PgIndexer] proving the SPI seam end-to-end: a third-party
+ * indexer that re-routes every op to a fixed `target` table and drops `dropColumn` on the way
+ * through. Registered via `META-INF/services` in the test source set and selected through
+ * `indexer: !TestReroute` in ATTACH YAML.
+ *
+ * Its proto carrier is a [Struct] (a well-known type) rather than a generated message — no module
+ * generates protobuf from a test source set, and a unique `typeUrl` plus the two string params is
+ * all the registry round-trip needs.
+ */
+class TestRerouteIndexer(
+    private val dbName: String,
+    private val target: String,
+    private val dropColumn: String,
+) : PgIndexer {
+
+    override fun indexTx(tx: PostgresDriver.Transaction, openTx: OpenTx) {
+        val rerouted = tx.ops.map { op ->
+            when (op) {
+                is RowOp.Put -> RowOp.Put("public", target, op.row - dropColumn)
+                is RowOp.Delete -> RowOp.Delete("public", target, op.row)
+            }
+        }
+        DirectMirror(dbName).indexTx(PostgresDriver.Transaction(tx.lsn, tx.commitTime, rerouted), openTx)
+    }
+
+    @Serializable
+    @SerialName("!TestReroute")
+    data class Factory(val target: String, val dropColumn: String) : PgIndexer.Factory {
+
+        override fun open(dbName: String): PgIndexer = TestRerouteIndexer(dbName, target, dropColumn)
+
+        class Registration : PgIndexer.Registration<Factory> {
+            override val protoTag: String get() = "$PROTO_TAG_PREFIX/google.protobuf.Struct"
+
+            override val factoryClass get() = Factory::class.java
+
+            override fun toProto(factory: Factory): ProtoAny = ProtoAny.pack(
+                Struct.newBuilder()
+                    .putFields("target", Value.newBuilder().setStringValue(factory.target).build())
+                    .putFields("dropColumn", Value.newBuilder().setStringValue(factory.dropColumn).build())
+                    .build(),
+                PROTO_TAG_PREFIX,
+            )
+
+            override fun fromProto(msg: ProtoAny): PgIndexer.Factory {
+                val struct = msg.unpack(Struct::class.java)
+                return Factory(
+                    target = struct.getFieldsOrThrow("target").stringValue,
+                    dropColumn = struct.getFieldsOrThrow("dropColumn").stringValue,
+                )
+            }
+
+            override fun registerSerde(builder: PolymorphicModuleBuilder<PgIndexer.Factory>) {
+                builder.subclass(Factory::class)
+            }
+        }
+
+        companion object {
+            private const val PROTO_TAG_PREFIX = "proto.xtdb.com"
+        }
+    }
+}

--- a/modules/postgres-source/src/test/resources/META-INF/services/xtdb.postgres.PgIndexer$Registration
+++ b/modules/postgres-source/src/test/resources/META-INF/services/xtdb.postgres.PgIndexer$Registration
@@ -1,0 +1,1 @@
+xtdb.postgres.TestRerouteIndexer$Factory$Registration


### PR DESCRIPTION
This is a standalone change with no surrounding issue, so the context lives here rather than in a linked issue.

## Summary

Gives the Postgres CDC source a pluggable indexer, so a user can reshape rows on the way into XT — drop or mask columns, derive `_id`, re-route tables, filter ops — instead of getting a fixed passthrough. The default behaviour is unchanged.

## Motivation

The Kafka Connect source lets a user change records on the way through, via a pluggable `RecordIndexer` SPI with `!Docs` as the reference indexer. The Postgres source had no equivalent — it looped a private `writeOp` over each transaction's ops straight into XT, with no seam to intervene.

The two sources don't share a transform vocabulary. Kafka Connect's off-the-shelf SMTs operate on `SinkRecord` and can't touch a Postgres `RowOp`, which carries its source schema/table natively. So rather than port that vocabulary, this pitches the seam lower: hand the user the whole source transaction *and* the `OpenTx`, and let them do the writing. The contract is one method — `indexTx(tx, openTx)` — with the full `OpenTx` write surface (`logPut`/`logDelete`, `executeSql`, `openQuery` read-your-writes, `patchDocs`) available exactly as the default uses it.

## Current vs future state

Today: `PostgresSource` holds a fixed loop — `for (op in tx.ops) writeOp(openTx, dbName, op)` — in both the snapshot and streaming paths, with `writeOp` private to the file.

After: `PostgresSource` holds a `PgIndexer`, built from a `PgIndexer.Factory` on the `!Postgres` config (defaulting to `!DirectMirror`). Both paths call `indexer.indexTx(tx, openTx)`. The relocated `writeOp` is now private to `!DirectMirror`, an ordinary `PgIndexer` with no privileged access. A third party authors a new indexer the same way `RecordIndexer` implementors do: a `@SerialName` `Factory`, a proto config, and a `META-INF/services` registration.

## Decision rationale

- **Whole-transaction granularity, not per-op.** The unit is a `PostgresDriver.Transaction`, so an indexer can reorder, merge, split or drop across a tx and derive cross-row state. Per-op was rejected as too weak.
- **The source keeps owning the token, system-time and failure model** — a deliberately narrower SPI than Kafka Connect's, where the indexer owns the whole `TxIndexer.indexTx` call. Token construction, the halt-on-failure model and the snapshot framing are Postgres-source concerns; the user's indexer runs *inside* a token-managed `OpenTx`.
- **The default is a named, registered indexer (`!DirectMirror`)**, not an unnamed passthrough — keeping the Postgres source uniform with Kafka Connect's `!Docs` and making the default visible in config. Debezium's precedent (the table-preserving default is unnamed; only the override is named) was considered and set aside in favour of SPI uniformity.
- **`writeOp` is intentionally not a public helper.** A custom indexer that wants 'mostly mirror, tweak one thing' reimplements the loop rather than delegating, which keeps third-party indexers off `writeOp`'s signature. The helpers can be promoted to the public API later, deliberately, if the duplication bites.

## Snapshot/streaming unification (behaviour-preserving)

Streaming yields a real `Transaction(lsn, commitTime, ops)`; snapshot yields batches of `Put` rows with no transaction. The snapshot path now synthesises a `Transaction` per batch so the indexer sees a single entry point. The synthesised `commitTime` comes from the tx's own system-time, and `!DirectMirror` ignores `commitTime` entirely (it writes from `openTx.systemFrom`, as the old code did) — so the snapshot result is unchanged. The relocation of `writeOp` into `!DirectMirror` is likewise behaviour-preserving.

## Compatibility

`PostgresSourceConfig` gains an `Any indexer` field, mirroring `KafkaConnectSourceConfig.indexer` and `DatabaseConfig.external_source`. Configs persisted before this landed carry no field; the absent `Any` decodes as `!DirectMirror`, so existing attached sources keep working untouched. No migration or operator action is required.

## Usage

A custom indexer is selected per-database in the `ATTACH` config:

```yaml
externalSource: !Postgres
  remote: pg
  slotName: my_slot
  publicationName: my_pub
  indexer: !MyIndexer       # omit for the default, !DirectMirror
    someParam: ...
```

Authoring one mirrors the Kafka Connect `RecordIndexer` path: implement `PgIndexer` + a `@SerialName`-tagged `PgIndexer.Factory` with a proto config, and register the `Factory.Registration` via `META-INF/services/xtdb.postgres.PgIndexer$Registration`.

## Test plan

- New unit tests (`PostgresSourceFactoryTest`): the indexer defaults to `!DirectMirror` and survives a proto round-trip; a config persisted without the field decodes to `!DirectMirror`.
- New integration test (`PostgresSourceIndexerTest`): a genuinely-registered, test-only `!TestReroute` indexer, selected through `ATTACH` YAML, re-routes rows to a different table and drops a column — exercising YAML deserialize → proto persist/restore → `open` → `indexTx` against a real Postgres container.
- The existing integration/property suites exercise the default path (now `!DirectMirror`) unchanged.
- Module compiles clean (no reflection or boxed-math warnings); `:modules:xtdb-postgres-source` unit + the new integration test green.

## Note for the reviewer

`DirectMirror.Factory` carries a hand-written `equals`/`hashCode` rather than being a `data class` like `DocsIndexer.Factory` — it's field-less, and Kotlin forbids a zero-arg data class.