### PR TITLE
test: hang watchdog — coroutine/thread dumps when tests go quiet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -220,6 +220,23 @@ allprojects {
             }
         }
 
+        // The hang watchdog's coroutine probes install statically via -javaagent (premain needs
+        // only java.instrument, already in the custom JRE) rather than dynamic self-attach,
+        // which would force jdk.attach into the jlink module list that production Docker images
+        // share. Test tasks only — no production artifact carries any of this.
+        val hangWatchdogAgent = configurations.create("hangWatchdogAgent") {
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            isTransitive = false // so .singleFile below resolves to exactly the agent jar
+        }
+        dependencies.addProvider("hangWatchdogAgent", libs.kotlinx.coroutines.debug)
+
+        tasks.withType<Test> {
+            jvmArgumentProviders.add(CommandLineArgumentProvider {
+                listOf("-javaagent:${hangWatchdogAgent.singleFile}")
+            })
+        }
+
         // Use custom JRE for all Test and JavaExec tasks (skip with -PfullJdk)
         if (useCustomJre) {
             val customLauncher = proj.customJreLauncher()
@@ -255,6 +272,9 @@ allprojects {
             testImplementation(libs.junit.jupiter.params)
             testRuntimeOnly(libs.junit.jupiter.engine)
             testRuntimeOnly(libs.junit.platform.launcher)
+
+            // dumps coroutines + threads when the test plan goes quiet too long — see #5711
+            testRuntimeOnly(project(":modules:test-watchdog"))
 
             testImplementation(libs.testcontainers)
             testImplementation(libs.testcontainers.kafka)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,7 @@ exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", versio
 
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "kotlin-coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.10.0" }
 mockk = { group = "io.mockk", name = "mockk", version = "1.14.9" }
 kaml = { group = "com.charleskorn.kaml", name = "kaml", version = "0.104.0" }

--- a/modules/test-watchdog/build.gradle.kts
+++ b/modules/test-watchdog/build.gradle.kts
@@ -1,0 +1,21 @@
+// Deliberately NOT `java-library`: the root build's shared test config assumes clojurephant
+// (`devRuntimeOnly` et al), which this pure-Kotlin test-infra module doesn't want. It declares
+// its own minimal test setup instead.
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+
+dependencies {
+    implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.coroutines.debug)
+    implementation(libs.junit.platform.launcher)
+
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangTracker.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangTracker.kt
@@ -1,0 +1,62 @@
+package xtdb.test.watchdog
+
+/**
+ * Tracks test-plan liveness and reports when it has gone quiet for too long.
+ *
+ * The trigger is deliberately "no test lifecycle event for [timeoutNanos]" rather than
+ * per-test elapsed time: it needs only one timestamp, and it also catches hangs *between*
+ * tests (fixtures, `@BeforeAll`/`@AfterAll`, engine teardown) — where this bug class lives —
+ * which per-test tracking misses.
+ *
+ * Pure bookkeeping with caller-supplied nanos, so the threshold logic is unit-testable with
+ * a fake clock. [event] is called from test threads; [overdue] from the single scanner
+ * thread.
+ */
+class HangTracker(
+    private val timeoutNanos: Long,
+    private val maxReports: Int = 2,
+) {
+    @Volatile
+    private var active = false
+
+    @Volatile
+    private var lastEventAt = 0L
+
+    @Volatile
+    private var lastEvent = ""
+
+    @Volatile
+    private var reports = 0
+
+    fun planStarted(now: Long) {
+        lastEvent = "test plan started"
+        lastEventAt = now
+        reports = 0
+        active = true
+    }
+
+    fun planFinished() {
+        active = false
+    }
+
+    fun event(description: String, now: Long) {
+        lastEvent = description
+        lastEventAt = now
+        reports = 0
+    }
+
+    data class Overdue(val quietNanos: Long, val lastEvent: String, val report: Int)
+
+    /**
+     * Non-null when the quiet period has crossed `timeout * (reports + 1)` — each crossing
+     * reports once, up to [maxReports], so a hang produces two dumps (movement between them
+     * distinguishes stuck from slow) and then goes quiet rather than flooding the log.
+     */
+    fun overdue(now: Long): Overdue? {
+        if (!active) return null
+        val quiet = now - lastEventAt
+        return if (reports < maxReports && quiet >= timeoutNanos * (reports + 1))
+            Overdue(quiet, lastEvent, ++reports)
+        else null
+    }
+}

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
@@ -1,0 +1,137 @@
+package xtdb.test.watchdog
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.debug.DebugProbes
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestIdentifier
+import org.junit.platform.launcher.TestPlan
+import java.io.FileDescriptor
+import java.io.FileOutputStream
+import java.io.PrintStream
+import java.lang.management.ManagementFactory
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Dumps coroutines and threads when the test plan goes quiet for too long, so a hung CI job
+ * names its stuck coroutine in the log instead of dying silently at the action timeout — see
+ * xtdb#5711.
+ *
+ * Diagnostic only: it never fails or interrupts anything; a slow-but-progressing run that
+ * trips it costs log noise, not a failure. Registered via ServiceLoader
+ * (`META-INF/services/org.junit.platform.launcher.TestExecutionListener`); this module rides
+ * every project's testRuntimeOnly classpath, so every `Test` task gets it with no per-project
+ * config.
+ *
+ * Coroutine probes are expected to be pre-installed by running the JVM with
+ * `-javaagent:kotlinx-coroutines-debug.jar` (the root build adds this to Test tasks) —
+ * static premain installation needs only `java.instrument`, unlike dynamic self-attach,
+ * which would force `jdk.attach` into the custom JRE that production Docker images share.
+ * Without the agent, the watchdog degrades to thread dumps.
+ *
+ * System properties: `xtdb.test.hang-watchdog.enabled` (default `true`),
+ * `xtdb.test.hang-watchdog.timeout-seconds` (default 240 — roughly 2× the longest
+ * legitimate quiet period observed on CI runners, and small enough that a hang starting
+ * late in a 15-minute job still dumps before the job timeout).
+ *
+ * The instance is a thin forwarder: all state lives in [Companion], so it's one tracker and
+ * one scanner per JVM however many listener instances JUnit/Gradle construct (the companion
+ * is a single per-class object, not per-instance). Every instance feeds the one tracker the
+ * one scanner reads.
+ */
+class HangWatchdog : TestExecutionListener {
+
+    override fun testPlanExecutionStarted(testPlan: TestPlan) {
+        if (!enabled) return
+        tracker.planStarted(System.nanoTime())
+        ensureScanner()
+    }
+
+    override fun testPlanExecutionFinished(testPlan: TestPlan) {
+        if (enabled) tracker.planFinished()
+    }
+
+    override fun executionStarted(id: TestIdentifier) {
+        if (enabled) tracker.event("started: ${id.displayName}", System.nanoTime())
+    }
+
+    override fun executionFinished(id: TestIdentifier, result: TestExecutionResult) {
+        if (enabled) tracker.event("finished: ${id.displayName}", System.nanoTime())
+    }
+
+    companion object {
+        private val enabled = System.getProperty("xtdb.test.hang-watchdog.enabled", "true").toBoolean()
+        private val timeoutSeconds = System.getProperty("xtdb.test.hang-watchdog.timeout-seconds", "240").toLong()
+
+        private val tracker = HangTracker(TimeUnit.SECONDS.toNanos(timeoutSeconds))
+
+        // NOT System.out/err: Gradle's test workers replace those to capture per-test output, and
+        // a hung test's captured output is never flushed to report or console — the dump would
+        // vanish. Write to the process's real stdout FD — the route log4j's console appender
+        // takes, and the only channel proven to stream into the CI log live.
+        private val out = PrintStream(FileOutputStream(FileDescriptor.out), true)
+
+        private val scannerStarted = AtomicBoolean(false)
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private val probesInstalled get() = DebugProbes.isInstalled
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private fun ensureScanner() {
+            if (!scannerStarted.compareAndSet(false, true)) return
+
+            // unconditional, so a silent watchdog is distinguishable from an unloaded one
+            out.println("[hang-watchdog] armed (timeout ${timeoutSeconds}s, coroutine probes installed: $probesInstalled)")
+
+            // off: creation traces capture a throwable per launch — ruinous for the sims, which
+            // spawn coroutines in the hundreds of thousands. The dump's suspension stacks suffice.
+            if (probesInstalled) DebugProbes.enableCreationStackTraces = false
+
+            Executors.newSingleThreadScheduledExecutor { r ->
+                Thread(r, "xtdb-test-hang-watchdog").apply { isDaemon = true }
+            }.scheduleWithFixedDelay(::scan, 30, 30, TimeUnit.SECONDS)
+        }
+
+        private fun scan() {
+            // scheduleWithFixedDelay permanently cancels the task if an execution throws — a freak
+            // dump failure must not silence the watchdog for the rest of the JVM.
+            try {
+                tracker.overdue(System.nanoTime())?.let(::dump)
+            } catch (t: Throwable) {
+                try {
+                    out.println("[hang-watchdog] scan failed: $t")
+                } catch (_: Throwable) {
+                }
+            }
+        }
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private fun dump(o: HangTracker.Overdue) {
+            out.println("=== [hang-watchdog] no test activity for ${TimeUnit.NANOSECONDS.toSeconds(o.quietNanos)}s (report ${o.report}; last event: ${o.lastEvent}) ===")
+
+            if (probesInstalled) {
+                try {
+                    DebugProbes.dumpCoroutines(out)
+                } catch (e: Throwable) {
+                    out.println("[hang-watchdog] coroutine dump failed: $e")
+                }
+            }
+
+            out.println("--- [hang-watchdog] thread dump ---")
+            // ThreadInfo.toString truncates stacks, so format by hand.
+            for (ti in ManagementFactory.getThreadMXBean().dumpAllThreads(true, true)) {
+                out.println(buildString {
+                    append("\"${ti.threadName}\" #${ti.threadId} ${ti.threadState}")
+                    ti.lockName?.let { append(" on $it") }
+                    ti.lockOwnerName?.let { append(" owned by \"$it\" #${ti.lockOwnerId}") }
+                })
+                ti.stackTrace.forEach { out.println("\tat $it") }
+                out.println()
+            }
+            out.println("=== [hang-watchdog] end of dump (report ${o.report}) ===")
+            out.flush()
+        }
+    }
+}

--- a/modules/test-watchdog/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/modules/test-watchdog/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+xtdb.test.watchdog.HangWatchdog

--- a/modules/test-watchdog/src/test/kotlin/xtdb/test/watchdog/HangTrackerTest.kt
+++ b/modules/test-watchdog/src/test/kotlin/xtdb/test/watchdog/HangTrackerTest.kt
@@ -1,0 +1,58 @@
+package xtdb.test.watchdog
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class HangTrackerTest {
+
+    private val timeout = TimeUnit.SECONDS.toNanos(360)
+    private val tracker = HangTracker(timeout)
+
+    @Test
+    fun `quiet before the threshold is not overdue`() {
+        tracker.planStarted(now = 0)
+        tracker.event("started: t1", now = 10)
+        assertNull(tracker.overdue(10 + timeout - 1))
+    }
+
+    @Test
+    fun `reports once at the threshold, again at double, then goes quiet`() {
+        tracker.planStarted(now = 0)
+        tracker.event("started: t1", now = 0)
+
+        val first = tracker.overdue(timeout)
+        assertEquals("started: t1" to 1, first?.let { it.lastEvent to it.report })
+
+        assertNull(tracker.overdue(timeout + 1), "no re-report before the next threshold")
+
+        val second = tracker.overdue(timeout * 2)
+        assertEquals(2, second?.report)
+
+        assertNull(tracker.overdue(timeout * 10), "capped at two reports")
+    }
+
+    @Test
+    fun `any event resets the quiet period and the report count`() {
+        tracker.planStarted(now = 0)
+        tracker.event("started: t1", now = 0)
+        assertEquals(1, tracker.overdue(timeout)?.report)
+
+        tracker.event("finished: t1", now = timeout + 1)
+        assertNull(tracker.overdue(timeout * 2))
+        assertEquals(1, tracker.overdue(timeout * 2 + 2)?.report)
+    }
+
+    @Test
+    fun `inactive plan is never overdue`() {
+        tracker.planStarted(now = 0)
+        tracker.planFinished()
+        assertNull(tracker.overdue(timeout * 5))
+    }
+
+    @Test
+    fun `not overdue before the plan starts`() {
+        assertNull(tracker.overdue(timeout * 5))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,9 @@ project(":modules:google-cloud").name = "xtdb-google-cloud"
 include("modules:bench", "modules:datasets")
 project(":modules:datasets").name = "xtdb-datasets"
 
+// test infra, not published
+include("modules:test-watchdog")
+
 include("monitoring")
 if (file("monitoring/docker-image").isDirectory) {
     include("monitoring:docker-image")


### PR DESCRIPTION
Part of #5711.

The teardown hangs in #5711 leave nothing to go on: the test stops emitting, the CI job times out, and the log names neither the test nor the stuck coroutine. This dumps at hang time so the next one is diagnosable from the log alone.

A JUnit Platform `TestExecutionListener` (ServiceLoader-registered onto every Test task via the root's shared test config) records the time of the last lifecycle event; a daemon thread dumps `DebugProbes`' coroutines plus a thread dump once the plan has been quiet past a threshold, again at twice that, then stops. The trigger is quiet-time rather than per-test elapsed time so it also catches hangs in fixtures and between tests, where these hangs sit; the observer is an out-of-band thread rather than a test timeout because timeouts respond by cancelling, and this bug class is exactly the waits cancellation can't reach.

Dumps go to the process's real stdout fd, not `System.out` — Gradle replaces the latter to capture per-test output, and that buffer never flushes for a test that doesn't finish. Coroutine probes install via `-javaagent` on Test tasks rather than dynamic self-attach, to keep `jdk.attach` out of the jlink module list the production images share; absent the agent it degrades to thread dumps. State lives in a companion object so it is one tracker and one scanner per JVM however many listener instances the worker constructs.

Diagnostic only: it never fails or interrupts a test, and the scan is guarded because `scheduleWithFixedDelay` drops its task on the first thrown exception — which would silence the watchdog indistinguishably from health.