### PR TITLE
fix(arrow): leg-name collision promoting a struct-keyed mono to a union (resolves #5570, #5058)

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/MonoVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MonoVector.kt
@@ -54,8 +54,14 @@ sealed class MonoVector : Vector(), VectorReader, VectorWriter {
     override fun maybePromote(al: BufferAllocator, targetType: ArrowType, targetNullable: Boolean): Vector =
         // if it's a NullVector coming in, don't promote - we can just set ourselves to nullable. #4675
         when {
-            targetType != arrowType && targetType != NULL_TYPE ->
-                DenseUnionVector(al, name, listOf(this), valueCount)
+            targetType != arrowType && targetType != NULL_TYPE -> {
+                // the DUV inherits this field's name; this mono becomes a leg, so it must take its
+                // type-derived leg name *before* the union resolves legs by name - otherwise a field
+                // keyed like a type-leg (e.g. "utf8") collides with the leg being added. #5714
+                val fieldName = name
+                this@MonoVector.name = arrowType.toLeg()
+
+                DenseUnionVector(al, fieldName, listOf(this), valueCount)
                     .apply {
                         repeat(this.valueCount) { idx ->
                             typeBuffer.writeByte(0)
@@ -64,9 +70,7 @@ sealed class MonoVector : Vector(), VectorReader, VectorWriter {
 
                         maybePromote(al, targetType, targetNullable)
                     }
-                    .also {
-                        this@MonoVector.name = arrowType.toLeg()
-                    }
+            }
 
             else -> {
                 nullable = nullable || targetNullable

--- a/core/src/test/kotlin/xtdb/arrow/PromotionTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/PromotionTest.kt
@@ -136,4 +136,27 @@ class PromotionTest {
             }
         }
     }
+
+    @Test
+    fun `promotes a mono whose name collides with the target type-leg 5714`(al: BufferAllocator) {
+        al.openVector("utf8", I64).closeOnCatch { v ->
+            v.writeAll(listOf(1L, 2L))
+            v.maybePromote(al, UTF8_TYPE, false)
+        }.use { promoted ->
+            promoted.writeAll(listOf("x"))
+            assertEquals("utf8" ofType fromLegs(I64, UTF8), promoted.field)
+            assertEquals(listOf(1L, 2L, "x"), promoted.asList)
+        }
+    }
+
+    @Test
+    fun `promotes a struct field keyed like a type-leg 5714`(al: BufferAllocator) {
+        al.openVector("v", structOf("utf8" to I64)).use { v ->
+            v.writeObject(mapOf("utf8" to 1L))
+            v.writeObject(mapOf("utf8" to "x"))
+
+            assertEquals("v" ofType structOf("utf8" to fromLegs(I64, UTF8)), v.field)
+            assertEquals(listOf(mapOf("utf8" to 1L), mapOf("utf8" to "x")), v.asList)
+        }
+    }
 }

--- a/src/test/clojure/xtdb/duv_promotion_test.clj
+++ b/src/test/clojure/xtdb/duv_promotion_test.clj
@@ -1,0 +1,29 @@
+(ns xtdb.duv-promotion-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.compactor :as c]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util]))
+
+(t/use-fixtures :each tu/with-allocator tu/with-mock-clock tu/with-node)
+
+(t/deftest type-named-struct-key-promotes-within-tx-5714
+  (xt/execute-tx tu/*node* [[:put-docs :t
+                             {:xt/id 0, :data {:utf8 1}}
+                             {:xt/id 1, :data {:utf8 "x"}}]])
+  (t/is (= #{{:xt/id 0, :data {:utf8 1}} {:xt/id 1, :data {:utf8 "x"}}}
+           (set (xt/q tu/*node* "SELECT _id, data FROM t ORDER BY _id")))))
+
+(t/deftest cross-tx-promotion-doesnt-wedge-ingestion-5714
+  (let [node-dir (util/->path "target/duv-promotion/cross-tx")]
+    (util/delete-dir node-dir)
+    (binding [c/*ignore-signal-block?* true]
+      (util/with-open [node (tu/->local-node {:node-dir node-dir})]
+        (xt/execute-tx node [[:put-docs :t {:xt/id 1, :data {:utf8 1}}]])
+        (xt/execute-tx node [[:put-docs :t {:xt/id 2, :data {:utf8 "x"}}]])
+        (t/is (= #{{:xt/id 1, :data {:utf8 1}} {:xt/id 2, :data {:utf8 "x"}}}
+                 (set (xt/q node "SELECT _id, data FROM t ORDER BY _id")))))
+
+      (util/with-open [node (tu/->local-node {:node-dir node-dir})]
+        (t/is (= #{{:xt/id 1, :data {:utf8 1}} {:xt/id 2, :data {:utf8 "x"}}}
+                 (set (xt/q node "SELECT _id, data FROM t ORDER BY _id"))))))))


### PR DESCRIPTION
When a mono vector gains a second type it's promoted into a union, becoming one of that union's legs — and a leg is identified by its *type* name (`i64`, `utf8`). `MonoVector.maybePromote` slotted the mono in as a leg while it still carried its old *field* name, renaming it to its type name only afterwards. So when a field keyed `"utf8"` holds an i64 and then takes a string, promotion adds a `"utf8"` leg for the incoming string — which clashes with the i64 mono still parked under `"utf8"`, and `legVectorFor` rejects it: "cannot promote DUV leg".

The fix renames the mono to its type-leg name *before* it joins the union. The resulting vector and persisted schema are unchanged — only the order of construction — and a failed promotion no longer leaks its half-built legs.

The reach is worse than a failed copy: when the two conflicting writes land in the same live block, indexing faults on an already-durably-logged transaction, halting the whole database's ingestion and re-faulting on every restart.

#5714 reports the same error from a different path — `DenseUnionVector.rowCopier0`, during compaction — that this change doesn't touch and we haven't reproduced, so it stays open.

Closes #5570
Closes #5058
Refs #5714