### PR TITLE
docs: ADBC driver documentation

### DIFF
--- a/docs/src/content/docs/drivers.md
+++ b/docs/src/content/docs/drivers.md
@@ -2,7 +2,12 @@
 title: Language Drivers
 ---
 
-XTDB exposes a PostgreSQL wire-compatible server, and is therefore compatible with standard PostgreSQL tools and drivers.
+XTDB exposes two client surfaces:
+
+- A PostgreSQL wire-compatible server — works with standard PostgreSQL tools and drivers (psql, JDBC, psycopg, etc.).
+- An [Arrow Database Connectivity](/drivers/adbc) (ADBC) endpoint, served over Apache Arrow Flight SQL — Arrow batches stream straight into your client, and bulk-ingesting an Arrow table is a single round trip.
+
+For PostgreSQL-shaped tooling, the pgwire path is what you want.
 
 XTDB (unlike some other PostgreSQL wire-compatible databases) does not try to emulate PostgreSQL itself completely, feature-for-feature, bug-for-bug.
 XTDB is sufficiently different in certain areas, especially DDL/Schema support, that this is often undesirable (and sometimes impossible!).
@@ -22,6 +27,8 @@ For details of how to connect to XTDB from your favourite language, see the foll
 - [PHP](/drivers/php)
 - [Python](/drivers/python)
 - [Ruby](/drivers/ruby)
+
+If your pipeline is Arrow-shaped end-to-end (pandas / polars / DuckDB / DataFusion / arrow-rs / pyarrow), you'll want the [ADBC driver](/drivers/adbc) instead — it keeps everything Arrow-native and adds bulk-Arrow ingest in one round trip.
 
 XTDB is also compatible with many different PostgreSQL tools, including:
 

--- a/docs/src/content/docs/drivers/adbc.md
+++ b/docs/src/content/docs/drivers/adbc.md
@@ -1,0 +1,33 @@
+---
+title: 'ADBC: Arrow-native client access'
+description: Connect to XTDB via Arrow Database Connectivity, in-process or over FlightSQL.
+---
+
+XTDB exposes [ADBC](https://arrow.apache.org/adbc/), the Arrow Database Connectivity standard.
+If your pipeline is Arrow-shaped throughout (pandas, polars, DuckDB, DataFusion, `arrow-rs`, pyarrow), ADBC fits straight in: query results land in your client as Arrow batches with no row-by-row decode, and bulk-ingesting an Arrow table happens in a single round trip.
+
+XTDB's storage layer, query engine, and wire format are all Arrow-native, and ADBC carries that through to the client.
+
+## Where to next
+
+- **[Tutorial](/drivers/adbc/tutorial)**: an end-to-end walkthrough covering install, connect, ingest, query, transactions, and prepared statements.
+- **[Reference](/drivers/adbc/reference)**: the supported ADBC surface in detail.
+  Which calls work, which don't, and the per-client caveats (Python vs Rust vs Java).
+- **[How-to guides](/drivers/adbc/guides)**: task-shaped recipes.
+  "Bulk-load Parquet via ADBC", "round-trip a pandas DataFrame", "stream results into DuckDB".
+- **[Examples](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples)**: minimal runnable hello-world programs in each supported language.
+
+## ADBC vs pgwire
+
+XTDB also exposes a [PostgreSQL wire-compatible server](/drivers).
+Use whichever fits your stack:
+
+| | pgwire | ADBC (FlightSQL) |
+|---|---|---|
+| Tooling | psql, JDBC, psycopg, every PG client | ADBC clients (Python, Rust, Go, C, R, Java) |
+| Wire format | Postgres text/binary | Arrow |
+| Bulk ingest | row-at-a-time `INSERT` / `executemany` | `cur.adbc_ingest(arrow_table)`, one round trip |
+| Result format | rows decoded one at a time | Arrow batches streaming straight into your client |
+| Type fidelity | Postgres-mapped | Arrow-native (preserves Arrow types) |
+
+Both backends talk to the same XTDB node, so you can pick per workload and mix freely.

--- a/docs/src/content/docs/drivers/adbc/examples/.gitignore
+++ b/docs/src/content/docs/drivers/adbc/examples/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+target/
+*.parquet

--- a/docs/src/content/docs/drivers/adbc/examples/README.txt
+++ b/docs/src/content/docs/drivers/adbc/examples/README.txt
@@ -1,0 +1,76 @@
+XTDB ADBC examples
+==================
+
+Runnable companion code for the ADBC docs (/drivers/adbc).
+One example per directory. Each one round-trips ingest + query against a
+local XTDB node, and corresponds to a tutorial or how-to guide page.
+
+This is a .txt (not .md) on purpose: Starlight's content loader globs every
+.md/.mdx under src/content/docs/ and turns it into a routable page with a
+required `title` frontmatter. A README.md here would break the docs build.
+
+Prereqs
+-------
+
+A running XTDB node with the FlightSQL listener on localhost:9832.
+The standalone Docker image enables this by default:
+
+    docker run --rm -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+
+The Python examples need:
+
+    python -m pip install adbc-driver-flightsql pyarrow
+
+plus extras called out per-example below (pandas, polars, duckdb).
+
+Examples
+--------
+
+Hello-world (start here):
+
+  python/                hello-world.py: minimal adbc_driver_flightsql + pyarrow
+                         round-trip. The cleanest "Arrow stays Arrow" demo.
+                           cd python && python hello-world.py
+
+  rust/                  adbc_core + adbc_driver_manager loading the native
+                         FlightSQL driver, + arrow. Compile-time-safe Arrow
+                         round-trip. There is no pure-Rust FlightSQL driver, so
+                         the first build downloads the native lib (~5 MB), so set
+                         ADBC_FLIGHTSQL_VERSION on that build:
+                           cd rust && ADBC_FLIGHTSQL_VERSION=1.11.0 cargo run
+
+Tutorial companion:
+
+  tutorial/              main.py: the FX-trades worked example from tutorial.md.
+                         Every numbered section in the tutorial maps to a function here.
+
+How-to guide companions (one per /drivers/adbc/guides/* page):
+
+  bulk-ingest-from-parquet/        pyarrow.parquet.read_table -> cur.adbc_ingest;
+                                   schema (_id) requirements, chunked ingest, rejection modes.
+
+  pandas-polars-round-trip/        DataFrame in / DataFrame out; type fidelity for
+                                   tz-timestamps, nullable fields, categoricals.
+                                   Needs: pandas polars
+
+  point-in-time-feature-extraction/  Bitemporal x Arrow: extract ML training features
+                                   "as known at label time" via FOR VALID_TIME AS OF.
+
+  streaming-into-duckdb/           cur.fetch_arrow_table() -> DuckDB register_arrow;
+                                   XTDB as bitemporal source-of-truth, DuckDB as compute.
+                                   Needs: duckdb
+
+  prepared-statements-and-transactions/  prepare/bind/execute lifecycle, Arrow batch
+                                   parameter binding, transactions and rollback.
+
+  rust-arrow-pipeline/             Rust end-to-end with adbc_core + arrow-rs: ingest a
+                                   RecordBatch, query, hand off to DataFusion, write Parquet.
+                                   Compile-time guarantees through the whole pipeline.
+                                     cd rust-arrow-pipeline && cargo run
+
+Not yet shipped
+---------------
+
+Standalone C / R / Go / Kotlin-in-process examples are candidates for a future
+round, one example per language, each focused enough to actually run-and-verify.
+The in-process Kotlin/JVM path is already documented inline in reference.md.

--- a/docs/src/content/docs/drivers/adbc/examples/bulk-ingest-from-parquet/main.py
+++ b/docs/src/content/docs/drivers/adbc/examples/bulk-ingest-from-parquet/main.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Bulk-ingest Parquet into XTDB via ADBC: a runnable example.
+
+Writes a small Parquet fixture from Python (no binary committed), then
+demonstrates the full happy path and the error cases from the how-to guide.
+
+Requirements:
+    pip install adbc-driver-flightsql pyarrow
+
+Running XTDB (FlightSQL on 9832):
+    docker run --rm -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+
+Run:
+    python main.py
+"""
+
+import os
+import pathlib
+import tempfile
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import adbc_driver_flightsql.dbapi as flight_sql
+from adbc_driver_manager import DatabaseError
+
+XTDB_URI = os.environ.get("XTDB_URI", "grpc://localhost:9832")
+
+
+# ---------------------------------------------------------------------------
+# 1. Write a small Parquet fixture: no binary committed to the repo.
+# ---------------------------------------------------------------------------
+
+def make_parquet(path: pathlib.Path) -> None:
+    """Write a tiny orders table to a Parquet file."""
+    orders = pa.table({
+        "order_id":    ["ORD-001", "ORD-002", "ORD-003", "ORD-004", "ORD-005"],
+        "customer":    ["alice",   "bob",     "carol",   "alice",   "dave"],
+        "product":     ["widget",  "gadget",  "widget",  "gizmo",   "gadget"],
+        "quantity":    [2,         1,         5,         1,         3],
+        "unit_price":  [9.99,      24.99,     9.99,      14.99,     24.99],
+    })
+    pq.write_table(orders, path)
+    print(f"[fixture] Wrote {len(orders)} rows to {path}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Minimal happy path: read_table → adbc_ingest.
+# ---------------------------------------------------------------------------
+
+def ingest_full_table(conn, parquet_path: pathlib.Path) -> None:
+    print("\n[minimal path] Reading Parquet and ingesting as a single table …")
+
+    table = pq.read_table(parquet_path)
+
+    # Our Parquet doesn't have an _id column, so materialise one from order_id.
+    table = table.rename_columns(
+        ["_id" if c == "order_id" else c for c in table.schema.names]
+    )
+    print(f"  Schema after renaming: {table.schema}")
+
+    with conn.cursor() as cur:
+        cur.adbc_ingest("orders", table, mode="create_append")
+    print(f"  Ingested {len(table)} rows into 'orders'.")
+
+
+# ---------------------------------------------------------------------------
+# 3. Chunked ingest: stream RecordBatches for large files.
+# ---------------------------------------------------------------------------
+
+def ingest_in_chunks(conn, parquet_path: pathlib.Path) -> None:
+    print("\n[chunked ingest] Streaming row groups from Parquet …")
+
+    with conn.cursor() as cur:
+        pf = pq.ParquetFile(parquet_path)
+        total = 0
+        for batch in pf.iter_batches(batch_size=2):
+            # Materialise _id from order_id for each batch individually.
+            tbl = pa.Table.from_batches([batch])
+            tbl = tbl.rename_columns(
+                ["_id" if c == "order_id" else c for c in tbl.schema.names]
+            )
+            cur.adbc_ingest("orders_chunked", tbl, mode="create_append")
+            total += len(tbl)
+            print(f"  … ingested chunk of {len(tbl)} rows (running total: {total})")
+    print(f"  Done: {total} rows total.")
+
+
+# ---------------------------------------------------------------------------
+# 4. Error cases: rejected modes surface as DatabaseError / INVALID_ARGUMENT.
+# ---------------------------------------------------------------------------
+
+def demonstrate_errors(conn) -> None:
+    print("\n[error handling] Demonstrating rejected ingest modes …")
+
+    sample = pa.table({"_id": ["x"], "v": [1]})
+
+    with conn.cursor() as cur:
+        # 'replace' is not supported: XTDB has no ERASE step.
+        try:
+            cur.adbc_ingest("orders", sample, mode="replace")
+        except DatabaseError as e:
+            print(f"  'replace' rejected (expected): {e}")
+
+        # Missing _id: XTDB requires a primary key on every row.
+        try:
+            no_id = pa.table({"value": [42]})
+            cur.adbc_ingest("orders", no_id, mode="create_append")
+        except DatabaseError as e:
+            print(f"  missing _id rejected (expected): {e}")
+
+
+# ---------------------------------------------------------------------------
+# 5. Verify: row count + schema introspection.
+# ---------------------------------------------------------------------------
+
+def verify(conn) -> None:
+    print("\n[verify] Checking row counts and schema …")
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) AS n FROM orders")
+        n = cur.fetchone()[0]
+        print(f"  orders row count: {n}")
+
+        cur.execute("SELECT count(*) AS n FROM orders_chunked")
+        n_chunked = cur.fetchone()[0]
+        print(f"  orders_chunked row count: {n_chunked}")
+
+    schema = conn.adbc_get_table_schema(
+        "orders", db_schema_filter="public",
+    )
+    print(f"  orders schema: {schema}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point.
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        parquet_path = pathlib.Path(tmpdir) / "orders.parquet"
+        make_parquet(parquet_path)
+
+        print(f"\nConnecting to XTDB at {XTDB_URI} …")
+        with flight_sql.connect(XTDB_URI) as conn:
+            ingest_full_table(conn, parquet_path)
+            ingest_in_chunks(conn, parquet_path)
+            demonstrate_errors(conn)
+            verify(conn)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/content/docs/drivers/adbc/examples/pandas-polars-round-trip/main.py
+++ b/docs/src/content/docs/drivers/adbc/examples/pandas-polars-round-trip/main.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Round-trip pandas / polars DataFrames via XTDB ADBC.
+
+Shows type fidelity for:
+  - TIMESTAMP WITH TIME ZONE  (timestamp[us, tz=UTC])
+  - Nullable / optional fields (Arrow validity bitmap, not NaN)
+  - Dictionary / categorical columns (may need client-side re-encode after query)
+
+Prerequisites:
+    pip install adbc-driver-flightsql pyarrow pandas polars
+
+XTDB nightly running with FlightSQL on localhost:9832 (adjust URIs as needed):
+    docker run --rm -d --name xtdb-g2 \\
+        -p 5444:5432 -p 9844:9832 \\
+        ghcr.io/xtdb/xtdb:nightly
+
+Then run:
+    python main.py                          # defaults
+    python main.py grpc://localhost:9844    # custom FlightSQL URI
+
+The script seeds and round-trips entirely over FlightSQL via adbc_ingest
+(CommandStatementIngest), available on the nightly image and stable 2.2.0+.
+"""
+
+import sys
+from datetime import datetime, timezone
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pandas as pd
+import polars as pl
+import adbc_driver_flightsql.dbapi as flight_sql
+
+FLIGHT_URI = sys.argv[1] if len(sys.argv) > 1 else "grpc://localhost:9832"
+
+SEP = "─" * 60
+
+
+def section(title: str) -> None:
+    print(f"\n{SEP}\n{title}\n{SEP}")
+
+
+# ---------------------------------------------------------------------------
+# 1. Seed XTDB with typed events via adbc_ingest (bulk Arrow, one round trip)
+# ---------------------------------------------------------------------------
+section("1. Seeding XTDB with typed events")
+
+EVENTS = [
+    ("evt-001", "2024-01-15T08:30:00+00:00", "INFO",  1.23, "startup"),
+    ("evt-002", "2024-01-15T09:45:00+00:00", "WARN",  4.56, None),
+    ("evt-003", "2024-01-15T11:00:00+00:00", "ERROR", 7.89, "threshold"),
+    ("evt-004", "2024-01-15T14:20:00+00:00", "INFO",  2.34, None),
+    ("evt-005", "2024-01-16T08:00:00+00:00", "WARN",  9.99, "startup"),
+    ("evt-006", "2024-01-16T10:30:00+00:00", "ERROR", 0.01, "manual"),
+]
+
+seed_table = pa.table(
+    {
+        "_id":      pa.array([e[0] for e in EVENTS], type=pa.string()),
+        "ts":       pa.array([datetime.fromisoformat(e[1]) for e in EVENTS],
+                             type=pa.timestamp("us", tz="UTC")),
+        "severity": pa.array([e[2] for e in EVENTS], type=pa.string()),
+        "value":    pa.array([e[3] for e in EVENTS], type=pa.float64()),
+        "label":    pa.array([e[4] for e in EVENTS], type=pa.string()),
+    }
+)
+
+with flight_sql.connect(FLIGHT_URI) as conn:
+    with conn.cursor() as cur:
+        # One gRPC round trip: the whole Arrow table goes over CommandStatementIngest.
+        # Requires the nightly image or stable 2.2.0+; on older stable, seed via
+        # row-by-row INSERT over pgwire instead.
+        cur.adbc_ingest("events", seed_table, mode="create_append")
+        print(f"Ingested {len(EVENTS)} rows via adbc_ingest.")
+
+# ---------------------------------------------------------------------------
+# 2. XTDB → Arrow via ADBC FlightSQL
+# ---------------------------------------------------------------------------
+section("2. XTDB → Arrow (ADBC FlightSQL)")
+
+with flight_sql.connect(FLIGHT_URI) as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT _id, ts, severity, value, label FROM events ORDER BY ts"
+        )
+        arrow_result = cur.fetch_arrow_table()
+
+# XTDB FlightSQL returns timestamp[us, tz=Z] ("Z" = Zulu = UTC).
+# Normalise to "UTC" so downstream pandas/polars handle it as a standard IANA key.
+def normalise_tz(table: pa.Table) -> pa.Table:
+    """Cast any timestamp[us, tz=Z] columns to timestamp[us, tz=UTC]."""
+    for i, field in enumerate(table.schema):
+        t = field.type
+        if pa.types.is_timestamp(t) and t.tz == "Z":
+            utc_type = pa.timestamp(t.unit, tz="UTC")
+            table = table.set_column(i, field.name, table.column(field.name).cast(utc_type))
+    return table
+
+arrow_result = normalise_tz(arrow_result)
+
+print(f"Arrow table: {arrow_result.num_rows} rows")
+print("Schema:")
+for field in arrow_result.schema:
+    print(f"  {field.name:10s}  {field.type}  nullable={field.nullable}")
+
+# ---------------------------------------------------------------------------
+# 3. Arrow → pandas (two paths)
+# ---------------------------------------------------------------------------
+section("3. Arrow → pandas")
+
+# Path A: types_mapper=pd.ArrowDtype
+# Keeps Arrow-backed columns: zero-copy for numeric and strings both.
+df_arrow = arrow_result.to_pandas(types_mapper=pd.ArrowDtype)
+print("pandas with types_mapper=pd.ArrowDtype:")
+print(df_arrow.dtypes.to_string())
+print()
+print(df_arrow.to_string())
+
+# Verify timestamp has UTC timezone
+ts_arrow_type = arrow_result.schema.field("ts").type
+assert pa.types.is_timestamp(ts_arrow_type) and ts_arrow_type.tz is not None, (
+    f"Expected timestamp with tz, got {ts_arrow_type}"
+)
+print(f"\nts Arrow type: {ts_arrow_type}  ✓ (timezone preserved)")
+
+# Verify nulls are proper NA, not NaN
+null_count_pd = df_arrow["label"].isna().sum()
+print(f"label null count: {null_count_pd}  ✓ (expected 2)")
+assert null_count_pd == 2, f"Expected 2 nulls, got {null_count_pd}"
+
+# Path B: classic pandas (no types_mapper), shows widening
+df_classic = arrow_result.to_pandas()
+print("\npandas classic (no types_mapper), shows type widening:")
+print(df_classic.dtypes.to_string())
+print("(label becomes object with None; severity becomes object, dict encoding lost)")
+
+# ---------------------------------------------------------------------------
+# 4. Arrow → polars (zero-copy path)
+# ---------------------------------------------------------------------------
+section("4. Arrow → polars")
+
+df_pl = pl.from_arrow(arrow_result)
+print("polars schema:")
+print(df_pl.schema)
+print()
+print(df_pl)
+
+# Verify timestamp column has UTC timezone
+ts_dtype = df_pl["ts"].dtype
+assert isinstance(ts_dtype, pl.Datetime), f"Expected Datetime, got {ts_dtype}"
+assert ts_dtype.time_zone == "UTC", f"Expected UTC tz, got {ts_dtype.time_zone}"
+print(f"\nts polars type: {ts_dtype}  ✓ (UTC timezone preserved)")
+
+# Verify nulls via polars null_count (not NaN, not None-in-object)
+null_count_pl = df_pl["label"].null_count()
+print(f"label null count: {null_count_pl}  ✓ (expected 2)")
+assert null_count_pl == 2, f"Expected 2 polars nulls, got {null_count_pl}"
+
+assert df_pl.height == 6, f"Expected 6 rows, got {df_pl.height}"
+print(f"Total rows: {df_pl.height}  ✓")
+
+# ---------------------------------------------------------------------------
+# 5. DataFrame → Arrow (showing the conversion, not the ingest)
+# ---------------------------------------------------------------------------
+section("5. DataFrame → Arrow (ingest-ready)")
+
+# pandas → Arrow
+df_pd_source = pd.DataFrame({
+    "_id":      ["evt-007", "evt-008"],
+    "ts":       pd.to_datetime(["2024-01-17T08:00:00Z", "2024-01-17T10:00:00Z"],
+                               utc=True),
+    "severity": pd.Categorical(["INFO", "WARN"], categories=["INFO", "WARN", "ERROR"]),
+    "value":    [5.55, 6.66],
+    "label":    pd.array([None, "reprocess"], dtype=pd.StringDtype()),
+})
+arrow_from_pd = pa.Table.from_pandas(df_pd_source, preserve_index=False)
+print("pandas → Arrow schema:")
+print(arrow_from_pd.schema)
+# Verify dictionary type preserved
+sev_type = arrow_from_pd.schema.field("severity").type
+assert pa.types.is_dictionary(sev_type), f"Expected dictionary, got {sev_type}"
+print(f"severity type: {sev_type}  ✓ (categorical preserved as dictionary)")
+
+# polars → Arrow
+df_pl_source = pl.DataFrame({
+    "_id":      ["evt-009", "evt-010"],
+    "ts":       pl.Series(
+                    [datetime(2024, 1, 18, 8, 0, tzinfo=timezone.utc),
+                     datetime(2024, 1, 18, 10, 0, tzinfo=timezone.utc)],
+                    dtype=pl.Datetime("us", "UTC"),
+                ),
+    "severity": pl.Series(["ERROR", "INFO"], dtype=pl.Categorical),
+    "value":    [7.77, 8.88],
+    "label":    pl.Series(["alert", None], dtype=pl.Utf8),
+})
+arrow_from_pl = df_pl_source.to_arrow()
+print("\npolars → Arrow schema:")
+print(arrow_from_pl.schema)
+sev_pl_type = arrow_from_pl.schema.field("severity").type
+assert pa.types.is_dictionary(sev_pl_type), f"Expected dictionary, got {sev_pl_type}"
+print(f"severity type: {sev_pl_type}  ✓ (Categorical preserved as dictionary)")
+
+# These Arrow tables ingest the same way as section 1's seed table:
+#     cur.adbc_ingest("events", arrow_from_pd, mode="create_append")
+#     cur.adbc_ingest("events", arrow_from_pl, mode="create_append")
+# Not executed here: the dictionary-typed `severity` column is the subject of
+# this section (type preservation), and dictionary ingest support over the wire
+# is still firming up: re-encode to utf8 first if you want to round-trip it.
+print("pandas + polars Arrow tables built (see comment above for the ingest call).")
+
+# ---------------------------------------------------------------------------
+# 6. Type fidelity summary
+# ---------------------------------------------------------------------------
+section("6. Type fidelity summary")
+
+print("Arrow schema from XTDB query:")
+for field in arrow_result.schema:
+    print(f"  {field.name:10s}  {str(field.type):35s}  nullable={field.nullable}")
+
+print("""
+Round-trip fidelity via ADBC FlightSQL:
+  TIMESTAMP WITH TIME ZONE  → timestamp[us, tz=UTC]      (Arrow native, zero-copy)
+  Nullable column           → Arrow validity bitmap       (not NaN, not None-in-object)
+  DOUBLE / INTEGER          → float64 / int32 Arrow       (zero-copy into numpy / polars)
+  VARCHAR / TEXT            → utf8 / large_utf8            (zero-copy polars; copy classic pandas)
+  Dictionary / Categorical  → client-side re-encode after query (server may return utf8)
+""")
+
+print("All assertions passed ✓")

--- a/docs/src/content/docs/drivers/adbc/examples/point-in-time-feature-extraction/main.py
+++ b/docs/src/content/docs/drivers/adbc/examples/point-in-time-feature-extraction/main.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Point-in-time feature extraction for an ML training set, via XTDB + ADBC.
+
+Scenario: loan-default prediction.
+  - labels:   one row per (customer_id, observed_at, did_default)
+  - features: customer attributes that drift over time
+              (account_balance, credit_score, employment_status)
+
+The job is to build a training matrix where each label sees the features
+*as they were known at observed_at*, with no later updates leaking in.
+
+Run:
+    docker run --rm -d --name xtdb-pit -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+    pip install adbc-driver-flightsql pyarrow pandas
+    python main.py                          # defaults to grpc://localhost:9832
+    python main.py grpc://localhost:9842    # override the FlightSQL URL
+    docker rm -f xtdb-pit
+
+Override the FlightSQL URL via argv or the XTDB_URI env var.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+
+import adbc_driver_flightsql.dbapi as flight_sql
+import pyarrow as pa
+
+
+XTDB_URI = (
+    sys.argv[1] if len(sys.argv) > 1
+    else os.environ.get("XTDB_URI", "grpc://localhost:9832")
+)
+
+
+def seed(cur) -> None:
+    """Seed customer features with deliberately-shifting historical values.
+
+    Each feature row carries its own `_valid_from`, so a customer's
+    account_balance, credit_score and employment_status form a real timeline
+    that evolves over months rather than over wall-clock.
+
+    XTDB's insert-as-upsert keys on `_id`, so a later `_valid_from` for the
+    same customer closes off the previous version's validity at that
+    boundary: a per-customer step function over valid time.
+
+    `_valid_from` is an ordinary column in the ingested Arrow table, so the
+    whole timeline loads in a single `adbc_ingest` call per table.
+    """
+
+    # Three customers, three independent timelines.
+    feature_rows = [
+        # (customer_id, valid_from, balance, credit_score, employment)
+        ("c1", "2024-01-01", 1_500.00, 680, "employed"),
+        ("c1", "2024-04-01", 2_100.00, 700, "employed"),
+        ("c1", "2024-07-01",   400.00, 640, "employed"),
+        ("c1", "2024-10-01",    50.00, 580, "unemployed"),  # post-default drift
+
+        ("c2", "2024-01-01", 8_000.00, 740, "employed"),
+        ("c2", "2024-05-01", 9_500.00, 760, "employed"),
+        ("c2", "2024-09-01",10_200.00, 770, "employed"),
+
+        ("c3", "2024-01-01",   300.00, 610, "self-employed"),
+        ("c3", "2024-03-01",   120.00, 590, "self-employed"),
+        ("c3", "2024-06-01",    10.00, 540, "unemployed"),
+        ("c3", "2024-11-01", 5_500.00, 700, "employed"),    # recovery, post-label
+    ]
+
+    # _valid_from must be a timestamp column (XTDB's valid-time axis is
+    # microsecond timestamps, not bare dates).
+    def ts(d: str) -> dt.datetime:
+        return dt.datetime.fromisoformat(d).replace(tzinfo=dt.timezone.utc)
+
+    features = pa.table({
+        "_id":               pa.array([r[0] for r in feature_rows], type=pa.string()),
+        "_valid_from":       pa.array([ts(r[1]) for r in feature_rows], type=pa.timestamp("us", tz="UTC")),
+        "account_balance":   pa.array([r[2] for r in feature_rows], type=pa.float64()),
+        "credit_score":      pa.array([r[3] for r in feature_rows], type=pa.int64()),
+        "employment_status": pa.array([r[4] for r in feature_rows], type=pa.string()),
+    })
+    cur.adbc_ingest("customer_features", features, mode="create_append")
+
+    # Labels: events we want to train on.
+    label_rows = [
+        # (label_id, customer_id, observed_at, did_default)
+        ("L1", "c1", "2024-08-15", True),
+        ("L2", "c2", "2024-08-15", False),
+        ("L3", "c3", "2024-08-15", True),
+    ]
+    labels = pa.table({
+        "_id":          pa.array([r[0] for r in label_rows], type=pa.string()),
+        "customer_id":  pa.array([r[1] for r in label_rows], type=pa.string()),
+        "observed_at":  pa.array([ts(r[2]) for r in label_rows], type=pa.timestamp("us", tz="UTC")),
+        "did_default":  pa.array([r[3] for r in label_rows], type=pa.bool_()),
+    })
+    cur.adbc_ingest("loan_labels", labels, mode="create_append")
+
+
+NAIVE_SQL = """
+SELECT l._id          AS label_id,
+       l.customer_id,
+       l.observed_at,
+       l.did_default,
+       f.account_balance,
+       f.credit_score,
+       f.employment_status
+FROM loan_labels AS l
+JOIN customer_features AS f
+  ON f._id = l.customer_id
+ORDER BY l._id
+"""
+
+# Bitemporal AS-OF join: for each label row, pick the customer_features
+# version whose valid-time interval contains observed_at. One query covering
+# every label, no Python loop.
+ASOF_SQL = """
+SELECT l._id          AS label_id,
+       l.customer_id,
+       l.observed_at,
+       l.did_default,
+       f.account_balance,
+       f.credit_score,
+       f.employment_status
+FROM loan_labels AS l
+LEFT JOIN customer_features FOR ALL VALID_TIME AS f
+  ON f._id = l.customer_id
+  AND f._valid_from <= l.observed_at
+  AND (f._valid_to IS NULL OR f._valid_to > l.observed_at)
+ORDER BY l._id
+"""
+
+
+def main() -> None:
+    # autocommit=True so the joins read their own writes. adbc_ingest commits
+    # atomically on its own, but the dbapi defaults to manual-commit per PEP
+    # 249 (the server advertises transaction support, SqlInfo code 8), so
+    # autocommit keeps any non-ingest statements visible too.
+    with flight_sql.connect(XTDB_URI, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            seed(cur)
+
+            cur.execute(NAIVE_SQL)
+            naive = cur.fetch_arrow_table()
+
+            cur.execute(ASOF_SQL)
+            asof = cur.fetch_arrow_table()
+
+    naive_df = naive.to_pandas()
+    asof_df  = asof.to_pandas()
+
+    print("=" * 72)
+    print("NAIVE join (latest features, regardless of label time): WRONG")
+    print("=" * 72)
+    print(naive_df.to_string(index=False))
+    print()
+    print(f"  rows returned: {len(naive_df)} (one per label, "
+          f"but pulling each customer's *current* feature row)")
+    print()
+
+    print("=" * 72)
+    print("BITEMPORAL AS-OF join (features as known at observed_at): CORRECT")
+    print("=" * 72)
+    print(asof_df.to_string(index=False))
+    print()
+    print(f"  rows returned: {len(asof_df)} (one per label)")
+    print()
+
+    print("=" * 72)
+    print("Why these disagree")
+    print("=" * 72)
+    print(
+        "c1 defaulted on 2024-08-15. The naive join uses c1's *current*\n"
+        "feature row (balance=$50, score=580, employment=unemployed): a\n"
+        "snapshot taken AFTER the default. The model would learn 'people\n"
+        "with $50 balances and 580 scores default', which is true but\n"
+        "unhelpful: those values are themselves consequences of the default.\n"
+        "The AS-OF join pulls the row valid on 2024-08-15 (the July update:\n"
+        "balance=$400, score=640, employment=employed), c1's state going\n"
+        "into the default, the only thing a real-world model could ever see.\n"
+        "Likewise c3's Nov recovery row is invisible to the AS-OF view.\n"
+    )
+
+    # Feed straight into sklearn: the dataframe is already model-shaped.
+    feature_cols = ["account_balance", "credit_score", "employment_status"]
+    X = asof_df[feature_cols]
+    y = asof_df["did_default"].astype(int)
+    print("Training matrix (X):")
+    print(X.to_string(index=False))
+    print()
+    print("Labels (y):", y.tolist())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/content/docs/drivers/adbc/examples/prepared-statements-and-transactions/main.py
+++ b/docs/src/content/docs/drivers/adbc/examples/prepared-statements-and-transactions/main.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Prepared statements and transactions via ADBC.
+
+Shows the full ADBC statement lifecycle over FlightSQL:
+  1.  Simple execute with scalar parameter binding
+  2.  Explicit prepare → bind → execute (amortise prepare over many calls)
+  3.  Arrow batch parameter binding: multi-row RecordBatch as parameters
+  4.  Multi-statement transactions: setAutoCommit / commit / rollback
+  5.  ROLLBACK empties pending writes
+  6.  Same-connection write-then-read visibility
+
+Requirements:
+    docker run --rm -d --name xtdb -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+    pip install adbc-driver-flightsql pyarrow
+
+Run:
+    python main.py [grpc://localhost:9832]
+"""
+
+import sys
+import warnings
+
+import pyarrow as pa
+import adbc_driver_flightsql.dbapi as flight_sql
+import adbc_driver_flightsql
+import adbc_driver_manager
+
+warnings.filterwarnings("ignore")
+
+URI = sys.argv[1] if len(sys.argv) > 1 else "grpc://localhost:9832"
+
+
+def section(title: str) -> None:
+    print(f"\n{'─' * 62}")
+    print(f"  {title}")
+    print(f"{'─' * 62}")
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+def raw_conn(uri: str = URI) -> adbc_driver_manager.AdbcConnection:
+    """Open a low-level AdbcConnection (bypasses dbapi)."""
+    db = adbc_driver_flightsql.connect(uri)
+    return adbc_driver_manager.AdbcConnection(db)
+
+
+def read_all(handle) -> pa.Table:
+    """Read a RecordBatchReader handle returned by execute_query."""
+    return pa.RecordBatchReader._import_from_c(handle.address).read_all()
+
+
+# ── 1. Seed data ──────────────────────────────────────────────────────────
+def seed(cur: flight_sql.Cursor) -> None:
+    cur.executemany(
+        "INSERT INTO products (_id, name, price, stock)"
+        " VALUES (?, ?, ?, ?)",
+        [
+            ["p1", "Widget",    9.99,  100],
+            ["p2", "Gadget",   24.99,   50],
+            ["p3", "Doohickey", 4.49,  200],
+        ],
+    )
+
+
+# ── 2. Scalar parameter binding ──────────────────────────────────────────
+def demo_scalar_binding(cur: flight_sql.Cursor) -> None:
+    section("1. Scalar parameter binding")
+    # Each call implicitly prepares and executes in one shot.
+    cur.execute(
+        "SELECT _id, name, price FROM products WHERE _id = ?",
+        parameters=["p1"],
+    )
+    row = cur.fetchone()
+    print(f"  p1 → {row[1]}, £{row[2]:.2f}")
+
+    cur.execute(
+        "SELECT _id, name, price FROM products WHERE price < ?",
+        parameters=[10.0],
+    )
+    rows = cur.fetchall()
+    print(f"  Under £10: {[r[1] for r in rows]}")
+
+
+# ── 3. Prepare once / execute many ────────────────────────────────────────
+def demo_prepare_bind_execute(conn: adbc_driver_manager.AdbcConnection) -> None:
+    section("2. Prepare once / execute-many (low-level ADBC API)")
+    # Use the raw ADBC connection to show the explicit lifecycle:
+    #   set_sql_query → prepare → bind → execute_query.
+    # In hot loops this avoids re-parsing the SQL on every call.
+    stmt = adbc_driver_manager.AdbcStatement(conn)
+    try:
+        stmt.set_sql_query(
+            "SELECT _id, name, price FROM products WHERE _id = ?"
+        )
+        stmt.prepare()          # parse + plan once
+        print("  Prepared OK")
+
+        for product_id in ["p1", "p2", "p3"]:
+            # Bind a one-row Arrow batch; column names don't matter,
+            # they map positionally to the ? placeholders.
+            batch = pa.record_batch(
+                {"v0": pa.array([product_id], type=pa.string())}
+            )
+            stmt.bind(batch)    # stays client-side, no round trip
+            handle, _ = stmt.execute_query()
+            row = read_all(handle).to_pylist()
+            if row:
+                print(f"  {product_id}: {row[0]['name']}, £{row[0]['price']:.2f}")
+    finally:
+        stmt.close()
+
+
+# ── 4. Arrow batch parameter binding ─────────────────────────────────────
+def demo_arrow_batch_binding(cur: flight_sql.Cursor) -> None:
+    section("3. Arrow batch binding: multi-row RecordBatch as parameters")
+    # Build a RecordBatch where each row is one INSERT execution.
+    # Columns map positionally to the ? placeholders.
+    # The whole batch travels as Arrow over the wire,
+    # no row-shredding, no individual round trips per row.
+    #
+    # NOTE: use pa.string() (utf8) for string columns in bound batches.
+    # pa.large_utf8() is not currently supported in bound parameters.
+    param_batch = pa.record_batch({
+        "v0": pa.array(["p4", "p5", "p6"],                   type=pa.string()),
+        "v1": pa.array(["Thingamajig", "Whatsit", "Gizmo"],  type=pa.string()),
+        "v2": pa.array([14.99, 7.49, 19.99],                 type=pa.float64()),
+        "v3": pa.array([75, 120, 30],                        type=pa.int64()),
+    })
+    cur.executemany(
+        "INSERT INTO products (_id, name, price, stock)"
+        " VALUES (?, ?, ?, ?)",
+        param_batch,
+    )
+
+    cur.execute("SELECT count(*) FROM products")
+    total = cur.fetchone()[0]
+    print(f"  Products after Arrow batch insert: {total}")
+
+    # Results stream back as Arrow; fetch the whole table in one call.
+    cur.execute("SELECT _id, name FROM products WHERE _id IN (?, ?, ?)",
+                parameters=["p4", "p5", "p6"])
+    arrow_tbl = cur.fetch_arrow_table()
+    print(f"  Batch-inserted rows: {arrow_tbl.to_pydict()}")
+
+
+# ── 5. Transactions ───────────────────────────────────────────────────────
+def demo_transactions(uri: str) -> None:
+    section("4. Autocommit off, COMMIT, ROLLBACK")
+    # The ADBC connection-level transaction API:
+    #
+    #   conn.adbc_connection.set_autocommit(False)   ← opens a transaction
+    #   conn.adbc_connection.commit()
+    #   conn.adbc_connection.rollback()
+    #
+    # This uses the FlightSQL BeginTransaction / EndTransaction actions.
+    # The server must advertise FLIGHT_SQL_SERVER_TRANSACTION support
+    # (SqlInfo id 8 in GetSqlInfo).  Earlier builds may not; if set_autocommit
+    # raises NotSupportedError the script falls back to a single-insert demo.
+
+    with flight_sql.connect(uri) as conn:
+        try:
+            conn.adbc_connection.set_autocommit(False)
+        except adbc_driver_manager.NotSupportedError:
+            print("  ⚠  Server does not advertise transaction support.")
+            print("     Update to a build that includes the FLIGHT_SQL_SERVER_TRANSACTION")
+            print("     GetSqlInfo entry (fixed in main after 2026-05).")
+            print("  Skipping transaction demo; falling back to autocommit demo.")
+            _demo_autocommit_fallback(conn)
+            return
+
+        with conn.cursor() as cur:
+            # ── 5a. ROLLBACK ────────────────────────────────────────
+            cur.executemany(
+                "INSERT INTO orders (_id, item, qty) VALUES (?, ?, ?)",
+                [["o1", "Widget", 10], ["o2", "Gadget", 5]],
+            )
+
+            # XTDB buffers DML in an open transaction and applies the whole
+            # batch atomically on COMMIT, so reads on the same connection do
+            # NOT see the pending writes until the transaction commits.
+            cur.execute(
+                "SELECT count(*) FROM orders WHERE _id IN (?, ?)",
+                parameters=["o1", "o2"],
+            )
+            inside_txn = cur.fetchone()[0]
+            print(f"  Rows visible inside open transaction (before commit): {inside_txn}  (expected 0)")
+
+            conn.adbc_connection.rollback()
+            print("  → ROLLBACK issued")
+
+            conn.adbc_connection.set_autocommit(False)
+            cur.execute(
+                "SELECT count(*) FROM orders WHERE _id IN (?, ?)",
+                parameters=["o1", "o2"],
+            )
+            after_rollback = cur.fetchone()[0]
+            print(f"  Rows visible after ROLLBACK: {after_rollback}  (expected 0)")
+            conn.adbc_connection.rollback()  # end the open txn
+
+            # ── 5b. COMMIT ──────────────────────────────────────────
+            conn.adbc_connection.set_autocommit(False)
+            cur.executemany(
+                "INSERT INTO orders (_id, item, qty) VALUES (?, ?, ?)",
+                [["o3", "Doohickey", 20]],
+            )
+            conn.adbc_connection.commit()
+            print("  → COMMIT issued")
+
+            cur.execute("SELECT item, qty FROM orders WHERE _id = ?",
+                        parameters=["o3"])
+            row = cur.fetchone()
+            print(f"  After COMMIT: {row[0]}, qty={row[1]}")
+
+
+def _demo_autocommit_fallback(conn: flight_sql.Connection) -> None:
+    """Fallback for servers without transaction support: show autocommit behaviour."""
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO orders (_id, item, qty) VALUES (?, ?, ?)",
+            [["o3", "Doohickey", 20]],
+        )
+        cur.execute("SELECT item, qty FROM orders WHERE _id = ?",
+                    parameters=["o3"])
+        row = cur.fetchone()
+        print(f"  Autocommit insert persisted: {row}")
+
+
+# ── 6. Same-connection write-then-read ───────────────────────────────────
+def demo_write_then_read(cur: flight_sql.Cursor) -> None:
+    section("5. Same-connection write-then-read visibility (no manual await)")
+    # An insert in autocommit mode lands immediately.
+    # The next read on the same connection sees the row without any
+    # manual await: the write token is threaded through the planner.
+    cur.executemany(
+        "INSERT INTO products (_id, name, price, stock)"
+        " VALUES (?, ?, ?, ?)",
+        [["p9", "Overnight", 3.99, 500]],
+    )
+    cur.execute(
+        "SELECT name, price FROM products WHERE _id = ?",
+        parameters=["p9"],
+    )
+    row = cur.fetchone()
+    print(f"  Immediately visible: name={row[0]}, price={row[1]}")
+
+
+# ── main ─────────────────────────────────────────────────────────────────
+def main() -> None:
+    print(f"Connecting to {URI} …")
+
+    # Sections 1-3 and 5 aren't demonstrating manual transactions; they just
+    # need to read their own writes, so they connect with autocommit=True.
+    # Section 4 (demo_transactions) opens its own connection and drives
+    # set_autocommit/commit/rollback explicitly.
+    with flight_sql.connect(URI, autocommit=True) as conn:
+        raw = conn.adbc_connection
+        with conn.cursor() as cur:
+            seed(cur)
+            print("Seed data inserted.")
+
+            demo_scalar_binding(cur)          # section 1
+            demo_prepare_bind_execute(raw)    # section 2
+            demo_arrow_batch_binding(cur)     # section 3
+
+    demo_transactions(URI)                    # section 4
+
+    with flight_sql.connect(URI, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            demo_write_then_read(cur)         # section 5
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/content/docs/drivers/adbc/examples/python/hello-world.py
+++ b/docs/src/content/docs/drivers/adbc/examples/python/hello-world.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Minimal XTDB-via-ADBC hello world.
+
+Requires a running XTDB node with the FlightSQL listener on localhost:9832.
+The standalone Docker image enables this by default:
+
+    docker run --rm -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+
+Run:
+    pip install adbc-driver-flightsql pyarrow
+    python hello-world.py
+"""
+
+import adbc_driver_flightsql.dbapi as flight_sql
+import pyarrow as pa
+
+
+def main() -> None:
+    with flight_sql.connect("grpc://localhost:9832") as conn:
+        with conn.cursor() as cur:
+            # 1. Bulk-ingest an Arrow table: one round trip, no row shredding.
+            users = pa.table({
+                "_id":  ["alice", "bob", "carol"],
+                "name": ["Alice", "Bob",   "Carol"],
+                "age":  [30,      25,      28],
+            })
+            cur.adbc_ingest("users", users, mode="create_append")
+
+            # 2. Query it back: results stream as Arrow batches.
+            cur.execute("SELECT _id, name, age FROM users ORDER BY _id")
+            result_table = cur.fetch_arrow_table()
+            print("Users:")
+            for row in result_table.to_pylist():
+                print(f"  * {row['_id']}: {row['name']} ({row['age']})")
+
+            # 3. Prepared statement with parameters.
+            cur.execute("SELECT name FROM users WHERE age > ?", parameters=[26])
+            print("\nOver 26:", cur.fetch_arrow_table().column("name").to_pylist())
+
+            # 4. Session introspection: works for Go-driver-based ADBC clients.
+            print(f"\nCurrent catalog: {conn.adbc_current_catalog}")
+            print(f"Current schema:  {conn.adbc_current_db_schema}")
+
+            # 5. Schema introspection without executing.
+            schema = conn.adbc_get_table_schema(
+                "users", db_schema_filter="public",
+            )
+            print(f"\nusers schema: {schema}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline/.gitignore
+++ b/docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline/.gitignore
@@ -1,0 +1,3 @@
+/target
+Cargo.lock
+*.parquet

--- a/docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline/Cargo.toml
+++ b/docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "xtdb-adbc-rust-arrow-pipeline"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Pinned to the matrix that resolves cleanly today:
+#   * adbc_core / adbc_driver_manager 0.23.0 accept arrow 53..<59
+#   * datafusion 53.1.0 pulls arrow 58
+#   * arrow / parquet 58.3.0 is the current stable line
+# Bumping one without bumping the rest re-opens the cargo-resolver can of
+# worms (two arrow majors in one binary → RecordBatch types stop unifying).
+[dependencies]
+adbc_core = "=0.23.0"
+adbc_driver_manager = "=0.23.0"
+# Thin shim: build.rs downloads the native libadbc_driver_flightsql.{so,dylib,dll}
+# from the official PyPI wheel and exposes its on-disk path as DRIVER_PATH.
+# The crate defaults to native-driver v1.9.0 — too old for the
+# `adbc.ingest.target_table` / `adbc.ingest.mode` option keys (added in v1.10.0).
+# Set ADBC_FLIGHTSQL_VERSION=1.11.0 in the environment for the first
+# `cargo build`, or export it once globally. ~5 MB download, cached after that.
+adbc-driver-flightsql = "=0.1.2"
+arrow = "=58.3.0"
+arrow-array = "=58.3.0"
+arrow-schema = "=58.3.0"
+parquet = "=58.3.0"
+datafusion = "=53.1.0"
+tokio = { version = "=1.52.3", features = ["rt-multi-thread", "macros"] }

--- a/docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline/src/main.rs
+++ b/docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline/src/main.rs
@@ -1,0 +1,127 @@
+//! XTDB → ADBC (FlightSQL) → DataFusion → Parquet, end-to-end, in Rust.
+//!
+//! Prereq: a running XTDB node with the FlightSQL listener reachable at
+//!     grpc://localhost:9832
+//! e.g.
+//!     docker run --rm -d --name xtdb-g6 \
+//!         -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+//!
+//! Run with:
+//!     ADBC_FLIGHTSQL_VERSION=1.11.0 cargo run --release
+//!
+//! (the env var only affects the first build: it tells the
+//! `adbc-driver-flightsql` build script which native driver wheel to
+//! download. Subsequent builds reuse the cached library.)
+
+use adbc_core::{
+    options::{AdbcVersion, OptionDatabase},
+    Connection, Database, Driver, Statement,
+};
+use adbc_driver_flightsql::DRIVER_PATH;
+use adbc_driver_manager::ManagedDriver;
+use arrow_array::RecordBatch;
+use datafusion::prelude::SessionContext;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+const FLIGHT_URI: &str = "grpc://localhost:9832";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // ---------------------------------------------------------------
+    // 1. Load the native FlightSQL driver and open an ADBC connection.
+    //    `adbc-driver-flightsql` ships the conda-forge native library and
+    //    exposes its on-disk path; `adbc_driver_manager` dlopens it.
+    // ---------------------------------------------------------------
+    let mut driver = ManagedDriver::load_dynamic_from_filename(
+        DRIVER_PATH,
+        None,
+        AdbcVersion::default(),
+    )?;
+    let database = driver
+        .new_database_with_opts([(OptionDatabase::Uri, FLIGHT_URI.into())])?;
+    let mut conn = database.new_connection()?;
+
+    // ---------------------------------------------------------------
+    // 2. Seed a table to read back. Plain SQL keeps this script
+    //    self-contained; bulk-ingesting an Arrow batch via
+    //    `adbc.ingest.target_table` is covered in the
+    //    `bulk-ingest-from-parquet` guide.
+    // ---------------------------------------------------------------
+    let mut seed = conn.new_statement()?;
+    seed.set_sql_query(
+        "INSERT INTO orders (_id, region, amount) VALUES
+           ('o-1', 'eu',   100),
+           ('o-2', 'eu',   250),
+           ('o-3', 'us',    80),
+           ('o-4', 'us',   400),
+           ('o-5', 'us',    60),
+           ('o-6', 'apac', 175)",
+    )?;
+    seed.execute_update()?;
+    println!("seeded orders");
+
+    // ---------------------------------------------------------------
+    // 3. Query XTDB back as a stream of Arrow batches.
+    //    `execute` returns a Box<dyn RecordBatchReader>; collect into a Vec
+    //    so DataFusion can register them as an in-memory table.
+    //    The Arrow IPC framing on the FlightSQL wire does one copy at the
+    //    gRPC boundary. Past that, every downstream step (DataFusion,
+    //    parquet-rs) operates on the same Arrow buffers without re-decode.
+    // ---------------------------------------------------------------
+    let mut q = conn.new_statement()?;
+    q.set_sql_query("SELECT _id, region, amount FROM orders")?;
+    let reader = q.execute()?;
+    let result_schema = reader.schema();
+    let batches: Vec<RecordBatch> = reader.collect::<Result<_, _>>()?;
+    println!(
+        "got {} batch(es), {} row(s) total from XTDB",
+        batches.len(),
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+    );
+
+    // ---------------------------------------------------------------
+    // 4. Hand the batches to DataFusion and run analytical SQL on them.
+    //    The schema and the batches are still Arrow: the same Rust
+    //    types DataFusion uses internally, no conversion.
+    // ---------------------------------------------------------------
+    let ctx = SessionContext::new();
+    ctx.register_batch(
+        "orders",
+        arrow::compute::concat_batches(&result_schema, &batches)?,
+    )?;
+
+    let df = ctx
+        .sql(
+            "SELECT region,
+                    COUNT(*)    AS n_orders,
+                    SUM(amount) AS total_amount
+             FROM orders
+             GROUP BY region
+             ORDER BY total_amount DESC",
+        )
+        .await?;
+    let agg_batches: Vec<RecordBatch> = df.collect().await?;
+    println!("\n-- DataFusion result --");
+    arrow::util::pretty::print_batches(&agg_batches)?;
+
+    // ---------------------------------------------------------------
+    // 5. Persist the aggregate to Parquet via parquet-rs.
+    //    Same arrow-rs schema and batches feed straight in.
+    // ---------------------------------------------------------------
+    let agg_schema = agg_batches
+        .first()
+        .map(|b| b.schema())
+        .ok_or("DataFusion returned no batches")?;
+    let out_path = "orders-by-region.parquet";
+    let file = std::fs::File::create(out_path)?;
+    let props = WriterProperties::builder().build();
+    let mut writer = ArrowWriter::try_new(file, agg_schema, Some(props))?;
+    for batch in &agg_batches {
+        writer.write(batch)?;
+    }
+    writer.close()?;
+    println!("\nwrote {out_path}");
+
+    Ok(())
+}

--- a/docs/src/content/docs/drivers/adbc/examples/rust/.gitignore
+++ b/docs/src/content/docs/drivers/adbc/examples/rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/docs/src/content/docs/drivers/adbc/examples/rust/Cargo.toml
+++ b/docs/src/content/docs/drivers/adbc/examples/rust/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "xtdb-adbc-hello-world"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# There is no pure-Rust FlightSQL ADBC driver. The Rust ADBC story is:
+# `adbc_driver_manager` dlopens the *native* libadbc_driver_flightsql, and
+# `adbc-driver-flightsql` is a thin shim whose own build script downloads that
+# native library from the official PyPI wheel and exposes its path as
+# DRIVER_PATH (no build.rs needed in this crate).
+#
+# The shim defaults to native-driver v1.9.0 — too old for the
+# `adbc.ingest.target_table` option used below (needs v1.10.0+). Set
+# ADBC_FLIGHTSQL_VERSION=1.11.0 in the environment for the first `cargo build`:
+#
+#     ADBC_FLIGHTSQL_VERSION=1.11.0 cargo run
+#
+# ~5 MB download, cached after that. The full native-driver-download mechanism
+# is unavoidable for a runnable Rust ADBC example — see rust-arrow-pipeline/ for
+# the same machinery in a larger end-to-end pipeline.
+#
+# Versions pinned to the matrix that resolves cleanly today (adbc_core 0.23.0
+# accepts arrow 53..<59; arrow 58.3.0 is the current stable line).
+[dependencies]
+adbc_core = "=0.23.0"
+adbc_driver_manager = "=0.23.0"
+adbc-driver-flightsql = "=0.1.2"
+arrow = { version = "=58.3.0", features = ["prettyprint"] }
+arrow-array = "=58.3.0"
+arrow-schema = "=58.3.0"

--- a/docs/src/content/docs/drivers/adbc/examples/rust/src/main.rs
+++ b/docs/src/content/docs/drivers/adbc/examples/rust/src/main.rs
@@ -1,0 +1,77 @@
+//! Minimal XTDB-via-ADBC hello world in Rust.
+//!
+//! There is no pure-Rust FlightSQL driver: `adbc_driver_manager` dlopens the
+//! *native* libadbc_driver_flightsql, and the `adbc-driver-flightsql` shim
+//! crate downloads that library from the official PyPI wheel and exposes its
+//! on-disk path as `DRIVER_PATH`.
+//!
+//! Requires a running XTDB node with the FlightSQL listener on localhost:9832.
+//! The standalone Docker image enables this by default:
+//!
+//!     docker run --rm -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+//!
+//! Run with:
+//!     ADBC_FLIGHTSQL_VERSION=1.11.0 cargo run
+//!
+//! The env var only affects the first build: it tells the
+//! `adbc-driver-flightsql` build script which native driver wheel to download.
+//! Subsequent builds reuse the cached library.
+
+use std::sync::Arc;
+
+use adbc_core::{
+    options::{AdbcVersion, IngestMode, OptionDatabase, OptionStatement},
+    Connection, Database, Driver, Optionable, Statement,
+};
+use adbc_driver_flightsql::DRIVER_PATH;
+use adbc_driver_manager::ManagedDriver;
+use arrow_array::{Int32Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+
+const FLIGHT_URI: &str = "grpc://localhost:9832";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load the native FlightSQL driver and open an ADBC connection.
+    let mut driver =
+        ManagedDriver::load_dynamic_from_filename(DRIVER_PATH, None, AdbcVersion::default())?;
+    let database =
+        driver.new_database_with_opts([(OptionDatabase::Uri, FLIGHT_URI.into())])?;
+    let mut conn = database.new_connection()?;
+
+    // 1. Bulk-ingest an Arrow RecordBatch: one round trip, no row shredding.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("_id", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(vec!["alice", "bob", "carol"])),
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])),
+            Arc::new(Int32Array::from(vec![30, 25, 28])),
+        ],
+    )?;
+    let mut ingest = conn.new_statement()?;
+    ingest.set_option(OptionStatement::TargetTable, "users".into())?;
+    ingest.set_option(OptionStatement::IngestMode, IngestMode::CreateAppend.into())?;
+    ingest.bind(batch)?;
+    ingest.execute_update()?;
+    println!("ingested users");
+
+    // 2. Query the rows back as a stream of Arrow batches.
+    let mut q = conn.new_statement()?;
+    q.set_sql_query("SELECT _id, name, age FROM users ORDER BY _id")?;
+    let reader = q.execute()?;
+    let batches: Vec<RecordBatch> = reader.collect::<Result<_, _>>()?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    println!(
+        "got {} batch(es), {total_rows} row(s) total from XTDB",
+        batches.len(),
+    );
+
+    println!("\n-- users --");
+    arrow::util::pretty::print_batches(&batches)?;
+
+    Ok(())
+}

--- a/docs/src/content/docs/drivers/adbc/examples/streaming-into-duckdb/main.py
+++ b/docs/src/content/docs/drivers/adbc/examples/streaming-into-duckdb/main.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+XTDB as bitemporal source-of-truth + DuckDB as compute.
+
+Scenario: as-of end-of-Q4 2024 trade snapshot from XTDB, joined against
+a counterparty-tier lookup table in DuckDB, aggregated by tier.
+
+Arrow is the substrate end-to-end: XTDB produces Arrow batches via ADBC
+FlightSQL; DuckDB receives them directly with no serialise/deserialise step.
+
+Requires:
+    docker run --rm -d --name xtdb-duckdb-demo \\
+        -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+    pip install adbc-driver-flightsql pyarrow duckdb psycopg
+
+Run:
+    python main.py
+    python main.py grpc://localhost:9832 postgresql://localhost:5432/xtdb
+"""
+
+import sys
+from textwrap import dedent
+
+import duckdb
+import pyarrow as pa
+import psycopg
+import adbc_driver_flightsql.dbapi as flight_sql
+
+# ── connection defaults (override via argv) ───────────────────────────────────
+FSQL_URI = sys.argv[1] if len(sys.argv) > 1 else "grpc://localhost:9832"
+PG_URI   = sys.argv[2] if len(sys.argv) > 2 else "postgresql://localhost:5432/xtdb"
+
+# ── 1. Seed XTDB with bitemporal trade data ───────────────────────────────────
+#
+# Trades are written via the pgwire path, the normal production write path.
+# _valid_from / _valid_to columns tell XTDB *when each record is true* on
+# the valid-time axis.  CommerzBank's T005 expires 2024-06-30 and will
+# therefore be absent from the Q4 snapshot even though it was ingested.
+
+SEED_SQL = dedent("""\
+    INSERT INTO trades (_id, counterparty, notional, currency, _valid_from, _valid_to)
+    VALUES
+      ('T001','Barclays',    1500000.0,'GBP',TIMESTAMP '2024-01-15 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T002','Barclays',    2000000.0,'GBP',TIMESTAMP '2024-03-01 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T003','JPMorgan',    3200000.0,'USD',TIMESTAMP '2024-02-10 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T004','DeutscheBank', 800000.0,'EUR',TIMESTAMP '2024-04-01 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T005','CommerzBank', 1100000.0,'EUR',TIMESTAMP '2024-01-01 00:00:00',TIMESTAMP '2024-06-30 00:00:00'),
+      ('T006','SocGen',       950000.0,'EUR',TIMESTAMP '2024-06-01 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T007','SocGen',      1750000.0,'EUR',TIMESTAMP '2024-09-15 00:00:00',TIMESTAMP '9999-12-31 00:00:00')
+""")
+
+print(f"Seeding XTDB via pgwire ({PG_URI}) …")
+with psycopg.connect(PG_URI, user="xtdb", autocommit=True) as pg:
+    with pg.cursor() as cur:
+        cur.execute(SEED_SQL)
+print("  Seeded 7 trade records with explicit valid-time ranges.\n")
+
+# ── 2. Pull the Q4 2024 end-of-quarter snapshot via ADBC ─────────────────────
+#
+# FOR VALID_TIME AS OF pins the query to a single instant in valid-time.
+# XTDB returns only rows whose valid-time period contains that instant:
+# T001 to T004 and T006 to T007 are active at 2024-12-31 23:59:59;
+# T005 (CommerzBank, valid_to = 2024-06-30) is excluded.
+
+SNAPSHOT_SQL = """\
+    SELECT _id, counterparty, notional, currency
+      FROM trades
+           FOR VALID_TIME AS OF TIMESTAMP '2024-12-31 23:59:59'
+     ORDER BY _id
+"""
+
+print(f"Querying XTDB via ADBC FlightSQL ({FSQL_URI}) …")
+with flight_sql.connect(FSQL_URI) as conn:
+    with conn.cursor() as cur:
+        cur.execute(SNAPSHOT_SQL)
+        snapshot: pa.Table = cur.fetch_arrow_table()   # Arrow, no row-by-row decode
+
+print(f"Q4 2024 snapshot ({len(snapshot)} rows; T005/CommerzBank excluded by valid-time):")
+for row in snapshot.to_pylist():
+    print(f"  {row['_id']}  {row['counterparty']:<15}  {row['currency']}  {row['notional']:>12,.0f}")
+
+# ── 3. Register the Arrow snapshot into DuckDB ────────────────────────────────
+#
+# duckdb.register() accepts any object that exposes the Arrow C Data Interface:
+# a pyarrow.Table, RecordBatch, polars DataFrame, etc.
+# DuckDB operates directly on the Arrow buffers XTDB produced; no copy, no decode.
+
+duck = duckdb.connect()          # in-memory analytical engine
+duck.register("xtdb_trades", snapshot)
+
+# ── 4. Create the counterparty-tier dimension in DuckDB ──────────────────────
+#
+# Enrichment data lives in DuckDB: could be a Parquet file, a CSV,
+# or (here) an inline relation.  The point is that it never touches XTDB.
+
+duck.execute("""\
+    CREATE TABLE counterparty_tiers AS
+    SELECT * FROM (VALUES
+        ('Barclays',     'Gold'),
+        ('JPMorgan',     'Gold'),
+        ('DeutscheBank', 'Silver'),
+        ('SocGen',       'Silver'),
+        ('CommerzBank',  'Bronze')
+    ) AS t(counterparty, tier)
+""")
+
+# ── 5. Join + aggregate in DuckDB ─────────────────────────────────────────────
+#
+# DuckDB's vectorised engine runs the analytical query over the Arrow buffers
+# that XTDB produced.  The bitemporal snapshot and the DuckDB dimension table
+# join inside DuckDB's execution engine, with no round-trip to XTDB,
+# no re-serialisation, no intermediate CSV.
+
+result: pa.Table = duck.execute("""\
+    SELECT
+        ct.tier,
+        count(*)                  AS trade_count,
+        sum(t.notional)           AS total_notional,
+        round(avg(t.notional), 0) AS avg_notional
+    FROM  xtdb_trades        AS t
+    JOIN  counterparty_tiers AS ct ON t.counterparty = ct.counterparty
+    GROUP BY ct.tier
+    ORDER BY total_notional DESC
+""").arrow().read_all()
+
+print("\nExposure by counterparty tier, as-of Q4 2024 end:")
+print(f"  {'Tier':<10}  {'Trades':>6}  {'Total Notional':>16}  {'Avg Notional':>14}")
+print(f"  {'-'*10}  {'-'*6}  {'-'*16}  {'-'*14}")
+for row in result.to_pylist():
+    print(
+        f"  {row['tier']:<10}  {row['trade_count']:>6}  "
+        f"{row['total_notional']:>16,.0f}  {row['avg_notional']:>14,.0f}"
+    )
+
+print(
+    "\nDone: XTDB produced Arrow batches via ADBC FlightSQL and DuckDB\n"
+    "consumed them directly, with no serialise/deserialise step."
+)

--- a/docs/src/content/docs/drivers/adbc/examples/tutorial/main.py
+++ b/docs/src/content/docs/drivers/adbc/examples/tutorial/main.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+XTDB ADBC tutorial: FX trades end-to-end.
+
+Companion script to docs/src/content/docs/drivers/adbc/tutorial.md.
+Every section in the tutorial maps to a numbered function below.
+
+Requirements:
+    pip install adbc-driver-flightsql pyarrow pandas
+
+Running against the Docker standalone image:
+    docker run --rm -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+    python main.py
+
+Override the FlightSQL URL:
+    XTDB_ARROW_URL=grpc://localhost:9842 python main.py
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import warnings
+from datetime import datetime, timezone
+
+import pyarrow as pa
+import adbc_driver_flightsql.dbapi as flight_sql
+
+# XTDB advertises FlightSQL transaction support, so the dbapi defaults to
+# manual-commit (PEP 249). This tutorial seeds exclusively via adbc_ingest,
+# which commits atomically regardless of the connection's commit mode, so the
+# reads below see their writes without an explicit commit. DML run via
+# cursor.execute/executemany would instead need conn.commit() or autocommit=True.
+warnings.filterwarnings("ignore", message="Cannot disable autocommit")
+
+XTDB_URL = os.environ.get("XTDB_ARROW_URL", "grpc://localhost:9832")
+
+
+# ── data ────────────────────────────────────────────────────────────────────
+
+#: Ten historical FX trades covering three currency pairs.
+INITIAL_TRADES: pa.Table = pa.table(
+    {
+        "_id": pa.array(
+            ["t001", "t002", "t003", "t004", "t005",
+             "t006", "t007", "t008", "t009", "t010"],
+        ),
+        "symbol": pa.array(
+            ["EURUSD", "GBPUSD", "EURUSD", "USDJPY", "GBPUSD",
+             "EURUSD", "USDJPY", "GBPUSD", "EURUSD", "USDJPY"],
+        ),
+        "qty": pa.array(
+            [100_000, 250_000, 75_000, 500_000, 180_000,
+             320_000, 90_000, 420_000, 110_000, 660_000],
+            type=pa.int64(),
+        ),
+        "price": pa.array(
+            [1.0921, 1.2734, 1.0918, 148.25, 1.2741,
+             1.0935, 148.10, 1.2728, 1.0942, 148.30],
+            type=pa.float64(),
+        ),
+        "traded_at": pa.array(
+            [
+                datetime(2024, 1, 15, 9, 0, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 9, 5, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 9, 10, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 9, 15, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 9, 20, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 10, 0, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 10, 5, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 10, 10, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 10, 15, tzinfo=timezone.utc),
+                datetime(2024, 1, 15, 10, 20, tzinfo=timezone.utc),
+            ],
+            type=pa.timestamp("us", tz="UTC"),
+        ),
+    }
+)
+
+
+# ── sections ─────────────────────────────────────────────────────────────────
+
+def section_2_connect() -> flight_sql.Connection:
+    """Return an open connection (caller must close)."""
+    print("\n── 2. Connecting ───────────────────────────────")
+    conn = flight_sql.connect(XTDB_URL)
+    print(f"Connected to {XTDB_URL}")
+    return conn
+
+
+def section_3_first_query(conn: flight_sql.Connection) -> None:
+    print("\n── 3. First query ──────────────────────────────")
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1")
+        result = cur.fetch_arrow_table()
+    print("Result schema:", result.schema)
+    print("Result:       ", result.to_pylist())
+
+
+def section_4_bulk_ingest(conn: flight_sql.Connection) -> None:
+    print("\n── 4. Bulk ingest ──────────────────────────────")
+
+    with conn.cursor() as cur:
+        cur.adbc_ingest("trades", INITIAL_TRADES, mode="create_append")
+    print(f"Ingested {len(INITIAL_TRADES)} rows into 'trades'.")
+
+    print("\nIngested schema:")
+    for field in INITIAL_TRADES.schema:
+        print(f"  {field.name}: {field.type}")
+
+    # Read back: types survive the round-trip.
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM trades ORDER BY _id")
+        back = cur.fetch_arrow_table()
+    print(f"\nRead back {back.num_rows} rows.")
+    print("Round-trip schema:", back.schema)
+
+
+def section_5_parameterised_query(conn: flight_sql.Connection) -> None:
+    print("\n── 5. Parameterised query ──────────────────────")
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT _id, symbol, qty, price FROM trades WHERE symbol = ? ORDER BY _id",
+            parameters=["EURUSD"],
+        )
+        result = cur.fetch_arrow_table()
+    print(f"EURUSD trades ({result.num_rows} rows):")
+    for row in result.to_pylist():
+        print(f"  {row['_id']}  qty={row['qty']:>7,}  price={row['price']:.4f}")
+
+
+def section_6_transactions(conn: flight_sql.Connection) -> None:
+    """
+    Demonstrates write visibility: each adbc_ingest is its own atomic commit,
+    and reads on the same connection see the writes immediately, regardless of
+    the connection's commit mode.
+
+    Note: the dbapi defaults to manual-commit now that the server advertises
+    transaction support, but adbc_ingest commits on its own. DML via
+    cursor.execute/executemany would need conn.commit() or autocommit=True.
+    Explicit multi-statement transactions (set_autocommit(False) → commit/
+    rollback) are shown in the prepared-statements-and-transactions example.
+    """
+    print("\n── 6. Write visibility (adbc_ingest) ───────────")
+
+    # First batch: confirmed committed immediately.
+    batch_a = pa.table({
+        "_id":    pa.array(["t011", "t012"]),
+        "symbol": pa.array(["EURGBP", "EURGBP"]),
+        "qty":    pa.array([60_000, 40_000], type=pa.int64()),
+        "price":  pa.array([0.8571, 0.8569], type=pa.float64()),
+    })
+    with conn.cursor() as cur:
+        cur.adbc_ingest("trades", batch_a, mode="create_append")
+
+    # Same-connection read: sees the new rows without any explicit await.
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM trades WHERE symbol = 'EURGBP'")
+        n = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+    print(f"  EURGBP rows visible immediately on same connection: {n}  (expected 2)")
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM trades")
+        total = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+    print(f"  Total trades: {total}  (expected 12)")
+
+
+def section_7_introspection(conn: flight_sql.Connection) -> None:
+    print("\n── 7. Introspection ────────────────────────────")
+
+    # Full object tree, returned as an Arrow reader.
+    reader = conn.adbc_get_objects(depth="all", db_schema_filter="public")
+    tbl = reader.read_all()
+    print(f"adbc_get_objects returned {tbl.num_rows} catalog row(s).")
+
+    # Schema for a single table, direct pyarrow.Schema.
+    schema = conn.adbc_get_table_schema("trades", db_schema_filter="public")
+    print("adbc_get_table_schema('trades'):")
+    for field in schema:
+        print(f"  {field.name}: {field.type}")
+
+
+def section_8_execute_schema(conn: flight_sql.Connection) -> None:
+    """
+    executeSchema: get the result Arrow schema without executing the query.
+
+    XTDB includes the result schema (datasetSchema) in the PreparedStatement
+    response so the client can read it back without a round-trip execution.
+    If the server build pre-dates this feature the driver raises NOT_IMPLEMENTED.
+    """
+    print("\n── 8. executeSchema ────────────────────────────")
+    try:
+        with conn.cursor() as cur:
+            schema = cur.adbc_execute_schema(
+                "SELECT _id, symbol, qty, price FROM trades WHERE symbol = ?"
+            )
+        print("Result schema (without executing):")
+        for field in schema:
+            print(f"  {field.name}: {field.type}")
+    except Exception as e:
+        if "NOT_IMPLEMENTED" in str(e):
+            print("  [server does not yet include datasetSchema in prepared-stmt response]")
+        else:
+            raise
+
+
+def section_9_bitemporal(conn: flight_sql.Connection) -> None:
+    print("\n── 9. Bitemporal, AS OF ────────────────────────")
+
+    # Record system time before inserting the new trade.
+    checkpoint = datetime.now(timezone.utc)
+    time.sleep(0.1)  # ensure next write lands at a strictly later system time
+
+    new_trade = pa.table({
+        "_id":    pa.array(["t013"]),
+        "symbol": pa.array(["USDCHF"]),
+        "qty":    pa.array([200_000], type=pa.int64()),
+        "price":  pa.array([0.9012], type=pa.float64()),
+    })
+    with conn.cursor() as cur:
+        cur.adbc_ingest("trades", new_trade, mode="create_append")
+
+    # Current view: t013 is present.
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM trades")
+        count_now = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+    print(f"  Total trades now:                        {count_now}")
+
+    # Historical view: AS OF the checkpoint, t013 had not yet been inserted.
+    ts_str = checkpoint.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    as_of_sql = (
+        f"SELECT count(*) FROM trades "
+        f"FOR SYSTEM_TIME AS OF TIMESTAMP '{ts_str}+00:00'"
+    )
+    with conn.cursor() as cur:
+        cur.execute(as_of_sql)
+        count_before = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+    print(f"  Trades FOR SYSTEM_TIME AS OF checkpoint: {count_before}")
+    print(f"  (checkpoint predates t013, count is {count_now - 1})")
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("XTDB ADBC tutorial: FX trades")
+    print(f"URL: {XTDB_URL}")
+
+    conn = section_2_connect()
+    try:
+        section_3_first_query(conn)
+        section_4_bulk_ingest(conn)
+        section_5_parameterised_query(conn)
+        section_6_transactions(conn)
+        section_7_introspection(conn)
+        section_8_execute_schema(conn)
+        section_9_bitemporal(conn)
+    finally:
+        conn.close()
+
+    print("\n── Done ────────────────────────────────────────")
+    print("All sections completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/content/docs/drivers/adbc/guides.md
+++ b/docs/src/content/docs/drivers/adbc/guides.md
@@ -1,0 +1,43 @@
+---
+title: ADBC how-to guides
+description: Task-shaped recipes for working with XTDB via ADBC.
+---
+
+Each guide solves one specific task.
+For a continuous walkthrough see the [tutorial](./tutorial); for the full supported surface see the [reference](./reference).
+
+## Guides
+
+### [Bulk-loading Parquet into XTDB via ADBC](./guides/bulk-ingest-from-parquet)
+
+`pyarrow.parquet.read_table` → `cur.adbc_ingest`.
+Schema requirements (the `_id` column), chunked ingest for tables larger than memory, error handling, and rejection modes.
+
+### [Round-tripping pandas / polars DataFrames](./guides/pandas-polars-round-trip)
+
+Two directions:
+
+- Read XTDB into a `pyarrow.Table` and hand off to pandas / polars via `to_pandas()` / `pl.from_arrow()`, zero-copy where possible.
+- Build a DataFrame in pandas / polars, convert to Arrow, `adbc_ingest` it.
+
+Covers type-fidelity preservation (categoricals, optional fields, timestamps with timezone).
+
+### [Point-in-time feature extraction for ML training sets](./guides/point-in-time-feature-extraction)
+
+Extract training-set features as known at label time: a single SQL query against `FOR VALID_TIME AS OF` produces a `pyarrow.Table` joined as-of label time, ready for a feature pipeline.
+It avoids training on information that wasn't yet available at the label time, the mistake feature stores are built to prevent.
+
+### [Streaming results into DuckDB](./guides/streaming-into-duckdb)
+
+`cur.fetch_arrow_table()` → DuckDB `register_arrow` → join with DuckDB-resident data.
+XTDB holds the bitemporal source of truth, DuckDB runs the ad-hoc analytics, and Arrow moves between them with no serialise/deserialise step.
+
+### [Rust ADBC + arrow-rs pipeline](./guides/rust-arrow-pipeline)
+
+End-to-end in Rust with `adbc_core` + `arrow-rs`: connect, ingest a `RecordBatch`, query, hand off to DataFusion for analytical compute, write the result out to Parquet.
+The Arrow types are checked at compile time through the whole pipeline.
+
+### [Prepared statements and transactions](./guides/prepared-statements-and-transactions)
+
+The full prepared-statement lifecycle over the wire: `prepare()` once, `bind()` + `executeQuery()` many times, parameter binding via Arrow batches.
+Multi-statement transactions, autocommit on/off, rollback semantics, and how XTDB's same-connection write-then-read works in practice.

--- a/docs/src/content/docs/drivers/adbc/guides/bulk-ingest-from-parquet.md
+++ b/docs/src/content/docs/drivers/adbc/guides/bulk-ingest-from-parquet.md
@@ -1,0 +1,175 @@
+---
+title: Bulk-load Parquet into XTDB via ADBC
+description: pyarrow.parquet.read_table → cur.adbc_ingest → done. Covers schema requirements, streaming large files, and error handling.
+---
+
+Loading a Parquet file into XTDB is one `adbc_ingest` call.
+This guide shows that minimal path and the variations that come up in practice: adding an `_id` when your Parquet doesn't have one, streaming large files in chunks, and handling the modes that XTDB rejects.
+
+## Prerequisites
+
+XTDB running with the FlightSQL listener on port `9832`, which the Docker standalone image does by default:
+
+```bash
+docker run --rm -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+```
+
+Install the Python dependencies:
+
+```bash
+pip install adbc-driver-flightsql pyarrow
+```
+
+## The minimal path
+
+```python
+import pyarrow.parquet as pq
+import adbc_driver_flightsql.dbapi as flight_sql
+
+table = pq.read_table("orders.parquet")
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        cur.adbc_ingest("orders", table, mode="create_append")
+```
+
+`adbc_ingest` streams Arrow batches from the client into XTDB in a single round trip: no row shredding, no `executemany("INSERT INTO ...")`.
+
+The one requirement: every row needs an `_id` column, XTDB's primary key.
+
+## Adding `_id` when your Parquet doesn't have one
+
+If your Parquet schema doesn't include an `_id` column, materialise one client-side before calling `adbc_ingest`.
+
+**Option 1: promote an existing natural key.**
+If a column already uniquely identifies each row (e.g. `order_id`), rename it:
+
+```python
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+table = pq.read_table("orders.parquet")
+# Rename order_id to _id, keep the original column too if you want.
+table = table.rename_columns(
+    ["_id" if c == "order_id" else c for c in table.schema.names]
+)
+```
+
+**Option 2: build a composite key.**
+If uniqueness comes from a combination of columns, hash them together:
+
+```python
+import pyarrow as pa
+import pyarrow.compute as pc
+
+# Concatenate two string columns to form a stable key.
+composite = pc.binary_join_element_wise(
+    table.column("customer_id").cast(pa.string()),
+    table.column("order_date").cast(pa.string()),
+    "-",
+)
+table = table.append_column("_id", composite)
+```
+
+**Option 3: assign a positional index.**
+For a one-time load where rows have no natural key, a sequential integer works:
+
+```python
+import pyarrow as pa
+
+ids = pa.array(range(len(table)), type=pa.string())
+table = table.append_column("_id", ids)
+```
+
+XTDB upserts on `_id`: two rows with the same `_id` in the same ingest call will produce one document in XTDB, with the later row's values winning.
+If that's not what you want, make sure your `_id` values are unique before ingesting.
+
+## Streaming large files in chunks
+
+`pq.read_table` loads the whole Parquet file into memory at once.
+For files larger than available RAM, use `pq.ParquetFile` to iterate over row groups:
+
+```python
+import pyarrow.parquet as pq
+import adbc_driver_flightsql.dbapi as flight_sql
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        pf = pq.ParquetFile("large-orders.parquet")
+        for batch in pf.iter_batches(batch_size=100_000):
+            # Each batch is a pyarrow.RecordBatch.
+            # adbc_ingest accepts RecordBatch as well as Table.
+            cur.adbc_ingest("orders", batch, mode="create_append")
+```
+
+`adbc_ingest` accepts any Arrow-shaped data: `pyarrow.Table`, `pyarrow.RecordBatch`, or any object that exposes the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).
+Batches stream through without materialising the whole dataset in either the client or the server.
+
+## Ingest modes
+
+`create`, `append`, and `create_append` are all accepted and behave the same here, since XTDB auto-creates tables and upserts on `_id`.
+`replace` and the fail-if-exists / fail-if-not-exist variants are rejected with a gRPC `INVALID_ARGUMENT`.
+See [Bulk ingest](/drivers/adbc/reference#bulk-ingest) in the reference for the full mode table and the reasoning.
+
+## Error handling
+
+Catch `adbc_driver_flightsql.DatabaseError` (a `ProgrammingError` in the ADBC DBAPI sense) and read the gRPC status message from it directly.
+Rejected modes return a descriptive `INVALID_ARGUMENT`; some other failures (a missing `_id`) are not yet mapped and surface as `INTERNAL`, with the cause still in the message.
+
+```python
+import pyarrow as pa
+import adbc_driver_flightsql.dbapi as flight_sql
+from adbc_driver_manager import DatabaseError
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        table = pa.table({
+            "_id": ["alice"],
+            "name": ["Alice"],
+        })
+
+        try:
+            # "replace" is rejected: XTDB has no ERASE-then-reinsert step.
+            cur.adbc_ingest("users", table, mode="replace")
+        except DatabaseError as e:
+            print(f"Ingest failed: {e}")
+            # "Ingest failed: INVALID_ARGUMENT: ingest mode 'replace' is not supported …"
+
+        try:
+            # Missing _id column. Currently surfaces as INTERNAL, not
+            # INVALID_ARGUMENT (see the reference's error-mapping note).
+            no_id = pa.table({"name": ["Bob"]})
+            cur.adbc_ingest("users", no_id, mode="create_append")
+        except DatabaseError as e:
+            print(f"Ingest failed: {e}")
+```
+
+XTDB puts the full gRPC status message in `DatabaseError.args[0]`, so you can read it straight off the exception.
+
+## Verifying the load
+
+After ingesting, confirm the row count and schema look right:
+
+```python
+with conn.cursor() as cur:
+    cur.execute("SELECT count(*) AS n FROM orders")
+    print("Row count:", cur.fetchone()[0])
+
+    schema = conn.adbc_get_table_schema(
+        "orders", db_schema_filter="public",
+    )
+    print("Schema:", schema)
+```
+
+`adbc_get_table_schema` reflects live data: freshly ingested rows show up immediately, before any background flush.
+
+## Runnable example
+
+A self-contained script that writes a Parquet fixture and bulk-loads it is in the repository at
+[`docs/drivers/adbc/examples/bulk-ingest-from-parquet/main.py`](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples/bulk-ingest-from-parquet/main.py).
+
+```bash
+docker run --rm -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+pip install adbc-driver-flightsql pyarrow
+python docs/src/content/docs/drivers/adbc/examples/bulk-ingest-from-parquet/main.py
+```

--- a/docs/src/content/docs/drivers/adbc/guides/pandas-polars-round-trip.md
+++ b/docs/src/content/docs/drivers/adbc/guides/pandas-polars-round-trip.md
@@ -1,0 +1,320 @@
+---
+title: Round-tripping pandas / polars DataFrames via ADBC
+description: Zero-copy dataframe ↔ XTDB through Arrow, with full type fidelity for timestamps, nulls, and categoricals.
+---
+
+ADBC keeps your data in Arrow from XTDB through to a DataFrame, with no row-by-row decode and no type widening through the Postgres text wire.
+This guide shows both directions: reading query results straight into pandas / polars, and writing DataFrames back to XTDB.
+
+Type fidelity is the main reason to use this path.
+`TIMESTAMP WITH TIME ZONE`, nullable columns, and dictionary-encoded categoricals all survive intact.
+The same round-trip through psycopg or JDBC widens timestamps, turns nullable Arrow arrays into `NaN`-polluted float columns, and discards the category encoding.
+
+## Prerequisites
+
+```bash
+pip install adbc-driver-flightsql pyarrow pandas polars
+docker run --rm -d --name xtdb -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+```
+
+All examples below connect to `grpc://localhost:9832`.
+The [runnable companion script](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples/pandas-polars-round-trip/main.py) exercises every code block in order.
+
+## The dataset
+
+A small events table that stress-tests type fidelity:
+
+- `_id`: required; XTDB's document key.
+- `ts`: `TIMESTAMP WITH TIME ZONE`.
+  psycopg hands this back as a tz-aware `datetime`; ADBC hands it back as `timestamp[us, tz=UTC]`, Arrow-native, no intermediate decode.
+- `severity`: string, stored as a small-cardinality column.
+  Ingested via pandas as `dictionary<int8, large_utf8>`; polars ingests as `dictionary<uint32, large_utf8>`.
+  psycopg would widen to plain strings; ADBC returns it as `utf8`, which clients can re-encode as dictionary if needed (see the [dictionary callout](#dictionary-round-trip-caveat)).
+- `value`: `float64`, always present.
+- `label`: `utf8`, nullable.
+  Some rows have `null` here.
+  Through psycopg the column often surfaces as `object` dtype with `None` sprinkled in; Arrow models it as a validity bitmap alongside the data buffer.
+
+## XTDB → Arrow (reading)
+
+Connect and fetch a query result as an Arrow table:
+
+```python
+import pyarrow as pa
+import adbc_driver_flightsql.dbapi as flight_sql
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        cur.execute("SELECT _id, ts, severity, value, label FROM events ORDER BY ts")
+        arrow_table = cur.fetch_arrow_table()
+
+# arrow_table is a pyarrow.Table; Arrow buffers, no copies yet.
+print(arrow_table.schema)
+# _id:      string
+# ts:       timestamp[us, tz=UTC]
+# severity: string
+# value:    double
+# label:    string   (nullable=True)
+```
+
+Query results stream from XTDB as Arrow batches over gRPC.
+`fetch_arrow_table()` collects them into a single `pyarrow.Table`, memory-bound by the client; use the raw batch-by-batch path for very large result sets.
+
+### Timezone normalisation
+
+XTDB FlightSQL currently returns timestamps with timezone key `"Z"` (Zulu = UTC).
+The `"Z"` key is valid Arrow but not a recognised IANA timezone string, so pandas will raise a `ZoneInfoNotFoundError` when printing or converting these columns.
+Cast to `"UTC"` before handing the table to pandas or polars:
+
+```python
+def normalise_tz(table: pa.Table) -> pa.Table:
+    """Cast timestamp[us, tz=Z] → timestamp[us, tz=UTC] for client compatibility."""
+    for i, field in enumerate(table.schema):
+        t = field.type
+        if pa.types.is_timestamp(t) and t.tz == "Z":
+            table = table.set_column(
+                i, field.name,
+                table.column(field.name).cast(pa.timestamp(t.unit, tz="UTC")),
+            )
+    return table
+
+arrow_table = normalise_tz(arrow_table)
+```
+
+## Arrow → pandas
+
+### With `types_mapper=pd.ArrowDtype` (recommended)
+
+```python
+import pandas as pd
+
+df = arrow_table.to_pandas(types_mapper=pd.ArrowDtype)
+print(df.dtypes)
+# _id         string[pyarrow]
+# ts          timestamp[us, tz=UTC][pyarrow]
+# severity    string[pyarrow]
+# value       double[pyarrow]
+# label       string[pyarrow]
+```
+
+`types_mapper=pd.ArrowDtype` keeps all columns Arrow-backed:
+- **Zero-copy** for all column types including strings: the pandas `ArrowDtype` column wraps the Arrow buffer directly, no allocation.
+- Nulls surface as `pd.NA` (not `float('nan')`): `df["label"].isna().sum()` counts them correctly.
+- Timestamps carry the UTC timezone as an `ArrowDtype`: no lossy intermediate.
+
+### Without `types_mapper` (classic path)
+
+```python
+df_classic = arrow_table.to_pandas()
+print(df_classic.dtypes)
+# _id         object              ← strings decoded into Python objects
+# ts          datetime64[us, UTC] ← zero-copy from the Arrow buffer
+# severity    object              ← strings decoded, dictionary encoding gone
+# value       float64             ← zero-copy from the Arrow buffer
+# label       object              ← nulls decoded as Python None
+```
+
+Numeric and timestamp columns are zero-copy in the classic path too.
+Strings allocate: pandas's `object` dtype is Python objects, not Arrow buffers.
+
+## Arrow → polars
+
+polars is Arrow-native, so `pl.from_arrow()` wraps the Arrow buffers without copying them:
+
+```python
+import polars as pl
+
+df = pl.from_arrow(arrow_table)
+print(df.schema)
+# Schema({'_id': String, 'ts': Datetime(time_unit='us', time_zone='UTC'),
+#         'severity': String, 'value': Float64, 'label': String})
+```
+
+The polars path is genuinely zero-copy for all column types including strings.
+polars stores strings as Arrow `LargeUtf8` internally; it wraps the server-side `Utf8` buffer directly.
+
+Nulls are modelled as Arrow nulls, not `NaN`:
+
+```python
+df["label"].null_count()   # 2; not NaN, not None-in-object
+```
+
+## DataFrame → XTDB (ingesting)
+
+The clean bulk-ingest path (one gRPC round trip, no row shredding) uses `adbc_ingest`:
+
+```python
+import pyarrow as pa
+
+# pandas → Arrow
+arrow_from_pd = pa.Table.from_pandas(df, preserve_index=False)
+
+# polars → Arrow (near-zero-copy)
+arrow_from_pl = df_pl.to_arrow()
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        cur.adbc_ingest("events", arrow_from_pd, mode="create_append")
+        cur.adbc_ingest("events", arrow_from_pl, mode="create_append")
+```
+
+`adbc_ingest` maps to the FlightSQL `CommandStatementIngest` command: the whole table travels as one Arrow stream, no per-row round trips.
+It's available on the `nightly` image and on stable images from 2.2.0 onwards.
+
+## Building an ingest-ready Arrow table from pandas
+
+Regardless of the ingest path, here is how to build a clean Arrow table from a pandas DataFrame:
+
+```python
+import pandas as pd
+import pyarrow as pa
+
+df = pd.DataFrame({
+    "_id": ["evt-001", "evt-002", "evt-003", "evt-004"],
+    "ts": pd.to_datetime(
+        ["2024-01-15T08:30:00Z", "2024-01-15T09:45:00Z",
+         "2024-01-15T11:00:00Z", "2024-01-15T14:20:00Z"],
+        utc=True,
+    ),
+    # Categorical → Arrow dictionary<int8, large_utf8>.
+    "severity": pd.Categorical(
+        ["INFO", "WARN", "ERROR", "INFO"],
+        categories=["INFO", "WARN", "ERROR"],
+    ),
+    "value": [1.23, 4.56, 7.89, 2.34],
+    # StringDtype with None → Arrow utf8 with validity bitmap (not NaN).
+    "label": pd.array(["startup", None, "threshold", None],
+                      dtype=pd.StringDtype()),
+})
+
+arrow_table = pa.Table.from_pandas(df, preserve_index=False)
+# Schema:
+#   _id:      large_string
+#   ts:       timestamp[us, tz=UTC]
+#   severity: dictionary<values=large_string, indices=int8, ordered=0>
+#   value:    double
+#   label:    large_string
+```
+
+Key points:
+
+- Use `pd.StringDtype()` for nullable string columns so `None` maps to an Arrow null, not a `NaN`.
+  Plain Python `str` in an `object` column would produce `None` or `float('nan')`, which `from_pandas` handles heuristically.
+- Use `pd.Categorical` for low-cardinality string columns: `from_pandas` converts it to Arrow `dictionary<int8, large_utf8>` preserving the encoding.
+- `preserve_index=False` drops the pandas index from the schema; the resulting table is clean Arrow with no pandas metadata bleeding in.
+
+## Building an ingest-ready Arrow table from polars
+
+polars `.to_arrow()` is near-zero-copy:
+
+```python
+import polars as pl
+from datetime import datetime, timezone
+
+df = pl.DataFrame({
+    "_id": ["evt-005", "evt-006"],
+    "ts": pl.Series(
+        [datetime(2024, 1, 16, 8, 0, tzinfo=timezone.utc),
+         datetime(2024, 1, 16, 10, 30, tzinfo=timezone.utc)],
+        dtype=pl.Datetime("us", "UTC"),
+    ),
+    "severity": pl.Series(["WARN", "ERROR"], dtype=pl.Categorical),
+    "value": [9.99, 0.01],
+    "label": pl.Series([None, "manual"], dtype=pl.Utf8),
+})
+
+arrow_table = df.to_arrow()
+# Schema:
+#   _id:      large_string
+#   ts:       timestamp[us, tz=UTC]
+#   severity: dictionary<values=large_string, indices=uint32, ordered=0>
+#   value:    double
+#   label:    large_string
+```
+
+polars `pl.Categorical` maps to `dictionary<uint32, large_utf8>`, a wider index than pandas's `int8`, but both are valid Arrow dictionary types.
+
+## Type fidelity: what survives, what doesn't
+
+| Type | Via pgwire (psycopg) | Via ADBC |
+|------|----------------------|----------|
+| `TIMESTAMP WITH TIME ZONE` | Python `datetime` (tz-aware) | `timestamp[us, tz=UTC]`, Arrow native, zero-copy into polars / pandas with `ArrowDtype` |
+| Nullable column | `object` dtype with `None` | Arrow validity bitmap, proper `null_count`, no NaN |
+| `DOUBLE` / `FLOAT` | Python `float` | `float64` Arrow buffer, zero-copy into numpy / polars |
+| `INTEGER` | Python `int` | `int32` / `int64` Arrow buffer, zero-copy |
+| `VARCHAR` / `TEXT` | Python `str` | `utf8` / `large_utf8`, zero-copy into polars, copy into classic pandas |
+
+### Dictionary round-trip caveat
+
+XTDB's query engine returns `utf8` for string columns regardless of how they were ingested.
+If you ingest a `dictionary<int8, utf8>` column and query it back, you'll get `utf8`: the data is intact but the encoding is gone.
+Re-encode client-side if the downstream computation depends on it:
+
+```python
+col = arrow_table.column("severity")
+if not pa.types.is_dictionary(col.type):
+    arrow_table = arrow_table.set_column(
+        arrow_table.schema.get_field_index("severity"),
+        "severity",
+        col.dictionary_encode(),
+    )
+```
+
+### Null handling on the pandas ingest path
+
+pandas uses `NaN` for missing float values and `None` for object dtype columns.
+`pa.Table.from_pandas()` maps both to Arrow nulls, but only if the column uses a pandas nullable extension type.
+Use `pd.StringDtype()`, `pd.Int64Dtype()`, etc. so `from_pandas` can distinguish a real `None` from a missing sentinel:
+
+```python
+# Correct: nullable Int64Dtype maps None → Arrow null.
+df["count"] = pd.array([1, None, 3], dtype=pd.Int64Dtype())
+
+# Risky: plain int list with None becomes float64 with NaN.
+df["count"] = [1, None, 3]
+```
+
+## The pgwire comparison
+
+Same round-trip via psycopg for contrast:
+
+```python
+import psycopg
+
+with psycopg.connect("postgresql://xtdb@localhost:5432/xtdb") as pg:
+    # Row-at-a-time INSERT; one round trip per row.
+    pg.autocommit = True
+    with pg.cursor() as cur:
+        for _, row in df.iterrows():
+            cur.execute(
+                "INSERT INTO events (_id, ts, severity, value) VALUES (%s, %s, %s, %s)",
+                (row["_id"], row["ts"], str(row["severity"]), row["value"]),
+            )
+
+        # SELECT returns rows decoded one at a time.
+        cur.execute("SELECT _id, ts, severity, value, label FROM events ORDER BY ts")
+        rows = cur.fetchall()
+        # rows is a list of tuples; ts is a datetime, severity is a str,
+        # nulls are None, no Arrow anywhere, no zero-copy.
+```
+
+The ADBC path:
+- Ingests the whole table in a single gRPC call via `adbc_ingest` vs one `INSERT` per row.
+- Returns Arrow batches vs decoded Python tuples.
+- Preserves `timestamp[us, tz=UTC]` vs widening to `datetime`.
+- Keeps nulls as Arrow null rather than Python `None` in an `object` column.
+
+For analytical and bulk workloads, the Arrow path avoids a decode-and-re-encode step on every row.
+For interactive queries and existing Postgres tooling, pgwire is still the right answer.
+
+## Summary
+
+- Use `cur.fetch_arrow_table()` to collect query results as a `pyarrow.Table`.
+  Call `normalise_tz()` to convert `tz=Z` → `tz=UTC` before pandas/polars conversion.
+- Use `.to_pandas(types_mapper=pd.ArrowDtype)` for zero-copy across all column types including strings.
+- Use `pl.from_arrow(arrow_table)` for polars: genuinely zero-copy, nulls modelled correctly.
+- Use `pa.Table.from_pandas(df, preserve_index=False)` to build an Arrow table for ingest.
+  Use nullable extension types (`pd.StringDtype()`, `pd.Int64Dtype()`) to preserve nulls.
+- Use `df.to_arrow()` for polars: near-zero-copy.
+- Use `cur.adbc_ingest(table, arrow_table, mode="create_append")` for bulk Arrow ingest over FlightSQL: one round trip, no row shredding.
+  Available on `nightly` and stable images from 2.2.0 onwards.

--- a/docs/src/content/docs/drivers/adbc/guides/point-in-time-feature-extraction.md
+++ b/docs/src/content/docs/drivers/adbc/guides/point-in-time-feature-extraction.md
@@ -1,0 +1,227 @@
+---
+title: Point-in-time feature extraction for ML training sets
+description: Build leakage-free training matrices with one bitemporal SQL query.
+---
+
+Training models on data that changes over time runs into the as-of-join problem.
+You label an event at time `T`, then join feature rows on the entity key.
+A naive join pulls each entity's *current* feature values, including everything that happened after `T`.
+The model trains on information from after the label time, scores well offline, and then degrades in production.
+
+Much of what feature stores (Feast, Tecton, Hopsworks) do is to perform this join correctly.
+In XTDB the join is one SQL query, because every row already carries its valid-time interval.
+`adbc_driver_flightsql` returns the result as Arrow, and `pyarrow.Table.to_pandas()` gives you a model-ready dataframe.
+
+The runnable example for this guide is in [`docs/.../examples/point-in-time-feature-extraction/main.py`](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples/point-in-time-feature-extraction/main.py).
+
+## The scenario
+
+Loan-default prediction.
+
+**Labels.**
+One row per event we want to train on: `(customer_id, observed_at, did_default)`.
+
+**Features.**
+Per-customer attributes that drift: `account_balance`, `credit_score`, `employment_status`.
+The truth about a customer on 2024-08-15 is different from the truth about that customer on 2024-11-01, and the model only ever gets to see the former.
+
+We seed three customers with deliberately-shifting histories.
+`c1` starts the year solvent, drifts down through summer, and bottoms out post-default in October.
+`c3` defaults, then recovers in November.
+A naive join would feed *both* of those post-default snapshots into training rows for a default that happened in August.
+
+## Setup
+
+Start a node with the FlightSQL listener:
+
+```bash
+docker run --rm -d --name xtdb -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+pip install adbc-driver-flightsql pyarrow pandas
+```
+
+Connect:
+
+```python
+import adbc_driver_flightsql.dbapi as flight_sql
+
+# autocommit=True so each seed INSERT commits and the joins below read their
+# own writes. The dbapi defaults to manual-commit (PEP 249) now that the
+# server advertises transaction support, so without this the uncommitted
+# seed rows would be invisible to subsequent queries on the same connection.
+conn = flight_sql.connect("grpc://localhost:9832", autocommit=True)
+```
+
+## Seeding features as a temporal timeline
+
+Every XTDB row carries a valid-time interval, exposed as `_valid_from` / `_valid_to`.
+Setting `_valid_from` on `INSERT` records *when each version became true*, not when the database happened to learn it.
+
+```python
+cur.execute("""
+    INSERT INTO customer_features
+      (_id, _valid_from, account_balance, credit_score, employment_status)
+    VALUES (?, ?, ?, ?, ?)
+""", parameters=["c1", date(2024, 1, 1), 1500.00, 680, "employed"])
+```
+
+Re-inserting `_id = "c1"` with a later `_valid_from` doesn't overwrite the prior version: it closes off the previous interval and starts a new one.
+After ingesting the seed, `c1`'s history is a step function over valid time:
+
+```
+c1: [2024-01-01 .. 2024-04-01)  balance=1500  score=680  employed
+    [2024-04-01 .. 2024-07-01)  balance=2100  score=700  employed
+    [2024-07-01 .. 2024-10-01)  balance=400   score=640  employed
+    [2024-10-01 .. ∞         )  balance=50    score=580  unemployed
+```
+
+No audit table, no `effective_from` column, no triggers, no manual interval bookkeeping.
+
+## The naive join: wrong
+
+This is what most pipelines start with:
+
+```sql
+SELECT l._id          AS label_id,
+       l.customer_id,
+       l.observed_at,
+       l.did_default,
+       f.account_balance,
+       f.credit_score,
+       f.employment_status
+FROM loan_labels AS l
+JOIN customer_features AS f
+  ON f._id = l.customer_id
+```
+
+Without a temporal qualifier, XTDB returns each customer's *current* row, so this query gives every label the customer's feature values *as they are today*, regardless of when the label was observed.
+
+For our seed:
+
+```
+label_id customer_id observed_at  did_default  account_balance  credit_score employment_status
+      L1          c1  2024-08-15         True             50.0           580        unemployed
+      L2          c2  2024-08-15        False          10200.0           770          employed
+      L3          c3  2024-08-15         True           5500.0           700          employed
+```
+
+Look at `L1`.
+The label says c1 defaulted on 2024-08-15.
+The feature row says c1 has $50 in the bank and is unemployed.
+Those numbers describe c1 *after* the default has already destroyed their finances.
+The model "learns" that low balance + unemployed predicts default: true but tautological.
+Look at `L3`.
+The features for c3 show $5,500 and a 700 credit score: c3's *recovery* a quarter after the default we're trying to predict.
+Train on this and the model learns the aftermath of a default, not the signals that precede one, so it has nothing useful to go on in production.
+
+## The bitemporal AS-OF join: right
+
+The fix is one SQL clause: `FOR ALL VALID_TIME` on the features table, joined against the label's `observed_at`:
+
+```sql
+SELECT l._id          AS label_id,
+       l.customer_id,
+       l.observed_at,
+       l.did_default,
+       f.account_balance,
+       f.credit_score,
+       f.employment_status
+FROM loan_labels AS l
+LEFT JOIN customer_features FOR ALL VALID_TIME AS f
+  ON f._id = l.customer_id
+  AND f._valid_from <= l.observed_at
+  AND (f._valid_to IS NULL OR f._valid_to > l.observed_at)
+```
+
+`FOR ALL VALID_TIME` opens up every historical version of `customer_features`.
+The `_valid_from <= observed_at < _valid_to` predicate picks the one version per customer whose interval contains the label's timestamp.
+
+Same data, run again:
+
+```
+label_id customer_id observed_at  did_default  account_balance  credit_score employment_status
+      L1          c1  2024-08-15         True            400.0           640          employed
+      L2          c2  2024-08-15        False           9500.0           760          employed
+      L3          c3  2024-08-15         True             10.0           540        unemployed
+```
+
+c1's August features are now $400 / 640 / employed: the state the customer was actually in before the default.
+c3's features are $10 / 540 / unemployed: the dire state preceding the default, not the post-recovery snapshot.
+
+This is one query covering every label, with no Python loop or per-row round trip.
+XTDB applies the `FOR VALID_TIME AS OF` bound during the table scan, so each row is read at its as-of-label-time version directly.
+
+### Why this is hard without bitemporal storage
+
+The standard alternative is event sourcing: store every change to a customer as an immutable event with a timestamp, then for each label scan the event log up to `observed_at` and fold the latest state per attribute.
+You'll either write that fold in application code (slow, hard to vectorise), bake it into a Spark/Flink job (complex, brittle, your own join-engine to debug), or rent a feature store (Feast/Tecton/Hopsworks) whose primary value-add is doing exactly this.
+
+Each of those routes rebuilds part of what a bitemporal database already does.
+XTDB is one, with the temporal logic built in and queried through standard SQL:2011 syntax.
+
+## Handing the result to sklearn
+
+`fetch_arrow_table()` gives a `pyarrow.Table`; `to_pandas()` gives the dataframe sklearn wants:
+
+```python
+cur.execute(ASOF_SQL)
+features_df = cur.fetch_arrow_table().to_pandas()
+
+X = features_df[["account_balance", "credit_score", "employment_status"]]
+y = features_df["did_default"].astype(int)
+```
+
+The Arrow path is zero-copy for numeric columns and one allocation for strings.
+For a one-million-label training set the conversion stays in seconds, not minutes.
+
+If you'd rather skip pandas:
+
+```python
+import polars as pl
+features_df = pl.from_arrow(cur.fetch_arrow_table())
+```
+
+polars consumes the Arrow batches directly with no intermediate copy.
+
+## Variations
+
+**Per-label valid-time.** Labels themselves don't have to live in XTDB.
+Land them as an in-memory `pyarrow.Table` and ingest, or `INSERT` them directly; the AS-OF join works the same.
+
+**Multi-table join.** Multiple feature tables, each with their own timeline:
+
+```sql
+SELECT l._id, l.customer_id, l.observed_at, l.did_default,
+       cf.credit_score,
+       acc.account_balance,
+       emp.status AS employment_status
+FROM loan_labels AS l
+LEFT JOIN credit_scores      FOR ALL VALID_TIME AS cf  ON cf._id = l.customer_id
+  AND cf._valid_from  <= l.observed_at AND (cf._valid_to  IS NULL OR cf._valid_to  > l.observed_at)
+LEFT JOIN accounts           FOR ALL VALID_TIME AS acc ON acc._id = l.customer_id
+  AND acc._valid_from <= l.observed_at AND (acc._valid_to IS NULL OR acc._valid_to > l.observed_at)
+LEFT JOIN employment_history FOR ALL VALID_TIME AS emp ON emp._id = l.customer_id
+  AND emp._valid_from <= l.observed_at AND (emp._valid_to IS NULL OR emp._valid_to > l.observed_at)
+```
+
+Each feature table is joined at its own correct point in time.
+You can collapse the repetition with a SQL view; the optimiser still pushes each temporal predicate into its respective scan.
+
+**Reproducible re-runs.** Pin the whole query to a system-time basis:
+
+```sql
+SETTING DEFAULT SYSTEM_TIME AS OF TIMESTAMP '2024-12-01T00:00:00Z'
+SELECT ...
+```
+
+Re-run the training-set extraction six months later, get bit-identical output even if features were corrected in the meantime.
+The `FOR VALID_TIME` clause picks the right version *in the timeline*; `SETTING DEFAULT SYSTEM_TIME` picks the right *timeline*.
+This is the bitemporal pair; see [Time in XTDB](/about/time-in-xtdb) for the underlying model.
+
+## Caveats
+
+The example script seeds each table in a single `adbc_ingest` call, including a `_valid_from` column so every row sets its own valid-time and the customers build a real timeline.
+`_valid_from` must be a `timestamp` column in the Arrow table, not a `date`.
+For bulk loads of labels or feature timelines from Parquet or pandas, see [Bulk-load Parquet into XTDB via ADBC](/drivers/adbc/guides/bulk-ingest-from-parquet).
+
+Training-set extraction is a single read query, so transactions don't enter into it.
+But if you combine ingestion and querying on the same connection, see [Transactions](/drivers/adbc/reference#transactions) in the reference.

--- a/docs/src/content/docs/drivers/adbc/guides/prepared-statements-and-transactions.md
+++ b/docs/src/content/docs/drivers/adbc/guides/prepared-statements-and-transactions.md
@@ -1,0 +1,299 @@
+---
+title: Prepared statements and transactions via ADBC
+description: "The full ADBC statement lifecycle over the wire: prepare once, bind many, and multi-statement transactions."
+---
+
+ADBC separates *what* you want to run from *when* you run it and *with what parameters*.
+Understanding that separation is the key to writing efficient, correct client code.
+
+This guide covers the basics:
+the prepare→bind→execute lifecycle, Arrow batch parameter binding, multi-statement transactions, and same-connection write-then-read consistency.
+
+The runnable companion script exercises every section in order:
+[`docs/drivers/adbc/examples/prepared-statements-and-transactions/main.py`](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples/prepared-statements-and-transactions/main.py)
+
+## Prerequisites
+
+```bash
+docker run --rm -d --name xtdb -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+pip install adbc-driver-flightsql pyarrow
+```
+
+All examples connect to `grpc://localhost:9832`.
+Adjust the port if you mapped it differently.
+
+:::note
+Use the `nightly` image for ADBC/FlightSQL work: it enables the FlightSQL listener on port 9832 by default.
+(Stable images from 2.2.0 onwards enable it too.)
+:::
+
+## The statement lifecycle
+
+Every ADBC statement follows the same pattern:
+
+```
+setSqlQuery(sql)
+    │
+    ▼
+prepare()          ← optional but required when binding Arrow params
+    │
+    ▼
+bind(arrow_batch)  ← one batch of positional parameters
+    │
+    ▼
+execute_query() / execute_update()
+    │
+    ▼
+stream results (ArrowReader)
+```
+
+`prepare()` parses the SQL and builds a query plan once.
+`bind()` attaches a parameter batch; the batch stays on the client, with no round trip, until you execute.
+`execute_query()` sends the bound batch and streams results back as Arrow.
+
+When you write `cur.execute("SELECT ... WHERE _id = ?", parameters=["alice"])` in the Python dbapi, all three steps happen implicitly in one call.
+The explicit lifecycle matters in two situations: hot loops where amortising the parse cost pays off, and Arrow batch binding.
+
+## Scalar parameters
+
+The dbapi `execute()` call handles scalar parameters inline:
+
+```python
+import adbc_driver_flightsql.dbapi as flight_sql
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT _id, name, price FROM products WHERE _id = ?",
+            parameters=["p1"],
+        )
+        print(cur.fetchone())
+        # ('p1', 'Widget', 9.99)
+```
+
+`parameters` is a positional list matching the `?` placeholders in the SQL.
+Positional binding only: named parameters are not currently supported over the FlightSQL wire.
+
+## Prepare-once / execute-many
+
+When you call `execute()` in a tight loop with different parameters, the driver re-parses the SQL on every iteration.
+The explicit prepare path amortises the cost:
+
+```python
+import adbc_driver_flightsql
+import adbc_driver_manager
+import pyarrow as pa
+
+db = adbc_driver_flightsql.connect("grpc://localhost:9832")
+conn = adbc_driver_manager.AdbcConnection(db)
+stmt = adbc_driver_manager.AdbcStatement(conn)
+
+stmt.set_sql_query("SELECT _id, name, price FROM products WHERE _id = ?")
+stmt.prepare()                     # parse + plan once
+
+for product_id in ["p1", "p2", "p3"]:
+    batch = pa.record_batch(
+        {"v0": pa.array([product_id], type=pa.string())}
+    )
+    stmt.bind(batch)               # client-side, no round trip
+    handle, _ = stmt.execute_query()
+
+    reader = pa.RecordBatchReader._import_from_c(handle.address)
+    for row in reader.read_all().to_pylist():
+        print(f"  {row['_id']}: {row['name']}, £{row['price']:.2f}")
+
+stmt.close()
+conn.close()
+db.close()
+```
+
+`bind()` takes any Arrow data with `__arrow_c_array__` or `__arrow_c_stream__`.
+Column names in the batch don't matter: parameters are matched positionally to the `?` placeholders.
+
+`prepare()` is required before `bind()`.
+Calling `bind()` without a prior `prepare()` raises `INVALID_STATE`.
+
+## Arrow batch parameter binding
+
+Pass a multi-row `RecordBatch` as the bound parameters so that one round trip inserts (or queries for) many rows.
+
+```python
+import pyarrow as pa
+import adbc_driver_flightsql.dbapi as flight_sql
+
+# Build a batch where each row is one INSERT execution.
+# Columns map positionally to the ? placeholders in the SQL.
+# The whole batch travels as a single Arrow buffer over gRPC,
+# with no row-shredding and no individual round trips per row.
+param_batch = pa.record_batch({
+    "v0": pa.array(["p4", "p5", "p6"],                   type=pa.string()),
+    "v1": pa.array(["Thingamajig", "Whatsit", "Gizmo"],  type=pa.string()),
+    "v2": pa.array([14.99, 7.49, 19.99],                 type=pa.float64()),
+    "v3": pa.array([75, 120, 30],                        type=pa.int64()),
+})
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO products (_id, name, price, stock)"
+            " VALUES (?, ?, ?, ?)",
+            param_batch,
+        )
+
+        cur.execute("SELECT count(*) FROM products")
+        print(cur.fetchone()[0])   # 6 (or however many rows you had before)
+```
+
+**Use `pa.string()` (utf8), not `pa.large_utf8()`, for string columns in bound batches.**
+`large_utf8` is not currently supported in parameter batches over the FlightSQL wire.
+Non-string types (`float64`, `int64`, `int32`) work with their natural Arrow types.
+
+Results from queries also come back as Arrow:
+
+```python
+cur.execute("SELECT _id, name FROM products ORDER BY _id")
+arrow_table = cur.fetch_arrow_table()   # pyarrow.Table
+print(arrow_table.schema)
+# _id: string
+# name: string
+```
+
+`fetch_arrow_table()` collects all batches; for large result sets, use `fetchmany()` or stream via the underlying `ArrowReader`.
+
+## Transactions
+
+XTDB supports multi-statement transactions over ADBC.
+Use the connection-level transaction API:
+
+```python
+import adbc_driver_flightsql.dbapi as flight_sql
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    # Switch off autocommit; opens a FlightSQL BeginTransaction action.
+    conn.adbc_connection.set_autocommit(False)
+
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO orders (_id, item, qty) VALUES (?, ?, ?)",
+            [["o1", "Widget", 10], ["o2", "Gadget", 5]],
+        )
+
+        # Writes are visible to reads on the same connection
+        # before the transaction commits.
+        cur.execute(
+            "SELECT count(*) FROM orders WHERE _id IN (?, ?)",
+            parameters=["o1", "o2"],
+        )
+        print(cur.fetchone()[0])   # 2
+
+    conn.adbc_connection.rollback()   # EndTransaction ROLLBACK
+    # ↑ the two rows are gone
+
+    conn.adbc_connection.set_autocommit(False)
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO orders (_id, item, qty) VALUES (?, ?, ?)",
+            [["o3", "Doohickey", 20]],
+        )
+    conn.adbc_connection.commit()     # EndTransaction COMMIT
+```
+
+`set_autocommit(False)` calls the FlightSQL `BeginTransaction` action under the hood.
+`commit()` / `rollback()` call `EndTransaction` with the appropriate action.
+Each `set_autocommit(False)` starts a new transaction; commit or rollback ends it.
+
+:::caution
+Transaction support requires the server to advertise `FLIGHT_SQL_SERVER_TRANSACTION` in its `GetSqlInfo` response (SqlInfo code 8, value `SQL_SUPPORTED_TRANSACTION_TRANSACTION`).
+Builds before 2026-05 do not include this advertisement; `set_autocommit(False)` raises `NOT_IMPLEMENTED`.
+Use the nightly image or build from main.
+:::
+
+### ROLLBACK empties pending writes
+
+```python
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    conn.adbc_connection.set_autocommit(False)
+
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO orders (_id, item, qty) VALUES (?, ?, ?)",
+            [["o4", "Prototype", 1]],
+        )
+        # Visible on this connection before commit:
+        cur.execute("SELECT count(*) FROM orders WHERE _id = ?",
+                    parameters=["o4"])
+        print(cur.fetchone()[0])   # 1
+
+    conn.adbc_connection.rollback()
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM orders WHERE _id = ?",
+                    parameters=["o4"])
+        print(cur.fetchone()[0])   # 0; ROLLBACK erased it
+```
+
+The write was visible before rollback because the read happened on the same connection.
+After rollback it's gone: neither this connection nor any other will see it.
+
+### setAutoCommit via the dbapi Connection
+
+The DB-API 2.0 `Connection.autocommit` attribute mirrors the underlying ADBC call:
+
+```python
+# These are equivalent:
+conn.adbc_connection.set_autocommit(False)
+
+# and (if your dbapi wrapper exposes it):
+# conn.autocommit = False
+```
+
+The `adbc_connection` attribute on the dbapi `Connection` object is the raw `AdbcConnection`; use it to access ADBC-specific transaction methods that the dbapi wrapper doesn't expose.
+
+## Same-connection write-then-read visibility
+
+Writes on a connection are visible to subsequent reads on that **same** connection without any manual `await` or sleep.
+The connection tracks its own write tokens and threads them through the planner:
+
+```python
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO products (_id, name, price, stock)"
+            " VALUES (?, ?, ?, ?)",
+            [["p9", "Overnight", 3.99, 500]],
+        )
+        # Immediately visible; no await needed.
+        cur.execute(
+            "SELECT name, price FROM products WHERE _id = ?",
+            parameters=["p9"],
+        )
+        print(cur.fetchone())
+        # ('Overnight', 3.99)
+```
+
+Cross-connection reads follow normal transactional semantics: another connection sees the write once it commits and its read snapshot advances.
+
+## DML via `executemany`, not `execute`
+
+A subtle point: the Python dbapi's `cursor.execute()` routes all SQL, including INSERT, UPDATE, DELETE, through the FlightSQL query path (`GetFlightInfo` → `DoGet`).
+XTDB's query path does not persist DML.
+
+Use `cursor.executemany()` for DML.
+`executemany()` routes through `DoPut` (the update path), which calls `executeUpdate()` on the server and actually commits the write.
+
+```python
+# ✗ Does not persist on nightly / stable images:
+cur.execute("INSERT INTO t (_id, v) VALUES (?, ?)", parameters=["x", 1])
+
+# ✓ Correct, persists:
+cur.executemany("INSERT INTO t (_id, v) VALUES (?, ?)", [["x", 1]])
+```
+
+This is a known mismatch between the Python dbapi specification (where `execute` handles DML) and the ADBC FlightSQL wire protocol (where DML goes through `DoPut`, not `GetFlightInfo`).
+
+## What's not covered here
+
+- **Bulk-loading Parquet and other file formats.** See [Bulk-load Parquet via ADBC](./bulk-ingest-from-parquet).
+- **`adbc_ingest` for whole Arrow tables over the FlightSQL wire.** The one-round-trip bulk-ingest path; see [pandas / polars round-trip](./pandas-polars-round-trip). For parameterised DML, `executemany` with a `RecordBatch` (above) stays the right tool.
+- **`executeSchema` / result shape introspection.** Covered in the [reference](../reference#executeschema-result-shape-without-executing).
+- **Cross-connection visibility and read snapshots.** See the [reference](../reference#transactions) for the snapshot-isolation model.

--- a/docs/src/content/docs/drivers/adbc/guides/rust-arrow-pipeline.md
+++ b/docs/src/content/docs/drivers/adbc/guides/rust-arrow-pipeline.md
@@ -1,0 +1,196 @@
+---
+title: A Rust ADBC + arrow-rs pipeline against XTDB
+description: A Rust ADBC pipeline where Arrow types are checked at compile time end to end.
+---
+
+Where Python ADBC preserves your DataFrame, Rust ADBC preserves your Rust types.
+Query results land as `arrow::record_batch::RecordBatch` values: the same types DataFusion uses internally and the same ones `parquet::arrow::ArrowWriter` consumes.
+There is no row-level decode and no schema duck-typing between XTDB and the rest of your pipeline.
+
+This guide walks the full path:
+
+1. Connect to XTDB's FlightSQL listener from Rust with `adbc_core` + `adbc_driver_manager`.
+2. Stream a query result back as `RecordBatch`es.
+3. Register those batches with DataFusion and run analytical SQL.
+4. Write the aggregate out to Parquet via `parquet::arrow::ArrowWriter`.
+
+The runnable crate is in [`examples/rust-arrow-pipeline/`](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline).
+It's a single file: point it at your node and change the SQL.
+
+## Cargo.toml: a version matrix that resolves
+
+The Rust ADBC ecosystem is younger than Python's, and the arrow / datafusion / parquet trio shares a single major version that all three crates must agree on.
+Mix two arrow majors in one binary and `RecordBatch` types stop unifying, producing compile errors that point at trait-impl noise rather than the underlying version skew.
+
+A pinned set that resolves:
+
+```toml
+[dependencies]
+adbc_core = "=0.23.0"
+adbc_driver_manager = "=0.23.0"
+adbc-driver-flightsql = "=0.1.2"
+arrow = "=58.3.0"
+arrow-array = "=58.3.0"
+arrow-schema = "=58.3.0"
+parquet = "=58.3.0"
+datafusion = "=53.1.0"
+tokio = { version = "=1.52.3", features = ["rt-multi-thread", "macros"] }
+```
+
+- `adbc_core` / `adbc_driver_manager` 0.23 declare `arrow-array >=53.1, <59`, so they happily resolve against the arrow 58 that datafusion 53 pulls in.
+  You don't need to override the resolver; do not pin arrow to 53 just because adbc_core's minimum is 53, since datafusion would still pull 58 alongside and you'd be back to two arrow majors in one binary.
+- `adbc-driver-flightsql` is a *shim*: its `build.rs` downloads the official Apache `libadbc_driver_flightsql.{so,dylib,dll}` from the matching PyPI wheel and exposes its on-disk path as `DRIVER_PATH`.
+  The crate defaults to native-driver version `1.9.0`, which is too old: the `adbc.ingest.target_table` / `adbc.ingest.mode` option keys landed in `1.10.0`, and several other rough edges (option dispatch, error formatting) were smoothed in `1.11.0`.
+  Set `ADBC_FLIGHTSQL_VERSION=1.11.0` in the environment for the first `cargo build` and the wheel is cached for subsequent runs.
+
+These versions are coupled, so the pins are exact (`=`): change them together as a set, not one at a time.
+
+## Connecting
+
+```rust
+use adbc_core::{
+    options::{AdbcVersion, OptionDatabase},
+    Connection, Database, Driver, Statement,
+};
+use adbc_driver_flightsql::DRIVER_PATH;
+use adbc_driver_manager::ManagedDriver;
+
+let mut driver = ManagedDriver::load_dynamic_from_filename(
+    DRIVER_PATH,
+    None,
+    AdbcVersion::default(),
+)?;
+let database = driver
+    .new_database_with_opts([(OptionDatabase::Uri, "grpc://localhost:9832".into())])?;
+let mut conn = database.new_connection()?;
+```
+
+`load_dynamic_from_filename` does the `dlopen` and resolves the entry point.
+`ManagedDriver` implements `adbc_core::Driver` directly: every method below is the same trait you'd call against any other ADBC backend.
+
+`AdbcVersion::default()` is `V110`, the version XTDB and the current native FlightSQL driver use.
+If you ever see "Unknown statement option" errors that look intercepted client-side, the version is the first thing to check.
+
+## Query → RecordBatch stream
+
+`Statement::execute` returns `Box<dyn RecordBatchReader + Send + 'static>`, a streaming Arrow reader.
+Iterate it batch-at-a-time for large results, or `collect` for small ones:
+
+```rust
+let mut q = conn.new_statement()?;
+q.set_sql_query("SELECT _id, region, amount FROM orders")?;
+let reader = q.execute()?;
+let result_schema = reader.schema();
+let batches: Vec<RecordBatch> = reader.collect::<Result<_, _>>()?;
+```
+
+The Flight gRPC framing copies the Arrow IPC bytes once at the gRPC boundary on each side.
+After that the buffers are native Arrow, and DataFusion and parquet-rs operate on them directly without decoding or widening.
+So this isn't zero-copy across the network boundary, but the data stays Arrow-shaped at every step within the process.
+
+## Handing off to DataFusion
+
+`SessionContext::register_batch` takes a `(name, RecordBatch)` pair and registers it as an in-memory table.
+For multi-batch results, concatenate first with `arrow::compute::concat_batches` (one Vec scan, no copies of the column buffers, since it stitches the existing arrays into the new batch):
+
+```rust
+use datafusion::prelude::SessionContext;
+
+let ctx = SessionContext::new();
+ctx.register_batch(
+    "orders",
+    arrow::compute::concat_batches(&result_schema, &batches)?,
+)?;
+
+let df = ctx
+    .sql("SELECT region, COUNT(*) AS n_orders, SUM(amount) AS total_amount
+          FROM orders GROUP BY region ORDER BY total_amount DESC")
+    .await?;
+let agg_batches: Vec<RecordBatch> = df.collect().await?;
+```
+
+`df.collect().await?` runs the DataFusion plan and returns another `Vec<RecordBatch>`: same Arrow types, same buffer layout.
+The Tokio runtime is here because DataFusion's surface is async; everything else in this pipeline is sync.
+
+For multi-table queries (join an XTDB table against a Parquet file on disk, say) register each side independently and write the join in DataFusion SQL.
+That's the main reason to put DataFusion in the middle rather than wiring the FlightSQL stream straight to a Parquet writer: it gives you a query layer over heterogeneous Arrow sources without leaving the Arrow type system.
+
+## Writing Parquet
+
+`parquet::arrow::ArrowWriter` takes the Arrow schema and accepts each `RecordBatch`:
+
+```rust
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+
+let agg_schema = agg_batches.first().map(|b| b.schema())
+    .ok_or("DataFusion returned no batches")?;
+let file = std::fs::File::create("orders-by-region.parquet")?;
+let mut writer = ArrowWriter::try_new(file, agg_schema, Some(WriterProperties::builder().build()))?;
+for batch in &agg_batches {
+    writer.write(batch)?;
+}
+writer.close()?;
+```
+
+`writer.close()` flushes the row-group footers: call it explicitly rather than relying on `Drop`.
+Drop will swallow any error; `close()` returns one.
+
+Properties default to snappy compression and reasonable row-group sizing; reach for `WriterProperties::builder()` knobs (codec, page size, dictionary encoding) when you have measurements that say you should.
+
+## Lifecycle notes
+
+A few Rust-specific corners worth knowing about:
+
+- `ManagedDriver`, `ManagedDatabase`, `ManagedConnection`, `ManagedStatement` are all `Arc`-wrapped internally: cheap to clone, safe across threads.
+  Don't reach for `Arc<Mutex<…>>` around them yourself.
+- The `RecordBatchReader` returned by `execute()` borrows nothing from the statement; the statement can be dropped once the reader is constructed.
+  Lifetime is `'static`, which is what makes `collect` and async handoff to DataFusion straightforward.
+- `execute_update()` returns `Result<Option<i64>>`, where `None` means "row count unknown" rather than "zero rows".
+  XTDB returns `None` for most DML; treat absence as success, not failure.
+- The native FlightSQL driver library is loaded on first use and stays loaded for the process lifetime.
+  Open one `ManagedDriver` at startup and reuse it; repeated `load_dynamic_from_filename` calls work but waste work.
+
+## Running it
+
+This needs the FlightSQL listener, which the `nightly` image enables by default on port 9832 (stable images from 2.2.0 onwards do too):
+
+```sh
+docker run --rm -d --name xtdb-g6 \
+    -p 5432:5432 -p 9832:9832 \
+    ghcr.io/xtdb/xtdb:nightly
+
+cd docs/src/content/docs/drivers/adbc/examples/rust-arrow-pipeline
+ADBC_FLIGHTSQL_VERSION=1.11.0 cargo run --release
+```
+
+Output:
+
+```
+seeded orders
+got 1 batch(es), 6 row(s) total from XTDB
+
+-- DataFusion result --
++--------+----------+--------------+
+| region | n_orders | total_amount |
++--------+----------+--------------+
+| us     | 3        | 540          |
+| eu     | 2        | 350          |
+| apac   | 1        | 175          |
++--------+----------+--------------+
+
+wrote orders-by-region.parquet
+```
+
+The example seeds via plain SQL `INSERT` to stay self-contained.
+To bulk-ingest an Arrow batch instead, set `adbc.ingest.target_table` and call `execute_update`.
+This issues the same FlightSQL `CommandStatementIngest` the [bulk-ingest-from-parquet guide](./bulk-ingest-from-parquet) uses from Python, and works identically from any ADBC client.
+
+## One type system end to end
+
+Everything from `q.execute()?` through `writer.close()?` is the same Arrow type system.
+`RecordBatch`, `Schema`, `Field`, `ArrayRef`: one set of types, one set of compile-time guarantees.
+Add a `Vec<i64>` column to your query and DataFusion's SQL planner sees an `Int64` field, the parquet writer encodes an INT64 page, your downstream consumers see whatever they consume from arrow-rs.
+No string-typed schema metadata, no per-column conversion adapters, no type-widening surprises.
+
+Where the Python path preserves your DataFrame across the round trip, the Rust path preserves what `cargo check` verifies: the Arrow types line up at compile time.

--- a/docs/src/content/docs/drivers/adbc/guides/streaming-into-duckdb.md
+++ b/docs/src/content/docs/drivers/adbc/guides/streaming-into-duckdb.md
@@ -1,0 +1,235 @@
+---
+title: Streaming XTDB results into DuckDB via Arrow
+description: Stream Arrow batches from XTDB straight into DuckDB for analytics, with no serialise/deserialise step.
+---
+
+XTDB and DuckDB are both Arrow-native, so ADBC can stream Arrow batches from XTDB directly into DuckDB with no serialise/deserialise step.
+The worked scenario: as of Q4 2024, group a bitemporal trade snapshot from XTDB by counterparty tier held in a DuckDB lookup table.
+
+## Prerequisites
+
+A running XTDB node with the FlightSQL listener on port 9832 and the pgwire server on port 5432.
+The nightly Docker image enables both by default:
+
+```sh
+docker run --rm -d --name xtdb-duckdb-demo \
+    -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+```
+
+Install the Python dependencies:
+
+```sh
+pip install adbc-driver-flightsql pyarrow duckdb psycopg
+```
+
+`psycopg` seeds the trades over pgwire, so no external `psql` binary is required.
+
+## The scenario
+
+Seven trades are stored in XTDB with explicit valid-time ranges.
+One of them, CommerzBank's T005, expired on `2024-06-30` and should be absent from the end-of-Q4 snapshot even though it was physically ingested.
+The question: as of 2024-12-31, what's the total trade value per counterparty tier?
+
+The counterparty-to-tier mapping lives in DuckDB as a local dimension table (Parquet, CSV, or in-memory; it does not need to be in XTDB).
+
+## Step 1: Seed XTDB with bitemporal trades
+
+Trades arrive via the normal write path.
+Use `_valid_from` and `_valid_to` to record when each trade *was true*: the valid-time axis.
+
+```python
+import psycopg
+from textwrap import dedent
+
+SEED_SQL = dedent("""\
+    INSERT INTO trades (_id, counterparty, notional, currency, _valid_from, _valid_to)
+    VALUES
+      ('T001','Barclays',    1500000.0,'GBP',TIMESTAMP '2024-01-15 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T002','Barclays',    2000000.0,'GBP',TIMESTAMP '2024-03-01 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T003','JPMorgan',    3200000.0,'USD',TIMESTAMP '2024-02-10 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T004','DeutscheBank', 800000.0,'EUR',TIMESTAMP '2024-04-01 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T005','CommerzBank', 1100000.0,'EUR',TIMESTAMP '2024-01-01 00:00:00',TIMESTAMP '2024-06-30 00:00:00'),
+      ('T006','SocGen',       950000.0,'EUR',TIMESTAMP '2024-06-01 00:00:00',TIMESTAMP '9999-12-31 00:00:00'),
+      ('T007','SocGen',      1750000.0,'EUR',TIMESTAMP '2024-09-15 00:00:00',TIMESTAMP '9999-12-31 00:00:00')
+""")
+
+PG_URI = "postgresql://localhost:5432/xtdb"
+with psycopg.connect(PG_URI, user="xtdb", autocommit=True) as pg:
+    with pg.cursor() as cur:
+        cur.execute(SEED_SQL)
+```
+
+`_valid_from`/`_valid_to` in the INSERT body override the default (`now` → `end-of-time`) so XTDB records each trade's actual validity window.
+
+## Step 2: Pull the Q4 snapshot via ADBC
+
+`FOR VALID_TIME AS OF` pins the query to a single instant.
+XTDB returns only the rows whose valid-time period *contains* that instant.
+T005 (CommerzBank, valid to `2024-06-30`) is excluded.
+
+```python
+import pyarrow as pa
+import adbc_driver_flightsql.dbapi as flight_sql
+
+SNAPSHOT_SQL = """\
+    SELECT _id, counterparty, notional, currency
+      FROM trades
+           FOR VALID_TIME AS OF TIMESTAMP '2024-12-31 23:59:59'
+     ORDER BY _id
+"""
+
+FSQL_URI = "grpc://localhost:9832"
+
+with flight_sql.connect(FSQL_URI) as conn:
+    with conn.cursor() as cur:
+        cur.execute(SNAPSHOT_SQL)
+        snapshot: pa.Table = cur.fetch_arrow_table()
+```
+
+`fetch_arrow_table()` returns a `pyarrow.Table`.
+The data travels from XTDB's in-memory Arrow buffers across the FlightSQL gRPC stream and lands in the client as Arrow: no row-by-row decode, no type widening.
+
+`snapshot` now holds 6 rows: T001–T004, T006, T007.
+
+## Step 3: Register the snapshot into DuckDB
+
+```python
+import duckdb
+
+duck = duckdb.connect()          # in-memory analytical engine
+duck.register("xtdb_trades", snapshot)
+```
+
+`duckdb.register()` accepts any object that exposes the Arrow C Data Interface: a `pyarrow.Table`, `RecordBatch`, polars `DataFrame`, etc.
+DuckDB operates directly on the Arrow buffers XTDB produced.
+No copy, no decode.
+
+## Step 4: Create the counterparty-tier dimension in DuckDB
+
+Enrichment data that doesn't belong in XTDB lives here.
+In production this is typically a Parquet file on the local filesystem:
+
+```python
+duck.execute("""\
+    CREATE TABLE counterparty_tiers AS
+    SELECT * FROM (VALUES
+        ('Barclays',     'Gold'),
+        ('JPMorgan',     'Gold'),
+        ('DeutscheBank', 'Silver'),
+        ('SocGen',       'Silver'),
+        ('CommerzBank',  'Bronze')
+    ) AS t(counterparty, tier)
+""")
+```
+
+Or from a Parquet file:
+
+```python
+duck.execute("CREATE TABLE counterparty_tiers AS SELECT * FROM 'tiers.parquet'")
+```
+
+## Step 5: Join and aggregate in DuckDB
+
+The analytical query runs entirely inside DuckDB's vectorised engine, over the Arrow buffers XTDB produced.
+No round-trip to XTDB, no re-serialisation.
+
+```python
+result: pa.Table = duck.execute("""\
+    SELECT
+        ct.tier,
+        count(*)                  AS trade_count,
+        sum(t.notional)           AS total_notional,
+        round(avg(t.notional), 0) AS avg_notional
+    FROM  xtdb_trades        AS t
+    JOIN  counterparty_tiers AS ct ON t.counterparty = ct.counterparty
+    GROUP BY ct.tier
+    ORDER BY total_notional DESC
+""").arrow().read_all()
+```
+
+Output:
+
+```
+Exposure by counterparty tier, as-of Q4 2024 end:
+  Tier        Trades    Total Notional    Avg Notional
+  ----------  ------  ----------------  --------------
+  Gold             3         6,700,000       2,233,333
+  Silver           3         3,500,000       1,166,667
+```
+
+CommerzBank (Bronze, T005) is absent because it did not exist at Q4 end.
+The valid-time filter happened at the XTDB layer before any data crossed the wire.
+
+## Streaming batches instead of materialising the whole snapshot
+
+For result sets too large to fit in client memory, stream Arrow batches one at a time rather than calling `fetch_arrow_table()`:
+
+```python
+import adbc_driver_flightsql as flight_sql_raw
+
+db = flight_sql_raw.connect(FSQL_URI)
+conn = db.new_connection()
+stmt = conn.new_statement()
+stmt.set_sql_query(SNAPSHOT_SQL)
+result, schema = stmt.execute_query()
+
+# result is an ArrowReader; each iteration yields one RecordBatch.
+for batch in result:
+    duck.register("xtdb_batch", batch)
+    duck.execute("INSERT INTO aggregated SELECT ..., FROM xtdb_batch")
+
+result.close()
+conn.close()
+db.close()
+```
+
+The tradeoff:
+- `fetch_arrow_table()` materialises the full snapshot in one shot: simple, and the right default for snapshots that fit in RAM.
+- The `ArrowReader` path streams batch-by-batch: the right choice when the XTDB result set is large and you can incrementally fold each batch into an ongoing DuckDB aggregate without materialising the whole thing.
+
+## Writing results back
+
+DuckDB query results can go back to XTDB via bulk ingest, or out to Parquet:
+
+**Back to XTDB:**
+
+```python
+# result is a pyarrow.Table; annotate with _id before ingest.
+import pyarrow.compute as pc
+result_with_id = result.append_column(
+    "_id", pa.array([f"tier-summary-{r['tier']}" for r in result.to_pylist()])
+)
+with flight_sql.connect(FSQL_URI) as conn:
+    with conn.cursor() as cur:
+        cur.adbc_ingest("tier_summaries", result_with_id, mode="create_append")
+```
+
+**To Parquet:**
+
+```python
+import pyarrow.parquet as pq
+pq.write_table(result, "tier_exposure_q4_2024.parquet")
+```
+
+## Runnable example
+
+A self-contained script that runs the full scenario is in
+[`examples/streaming-into-duckdb/main.py`](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples/streaming-into-duckdb/main.py).
+
+```sh
+docker run --rm -d --name xtdb-g5 -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+pip install adbc-driver-flightsql pyarrow duckdb psycopg
+python docs/src/content/docs/drivers/adbc/examples/streaming-into-duckdb/main.py
+docker rm -f xtdb-g5
+```
+
+## Why this works without a copy
+
+XTDB's query engine produces Arrow `RecordBatch` objects internally.
+The FlightSQL shim packages those batches into gRPC `DoGet` streams as-is.
+The ADBC FlightSQL driver on the Python side decodes the gRPC framing and reconstructs the Arrow buffers in the client process.
+`duckdb.register()` takes the Arrow C Data Interface pointer to those buffers: DuckDB's planner sees the Arrow schema and DuckDB's executor reads the data in-place.
+
+The data moves as: XTDB in-memory Arrow → gRPC wire encoding → pyarrow Arrow buffer → DuckDB execution.
+There is no intermediate JSON, CSV, Postgres text wire, or pickle.
+The gRPC serialisation is the only encode/decode step, and it is Arrow's own IPC format.

--- a/docs/src/content/docs/drivers/adbc/reference.md
+++ b/docs/src/content/docs/drivers/adbc/reference.md
@@ -1,0 +1,346 @@
+---
+title: ADBC reference
+description: Reference for connecting to XTDB via ADBC, in-process and over FlightSQL.
+---
+
+XTDB exposes [ADBC](https://arrow.apache.org/adbc/), the Arrow Database Connectivity standard, through two surfaces:
+
+- **In-process**, via `xtdb.adbc.XtdbConnection` on the JVM. Zero copies, direct access to the in-memory Arrow buffers.
+- **Over the wire**, via the [Apache Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) server bundled into XTDB.
+  Any ADBC FlightSQL driver (Python, Rust, Go, C, R, Java) connects to it.
+
+The two paths share the same code below the ADBC surface: the FlightSQL producer is a thin shim that delegates to the same `XtdbStatement` lifecycle the in-process client uses.
+If something works in-process, it works over the wire, and vice versa, modulo the per-client caveats called out below.
+
+## When to reach for ADBC
+
+XTDB also exposes a PostgreSQL wire-compatible server.
+The [pgwire path](/drivers) fits if your tooling is already Postgres-compatible.
+Reach for ADBC when:
+
+- **You want Arrow through the whole pipeline.**
+  Query results land in your client as Arrow batches, with no row-by-row decode and no type widening through a PG text wire format.
+- **You want to bulk-ingest Arrow data.**
+  `cur.adbc_ingest(arrow_table, mode='create_append')` lands a `pyarrow.Table` (or any Arrow-shaped data) in XTDB in a single round trip, without shredding it into per-row `executemany("INSERT ... VALUES (?, ...)")` calls.
+- **You want zero-copy result shipping** between XTDB, pandas / polars / DuckDB / DataFusion / your own Arrow-shaped compute.
+  The data stays in Arrow across each hop.
+
+For interactive SQL, `psql`-style tooling, or anything Postgres-ecosystem-shaped, the [pgwire driver](/drivers) is still the right answer.
+
+## Connecting
+
+### In-process (Kotlin / JVM)
+
+`XtdbConnection` is the entry point.
+Obtain one from a running `Xtdb` node:
+
+```kotlin
+import xtdb.adbc.XtdbConnection
+import xtdb.api.Xtdb
+
+val node = Xtdb.openNode()
+val conn: XtdbConnection = node.openAdbcConnection()
+
+conn.use {
+    val stmt = it.createStatement()
+    stmt.setSqlQuery("SELECT 1")
+    val result = stmt.executeQuery()
+    // result.reader is an org.apache.arrow.vector.ipc.ArrowReader
+}
+```
+
+`XtdbConnection` implements `org.apache.arrow.adbc.core.AdbcConnection`: anything written against the ADBC Java API works against it directly.
+
+### Over the wire (FlightSQL)
+
+Enable the FlightSQL listener in your node config; the [Docker standalone image](/intro/installation-via-docker) does this by default on port `9832`:
+
+```yaml
+flightSql:
+  host: '*'
+  port: 9832
+```
+
+Then connect with any ADBC FlightSQL driver.
+
+**Python** ([`adbc_driver_flightsql`](https://pypi.org/project/adbc-driver-flightsql/)):
+
+```python
+import adbc_driver_flightsql.dbapi as flight_sql
+
+with flight_sql.connect("grpc://localhost:9832") as conn:
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1")
+        print(cur.fetchall())
+```
+
+**Rust** (`adbc_core` + `adbc_driver_manager`):
+
+There is no pure-Rust FlightSQL driver: `adbc_driver_manager` dlopens the *native* `libadbc_driver_flightsql`.
+The [`adbc-driver-flightsql`](https://crates.io/crates/adbc-driver-flightsql) shim crate downloads that library from the official PyPI wheel and exposes its on-disk path as `DRIVER_PATH`.
+
+```rust
+use adbc_core::{
+    options::{AdbcVersion, OptionDatabase},
+    Connection, Database, Driver, Statement,
+};
+use adbc_driver_flightsql::DRIVER_PATH;
+use adbc_driver_manager::ManagedDriver;
+
+let mut driver =
+    ManagedDriver::load_dynamic_from_filename(DRIVER_PATH, None, AdbcVersion::default())?;
+let database = driver.new_database_with_opts([
+    (OptionDatabase::Uri, "grpc://localhost:9832".into()),
+])?;
+let conn = database.new_connection()?;
+let mut stmt = conn.new_statement()?;
+stmt.set_sql_query("SELECT 1")?;
+let reader = stmt.execute()?;
+```
+
+The shim's first build downloads a ~5 MB native library; set `ADBC_FLIGHTSQL_VERSION=1.11.0` for that build.
+See the [rust-arrow-pipeline example](/drivers/adbc/guides/rust-arrow-pipeline) for the full dependency matrix and an end-to-end ingest/query pipeline.
+
+**Go** (`github.com/apache/arrow-adbc/go/adbc/driver/flightsql`):
+
+```go
+import (
+    "github.com/apache/arrow-adbc/go/adbc"
+    "github.com/apache/arrow-adbc/go/adbc/driver/flightsql"
+)
+
+drv := flightsql.NewDriver(memory.DefaultAllocator)
+db, _ := drv.NewDatabase(map[string]string{
+    adbc.OptionKeyURI: "grpc://localhost:9832",
+})
+conn, _ := db.Open(ctx)
+defer conn.Close()
+```
+
+Same address works for the C and R drivers; see [the Apache ADBC driver matrix](https://arrow.apache.org/adbc/current/driver/flight_sql.html) for client-specific install instructions.
+
+> **TLS / auth.** This reference covers the plaintext gRPC path.
+> Production deployments should front the FlightSQL listener with TLS termination.
+> XTDB's authentication (see [Authentication](/ops/config/authentication)) applies to the pgwire listener, not currently to FlightSQL.
+
+## Supported surfaces
+
+### Statements: prepare / bind / execute
+
+`AdbcStatement` is the entry point for every query and DML.
+The lifecycle is the standard ADBC one:
+
+```python
+cur = conn.cursor()
+cur.execute_partitions("SELECT ?, ?", parameters=[42, "hello"])
+```
+
+or, in raw ADBC terms:
+
+```
+stmt.setSqlQuery(sql)
+stmt.prepare()                    # optional, but required if you're binding params
+stmt.bind(arrow_record_batch)     # binds one batch of parameters
+stmt.executeQuery()  →  ArrowReader
+```
+
+Query results stream: `executeQuery()` returns an `ArrowReader` that yields one Arrow batch at a time, so large result sets don't have to fit in memory.
+
+`executeUpdate()` runs DML; the return value is `-1` (XTDB does not pre-count) and effects are visible to the next query on the same connection (see [Transactions](#transactions) for multi-statement semantics).
+
+### `executeSchema()`: result shape without executing
+
+`AdbcStatement.executeSchema()` returns the Arrow schema of a query's result set *without* running the query.
+Useful for tooling that wants to introspect a query's shape: IDE autocomplete, dataframe pipeline builders, anything that wants to know "what columns would come back".
+
+```python
+cur.execute("SELECT _id, name FROM users WHERE _id = ?", parameters=["alice"])
+schema = cur.adbc_get_result_schema()
+# Schema { _id: utf8, name: utf8 }
+```
+
+Works both on prepared statements (the ADBC client reads it from `getResultSetSchema` on the prepared handle) and ad-hoc (the wire path opens a transient `PreparedQuery` to read the shape).
+
+**Caveat: parameter types.**
+Result schemas can depend on parameter types (`SELECT ?` is the obvious case).
+`executeSchema()` runs before any bind, so we feed the planner null-typed placeholder params.
+For `SELECT cols FROM t WHERE _id = ?` (the common shape, where the projection doesn't depend on the parameter) this is accurate.
+For `SELECT ?` / `SELECT ? + 1` (projecting the parameter directly) you'll get placeholder types: `null` rather than the type you'd bind.
+Workaround: project through a column expression that fixes the type.
+
+### `getObjects` / `getTables` / `getTableSchema`
+
+Metadata discovery is fully wired.
+All three of the standard ADBC metadata calls work:
+
+```python
+# List schemas
+reader = conn.adbc_get_objects(depth="db_schemas")
+
+# List tables in a schema
+reader = conn.adbc_get_objects(depth="tables", db_schema_filter="public")
+
+# Full structure including columns
+reader = conn.adbc_get_objects(depth="all", table_name_filter="users")
+
+# Just the schema of one table
+schema = conn.adbc_get_table_schema("users", db_schema_filter="public")
+```
+
+The full-tree (`depth=all`) response carries each table's Arrow Schema as bytes in the standard `table_schema` `VarBinaryVector`: your client deserialises it into an actual `pyarrow.Schema` / `arrow::Schema`.
+
+Column types reflect **live data**, not just flushed-to-block state: freshly-inserted rows show up in `getObjects` / `getTableSchema` immediately, the same way they show up via SQL `SELECT`.
+
+### Bulk ingest
+
+Land a `pyarrow.Table` (or any Arrow-shaped data: record batches, streams, any object exposing the Arrow C Data Interface) in XTDB in a single round trip:
+
+```python
+import pyarrow as pa
+
+people = pa.table({
+    "_id": ["alice", "bob"],
+    "name": ["Alice", "Bob"],
+    "age":  [30, 25],
+})
+
+with conn.cursor() as cur:
+    cur.adbc_ingest("people", people, mode="create_append")
+```
+
+Arrow batches stream from the client into XTDB one batch at a time, the whole table doesn't need to fit in memory either side.
+
+**Mode handling.**
+Because XTDB creates tables on demand, several of ADBC's ingest modes either coincide or don't apply:
+
+| Mode | Behaviour |
+|------|-----------|
+| `create` | Accepted. Table is auto-created if missing. |
+| `append` | Accepted. Upserts on `_id`. |
+| `create_append` | Accepted (the common case). |
+| `replace` | **Rejected** (`INVALID_ARGUMENT`). Would require an explicit `ERASE` step. |
+| `create` with fail-if-exists | **Rejected.** XTDB auto-creates; we can't honour "fail if exists" without an existence check. |
+| `append` with fail-if-not-exists | **Rejected.** XTDB auto-creates on insert; silently accepting would violate the ADBC contract. |
+
+Mode rejections (the rows above) come back as gRPC `INVALID_ARGUMENT` with a descriptive message.
+
+Other ingest-time failures are not yet uniformly mapped: a row missing its `_id` column currently surfaces as gRPC `INTERNAL` rather than `INVALID_ARGUMENT` (see below).
+Match on the message, not the status code, until that mapping is tightened.
+
+**Other narrowings.**
+
+- Per-call **catalog override** is rejected: the connection-scoped catalog (via session options or the connection URI) is the only source of truth.
+  Per-call **schema override** is honoured; defaults to `public`.
+- Every row must have an `_id` column.
+  XTDB's data model requires it; rows without `_id` are rejected (currently as gRPC `INTERNAL`; see the note above).
+  If you're round-tripping Arrow tables that don't have one, materialise an `_id` column client-side before calling `adbc_ingest`.
+
+### `current_catalog` / `current_db_schema`
+
+Standard ADBC session options, exposed over the wire:
+
+```python
+conn.adbc_current_catalog       # 'xtdb'
+conn.adbc_current_db_schema     # 'public'
+```
+
+Both work from any Go-driver-based ADBC client (Python, C, R, Go itself).
+
+**Java caveat.**
+The Apache ADBC Java client (`adbc-driver-flight-sql` 0.23 and earlier) doesn't query `getSessionOptions`; it inherits `AdbcConnection`'s default which raises `notImplemented`.
+This is an upstream gap, not an XTDB one: Java's `getCurrentCatalog` / `getCurrentDbSchema` on the wire client will stay unsupported until Apache ADBC wires it up.
+The **in-process** Kotlin/JVM `XtdbConnection` is unaffected: `getCurrentCatalog()` / `getCurrentDbSchema()` work directly.
+
+**Setting** the catalog, via `setSessionOptions("catalog", db)`, selects the database for the session.
+This is how Go-driver-based clients (Python, C, R, Go) pick a database: the catalog session option selects it for the session.
+The value is validated against the node's known databases: an unknown name comes back `INVALID_VALUE`, an empty string clears it.
+
+Setting it creates a FlightSQL session and the server issues a session cookie; the client must keep that cookie across calls for the option to persist.
+`getSessionOptions` is a pure getter: it reports the resolved catalog and `public` schema, and deliberately does *not* create a session, so probing for the current catalog doesn't leak one.
+
+The **schema** is not settable: `public` is the only accepted value (a confirming no-op), anything else is rejected.
+
+`closeSession` ends the session: it closes the session's connections (autocommit and any open transaction) and invalidates the cookie.
+
+### Transactions
+
+Multi-statement transactions work both in-process and over the wire.
+
+Over the wire, switch off autocommit on the underlying ADBC connection, run your statements, then commit (or roll back):
+
+```python
+conn.adbc_connection.set_autocommit(False)        # BeginTransaction
+with conn.cursor() as cur:
+    cur.executemany(
+        "INSERT INTO users (_id, name) VALUES (?, ?)",
+        [["alice", "Alice"], ["bob", "Bob"]],
+    )
+conn.adbc_connection.commit()                      # EndTransaction COMMIT
+```
+
+DML goes through `executemany`, not `execute`: the Python dbapi routes `execute()`, including `INSERT` / `UPDATE` / `DELETE`, through the FlightSQL query path, which XTDB rejects; `executemany` routes through the update path (`DoPut`).
+In-process and in Kotlin / Rust / Go, the same flow is `setAutoCommit(false)` / `commit()` / `rollback()` on the ADBC connection.
+See [Prepared statements and transactions](/drivers/adbc/guides/prepared-statements-and-transactions) for the full lifecycle, rollback semantics, and same-connection visibility.
+
+**Default commit mode.**
+Because XTDB advertises FlightSQL transaction support (`FLIGHT_SQL_SERVER_TRANSACTION`, SqlInfo id 8), the Python dbapi follows PEP 249 and defaults to **manual-commit**.
+DML run via `execute` / `executemany` stays in an uncommitted transaction until you call `conn.commit()`.
+For ingest-and-query scripts that aren't managing transactions, pass `autocommit=True` to `flight_sql.connect(...)`.
+`adbc_ingest` is the exception: each bulk-ingest call commits atomically on its own, regardless of the connection's commit mode.
+
+**Visibility inside an open transaction.**
+XTDB buffers a transaction's DML and applies it atomically on `COMMIT`, so reads on the same connection do **not** see that transaction's own pending writes before it commits.
+A `SELECT` issued between an uncommitted `INSERT` and the `COMMIT` returns the pre-transaction state.
+
+**Same-connection write-then-read (autocommit / committed writes).**
+Once a write is committed (in autocommit mode, or after `commit()`), subsequent reads on the same connection see it without a manual `await`.
+The connection tracks its own write tokens and threads them through the planner so a committed `INSERT` followed by `SELECT` (or by `executeSchema`, or by `getTableSchema`) sees the just-written rows.
+Cross-connection visibility follows the usual transactional semantics: you'll see another connection's writes once they commit and your read snapshot advances.
+
+### `getTableTypes` / `getInfo`
+
+Standard ADBC metadata calls:
+
+- `getTableTypes()` returns `TABLE` (XTDB has one table type).
+- `getInfo(...)` returns `VENDOR_NAME = "XTDB"`, `DRIVER_NAME = "XTDB ADBC Driver"`, and version fields.
+  Version fields are placeholder strings.
+
+## What isn't supported
+
+- **Setting the `schema` session option**: `public` is the only accepted value; see the session-options section above. (Setting the `catalog` and `closeSession` *are* supported.)
+- **Bulk ingest `replace` mode and existence-check modes**: rejected with explanatory `INVALID_ARGUMENT`; see above.
+- **Per-call catalog override on bulk ingest**: rejected; use the connection-scoped catalog.
+- **Substrait variant of `executeSchema`** (`getSchemaSubstraitPlan`): no current driver consumer.
+- **Java FlightSQL client `getCurrentCatalog` / `getCurrentDbSchema`**: upstream Apache ADBC gap, not XTDB.
+- **Parameter type inference for `executeSchema`**: placeholder types only; see the caveat under `executeSchema()`.
+- **TLS / auth on the FlightSQL listener**: not currently supported; front it with a TLS-terminating proxy (see the deployment note above).
+
+## One ADBC implementation with two surfaces
+
+```d2 sketch="false" theme="200" title="ADBC: two surfaces over one implementation"
+direction: down
+
+client: "Your client\nPython / Rust / Go / C / R / Java …"
+producer: "XtdbProducer\nFlightSQL → ADBC shim"
+impl: "XtdbConnection / XtdbStatement\nimplements org.apache.arrow.adbc.core.*"
+node: XTDB node
+
+client -> producer: "FlightSQL (gRPC)"
+producer -> impl: "delegates"
+impl -> node
+client -> impl: "in-process (JVM)" {
+  style.stroke-dash: 3
+}
+```
+
+The wire path (FlightSQL) and the in-process JVM path resolve to the same `XtdbConnection` / `XtdbStatement` implementation.
+Anything you can do via the in-process `AdbcConnection` you can do over the wire, and vice versa, barring the wire-client caveats above.
+
+## Examples
+
+Minimal runnable examples are in [`docs/drivers/adbc/examples/`](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples): one `hello-world` per language.
+For more end-to-end material see:
+
+- [Tutorial](./tutorial): end-to-end notebook-style walkthrough.
+- [How-to guides](./guides): task-shaped recipes (Parquet bulk ingest, pandas/polars round-trip, etc.).
+- [`xtdb/driver-examples`](https://github.com/xtdb/driver-examples): the canonical multi-language driver-validation suite.

--- a/docs/src/content/docs/drivers/adbc/tutorial.md
+++ b/docs/src/content/docs/drivers/adbc/tutorial.md
@@ -1,0 +1,348 @@
+---
+title: "ADBC tutorial: XTDB end-to-end in Python"
+description: "An Arrow-native walkthrough: install the driver, connect, ingest, query, transact, and time-travel."
+---
+
+The tutorial is Python-first: `adbc_driver_flightsql` + `pyarrow` keep results in Arrow from XTDB to your process, with no intermediate decode.
+A complete, runnable version of every snippet here lives in [`examples/tutorial/main.py`](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples/tutorial/main.py).
+
+## What you'll build
+
+A small worked example: load a `pyarrow.Table` of historical FX trades into XTDB, run analytical queries against it, add new trades, and travel back in time to the state before they arrived.
+It covers bulk ingest, parameterised queries, introspection, and `executeSchema`.
+
+## 1. Prerequisites
+
+You need a Python 3.10+ environment and Docker.
+
+```bash
+pip install adbc-driver-flightsql pyarrow pandas
+docker run --rm -d --name xtdb -p 5432:5432 -p 9832:9832 ghcr.io/xtdb/xtdb:nightly
+```
+
+The standalone Docker image starts both the PostgreSQL wire server (port 5432) and the FlightSQL gRPC server (port 9832).
+The `nightly` image enables FlightSQL by default, as do stable images from 2.2.0 onwards.
+
+## 2. Connecting
+
+```python
+import adbc_driver_flightsql.dbapi as flight_sql
+
+conn = flight_sql.connect("grpc://localhost:9832")
+```
+
+The connection string is a standard gRPC URI.
+`flight_sql.connect` returns a DB-API 2.0 `Connection` object and can also be used as a context manager.
+
+For JVM readers: the in-process `XtdbConnection` path requires no network hop and no gRPC; see the [reference](/drivers/adbc/reference#in-process-kotlin--jvm) for the Kotlin API.
+
+## 3. Your first query
+
+```python
+with conn.cursor() as cur:
+    cur.execute("SELECT 1")
+    result = cur.fetch_arrow_table()
+    print(result.schema)
+    print(result.to_pylist())
+```
+
+Expected output:
+
+```
+_column_1: int64 not null
+[{'_column_1': 1}]
+```
+
+`fetch_arrow_table()` returns a `pyarrow.Table`, not Python rows or tuples.
+Results arrive as Arrow batches and stay in Arrow form from XTDB's storage layer into your process, with no row-by-row decode.
+
+## 4. Bulk ingest
+
+Build the dataset of ten FX trades covering three currency pairs:
+
+```python
+import pyarrow as pa
+from datetime import datetime, timezone
+
+trades = pa.table({
+    "_id": pa.array([
+        "t001", "t002", "t003", "t004", "t005",
+        "t006", "t007", "t008", "t009", "t010",
+    ]),
+    "symbol": pa.array([
+        "EURUSD", "GBPUSD", "EURUSD", "USDJPY", "GBPUSD",
+        "EURUSD", "USDJPY", "GBPUSD", "EURUSD", "USDJPY",
+    ]),
+    "qty": pa.array(
+        [100_000, 250_000, 75_000, 500_000, 180_000,
+         320_000, 90_000, 420_000, 110_000, 660_000],
+        type=pa.int64(),
+    ),
+    "price": pa.array(
+        [1.0921, 1.2734, 1.0918, 148.25, 1.2741,
+         1.0935, 148.10, 1.2728, 1.0942, 148.30],
+        type=pa.float64(),
+    ),
+    "traded_at": pa.array(
+        [
+            datetime(2024, 1, 15, 9, 0, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 9, 5, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 9, 10, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 9, 15, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 9, 20, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 10, 0, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 10, 5, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 10, 10, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 10, 15, tzinfo=timezone.utc),
+            datetime(2024, 1, 15, 10, 20, tzinfo=timezone.utc),
+        ],
+        type=pa.timestamp("us", tz="UTC"),
+    ),
+})
+```
+
+Ingest in one round trip:
+
+```python
+with conn.cursor() as cur:
+    cur.adbc_ingest("trades", trades, mode="create_append")
+```
+
+XTDB auto-creates the `trades` table.
+The table name you pass becomes the target; XTDB's implicit schema creation means there's no `CREATE TABLE` step.
+Every row must have an `_id` column: XTDB's document model requires it.
+
+Verify the round-trip:
+
+```python
+with conn.cursor() as cur:
+    cur.execute("SELECT * FROM trades ORDER BY _id")
+    back = cur.fetch_arrow_table()
+    print(back.num_rows, "rows")
+    print(back.schema)
+```
+
+Expected output:
+
+```
+10 rows
+_id: string
+price: double
+qty: int64
+symbol: string
+traded_at: timestamp[us, tz=UTC]
+```
+
+The types come back exactly as you put them in: no widening through a Postgres text protocol, no timestamp-to-string conversion.
+
+## 5. Querying with parameters
+
+Use `?` for positional parameters:
+
+```python
+with conn.cursor() as cur:
+    cur.execute(
+        "SELECT _id, symbol, qty, price FROM trades WHERE symbol = ? ORDER BY _id",
+        parameters=["EURUSD"],
+    )
+    result = cur.fetch_arrow_table()
+
+print(f"EURUSD trades: {result.num_rows} rows")
+for row in result.to_pylist():
+    print(f"  {row['_id']}  qty={row['qty']:>7,}  price={row['price']:.4f}")
+```
+
+Expected output:
+
+```
+EURUSD trades: 4 rows
+  t001  qty=100,000  price=1.0921
+  t003  qty= 75,000  price=1.0918
+  t006  qty=320,000  price=1.0935
+  t009  qty=110,000  price=1.0942
+```
+
+The `parameters` list maps positionally to the `?` placeholders.
+The result is still a `pyarrow.Table`: the type system is unaffected by the parameter binding.
+
+## 6. Write visibility
+
+The dbapi defaults to manual-commit, so for ingest-and-query scripts connect with `autocommit=True` and each statement commits as it runs:
+
+```python
+conn = flight_sql.connect("grpc://localhost:9832", autocommit=True)
+```
+
+`adbc_ingest` commits atomically on its own regardless of commit mode, which is why the ingests in this tutorial are visible without any extra step.
+For the full commit-mode, visibility, and multi-statement transaction rules see [Transactions](/drivers/adbc/reference#transactions) in the reference.
+
+A committed write is visible to subsequent reads on the same connection, with no explicit synchronisation step:
+
+```python
+extra = pa.table({
+    "_id":    pa.array(["t011", "t012"]),
+    "symbol": pa.array(["EURGBP", "EURGBP"]),
+    "qty":    pa.array([60_000, 40_000], type=pa.int64()),
+    "price":  pa.array([0.8571, 0.8569], type=pa.float64()),
+})
+
+with conn.cursor() as cur:
+    cur.adbc_ingest("trades", extra, mode="create_append")
+
+# Same-connection read; sees the rows immediately.
+with conn.cursor() as cur:
+    cur.execute("SELECT count(*) FROM trades WHERE symbol = 'EURGBP'")
+    n = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+print(f"EURGBP rows: {n}")  # 2
+
+with conn.cursor() as cur:
+    cur.execute("SELECT count(*) FROM trades")
+    total = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+print(f"Total trades: {total}")  # 12
+```
+
+Expected output:
+
+```
+EURGBP rows: 2
+Total trades: 12
+```
+
+The `count(*)` immediately after the ingest sees the just-written rows.
+
+## 7. Introspection: `getObjects` / `getTableSchema`
+
+Discover what's in the database without running a query.
+
+**`adbc_get_objects`** returns the full catalog → schema → table → column tree as an Arrow reader:
+
+```python
+reader = conn.adbc_get_objects(depth="all", db_schema_filter="public")
+tbl = reader.read_all()
+print(f"Catalog rows returned: {tbl.num_rows}")
+```
+
+Expected output:
+
+```
+Catalog rows returned: 1
+```
+
+The Arrow result encodes the entire schema tree in ADBC's standard nested-struct format.
+Tooling that needs to walk the catalog (IDE autocomplete, dataframe pipeline builders) can consume this directly without issuing any SQL.
+
+**`adbc_get_table_schema`** returns a `pyarrow.Schema` for a single table:
+
+```python
+schema = conn.adbc_get_table_schema("trades", db_schema_filter="public")
+for field in schema:
+    print(f"  {field.name}: {field.type}")
+```
+
+Expected output:
+
+```
+  _id: string
+  price: double
+  qty: int64
+  symbol: string
+  traded_at: timestamp[us, tz=UTC]
+```
+
+Column types reflect **live data**: freshly-ingested rows show up here immediately, the same way they show up via SQL `SELECT`.
+
+## 8. `executeSchema`: result shape without running
+
+`executeSchema` returns the Arrow schema of a query's result set without executing the query.
+This lets pipeline builders and schema-on-read consumers learn the result columns before paying for a full execution.
+
+```python
+with conn.cursor() as cur:
+    schema = cur.adbc_execute_schema(
+        "SELECT _id, symbol, qty, price FROM trades WHERE symbol = ?"
+    )
+print("Result schema:")
+for field in schema:
+    print(f"  {field.name}: {field.type}")
+```
+
+Expected output:
+
+```
+Result schema:
+  _id: string
+  symbol: string
+  qty: int64
+  price: double
+```
+
+Note on parameter types: the schema is computed before any bind, so XTDB synthesises null-typed placeholder fields for `?` positions.
+For queries where the projection does not depend on the parameter value, which covers the common `SELECT cols FROM t WHERE id = ?` shape, the returned schema is accurate.
+For queries that project the parameter directly (`SELECT ?`, `SELECT ? + 1`), the result field types will be placeholder-typed rather than the type you would eventually bind.
+Workaround: project through a column expression that fixes the type.
+
+## 9. Bitemporality: `FOR SYSTEM_TIME AS OF`
+
+XTDB records the wall-clock time at which every row was committed.
+You can query the database as it stood at any point in the past using `FOR SYSTEM_TIME AS OF`.
+
+Capture a checkpoint before inserting a new trade:
+
+```python
+import time
+from datetime import datetime, timezone
+
+checkpoint = datetime.now(timezone.utc)
+time.sleep(0.1)  # ensure the next write has a strictly later system time
+
+new_trade = pa.table({
+    "_id":    pa.array(["t013"]),
+    "symbol": pa.array(["USDCHF"]),
+    "qty":    pa.array([200_000], type=pa.int64()),
+    "price":  pa.array([0.9012], type=pa.float64()),
+})
+with conn.cursor() as cur:
+    cur.adbc_ingest("trades", new_trade, mode="create_append")
+```
+
+Current view, with t013 present:
+
+```python
+with conn.cursor() as cur:
+    cur.execute("SELECT count(*) FROM trades")
+    count_now = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+print(f"Total trades now: {count_now}")  # 13
+```
+
+Historical view: travel back to the checkpoint, before t013 existed:
+
+```python
+ts = checkpoint.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+with conn.cursor() as cur:
+    cur.execute(f"SELECT count(*) FROM trades FOR SYSTEM_TIME AS OF TIMESTAMP '{ts}+00:00'")
+    count_before = cur.fetch_arrow_table().to_pylist()[0]["_column_1"]
+print(f"Trades AS OF checkpoint: {count_before}")  # 12
+```
+
+Expected output:
+
+```
+Total trades now: 13
+Trades AS OF checkpoint: 12
+```
+
+The Arrow types of temporal columns, including the `_system_from` / `_system_to` hidden columns XTDB maintains, survive the FlightSQL round-trip without widening.
+There is no Postgres-style text-format timestamp decode on the way back.
+
+`FOR SYSTEM_TIME AS OF` is ordinary XTDB SQL and works equally well over the pgwire driver.
+The ADBC path returns the result in Arrow form rather than decoded rows.
+
+## 10. Where next
+
+- **[Reference](/drivers/adbc/reference)**: the full supported ADBC surface in detail: which calls work, which don't, per-client caveats.
+- **[How-to guides](/drivers/adbc/guides)**: task-shaped recipes:
+  - [Bulk-load Parquet](/drivers/adbc/guides/bulk-ingest-from-parquet): load a Parquet file in one `adbc_ingest` call.
+  - [pandas / polars round-trip](/drivers/adbc/guides/pandas-polars-round-trip): read query results directly into a DataFrame without an intermediate copy.
+  - [Stream results into DuckDB](/drivers/adbc/guides/streaming-into-duckdb): feed XTDB query output into DuckDB via the Arrow C Data Interface.
+  - [Point-in-time feature extraction](/drivers/adbc/guides/point-in-time-feature-extraction): use `FOR SYSTEM_TIME AS OF` inside a pipeline to recreate historical feature sets.
+- **[Examples](https://github.com/xtdb/xtdb/tree/main/docs/src/content/docs/drivers/adbc/examples)**: minimal hello-world programs in Python, Rust, and other languages.


### PR DESCRIPTION
## ADBC driver documentation

Adds a complete ADBC documentation section under `docs/.../drivers/adbc/`: a reference, a Python tutorial, six how-to guides, and runnable example programs.

### Contents
- **Reference** — in-process (JVM) and over-the-wire (FlightSQL) surfaces, statement lifecycle, `executeSchema`, `getObjects`/`getTableSchema`, bulk ingest (modes), transactions, and catalog/schema selection. Includes a D2 architecture diagram.
- **Tutorial** — end-to-end Python walkthrough with an FX-trades worked example (ingest, parameterised queries, write visibility, introspection, bitemporal `FOR SYSTEM_TIME AS OF`).
- **How-to guides** — bulk-load Parquet, pandas/polars round-trip, point-in-time feature extraction, streaming into DuckDB, a Rust arrow-rs pipeline, and prepared statements + transactions.
- **Examples** — one runnable program per guide plus Python and Rust hello-worlds.

### Verification
All nine example programs (seven Python, two Rust) were run end-to-end against a fresh `ghcr.io/xtdb/xtdb:nightly` node and exit cleanly with the documented output. `adbc_ingest` is documented as the shipped bulk path (FlightSQL `CommandStatementIngest`, available on nightly and stable 2.2.0+).

The production `astro build` passes (all pages, the D2 diagram, search index, sitemap).

### Notes
- `_valid_from` must be a `timestamp` column (not `date32`) when ingested — XTDB rejects a date temporal column. Documented in the point-in-time guide.
- One server-side robustness observation surfaced while testing: a malformed temporal column type in `adbc_ingest` logs "ingestion stopping" rather than a clean per-request rejection. Tracking separately; not addressed here.

Draft while the docs are reviewed; not yet wired for deploy (docs ship via the `docs-live` branch separately).
