### PR TITLE
tidy(indexer): serialise external-source txs against source-log messages

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -3,7 +3,6 @@ package xtdb.indexer
 import io.micrometer.core.instrument.Counter
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
 import kotlinx.coroutines.selects.selectUnbiased
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.Metrics.withSpan
@@ -58,7 +57,6 @@ class LeaderLogProcessor(
     afterReplicaMsgId: MessageId,
     private val instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration = Duration.ofMinutes(5),
-    // The leader term's scope, owned by the LogProcessor wrapper; cancelling it tears the leader down.
     scope: CoroutineScope,
     // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
     gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -126,7 +124,13 @@ class LeaderLogProcessor(
     }
 
     private sealed interface ExtSourceTask : PersisterTask {
-        data class ResolvedTx(val resolvedTx: ReplicaMessage.ResolvedTx) : ExtSourceTask {
+        class IndexTx(
+            val externalSourceToken: ExternalSourceToken?,
+            val systemTime: Instant?,
+            val writer: suspend (OpenTx) -> TxResult,
+        ) : ExtSourceTask {
+            val result = CompletableDeferred<TxResult>()
+
             override val onComplete = CompletableDeferred<Unit>()
         }
     }
@@ -138,11 +142,11 @@ class LeaderLogProcessor(
     }
 
     private val sourceLogCh =
-        Channel<SourceLogTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
+        Channel<SourceLogTask>(onUndeliveredElement = { it.onComplete.cancel() })
     private val extSourceCh =
-        Channel<ExtSourceTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
+        Channel<ExtSourceTask>(onUndeliveredElement = { it.onComplete.cancel() })
     private val gcCh =
-        Channel<GcTask>(RENDEZVOUS, onUndeliveredElement = { it.onComplete.cancel() })
+        Channel<GcTask>(onUndeliveredElement = { it.onComplete.cancel() })
 
     private suspend fun handleSourceLogRecord(task: SourceLogTask.Record) {
         val record = task.record
@@ -225,17 +229,18 @@ class LeaderLogProcessor(
         }
     }
 
-    // Ext-source txs carry no source-log position of their own (`srcMsgId == null` on the way in)
-    // and track progress via `externalSourceToken`, so they don't advance the leader's
-    // `latestSourceMsgId` (which is driven by the source log). We do stamp the current source-log
-    // watermark onto the replicated record, though: without it a follower's `latestSourceMsgId`
-    // lags between block boundaries, and on promotion it resumes the source log from a stale point
-    // and replays an already-covered block boundary.
     private suspend fun handleResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx, srcMsgId: MessageId?) {
         val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
         val txResult = if (resolvedTx.committed) Committed(txKey) else Aborted(txKey, resolvedTx.error)
 
+        // Ext-source txs carry no source-log position of their own (`srcMsgId == null` on the way in)
+        // and track progress via `externalSourceToken`, so they don't advance the leader's
+        // `latestSourceMsgId` (which is driven by the source log). We do stamp the current source-log
+        // watermark onto the replicated record, though: without it a follower's `latestSourceMsgId`
+        // lags between block boundaries, and on promotion it resumes the source log from a stale point
+        // and replays an already-covered block boundary.
         val effectiveSrcMsgId = srcMsgId ?: watchers.latestSourceMsgId
+
         appendToReplica(resolvedTx.copy(srcMsgId = effectiveSrcMsgId))
         liveIndex.importTx(resolvedTx)
 
@@ -243,6 +248,37 @@ class LeaderLogProcessor(
 
         if (liveIndex.isFull())
             finishBlock(effectiveSrcMsgId, resolvedTx.externalSourceToken)
+    }
+
+    private suspend fun handleIndexTx(task: ExtSourceTask.IndexTx) {
+        val txKey = TransactionKey(
+            (liveIndex.latestCompletedTx?.txId ?: -1) + 1,
+            smoothSystemTime(task.systemTime ?: instantSource.instant())
+        )
+
+        var openTx = openTx(txKey, task.externalSourceToken)
+
+        @Suppress("ConvertTryFinallyToUseCall") // because openTx is a var
+        try {
+            val writerResult = task.writer(openTx)
+            val resolvedTx = when (writerResult) {
+                is TxResult.Committed ->
+                    openTx.commitTx(error = null, writerResult.userMetadata)
+
+                is TxResult.Aborted -> {
+                    txErrorCounter?.increment()
+                    openTx.close()
+                    // fresh tx for the abort row — the original openTx may hold partial writes
+                    openTx = openTx(txKey, task.externalSourceToken)
+                    openTx.commitTx(writerResult.error, writerResult.userMetadata)
+                }
+            }
+
+            handleResolvedTx(resolvedTx, srcMsgId = null)
+            task.result.complete(writerResult)
+        } finally {
+            openTx.close()
+        }
     }
 
     private suspend fun handleTriesDeleted(task: GcTask.TriesDeleted) {
@@ -292,13 +328,9 @@ class LeaderLogProcessor(
 
     private val txErrorCounter: Counter? = nodeBase.meterRegistry?.let { Counter.builder("tx.error").register(it) }
 
-    // Hosts the persister + the optional ext-source loop.
     private val termJob: Job = scope.launch {
         // supervisorScope so an ext-source crash doesn't kill the persister.
         supervisorScope {
-            // Persister: unbiased select across source-log records, external-source resolved
-            // txs, and GC trie deletions — so a slow producer on one channel can't starve the
-            // others.
             launch {
                 try {
                     while (true) {
@@ -311,7 +343,7 @@ class LeaderLogProcessor(
                             when (task) {
                                 is SourceLogTask.Record -> handleSourceLogRecord(task)
                                 is SourceLogTask.ResolvedTx -> handleResolvedTx(task.resolvedTx, task.srcMsgId)
-                                is ExtSourceTask.ResolvedTx -> handleResolvedTx(task.resolvedTx, srcMsgId = null)
+                                is ExtSourceTask.IndexTx -> handleIndexTx(task)
                                 is GcTask.TriesDeleted -> handleTriesDeleted(task)
                             }
                             task.onComplete.complete(Unit)
@@ -361,51 +393,13 @@ class LeaderLogProcessor(
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
         OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer)
 
-    private suspend fun commit(openTx: OpenTx, error: Throwable?, userMetadata: Map<*, *>?) {
-        submit(ExtSourceTask.ResolvedTx(openTx.commitTx(error, userMetadata)))
-    }
-
     override suspend fun indexTx(
-        externalSourceToken: ExternalSourceToken?,
-        txId: Long?,
-        systemTime: Instant?,
+        externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
         writer: suspend (OpenTx) -> TxResult,
-    ): TxResult {
-        val resolvedTxId = txId ?: ((liveIndex.latestCompletedTx?.txId ?: -1) + 1)
-        val resolvedSystemTime = systemTime ?: instantSource.instant()
-        val txKey = TransactionKey(resolvedTxId, smoothSystemTime(resolvedSystemTime))
-
-        try {
-            val openTx = openTx(txKey, externalSourceToken)
-            val result = try {
-                writer(openTx)
-            } catch (e: Throwable) {
-                openTx.close()
-                throw e
-            }
-
-            when (result) {
-                is TxResult.Committed -> openTx.use {
-                    commit(it, error = null, result.userMetadata)
-                }
-
-                is TxResult.Aborted -> {
-                    txErrorCounter?.increment()
-                    openTx.close()
-                    openTx(txKey, externalSourceToken).use { abortTx ->
-                        commit(abortTx, result.error, result.userMetadata)
-                    }
-                }
-            }
-
-            return result
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            watchers.notifyError(e)
-            throw e
-        }
-    }
+    ): TxResult =
+        ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer)
+            .also { submit(it) }
+            .result.await()
 
     private suspend fun maybeFlushBlock() {
         if (blockFlusher.checkBlockTimeout(blockCatalog, liveIndex)) {

--- a/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
@@ -31,7 +31,6 @@ interface TxIndexer {
      */
     suspend fun indexTx(
         externalSourceToken: ExternalSourceToken?,
-        txId: Long? = null,
         systemTime: Instant? = null,
         writer: suspend (OpenTx) -> TxResult,
     ): TxResult


### PR DESCRIPTION
Resolves #5730 — the first part of #5733 (DDL against external-source databases).

GRANT and CREATE TABLE on an external-source database need to serialise against that database's external-source (CDC) transactions: a CREATE TABLE's declared types must order *before* the rows they govern, and a grant must not race a transaction already in flight. The indexer had no point at which such a second producer could serialise against the external-source stream — `LeaderLogProcessor.indexTx` assigned the tx-id (`latestCompletedTx + 1`) and ran the source's writer on the external-source coroutine, handing only the resolved result to the persister. So assignment and execution sat *upstream* of the single serialization point, and the counter was an unguarded read-modify-write a concurrent producer would race. #5730 carries the full problem.

## Approach

Enqueue the `indexTx` *call* — the writer closure plus its metadata — rather than the resolved transaction, and let the persister assign the tx-id and run the writer on its single consumer (`handleIndexTx`). External-source transactions are then ordered against the source-log messages (and GC tasks) the persister already processes, so a future producer entering on the source log serialises against the CDC stream by construction. `indexTx` becomes a thin producer: submit the task, await its result.

## Behaviour-preserving

This is a refactor — nothing observable changes for the existing single-producer (CDC) path:

The external source is still the only caller, so queue order matches the previous assignment order; the tx-id sequence, replica-log output, and live-index state are unchanged.

The assignment, the writer, and the `systemTime` sample (when the source supplies none) all run on the persister now — the smoothing floor, which reads `latestCompletedTx`, already belonged there. Sampling the clock at dequeue rather than at the call shifts the recorded system time by the queue latency, which is immaterial: it was never deterministic, and smoothing keeps it monotonic.

The round-trip is preserved — `indexTx` still blocks until its transaction is fully processed.

A thrown writer or resolve failure propagates out of the handler to the persister's task loop, which calls `notifyError` and tears the leader term down — a transaction that throws still stops ingestion, as before, and the loop's existing catch keeps `CancellationException` distinct from a genuine fault. An `Aborted` `TxResult` remains the normal abort-row path. The handler holds the `OpenTx` open through the import via `try`/`finally`.

## Also

Drops the unused `txId` parameter from `TxIndexer.indexTx` — no source connector ever supplied it.

## Trade-off

The writer transform now runs on the persister's `selectUnbiased` loop, so a slow external-source transaction can hold up the source-log and GC channels. Accepted: the external source dominates wall-clock here and is the consumer downstream cares about; the other two are less time-critical.

## Out of scope

This provides only the serialization point. The DDL entry path itself, and what the statements do — grants (#5687) and CREATE TABLE with enforced types (#3411) against external-source databases — are tracked under #5733.

## Test plan

Behaviour-preserving, so the existing indexer and external-source suites pass unchanged: `xtdb.indexer.{LeaderLogProcessor,LogProcessor,FollowerLogProcessor,TransitionLogProcessor}Test`, `xtdb.database.ExternalSourceTest`, `xtdb.api.log.ExternalSourceTokenTest`, `xtdb.api.IngestNodeTest` — 36 tests green; `postgres-source` + `kafka` test sources compile against the `txId`-less SPI.