### PR TITLE
feat(indexer): zero-copy batch writes and a granular write API on OpenTx.Table

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/Relation.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Relation.kt
@@ -60,8 +60,8 @@ class Relation(
                     .also { vec -> repeat(rowCount) { vec.writeNull() } }
         }!!
 
-    override fun endRow() {
-        rowCount++
+    override fun endRows(rows: Int) {
+        rowCount += rows
         vectors.forEach { vec -> repeat(rowCount - vec.valueCount) { vec.writeNull() } }
     }
 

--- a/core/src/main/kotlin/xtdb/arrow/RelationWriter.kt
+++ b/core/src/main/kotlin/xtdb/arrow/RelationWriter.kt
@@ -17,7 +17,8 @@ interface RelationWriter : RelationReader {
     fun vectorFor(name: String, arrowType: ArrowType, nullable: Boolean): VectorWriter = unsupported("vectorFor/2")
     override fun get(name: String) = vectorFor(name)
 
-    fun endRow()
+    fun endRows(rows: Int)
+    fun endRow() = endRows(1)
 
     fun append(rel: RelationReader) {
         rel.vectors.forEach { vectorFor(it.name, it.arrowType, it.nullable).append(it) }

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -23,6 +23,7 @@ import xtdb.arrow.SingletonListReader
 import xtdb.arrow.VectorType.Companion.BOOL
 import xtdb.arrow.VectorType.Companion.I64
 import xtdb.arrow.VectorType.Companion.INSTANT
+import xtdb.arrow.VectorType.Companion.TRANSIT
 import xtdb.database.ExternalSourceToken
 import xtdb.error.Conflict
 import xtdb.error.Incorrect
@@ -40,7 +41,6 @@ import xtdb.trie.Trie
 import xtdb.types.ClojureForm
 import xtdb.util.asIid
 import xtdb.util.closeAll
-import xtdb.util.closeOnCatch
 import xtdb.util.logger
 import xtdb.util.warn
 import java.nio.ByteBuffer
@@ -79,6 +79,40 @@ class OpenTx(
 
     internal val tables: Iterable<Map.Entry<TableRef, Table>> get() = tableTxs.entries
 
+    private fun writeTxRow(error: Throwable?, userMetadata: Map<*, *>?) {
+        val txId = txKey.txId
+        val systemTimeMicros = txKey.systemTime.asMicros
+
+        val liveTable = table(TableRef(dbState.name, "xt", "txs"))
+        val docWriter = liveTable.putDocWriter
+
+        liveTable.writeId(txId)
+        liveTable.writeDefaultValidTime()
+
+        docWriter.vectorFor("_id", I64.arrowType, false).writeLong(txId)
+        docWriter.vectorFor("system_time", INSTANT.arrowType, false).writeLong(systemTimeMicros)
+        docWriter.vectorFor("committed", BOOL.arrowType, false).writeBoolean(error == null)
+        docWriter.vectorFor("user_metadata", VectorType.structOf().arrowType, true).writeObject(userMetadata)
+
+        val errorWriter = docWriter.vectorFor("error", TRANSIT.arrowType, true)
+
+        if (error == null) {
+            errorWriter.writeNull()
+        } else {
+            try {
+                errorWriter.writeObject(error)
+            } catch (e: Exception) {
+                error.addSuppressed(e)
+                LOG.warn(error, "Error serializing error, tx $txId")
+                errorWriter.writeObject(ClojureForm("error serializing error - see server logs"))
+            }
+        }
+
+        docWriter.endStruct()
+
+        liveTable.endPut()
+    }
+
     private fun serializeTableData(): Map<String, ByteArray> =
         tableTxs.entries.associate { (tableRef, tableTx) -> tableRef.schemaAndTable to tableTx.serializeTxData() }
 
@@ -101,37 +135,6 @@ class OpenTx(
             dbOp = null,
             externalSourceToken = externalSourceToken,
         )
-    }
-
-    private fun writeTxRow(error: Throwable?, userMetadata: Map<*, *>?) {
-        val txId = txKey.txId
-        val systemTimeMicros = txKey.systemTime.asMicros
-
-        val liveTable = table(TableRef(dbState.name, "xt", "txs"))
-        val docWriter = liveTable.putDocWriter
-
-        liveTable.logPut(ByteBuffer.wrap(txId.asIid), systemTimeMicros, MAX_LONG) {
-            docWriter.vectorFor("_id", I64.arrowType, false).writeLong(txId)
-            docWriter.vectorFor("system_time", INSTANT.arrowType, false).writeLong(systemTimeMicros)
-            docWriter.vectorFor("committed", BOOL.arrowType, false).writeBoolean(error == null)
-            docWriter.vectorFor("user_metadata", VectorType.structOf().arrowType, true).writeObject(userMetadata)
-
-            val errorWriter = docWriter.vectorFor("error", VectorType.TRANSIT.arrowType, true)
-
-            if (error == null) {
-                errorWriter.writeNull()
-            } else {
-                try {
-                    errorWriter.writeObject(error)
-                } catch (e: Exception) {
-                    error.addSuppressed(e)
-                    LOG.warn(error, "Error serializing error, tx $txId")
-                    errorWriter.writeObject(ClojureForm("error serializing error - see server logs"))
-                }
-            }
-
-            docWriter.endStruct()
-        }
     }
 
     private val queryCatalog: IQuerySource.QueryCatalog
@@ -245,7 +248,7 @@ class OpenTx(
                                 )
 
                                 table(stmt.table)
-                                    .logPuts(currentTimeMicros, MAX_LONG, RelationReader.from(putCols, rel.rowCount))
+                                    .writePuts(RelationReader.from(putCols, rel.rowCount), currentTimeMicros, MAX_LONG)
                             }
                         }
                     }
@@ -256,7 +259,7 @@ class OpenTx(
                         query.openQuery(args, qOpts).use { cursor ->
                             cursor.forEachRemaining { rel ->
                                 if (rel.rowCount > 0)
-                                    table(stmt.table).logPuts(0, MAX_LONG, rel)
+                                    table(stmt.table).writePuts(rel, 0, MAX_LONG)
                             }
                         }
                     }
@@ -267,7 +270,7 @@ class OpenTx(
                         query.openQuery(args, qOpts).use { cursor ->
                             cursor.forEachRemaining { rel ->
                                 if (rel.rowCount > 0)
-                                    table(stmt.table).logDeletes(0, MAX_LONG, rel)
+                                    table(stmt.table).writeDeletes(rel, 0, MAX_LONG)
                             }
                         }
                     }
@@ -278,7 +281,7 @@ class OpenTx(
                         query.openQuery(args, qOpts).use { cursor ->
                             cursor.forEachRemaining { rel ->
                                 if (rel.rowCount > 0)
-                                    table(stmt.table).logErases(rel.vectorFor("_iid"))
+                                    table(stmt.table).writeErases(rel.vectorFor("_iid"))
                             }
                         }
                     }
@@ -317,17 +320,20 @@ class OpenTx(
 
         val ts = currentTime.asMicros
         val table = table(TableRef(dbState.name, "xt", "role_membership"))
-        val iid = ByteBuffer.wrap(RoleMembership.membershipIid(user, role))
+
+        table.writeIid(RoleMembership.membershipIid(user, role))
+        table.writeValidTimeMicros(ts, MAX_LONG)
 
         if (revoke) {
-            table.logDelete(iid, ts, MAX_LONG)
+            table.endDelete()
         } else {
-            val docWriter = table.putDocWriter
-            table.logPut(iid, ts, MAX_LONG) {
-                docWriter.vectorFor("user", VectorType.UTF8.arrowType, false).writeObject(user)
-                docWriter.vectorFor("role", VectorType.UTF8.arrowType, false).writeObject(role)
-                docWriter.endStruct()
+            table.putDocWriter.apply {
+                vectorFor("user", VectorType.UTF8.arrowType, false).writeObject(user)
+                vectorFor("role", VectorType.UTF8.arrowType, false).writeObject(role)
+                endStruct()
             }
+
+            table.endPut()
         }
     }
 
@@ -368,7 +374,7 @@ class OpenTx(
         // openQuery takes ownership of the sliced args and closes them when the cursor closes —
         // no separate `.use` on the slice here or it'd double-free.
         pq.openQuery(patchArgs.openSlice(allocator), qOpts).use { cursor ->
-            cursor.forEachRemaining { rel -> table.logPuts(validFromMicros, validToMicros, rel) }
+            cursor.forEachRemaining { rel -> table.writePuts(rel, validFromMicros, validToMicros) }
         }
     }
 
@@ -456,45 +462,42 @@ class OpenTx(
         internal var trie: MemoryHashTrie = MemoryHashTrie.emptyTrie(iidVec)
             private set
 
-        fun logPut(iid: ByteBuffer, validFrom: Long, validTo: Long, writeDocFun: Runnable) {
-            val pos = txRelation.rowCount
+        fun writeIid(iid: ByteBuffer) = iidVec.writeBytes(iid)
+        fun writeIid(iid: ByteArray) = iidVec.writeBytes(iid)
+        fun writeId(id: Any) = iidVec.writeBytes(id.asIid)
 
-            iidVec.writeBytes(iid)
-            systemFromVec.writeLong(systemFrom)
+        fun writeValidTimeMicros(validFrom: Long, validTo: Long) {
             validFromVec.writeLong(validFrom)
             validToVec.writeLong(validTo)
-
-            writeDocFun.run()
-
-            txRelation.endRow()
-
-            trie += pos
         }
 
-        fun logDelete(iid: ByteBuffer, validFrom: Long, validTo: Long) {
+        fun writeDefaultValidTime() = writeValidTimeMicros(systemFrom, MAX_LONG)
+
+        @Suppress("IfThenToElvis") // because I wasn't sure that Elvis doesn't box primitives
+        fun writeValidTimes(validFrom: Instant? = null, validTo: Instant? = null) =
+            writeValidTimeMicros(
+                if (validFrom != null) validFrom.asMicros else MIN_LONG,
+                if (validTo != null) validTo.asMicros else MAX_LONG
+            )
+
+        private fun endOps(count: Int) {
             val pos = txRelation.rowCount
 
-            iidVec.writeBytes(iid)
-            systemFromVec.writeLong(systemFrom)
-            validFromVec.writeLong(validFrom)
-            validToVec.writeLong(validTo)
-            deleteVec.writeNull()
-            txRelation.endRow()
+            repeat(count) { systemFromVec.writeLong(systemFrom) }
 
-            trie += pos
+            txRelation.endRows(count)
+
+            trie = trie.addRange(pos, count)
         }
 
-        fun logErase(iid: ByteBuffer) {
-            val pos = txRelation.rowCount
+        fun endPuts(count: Int) = endOps(count)
+        fun endPut() = endPuts(1)
 
-            iidVec.writeBytes(iid)
-            systemFromVec.writeLong(systemFrom)
-            validFromVec.writeLong(MIN_LONG)
-            validToVec.writeLong(MAX_LONG)
-            eraseVec.writeNull()
-            txRelation.endRow()
-
-            trie += pos
+        fun writePut(doc: Map<String, *>, validFrom: Instant? = null, validTo: Instant? = null) {
+            writeId(doc["_id"] ?: throw Incorrect("missing _id", "xtdb.tx/missing-id", mapOf("doc" to doc)))
+            writeValidTimes(validFrom, validTo)
+            putDocWriter.writeObject(doc)
+            endPut()
         }
 
         /**
@@ -504,106 +507,120 @@ class OpenTx(
          * (user-facing id — iid computed per row via [xtdb.util.asIid]).
          *
          * Per-row valid times come from the rel's `_valid_from` / `_valid_to` columns when present and non-null;
-         * otherwise the [validFrom] / [validTo] defaults apply.
+         * otherwise the [defaultValidFromMicros] / [defaultValidToMicros] defaults apply.
          * Rejects zero-width or inverted ranges — one check over the defaults if the rel has no per-row
          * temporal columns; otherwise per-row.
          */
-        fun logPuts(validFrom: Long, validTo: Long, rel: RelationReader) {
+        fun writePuts(rel: RelationReader, defaultValidFromMicros: Long, defaultValidToMicros: Long) {
             val rowCount = rel.rowCount
             if (rowCount == 0) return
 
             val iidRdr = rel.vectorForOrNull("_iid")
-            val idRdr = if (iidRdr == null) rel.vectorFor("_id") else null
-            val docRdr = rel.vectorFor("doc")
+
+            if (iidRdr != null) {
+                iidVec.append(iidRdr)
+            } else {
+                val idRdr = rel.vectorFor("_id")
+
+                repeat(rowCount) { idx -> iidVec.writeBytes(ByteBuffer.wrap(idRdr.getObject(idx).asIid)) }
+            }
+
             val vfRdr = rel.vectorForOrNull("_valid_from")
             val vtRdr = rel.vectorForOrNull("_valid_to")
 
             val perRowCheck = vfRdr != null || vtRdr != null
-            if (!perRowCheck) checkValidTimes(validFrom, validTo)
-
-            val iidCopier = iidRdr?.rowCopier(iidVec)
-            val docCopier = docRdr.rowCopier(putDocWriter)
-
-            val startPos = txRelation.rowCount
+            if (!perRowCheck) checkValidTimes(defaultValidFromMicros, defaultValidToMicros)
 
             repeat(rowCount) { idx ->
-                val rowValidFrom = if (vfRdr != null && !vfRdr.isNull(idx)) vfRdr.getLong(idx) else validFrom
-                val rowValidTo = if (vtRdr != null && !vtRdr.isNull(idx)) vtRdr.getLong(idx) else validTo
+                val rowValidFrom =
+                    if (vfRdr != null && !vfRdr.isNull(idx)) vfRdr.getLong(idx) else defaultValidFromMicros
+
+                val rowValidTo =
+                    if (vtRdr != null && !vtRdr.isNull(idx)) vtRdr.getLong(idx) else defaultValidToMicros
+
                 if (perRowCheck) checkValidTimes(rowValidFrom, rowValidTo)
 
-                if (iidCopier != null) iidCopier.copyRow(idx)
-                else iidVec.writeBytes(ByteBuffer.wrap(idRdr!!.getObject(idx).asIid))
-
-                systemFromVec.writeLong(systemFrom)
                 validFromVec.writeLong(rowValidFrom)
                 validToVec.writeLong(rowValidTo)
-                docCopier.copyRow(idx)
-                txRelation.endRow()
             }
 
-            trie = trie.addRange(startPos, rowCount)
+            putDocWriter.append(rel.vectorFor("doc"))
+
+            endPuts(rowCount)
+        }
+
+        fun endDeletes(count: Int) {
+            repeat(count) { deleteVec.writeNull() }
+            endOps(count)
+        }
+
+        fun endDelete() = endDeletes(1)
+
+        fun writeDelete(id: Any, validFrom: Instant? = null, validTo: Instant? = null) {
+            writeId(id)
+            writeValidTimes(validFrom, validTo)
+            endDelete()
         }
 
         /**
          * Batch delete: deletes every row in [rel] (keyed by `_iid`).
          *
          * Per-row valid times come from the rel's `_valid_from` / `_valid_to` columns when present and non-null;
-         * otherwise the [validFromMicros] / [validToMicros] defaults apply.
+         * otherwise the [defaultValidFromMicros] / [defaultValidToMicros] defaults apply.
          * Rejects zero-width or inverted ranges — one check over the defaults if the rel has no per-row
          * temporal columns; otherwise per-row.
          */
-        fun logDeletes(validFromMicros: Long, validToMicros: Long, rel: RelationReader) {
+        fun writeDeletes(rel: RelationReader, defaultValidFromMicros: Long, defaultValidToMicros: Long) {
             val rowCount = rel.rowCount
             if (rowCount == 0) return
 
-            val iidRdr = rel.vectorFor("_iid")
+            iidVec.append(rel.vectorFor("_iid"))
+
             val vfRdr = rel.vectorForOrNull("_valid_from")
             val vtRdr = rel.vectorForOrNull("_valid_to")
 
             val perRowCheck = vfRdr != null || vtRdr != null
-            if (!perRowCheck) checkValidTimes(validFromMicros, validToMicros)
-
-            val iidCopier = iidRdr.rowCopier(iidVec)
-
-            val startPos = txRelation.rowCount
+            if (!perRowCheck) checkValidTimes(defaultValidFromMicros, defaultValidToMicros)
 
             repeat(rowCount) { idx ->
-                val rowValidFrom = if (vfRdr != null && !vfRdr.isNull(idx)) vfRdr.getLong(idx) else validFromMicros
-                val rowValidTo = if (vtRdr != null && !vtRdr.isNull(idx)) vtRdr.getLong(idx) else validToMicros
+                val rowValidFrom =
+                    if (vfRdr != null && !vfRdr.isNull(idx)) vfRdr.getLong(idx) else defaultValidFromMicros
+
+                val rowValidTo =
+                    if (vtRdr != null && !vtRdr.isNull(idx)) vtRdr.getLong(idx) else defaultValidToMicros
+
                 if (perRowCheck) checkValidTimes(rowValidFrom, rowValidTo)
 
-                iidCopier.copyRow(idx)
-                systemFromVec.writeLong(systemFrom)
                 validFromVec.writeLong(rowValidFrom)
                 validToVec.writeLong(rowValidTo)
-                deleteVec.writeNull()
-                txRelation.endRow()
             }
 
-            trie = trie.addRange(startPos, rowCount)
+            endDeletes(rowCount)
+        }
+
+        fun endErases(count: Int) {
+            repeat(count) { eraseVec.writeNull() }
+            endOps(count)
+        }
+
+        fun endErase() = endErases(1)
+
+        fun writeErase(id: Any) {
+            writeId(id)
+            writeValidTimeMicros(MIN_LONG, MAX_LONG)
+            endErase()
         }
 
         /**
          * Batch erase: erases every iid in [iids] across all valid time.
          */
-        fun logErases(iids: VectorReader) {
+        fun writeErases(iids: VectorReader) {
             val rowCount = iids.valueCount
             if (rowCount == 0) return
 
-            val iidCopier = iids.rowCopier(iidVec)
-
-            val startPos = txRelation.rowCount
-
-            repeat(rowCount) { idx ->
-                iidCopier.copyRow(idx)
-                systemFromVec.writeLong(systemFrom)
-                validFromVec.writeLong(MIN_LONG)
-                validToVec.writeLong(MAX_LONG)
-                eraseVec.writeNull()
-                txRelation.endRow()
-            }
-
-            trie = trie.addRange(startPos, rowCount)
+            iidVec.append(iids)
+            repeat(rowCount) { writeValidTimeMicros(MIN_LONG, MAX_LONG) }
+            endErases(rowCount)
         }
 
         internal fun serializeTxData(): ByteArray = txRelation.asArrowStream

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
@@ -140,7 +140,7 @@ internal class SourceLogTxIndexer(
                 txOpsRdr = txOpsRdr,
                 data = mapOf("table" to table, "tx-key" to opts.txKey, "tx-op-idx" to opIdx),
             ) {
-                liveTable.logPuts(validFrom, validTo, putRel)
+                liveTable.writePuts(putRel, validFrom, validTo)
             }
         }
 
@@ -167,14 +167,15 @@ internal class SourceLogTxIndexer(
             ) {
                 val validFrom = if (validFromRdr.isNull(opIdx)) opts.systemTime else validFromRdr.getLong(opIdx)
                 val validTo = if (validToRdr.isNull(opIdx)) Long.MAX_VALUE else validToRdr.getLong(opIdx)
-                openTxTable.logDeletes(
-                    validFrom, validTo,
+                openTxTable.writeDeletes(
                     RelationReader.from(
                         listOf(
                             iidRdr.select(iidsRdr.getListStartIndex(opIdx), iidsRdr.getListCount(opIdx))
                                 .withName("_iid"),
                         )
                     ),
+                    validFrom,
+                    validTo,
                 )
             }
         }
@@ -197,7 +198,7 @@ internal class SourceLogTxIndexer(
                 txOpsRdr = txOpsRdr,
                 data = mapOf("table" to table, "tx-key" to opts.txKey, "tx-op-idx" to opIdx),
             ) {
-                liveTable.logErases(
+                liveTable.writeErases(
                     iidRdr.select(iidsRdr.getListStartIndex(opIdx), iidsRdr.getListCount(opIdx))
                 )
             }

--- a/core/src/main/kotlin/xtdb/util/Iid.kt
+++ b/core/src/main/kotlin/xtdb/util/Iid.kt
@@ -4,17 +4,10 @@ package xtdb.util
 import clojure.lang.Keyword
 import xtdb.asBytes
 import xtdb.error.Incorrect
-import java.nio.ByteBuffer
 import java.security.MessageDigest
 import java.util.UUID
 
 private val messageDigest = ThreadLocal.withInitial { MessageDigest.getInstance("SHA-256") }
-
-private fun UUID.toIidBytes(): ByteArray =
-    ByteBuffer.allocate(16)
-        .putLong(mostSignificantBits)
-        .putLong(leastSignificantBits)
-        .array()
 
 val Any?.asIid: ByteArray
     get() = when (this) {

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -128,15 +128,7 @@ class LogProcessorSimTest : SimulationTestBase() {
                         is SimAction.Commit -> {
                             val table = openTx.table(docsTable)
                             for (id in action.rows) {
-                                table.logPut(
-                                    ByteBuffer.wrap(id.asIid),
-                                    openTx.systemTimeMicros,
-                                    Long.MAX_VALUE,
-                                ) {
-                                    table.putDocWriter.writeObject(
-                                        mapOf("_id" to id, "tx_id" to openTx.txKey.txId),
-                                    )
-                                }
+                                table.writePut(mapOf("_id" to id, "tx_id" to openTx.txKey.txId))
                             }
                             TxResult.Committed()
                         }

--- a/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
@@ -94,15 +94,18 @@ class DocsIndexer(
                 "xtdb.kafka-connect-source/docs-no-id-on-tombstone",
                 mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset()),
             )
-            openTxTable.logDelete(
-                ByteBuffer.wrap(unwrapKeyForId(id).asIid),
-                openTx.systemTimeMicros,
-                Long.MAX_VALUE,
-            )
+
+            openTxTable.apply {
+                writeId(unwrapKeyForId(id))
+                writeDefaultValidTime()
+                endDelete()
+            }
+
             return
         }
 
         val converted = convertValue(value, rec.valueSchema())
+
         @Suppress("UNCHECKED_CAST")
         val docMap = (converted as? Map<String, Any?>)?.toMutableMap()
             ?: throw Incorrect(
@@ -116,18 +119,20 @@ class DocsIndexer(
                 ),
             )
 
-        val id = docMap["_id"] ?: rec.key()?.let { unwrapKeyForId(it) }?.also { docMap["_id"] = it }
+        val id = docMap["_id"]
+            ?: rec.key()?.let { unwrapKeyForId(it) }?.also { docMap["_id"] = it }
             ?: throw Incorrect(
                 "no _id on doc and no record key — can't resolve _id",
                 "xtdb.kafka-connect-source/docs-no-id",
                 mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset()),
             )
 
-        openTxTable.logPut(
-            ByteBuffer.wrap(id.asIid),
-            openTx.systemTimeMicros,
-            Long.MAX_VALUE,
-        ) { openTxTable.putDocWriter.writeObject(docMap) }
+        openTxTable.apply {
+            writeId(id)
+            writeDefaultValidTime()
+            putDocWriter.writeObject(docMap)
+            endPut()
+        }
     }
 }
 
@@ -152,12 +157,19 @@ internal fun convertValue(v: Any?, schema: Schema?): Any? {
             Schema.Type.STRUCT -> structToMap(v as Struct)
             Schema.Type.ARRAY -> (v as List<Any?>).map { convertValue(it, schema.valueSchema()) }
             Schema.Type.MAP -> (v as Map<Any?, Any?>).entries
-                .associateTo(mutableMapOf<String, Any?>()) { (k, vv) -> k.toString() to convertValue(vv, schema.valueSchema()) }
+                .associateTo(mutableMapOf<String, Any?>()) { (k, vv) ->
+                    k.toString() to convertValue(
+                        vv,
+                        schema.valueSchema()
+                    )
+                }
+
             Schema.Type.BYTES -> when (v) {
                 is ByteBuffer -> ByteArray(v.remaining()).also { v.duplicate().get(it) }
                 is ByteArray -> v
                 else -> v
             }
+
             else -> v
         }
     }
@@ -165,7 +177,13 @@ internal fun convertValue(v: Any?, schema: Schema?): Any? {
     return when (v) {
         is Struct -> structToMap(v)
         is List<*> -> v.map { convertValue(it, null) }
-        is Map<*, *> -> v.entries.associateTo(mutableMapOf<String, Any?>()) { (k, vv) -> k.toString() to convertValue(vv, null) }
+        is Map<*, *> -> v.entries.associateTo(mutableMapOf<String, Any?>()) { (k, vv) ->
+            k.toString() to convertValue(
+                vv,
+                null
+            )
+        }
+
         is ByteBuffer -> ByteArray(v.remaining()).also { v.duplicate().get(it) }
         else -> v
     }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/DirectMirror.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/DirectMirror.kt
@@ -41,30 +41,34 @@ class DirectMirror(private val dbName: String) : PgIndexer {
                 val docMap = op.row.toMutableMap()
 
                 val id = docMap["_id"]
-                ?: throw Incorrect("Missing '_id' in row from ${op.schema}.${op.table}")
+                    ?: throw Incorrect("Missing '_id' in row from ${op.schema}.${op.table}")
 
                 val explicitValidFrom = explicitValidTimeMicros("_valid_from", docMap.remove("_valid_from"))
                 val explicitValidTo = explicitValidTimeMicros("_valid_to", docMap.remove("_valid_to"))
 
                 if (explicitValidTo != null && explicitValidFrom == null)
-                throw Incorrect("'_valid_to' requires '_valid_from'")
+                    throw Incorrect("'_valid_to' requires '_valid_from'")
 
-                openTxTable.logPut(
-                    ByteBuffer.wrap(id.asIid),
-                    explicitValidFrom ?: openTx.systemTimeMicros,
-                    explicitValidTo ?: Long.MAX_VALUE,
-                ) { openTxTable.putDocWriter.writeObject(docMap) }
+                openTxTable.apply {
+                    writeId(id)
+                    writeValidTimeMicros(
+                        explicitValidFrom ?: openTx.systemTimeMicros,
+                        explicitValidTo ?: Long.MAX_VALUE,
+                    )
+                    putDocWriter.writeObject(docMap)
+                    endPut()
+                }
             }
 
             is RowOp.Delete -> {
                 val id = op.row["_id"]
-                ?: throw Incorrect("Missing '_id' in delete on ${op.schema}.${op.table}")
+                    ?: throw Incorrect("Missing '_id' in delete on ${op.schema}.${op.table}")
 
-                openTxTable.logDelete(
-                    ByteBuffer.wrap(id.asIid),
-                    openTx.systemTimeMicros,
-                    Long.MAX_VALUE,
-                )
+                openTxTable.apply {
+                    writeId(id)
+                    writeDefaultValidTime()
+                    endDelete()
+                }
             }
         }
     }

--- a/src/test/clojure/xtdb/indexer/crash_logger_test.clj
+++ b/src/test/clojure/xtdb/indexer/crash_logger_test.clj
@@ -41,9 +41,10 @@
                                                                                       :default-tz (ZoneId/of "Europe/London")}))]
           (let [open-tx-table (.table open-tx #xt/table foo)
                 tx-ops-rdr (.getListElements (.vectorFor tx-ops-rel "tx-ops"))]
-            (.logPut open-tx-table (ByteBuffer/allocate 16) 0 0
-                     (fn []
-                       (.writeObject (.getPutDocWriter open-tx-table) {:xt/id 3, :version 0})))
+            (.writeIid open-tx-table (ByteBuffer/allocate 16))
+            (.writeValidTimeMicros open-tx-table 0 0)
+            (.writeObject (.getPutDocWriter open-tx-table) {:xt/id 3, :version 0})
+            (.endPut open-tx-table)
             (.writeCrashLog crash-logger
                             (pr-str {:table #xt/table foo, :foo "bar", :ex "test crash log"})
                             #xt/table foo live-idx open-tx-table

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -46,8 +46,10 @@
         (let [open-tx-table (.table open-tx #xt/table my-table)
               put-doc-wrt (.getPutDocWriter open-tx-table)]
           (doseq [^UUID iid iids]
-            (.logPut open-tx-table (util/uuid->byte-buffer iid) 0 0
-                     #(.writeObject put-doc-wrt {:some :doc})))
+            (.writeIid open-tx-table (util/uuid->byte-buffer iid))
+            (.writeValidTimeMicros open-tx-table 0 0)
+            (.writeObject put-doc-wrt {:some :doc})
+            (.endPut open-tx-table))
 
           (tu/commit-tx! live-index open-tx)
 
@@ -146,18 +148,20 @@
     (with-open [live-tx0 (tu/->open-tx #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"})]
       (let [foo-table-tx (.table live-tx0 #xt/table foo)
             doc-wtr (.getPutDocWriter foo-table-tx)]
-        (.logPut foo-table-tx (ByteBuffer/allocate 16) 0 0
-                 (fn []
-                   (.endStruct doc-wtr)))
+        (.writeIid foo-table-tx (ByteBuffer/allocate 16))
+        (.writeValidTimeMicros foo-table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut foo-table-tx)
         (tu/commit-tx! live-index live-tx0)))
 
     (t/testing "uncommitted tx data doesn't appear in live-index"
       (with-open [live-tx1 (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-02T00:00:00Z"})]
         (let [bar-table-tx (.table live-tx1 #xt/table bar)
               doc-wtr (.getPutDocWriter bar-table-tx)]
-          (.logPut bar-table-tx (ByteBuffer/allocate 16) 0 0
-                   (fn []
-                     (.endStruct doc-wtr)))
+          (.writeIid bar-table-tx (ByteBuffer/allocate 16))
+          (.writeValidTimeMicros bar-table-tx 0 0)
+          (.endStruct doc-wtr)
+          (.endPut bar-table-tx)
 
           ;; not committing — bar should not appear
           (t/is (some? (.table live-index #xt/table foo)))
@@ -193,7 +197,10 @@
     (with-open [live-tx (tu/->open-tx #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"})]
       (let [table-tx (.table live-tx table)
             doc-wtr (.getPutDocWriter table-tx)]
-        (.logPut table-tx iid 0 0 #(.endStruct doc-wtr))
+        (.writeIid table-tx iid)
+        (.writeValidTimeMicros table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut table-tx)
 
         ;; External snapshot (from live-index, not from tx) should NOT see the uncommitted row
         (with-open [external-snap (.openSnapshot live-index)]
@@ -228,7 +235,10 @@
     (with-open [live-tx1 (tu/->open-tx #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"})]
       (let [table-tx (.table live-tx1 table)
             doc-wtr (.getPutDocWriter table-tx)]
-        (.logPut table-tx iid1 0 0 #(.endStruct doc-wtr))
+        (.writeIid table-tx iid1)
+        (.writeValidTimeMicros table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut table-tx)
         (tu/commit-tx! live-index live-tx1)))
 
     ;; Take a snapshot BEFORE second transaction
@@ -240,7 +250,10 @@
         (with-open [live-tx2 (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-02T00:00:00Z"})]
           (let [table-tx (.table live-tx2 table)
                 doc-wtr (.getPutDocWriter table-tx)]
-            (.logPut table-tx iid2 0 0 #(.endStruct doc-wtr))
+            (.writeIid table-tx iid2)
+            (.writeValidTimeMicros table-tx 0 0)
+            (.endStruct doc-wtr)
+            (.endPut table-tx)
             (tu/commit-tx! live-index live-tx2)))
 
         ;; The snapshot taken before should still show only 1 row (immutability)
@@ -272,7 +285,10 @@
               "Multiple calls to liveTable should return same tx context")
 
         (let [doc-wtr (.getPutDocWriter table-tx-1)]
-          (.logPut table-tx-1 iid 0 0 #(.endStruct doc-wtr)))
+          (.writeIid table-tx-1 iid)
+          (.writeValidTimeMicros table-tx-1 0 0)
+          (.endStruct doc-wtr)
+          (.endPut table-tx-1))
 
         (with-open [tx-snap (.openSnapshot live-index live-tx)]
           (let [table-snaps (.table tx-snap table)]
@@ -289,9 +305,18 @@
       (let [table-tx (.table live-tx table)
             doc-wtr (.getPutDocWriter table-tx)]
 
-        (.logPut table-tx (.duplicate iid) 0 0 #(.endStruct doc-wtr))
-        (.logPut table-tx (.duplicate iid) 0 0 #(.endStruct doc-wtr))
-        (.logPut table-tx (.duplicate iid) 0 0 #(.endStruct doc-wtr))
+        (.writeIid table-tx (.duplicate iid))
+        (.writeValidTimeMicros table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut table-tx)
+        (.writeIid table-tx (.duplicate iid))
+        (.writeValidTimeMicros table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut table-tx)
+        (.writeIid table-tx (.duplicate iid))
+        (.writeValidTimeMicros table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut table-tx)
 
         (tu/commit-tx! live-index live-tx))
 
@@ -321,7 +346,10 @@
           (with-open [live-tx (tu/->open-tx allocator tu/*node* #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"})]
             (let [table-tx (.table live-tx table)
                   doc-wtr (.getPutDocWriter table-tx)]
-              (.logPut table-tx iid 0 0 #(.endStruct doc-wtr))
+              (.writeIid table-tx iid)
+              (.writeValidTimeMicros table-tx 0 0)
+              (.endStruct doc-wtr)
+              (.endPut table-tx)
               (tu/commit-tx! live-index live-tx)))
 
           ;; Use the openTx variant of openSnapshot to force a fresh capture each time —
@@ -369,7 +397,10 @@
           (with-open [live-tx (tu/->open-tx allocator tu/*node* #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"})]
             (let [table-tx (.table live-tx table)
                   doc-wtr (.getPutDocWriter table-tx)]
-              (.logPut table-tx iid 0 0 #(.endStruct doc-wtr))
+              (.writeIid table-tx iid)
+              (.writeValidTimeMicros table-tx 0 0)
+              (.endStruct doc-wtr)
+              (.endPut table-tx)
               (tu/commit-tx! live-index live-tx)))
 
           (t/is (some? (.table live-index table))
@@ -391,14 +422,20 @@
     (with-open [live-tx1 (tu/->open-tx #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"})]
       (let [table-tx (.table live-tx1 table)
             doc-wtr (.getPutDocWriter table-tx)]
-        (.logPut table-tx iid1 0 0 #(.endStruct doc-wtr))
+        (.writeIid table-tx iid1)
+        (.writeValidTimeMicros table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut table-tx)
         (tu/commit-tx! live-index live-tx1)))
 
     ;; Start second transaction and write more data
     (with-open [live-tx2 (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-02T00:00:00Z"})]
       (let [table-tx (.table live-tx2 table)
             doc-wtr (.getPutDocWriter table-tx)]
-        (.logPut table-tx iid2 0 0 #(.endStruct doc-wtr))
+        (.writeIid table-tx iid2)
+        (.writeValidTimeMicros table-tx 0 0)
+        (.endStruct doc-wtr)
+        (.endPut table-tx)
 
         ;; Transaction snapshot should see BOTH committed (iid1) and own uncommitted (iid2),
         ;; now as two separate TableSnapshot entries: live (committed) + tx (uncommitted).

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -43,10 +43,10 @@
           (with-open [open-tx-table (OpenTx$Table. #xt/table foo allocator 0)]
             (let [doc-wtr (.getPutDocWriter open-tx-table)]
               (dotimes [_n n]
-                (.logPut open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid))
-                         0 0
-                         (fn []
-                           (.endStruct doc-wtr))))
+                (.writeIid open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid)))
+                (.writeValidTimeMicros open-tx-table 0 0)
+                (.endStruct doc-wtr)
+                (.endPut open-tx-table))
 
               (.importData live-table (.getTxRelation open-tx-table))
 
@@ -76,9 +76,10 @@
             (let [doc-wtr (.getPutDocWriter open-tx-table)]
 
               (dotimes [_n n]
-                (.logPut open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid)) 0 0
-                         (fn []
-                           (.endStruct doc-wtr))))
+                (.writeIid open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid)))
+                (.writeValidTimeMicros open-tx-table 0 0)
+                (.endStruct doc-wtr)
+                (.endPut open-tx-table))
 
               (.importData live-table (.getTxRelation open-tx-table))
 
@@ -121,9 +122,10 @@
             doc-wtr (.getPutDocWriter open-tx-table)]
 
         (doseq [uuid uuids]
-          (.logPut open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid)) 0 0
-                   (fn []
-                     (.endStruct doc-wtr))))
+          (.writeIid open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid)))
+          (.writeValidTimeMicros open-tx-table 0 0)
+          (.endStruct doc-wtr)
+          (.endPut open-tx-table))
 
         (.importData live-table (.getTxRelation open-tx-table))
 
@@ -159,9 +161,10 @@
                   doc-wtr (.getPutDocWriter open-tx-table)]
 
               (doseq [uuid uuids]
-                (.logPut open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid)) 0 0
-                         (fn []
-                           (.endStruct doc-wtr))))
+                (.writeIid open-tx-table (ByteBuffer/wrap (util/uuid->bytes uuid)))
+                (.writeValidTimeMicros open-tx-table 0 0)
+                (.endStruct doc-wtr)
+                (.endPut open-tx-table))
 
               (tu/commit-tx! live-index open-tx)
 

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -361,9 +361,10 @@
         (doseq [{eid :xt/id, :as doc} docs
                 :let [{:keys [:xt/valid-from :xt/valid-to],
                        :or {valid-from system-time, valid-to (time/micros->instant Long/MAX_VALUE)}} (meta doc)]]
-          (.logPut open-tx-table (ByteBuffer/wrap (util/->iid eid))
-                   (time/instant->micros valid-from) (time/instant->micros valid-to)
-                   (fn [] (.writeObject doc-wtr doc)))))
+          (.writeIid open-tx-table (ByteBuffer/wrap (util/->iid eid)))
+          (.writeValidTimeMicros open-tx-table (time/instant->micros valid-from) (time/instant->micros valid-to))
+          (.writeObject doc-wtr doc)
+          (.endPut open-tx-table)))
 
       (.importData live-table (.getTxRelation open-tx-table)))))
 


### PR DESCRIPTION
Part of #5564.

`OpenTx.Table` is the writer surface external sources feed transactions through. This reworks its batch write path to drop per-row allocation and adds a granular, map-free write API for high-throughput writers — part of finalising the external-source SPI ahead of the 2.2 freeze.

## Context

The old path cost a Java allocation per row: `logPut` took a per-row `Runnable`; doc content was boxed through `writeObject(map)`; and the batch `logPuts`/`logDeletes`/`logErases` copied a row at a time (`copyRow`) and extended the persistent trie on every row. For the high-volume ingest external sources drive (Postgres, Kafka-Connect), that per-row garbage dominates.

## What changed

**Batch path (behaviour-preserving).** `writePuts`/`writeDeletes`/`writeErases` now copy whole columns in one shot — `iidVec.append(…)` and `putDocWriter.append(doc)` go through Arrow's `rowCopier`/`copyRange` (a buffer-level byte copy, no per-row boxing) — and `system_from` is stamped, the rows ended, and the trie extended once per batch (`endOps(count)`) rather than once per row. Existing SQL and source-log callers get identical results, just without the per-row garbage. `Relation.endRow()` becomes `endRows(n)` (with `endRow` delegating) to back that single batched row-count bump.

**Granular API (new).** Advanced writers can drive a table row-by-row with no intermediate map: `writeIid`/`writeId`, `writeValidTimeMicros`/`writeValidTimes`/`writeDefaultValidTime`, columns straight into `putDocWriter`, then `endPut`/`endDelete`/`endErase`. The map-based `writePut`/`writeDelete`/`writeErase` helpers sit on top for the common case. `endOps` is the sole writer of the `system_from` stamp, so the `write*` methods never double-stamp it.

## Usage

```kotlin
val table = openTx.table(tableRef)

// ergonomic — allocates a map, fine for most callers
table.writePut(mapOf("_id" to id, "name" to name))

// granular — no per-row map/boxing, for high-throughput writers
table.apply {
    writeIid(iidBuf)
    writeValidTimeMicros(validFromµs, validToµs)
    putDocWriter.apply {
        vectorFor("_id", I64.arrowType, false).writeLong(id)
        vectorFor("name", UTF8.arrowType, false).writeObject(name)
        endStruct()
    }
    endPut()
}
```

## Naming

The `log*` methods (internal jargon for the per-tx relation) are renamed `write*`; in-tree callers move with them — `SourceLogTxIndexer` and the `DirectMirror`/`DocsIndexer` external sources. `Iid.toIidBytes` is dropped — nothing calls it.

## Scope

Just the write path. Two sibling changes land separately: the `OpenTx.Table` visibility/rename tidy (merged ahead of this) and moving `patchDocs` onto `Table` (its own branch).

## Test plan

200 tests green across `sql_test`, `indexer_test`, `live_index_test`, `live_table_test`, `crash_logger_test`, and `segment_merge_test`; no reflection or boxed-math warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
