### PR TITLE
feat(ingest): ingest-only node for embedded external sources

### DIFF
--- a/core/src/main/kotlin/xtdb/api/IngestNode.kt
+++ b/core/src/main/kotlin/xtdb/api/IngestNode.kt
@@ -1,0 +1,125 @@
+package xtdb.api
+
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.NodeBase
+import xtdb.cache.DiskCache
+import xtdb.cache.MemoryCache
+import xtdb.database.Database
+import xtdb.database.DatabaseName
+import xtdb.error.Incorrect
+import xtdb.util.closeAll
+import xtdb.util.closeOnCatch
+import xtdb.util.safeMapValues
+import java.util.UUID.randomUUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A node that does nothing but ingest from external sources — it runs a [Database] per configured
+ * external source, joins leader election, and runs the source only on the database for which it's
+ * elected leader. There's no query/client surface: no pgwire, no Flight SQL, no healthz.
+ *
+ * Intended for embedding in a custom JVM application that supplies its own indexer programmatically.
+ * Because the configuration lives in code and is handed in fresh on every boot, an external source's
+ * indexer factory needn't be serialisable — it never travels as persisted secondary-database config.
+ */
+class IngestNode internal constructor(
+    private val base: NodeBase,
+    private val databases: Map<DatabaseName, Database>,
+) : AutoCloseable {
+    private val closing = AtomicBoolean(false)
+
+    override fun close() {
+        if (closing.compareAndSet(false, true)) {
+            // close the databases (each owns its own LogProcessor / external source) before the base,
+            // which owns the allocator they're children of.
+            databases.closeAll()
+            base.close()
+        }
+    }
+
+    class Config {
+        var allocator: BufferAllocator? = null
+
+        var logClusters: Map<RemoteAlias, Remote.Factory<*>> = emptyMap()
+        var remotes: Map<RemoteAlias, Remote.Factory<*>> = emptyMap()
+
+        /**
+         * The databases to ingest into, keyed by name. Each carries an `externalSource` whose indexer
+         * may be a programmatically-supplied, non-serialisable factory.
+         */
+        var databases: Map<DatabaseName, Database.Config> = emptyMap()
+
+        val memoryCache: MemoryCache.Factory = MemoryCache.Factory()
+        var diskCache: DiskCache.Factory? = null
+
+        val indexer: IndexerConfig = IndexerConfig()
+
+        var nodeId: String = System.getenv("XTDB_NODE_ID") ?: randomUUID().toString().takeWhile { it != '-' }
+
+        fun logClusters(clusters: Map<RemoteAlias, Remote.Factory<*>>) = apply { logClusters += clusters }
+        fun logCluster(alias: RemoteAlias, cluster: Remote.Factory<*>) = apply { logClusters += alias to cluster }
+
+        fun remotes(remotes: Map<RemoteAlias, Remote.Factory<*>>) = apply { this.remotes += remotes }
+        fun remote(alias: RemoteAlias, remote: Remote.Factory<*>) = apply { this.remotes += alias to remote }
+
+        fun databases(databases: Map<DatabaseName, Database.Config>) = apply { this.databases += databases }
+        fun database(name: DatabaseName, config: Database.Config) = apply { this.databases += name to config }
+
+        fun diskCache(diskCache: DiskCache.Factory?) = apply { this.diskCache = diskCache }
+
+        @JvmSynthetic
+        fun indexer(configure: IndexerConfig.() -> Unit) = apply { indexer.configure() }
+
+        fun nodeId(nodeId: String) = apply { this.nodeId = nodeId }
+
+        /**
+         * The base components ([NodeBase]) are assembled from an [Xtdb.Config] with no client surface
+         * (`server`, `flightSql`, `healthz` all null). The ingest databases aren't expressed here —
+         * [open] attaches them directly, bypassing the [xtdb.database.DatabaseCatalog] and its "xtdb"
+         * primary entirely.
+         */
+        private fun toBaseConfig(): Xtdb.Config =
+            Xtdb.Config(
+                server = null,
+                flightSql = null,
+                healthz = null,
+                logClusters = logClusters,
+                remotes = remotes,
+                memoryCache = memoryCache,
+                diskCache = diskCache,
+                indexer = indexer,
+                nodeId = nodeId,
+            ).also { it.allocator = allocator }
+
+        fun open(): IngestNode {
+            // "xtdb" is the primary database name; an ingest node has no primary, and opening a db so
+            // named with dbCatalog=null trips a LeaderLogProcessor invariant only once it's elected
+            // leader. Reject it up front rather than letting it surface as an async assertion failure.
+            if ("xtdb" in databases)
+                throw Incorrect(
+                    "'xtdb' is reserved for the primary database and can't be used as an ingest-node database name",
+                    errorCode = "xtdb.ingest-node/reserved-db-name",
+                    data = mapOf("db-name" to "xtdb"),
+                )
+
+            // Open each external-source database directly with no catalog (dbCatalog=null): an ext-src
+            // db never calls back into a catalog, so the ingest node needs neither the DatabaseCatalog
+            // nor its "xtdb" primary. Each db joins leader election and runs its source only when leader.
+            return NodeBase.openBase(toBaseConfig()).closeOnCatch { base ->
+                val dbs = databases.safeMapValues { dbName, dbConfig ->
+                    Database.open(base, dbName, dbConfig, base.compactor)
+                }
+                IngestNode(base, dbs)
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @JvmOverloads
+        fun openIngestNode(config: Config = Config()) = config.open()
+
+        @JvmSynthetic
+        fun openIngestNode(configure: Config.() -> Unit) = openIngestNode(Config().also(configure))
+    }
+}

--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -90,6 +90,15 @@ inline fun <C, L : Iterable<C>, R : AutoCloseable?> L.safeMapIndexed(block: (Int
         els
     }
 
+inline fun <K, V, R : AutoCloseable?> Map<K, V>.safeMapValues(block: (K, V) -> R): Map<K, R> =
+    LinkedHashMap<K, R>().closeAllOnCatch { acc ->
+        for ((k, v) in this) {
+            acc[k] = block(k, v)
+        }
+
+        acc
+    }
+
 class SafelyOpeningScope : AutoCloseable {
     val openedResources = mutableListOf<AutoCloseable>()
 

--- a/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
@@ -1,0 +1,105 @@
+package xtdb.api
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import xtdb.error.Incorrect
+import xtdb.api.log.Log
+import xtdb.api.storage.Storage
+import xtdb.database.Database
+import xtdb.database.ExternalSource
+import xtdb.database.ExternalSourceToken
+import xtdb.indexer.TxIndexer
+import xtdb.indexer.TxIndexer.TxResult
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import io.micrometer.core.instrument.MeterRegistry
+
+/**
+ * An [ExternalSource.Factory] with no [ExternalSource.Registration] — i.e. exactly what a user
+ * embedding XTDB supplies programmatically. It can't be serialised, and the ingest node never asks
+ * it to be: there's no catalog and no "xtdb" primary to persist it as a secondary.
+ *
+ * On leadership it indexes [rowsToIndex] one tx each, counting down [indexed] as it goes.
+ */
+private class CountingExternalSource(
+    private val rowsToIndex: Int,
+    val indexed: CountDownLatch,
+    val leaderFor: ConcurrentLinkedQueue<String>,
+    private val dbName: String,
+) : ExternalSource {
+
+    class Factory(
+        private val rows: Int,
+        val indexed: CountDownLatch,
+        val leaderFor: ConcurrentLinkedQueue<String>,
+    ) : ExternalSource.Factory {
+        override fun open(dbName: String, remotes: Map<RemoteAlias, Remote>, meterRegistry: MeterRegistry?) =
+            CountingExternalSource(rows, indexed, leaderFor, dbName)
+    }
+
+    override suspend fun onPartitionAssigned(partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer) {
+        leaderFor.add(dbName)
+        repeat(rowsToIndex) {
+            txIndexer.indexTx(externalSourceToken = null) { TxResult.Committed() }
+            indexed.countDown()
+        }
+    }
+
+    override fun close() = Unit
+}
+
+class IngestNodeTest {
+
+    private fun extDbConfig(source: ExternalSource.Factory) =
+        Database.Config(
+            log = Log.inMemoryLog,
+            storage = Storage.inMemory(),
+            externalSource = source,
+        )
+
+    @Test
+    fun `opens, runs the source on leadership, and closes cleanly — no catalog, no primary`() {
+        val indexed = CountDownLatch(2)
+        val leaderFor = ConcurrentLinkedQueue<String>()
+        val source = CountingExternalSource.Factory(rows = 2, indexed = indexed, leaderFor = leaderFor)
+
+        IngestNode.Config()
+            .database("orders", extDbConfig(source))
+            .open()
+            .use {
+                assertTrue(
+                    indexed.await(30, TimeUnit.SECONDS),
+                    "the programmatic source should be elected leader and index its rows",
+                )
+                assertEquals(listOf("orders"), leaderFor.toList())
+            }
+    }
+
+    @Test
+    fun `runs an independent source per database`() {
+        val ordersIndexed = CountDownLatch(1)
+        val paymentsIndexed = CountDownLatch(1)
+        val leaderFor = ConcurrentLinkedQueue<String>()
+
+        IngestNode.Config()
+            .database("orders", extDbConfig(CountingExternalSource.Factory(1, ordersIndexed, leaderFor)))
+            .database("payments", extDbConfig(CountingExternalSource.Factory(1, paymentsIndexed, leaderFor)))
+            .open()
+            .use {
+                assertTrue(ordersIndexed.await(30, TimeUnit.SECONDS), "orders source ran")
+                assertTrue(paymentsIndexed.await(30, TimeUnit.SECONDS), "payments source ran")
+                assertEquals(setOf("orders", "payments"), leaderFor.toSet())
+            }
+    }
+
+    @Test
+    fun `rejects 'xtdb' as a database name up front`() {
+        val source = CountingExternalSource.Factory(1, CountDownLatch(1), ConcurrentLinkedQueue())
+        val config = IngestNode.Config().database("xtdb", extDbConfig(source))
+
+        assertThrows(Incorrect::class.java) { config.open() }
+    }
+}

--- a/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/IngestNodeIntegrationTest.kt
+++ b/modules/kafka-connect-source/src/test/kotlin/xtdb/kafkaconnectsource/IngestNodeIntegrationTest.kt
@@ -1,0 +1,139 @@
+package xtdb.kafkaconnectsource
+
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.test.runTest
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.connect.sink.SinkRecord
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.Network
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.lifecycle.Startables
+import xtdb.api.IngestNode
+import xtdb.api.log.KafkaCluster
+import xtdb.api.storage.Storage
+import xtdb.database.Database
+import xtdb.indexer.TxIndexer
+import xtdb.indexer.TxIndexer.TxResult
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end test of the embedding story: a custom JVM app builds an [IngestNode.Config] with a
+ * [KafkaConnectSource.Factory] wrapping its own [RecordIndexer] — a plain, non-serialisable
+ * factory, no Registration — and runs it as an ingest-only node. We assert the indexer sees the
+ * records, proving the programmatic path works through the real Kafka consumer + ingest node.
+ */
+@Tag("integration")
+class IngestNodeIntegrationTest {
+
+    companion object {
+        private val network: Network = Network.newNetwork()
+
+        private val kafka = ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0")
+            .withNetwork(network)
+            .withNetworkAliases("kafka")
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            Startables.deepStart(kafka).join()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            kafka.stop()
+            network.close()
+        }
+    }
+
+    private fun createTopic(topic: String) {
+        AdminClient.create(mapOf("bootstrap.servers" to kafka.bootstrapServers)).use { admin ->
+            admin.createTopics(listOf(NewTopic(topic, 1, 1.toShort()))).all().get()
+        }
+    }
+
+    private fun produce(topic: String, key: String, value: ByteArray) {
+        val props = mapOf(
+            "bootstrap.servers" to kafka.bootstrapServers,
+            "key.serializer" to StringSerializer::class.java.name,
+            "value.serializer" to ByteArraySerializer::class.java.name,
+        )
+        KafkaProducer<String, ByteArray>(props).use { it.send(ProducerRecord(topic, key, value)).get() }
+    }
+
+    private suspend fun awaitCondition(description: String, timeout: Duration = 30.seconds, check: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (System.currentTimeMillis() < deadline) {
+            if (runCatching(check).getOrDefault(false)) return
+            runInterruptible { Thread.sleep(200) }
+        }
+        throw AssertionError("Timed out waiting for: $description")
+    }
+
+    /** A user-supplied indexer that records the keys it sees rather than writing them anywhere. */
+    private class CapturingIndexer(val seenKeys: ConcurrentLinkedQueue<String>) : RecordIndexer {
+        class Factory(val seenKeys: ConcurrentLinkedQueue<String>) : RecordIndexer.Factory {
+            override fun open(dbName: String): RecordIndexer = CapturingIndexer(seenKeys)
+        }
+
+        override suspend fun indexRecords(records: List<SinkRecord>, txIndexer: TxIndexer) {
+            for (rec in records) {
+                txIndexer.indexTx(externalSourceToken = null) {
+                    seenKeys.add(rec.key() as String)
+                    TxResult.Committed()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `programmatic indexer ingests through an ingest node`() = runTest(timeout = 120.seconds) {
+        val sourceTopic = "events-${UUID.randomUUID()}"
+        createTopic(sourceTopic)
+
+        produce(sourceTopic, "k1", """{"name":"Alice"}""".toByteArray())
+        produce(sourceTopic, "k2", """{"name":"Bob"}""".toByteArray())
+
+        val seenKeys = ConcurrentLinkedQueue<String>()
+
+        val dbConfig = Database.Config(
+            log = KafkaCluster.LogFactory("kafka", "replica-${UUID.randomUUID()}"),
+            storage = Storage.inMemory(),
+            externalSource = KafkaConnectSource.Factory(
+                remote = "kafka",
+                topic = sourceTopic,
+                connectConfig = mapOf(
+                    "key.converter" to "org.apache.kafka.connect.storage.StringConverter",
+                    "value.converter" to "org.apache.kafka.connect.json.JsonConverter",
+                    "value.converter.schemas.enable" to "false",
+                ),
+                indexer = CapturingIndexer.Factory(seenKeys),
+            ),
+        )
+
+        IngestNode.Config()
+            .remote("kafka", KafkaCluster.ClusterFactory(kafka.bootstrapServers))
+            .database("events", dbConfig)
+            .open()
+            .use {
+                awaitCondition("both records indexed") { seenKeys.toSet() == setOf("k1", "k2") }
+
+                produce(sourceTopic, "k3", """{"name":"Charlie"}""".toByteArray())
+                awaitCondition("streamed record indexed") { "k3" in seenKeys }
+            }
+
+        assertEquals(listOf("k1", "k2", "k3"), seenKeys.toList())
+    }
+}


### PR DESCRIPTION
Adds an ingest-only node for applications that embed XTDB as a library to pull data in through an external source — Kafka Connect today, Postgres next — using their own indexer, configured in code.

> **Note:** depends on the indexer/external-source `Factory` refactor (`Registration` owns the proto round-trip; a `Registration`-less factory is legal). Those commits are prerequisites and will be on `main` by merge time — draft until then.

## Motivation

The only entry point, `Xtdb.openNode`, brings up the full query/client surface — pgwire, Flight SQL, healthz, the query `Node` — that an ingest app never touches, and it stands up the multi-database catalog with its hardcoded `"xtdb"` primary. None of that is needed to consume from Kafka and index. The custom-indexer route also demanded a `@Serializable` config class, a protobuf message, a `Registration`, and a `META-INF/services` entry — ceremony that exists so a connector's config can travel as data and be reconstructed from a block catalog on failover. An app that builds its node in code doesn't need its indexer to travel as data at all.

## What it does

`IngestNodeConfig` opens a leaner node: a `NodeBase` plus one `Database` per configured external source, opened directly with **no `DatabaseCatalog` and no `"xtdb"` primary**. An external-source database opens with `dbCatalog = null` and never calls back into a catalog — leader election, indexing and block upload all run off its own log and storage — so the catalog and the primary it exists to hold are dead weight here. Each database joins leader election and runs its source only on the database it's elected leader for, so failover across instances is the **existing** mechanism, not new code.

The query engine (`NodeBase.querySource`) is **kept**, not dropped: `OpenTx` reaches for it during indexing to run `UPDATE`/`DELETE`/`PATCH` and other DML, so an "ingest-only" node still needs it. What's dropped is purely the outward surface — `toBaseConfig` builds the `NodeBase` from an `Xtdb.Config` with `server`, `flightSql` and `healthz` all null.

Because the configuration is handed in fresh on every boot and never persisted as secondary-database config, an external source's indexer factory needn't be serialisable — there's no `toProto` round-trip on this path. A user supplies a live `RecordIndexer.Factory` instance directly, with no `@Serializable` config, proto message, `Registration` or ServiceLoader entry.

## Usage

```kotlin
val node = IngestNodeConfig()
    .remote("my-kafka", KafkaCluster.ClusterFactory(bootstrapServers))
    .database("orders", Database.Config(
        log = KafkaCluster.LogFactory("my-kafka", "orders-replica"),
        storage = Storage.inMemory(),
        externalSource = KafkaConnectSource.Factory(
            remote = "my-kafka", topic = "orders",
            connectConfig = mapOf(/* converters */),
            indexer = MyRecordIndexerFactory(),   // a plain RecordIndexer.Factory — no Registration
        ),
    ))
    .open()    // returns an IngestNode (AutoCloseable); the app blocks on it and closes on shutdown
```

## Decisions

- **No Integrant.** `open-node`/`open-compactor` route through an Integrant system; the ingest node is a `NodeBase` plus a handful of directly-opened databases, with no system map to halt in order. A hand-rolled holder that closes the databases before the base they're allocator-children of is the honest shape — reusing Integrant here would mean inventing keys for a lifecycle that doesn't need them.
- **`"xtdb"` rejected up front.** Opening a database named `"xtdb"` with `dbCatalog = null` trips `LeaderLogProcessor`'s `require((dbCatalog != null) == (name == "xtdb"))` — but only once that database is elected leader, so the failure would surface asynchronously through the watchers. `open-ingest-node` rejects the name synchronously with an `xtdb.error/incorrect` a caller can act on.
- **No main-code change in `kafka-connect-source`.** `KafkaConnectSource.Factory` already takes a `RecordIndexer.Factory`, and a `Registration`-less factory is now legal; the module gains only an end-to-end integration test.

## Out of scope

- A CLI entry point in `xtdb.main` that boots an ingest node from YAML — which, with a user-written `Registration`, would let them deploy via the stock XTDB image (`FROM xtdb; COPY their-indexer.jar`). Phase 2, once this runtime is validated.

## Test plan

- `core` unit tests (`IngestNodeTest`): the node opens, the programmatic (non-serialisable) source is elected leader and indexes its rows, multiple databases each run their own source, and `"xtdb"` is rejected up front. Full `:xtdb-core:test` suite green (296 tests), no reflection/boxed-math warnings.
- `kafka-connect-source` integration test (`IngestNodeIntegrationTest`, `@Tag("integration")`): a custom capturing `RecordIndexer` wrapped in a `KafkaConnectSource.Factory`, run as an ingest node against a Testcontainers Kafka — asserts snapshot + streamed records reach the indexer. Verified locally against Docker.