### PR TITLE
fix(kafka): cancel in-flight delivery on subscription teardown (#5711)

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -164,6 +164,9 @@ class KafkaCluster(
             val epoch: Int,
             val listener: Log.SubscriptionListener<M>,
             var processor: Log.RecordProcessor<M>?,
+            // Delivery runs under this job — a child of the poll loop: cluster shutdown reaps it, a
+            // delivery error still tanks the loop, and teardown cancels just this subscription. #5711
+            val deliveryJob: Job,
             val completion: CompletableDeferred<Unit> = CompletableDeferred(),
         ) {
             // expecting a load of change here for multi-part.
@@ -298,6 +301,7 @@ class KafkaCluster(
             }
 
         private val pollingJob: Job = scope.launch {
+            val loopScope = this
             try {
                 var closed = false
                 while (!closed) {
@@ -316,7 +320,7 @@ class KafkaCluster(
                                         val sub = subscriptions[topic]
                                             ?: error("Received records for unsubscribed topic $topic")
 
-                                        sub.processRecords(recs)
+                                        loopScope.launch(sub.deliveryJob) { sub.processRecords(recs) }.join()
                                     }
                                 }
                             }
@@ -339,7 +343,7 @@ class KafkaCluster(
             epoch: Int,
             listener: Log.SubscriptionListener<M>,
         ): TopicSubscription<M> {
-            val sub = TopicSubscription(codec, epoch, listener, null)
+            val sub = TopicSubscription(codec, epoch, listener, null, deliveryJob = Job(pollingJob))
             commandCh.send(GroupCommand.Register(topic, sub))
             consumer.wakeup()
             return sub
@@ -640,6 +644,9 @@ class KafkaCluster(
             try {
                 sub.completion.await()
             } finally {
+                // Cancel any in-flight delivery first, so a loop stuck in processRecords is freed to
+                // handle the unregister below rather than deadlocking on it. #5711
+                sub.deliveryJob.cancel()
                 withContext(NonCancellable) { sharedGroupConsumer.unregister(topic) }
             }
         }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -5,6 +5,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -356,6 +357,43 @@ class KafkaClusterTest {
 
         override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
             revokedPartitions.add(partitions)
+        }
+    }
+
+    // The processor blocks in processRecords, standing in for a leader term's persister that never
+    // drains — the real #5711 deadlock. runBlocking (not runTest) keeps the timeout real.
+    @Test
+    fun `subscription teardown completes when the poll loop is blocked in processRecords`() = runBlocking {
+        val topic = "test-blocked-delivery-${UUID.randomUUID()}"
+        withClusterAndLogs(listOf(topic)) { _, logs ->
+            val log = logs.single()
+            val assigned = CompletableDeferred<Unit>()
+            val deliveryStarted = CompletableDeferred<Unit>()
+
+            val listener = object : SubscriptionListener<SourceMessage> {
+                private val processor = RecordProcessor<SourceMessage> {
+                    deliveryStarted.complete(Unit)
+                    awaitCancellation()
+                }
+
+                override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> {
+                    assigned.complete(Unit)
+                    return TailSpec(-1L, processor)
+                }
+
+                override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+            }
+
+            val subJob = launch { log.openGroupSubscription(listener) }
+            assigned.await()
+            log.appendMessage(txMessage(1))
+            deliveryStarted.await()
+
+            subJob.cancel()
+            assertNotNull(
+                withTimeoutOrNull(10.seconds) { subJob.join() },
+                "teardown deadlocked: poll loop blocked in processRecords, unregister waits on it (#5711)",
+            )
         }
     }
 


### PR DESCRIPTION
The shared Kafka poll loop drives each subscription's records by calling `processRecords` synchronously and joining it; for a leader that call sends into the term's persister over a rendezvous channel. When a database closes, its source-log subscription is cancelled and unregisters under `NonCancellable` — which needs the poll loop to process the command. If the loop is parked on that rendezvous send (the persister stopped draining mid-teardown), it never returns to its `select`, the unregister is never processed, and close hangs forever. The loop lives on the cluster scope, a different job tree, so the closing database's own cancellation can't reach it. Dump-confirmed as the Kafka instance of #5711.

Give each subscription its own delivery job — a child of the poll loop — and run `processRecords` under it. Teardown cancels that job before the NonCancellable unregister, interrupting the parked send so the loop's `join()` returns and the loop is free to process the unregister. The rescue reaches the wedged loop sideways rather than through the command channel, so it works precisely when the loop can't help itself.

Parenting to the loop preserves the existing semantics: cluster shutdown reaps the job, and a genuine delivery error still propagates up and tanks the loop. Cancellation is sticky, so a delivery that races teardown is born cancelled — a no-op — which is why no separate torn-down flag is needed.

This deliberately does not depend on the persister's cleanup closing the channel to free the send: the earlier attempt down that path (`leader-term-channel-cleanup`) left the CI hang identical, because the channel stayed open for reasons still not pinned. Cancelling the delivery sidesteps it.

The test reproduces the deadlock deterministically at the SharedGroupConsumer boundary — a processor that blocks in `processRecords`, then a cancelled subscription — using `runBlocking` so the timeout is real.

Refs #5711