### PR TITLE
refactor(table): make TableRef db-relative, thread the database alongside

### DIFF
--- a/api/src/main/clojure/xtdb/table.clj
+++ b/api/src/main/clojure/xtdb/table.clj
@@ -9,15 +9,11 @@
            xtdb.util.NormalForm))
 
 (defmethod print-method TableRef [^TableRef ref, ^java.io.Writer w]
-  (let [db-name (symbol (.getDbName ref))
-        schema (.getSchemaName ref)
+  (let [schema (.getSchemaName ref)
         schema+table (if (= schema "public")
                        (symbol (.getTableName ref))
                        (symbol schema (.getTableName ref)))]
-    (.write w (format "#xt/table %s"
-                      (pr-str (if (= db-name 'xtdb)
-                                schema+table
-                                [db-name schema+table]))))))
+    (.write w (format "#xt/table %s" (pr-str schema+table)))))
 
 (defmethod print-dup TableRef [ref w] (print-method ref w))
 (defmethod pp/simple-dispatch TableRef [it] (print-method it *out*))
@@ -25,23 +21,30 @@
 (s/def ::ref #(instance? TableRef %))
 
 (defn ->ref
-  (^xtdb.table.TableRef [ref-form]
-   (if (vector? ref-form)
-     (->ref (first ref-form) (second ref-form))
-     (->ref "xtdb" ref-form)))
-
-  (^xtdb.table.TableRef [db-name schema+table]
+  (^xtdb.table.TableRef [schema+table]
    (cond
-     (keyword? db-name) (recur (symbol db-name) schema+table)
-     (symbol? db-name) (recur (str (NormalForm/normalForm ^Symbol db-name)) schema+table)
+     (instance? TableRef schema+table) schema+table
      (string? schema+table) (let [[table schema] (reverse (str/split schema+table #"/" 2))]
-                              (->ref db-name schema table))
-     (simple-symbol? schema+table) (->ref db-name nil schema+table)
-     (qualified-symbol? schema+table) (->ref db-name (namespace schema+table) (name schema+table))
-     (keyword? schema+table) (recur db-name (symbol (NormalForm/normalTableName schema+table)))))
+                              (->ref schema table))
+     (simple-symbol? schema+table) (->ref nil schema+table)
+     (qualified-symbol? schema+table) (->ref (namespace schema+table) (name schema+table))
+     (keyword? schema+table) (recur (symbol (NormalForm/normalTableName schema+table)))
+     :else (throw (err/incorrect ::invalid-table-ref
+                                 (format "Expected a table reference (symbol, string, keyword, or TableRef), got: %s"
+                                         (pr-str schema+table))))))
 
-  (^xtdb.table.TableRef [db-name schema table]
-   (TableRef. (some-> db-name str) (or (some-> schema str) "public") (str table))))
+  (^xtdb.table.TableRef [schema table]
+   (TableRef. (or (some-> schema str) "public") (str table))))
+
+(defn normal-db-name
+  "Canonicalises a database name (keyword/symbol/string) to its normal-form string,
+   matching the names held in the database catalog."
+  [db]
+  (cond
+    (nil? db) nil
+    (keyword? db) (recur (symbol db))
+    (symbol? db) (str (NormalForm/normalForm ^Symbol db))
+    :else (str db)))
 
 (defn ref->schema+table [table-ref-or-sym]
   (cond
@@ -52,12 +55,11 @@
                             (format "Expected a TableRef or a symbol, got: %s" (pr-str table-ref-or-sym))))))
 
 (def transit-read-handlers
-  {"xt/table" (transit/read-handler (fn [{:keys [db-name schema-name table-name]}]
-                                      (->ref db-name schema-name table-name)))})
+  {"xt/table" (transit/read-handler (fn [{:keys [schema-name table-name]}]
+                                      (->ref schema-name table-name)))})
 
 (def transit-write-handlers
   {TableRef (transit/write-handler "xt/table"
                                    (fn [^TableRef table]
-                                     {:db-name (.getDbName table)
-                                      :schema-name (.getSchemaName table)
+                                     {:schema-name (.getSchemaName table)
                                       :table-name (.getTableName table)}))})

--- a/api/src/main/clojure/xtdb/xtql.clj
+++ b/api/src/main/clojure/xtdb/xtql.clj
@@ -310,7 +310,7 @@
     (throw (err/incorrect :xtql/malformed-unify "Unify must contain at least one sub clause" {:unify this})))
   (->Unify (mapv #(parse-unify-clause % env) clauses)))
 
-(defrecord From [^TableRef table for-valid-time for-system-time bindings project-all-cols?]
+(defrecord From [db-name ^TableRef table for-valid-time for-system-time bindings project-all-cols?]
   XtqlQuery
   XtqlQuery$UnifyClause
 
@@ -342,17 +342,17 @@
    bindings))
 
 (defn parse-from [[_ table-or-opts opts :as this] {:keys [default-db] :as env}]
-  (let [table-ref (cond
-                    (instance? TableRef table-or-opts) table-or-opts
-                    (map? table-or-opts) (let [{:keys [db table]} table-or-opts]
-                                           (when-not table
-                                             (throw (err/incorrect :xtql/malformed-from "`table` key must be present in `table` map"
-                                                                   {:from this})))
+  (let [[db-name table-ref] (cond
+                              (instance? TableRef table-or-opts) [default-db table-or-opts]
+                              (map? table-or-opts) (let [{:keys [db table]} table-or-opts]
+                                                     (when-not table
+                                                       (throw (err/incorrect :xtql/malformed-from "`table` key must be present in `table` map"
+                                                                             {:from this})))
 
-                                           (table/->ref (or db default-db) table))
-                    (keyword? table-or-opts) (table/->ref default-db table-or-opts)
-                    :else (throw (err/incorrect :xtql/malformed-from "`table` must be a keyword or map"
-                                                {:from this})))]
+                                                     [(or (table/normal-db-name db) default-db) (table/->ref table)])
+                              (keyword? table-or-opts) [default-db (table/->ref table-or-opts)]
+                              :else (throw (err/incorrect :xtql/malformed-from "`table` must be a keyword or map"
+                                                          {:from this})))]
 
     (cond
       (or (nil? opts) (map? opts))
@@ -370,7 +370,7 @@
 
             :else
             (let [{:keys [bind project-all-cols?]} (find-star-projection '* bind)]
-              (->From table-ref
+              (->From db-name table-ref
                       (some-> for-valid-time (parse-temporal-filter :for-valid-time this env))
                       (some-> for-system-time (parse-temporal-filter :for-system-time this env))
                       (parse-out-specs bind this env)
@@ -378,7 +378,8 @@
 
       (vector? opts)
       (let [{:keys [bind project-all-cols?]} (find-star-projection '* opts)]
-        (map->From {:table table-ref
+        (map->From {:db-name db-name
+                    :table table-ref
                     :bindings (parse-out-specs bind this env)
                     :project-all-cols? project-all-cols?}))
 

--- a/api/src/main/kotlin/xtdb/JsonLdSerde.kt
+++ b/api/src/main/kotlin/xtdb/JsonLdSerde.kt
@@ -126,7 +126,6 @@ object AnyJsonLdSerde : KSerializer<Any> {
                     "xt:table" -> {
                         val obj = value as? JsonObject ?: throw jsonIAEwithMessage("@value must be object!", this)
                         TableRef(
-                            obj["db"]?.asStringOrThrow() ?: throw jsonIAEwithMessage("db is required!", this),
                             obj["schema"]?.asString() ?: "public",
                             obj["table"]?.asStringOrThrow() ?: throw jsonIAEwithMessage("table is required!", this)
                         )
@@ -218,7 +217,7 @@ object AnyJsonLdSerde : KSerializer<Any> {
         is Interval -> toJsonLdElement("xt:interval")
         is TableRef -> mapOf(
             "@type" to "xt:table",
-            "@value" to mapOf("db" to dbName, "schema" to schemaName, "table" to tableName)
+            "@value" to mapOf("schema" to schemaName, "table" to tableName)
         ).toJsonLdElement()
 
         is VectorType -> mapOf("@type" to "xt:type", "@value" to RENDER_TYPE.invoke(this)).toJsonLdElement()

--- a/api/src/main/kotlin/xtdb/table/TableRef.kt
+++ b/api/src/main/kotlin/xtdb/table/TableRef.kt
@@ -6,7 +6,7 @@ typealias DatabaseName = String
 typealias SchemaName = String
 typealias TableName = String
 
-data class TableRef(val dbName: DatabaseName, val schemaName: SchemaName = "public", val tableName: TableName) {
+data class TableRef(val schemaName: SchemaName = "public", val tableName: TableName) {
 
     val sym: Symbol get() = Symbol.intern(schemaName, tableName)
 
@@ -14,10 +14,10 @@ data class TableRef(val dbName: DatabaseName, val schemaName: SchemaName = "publ
 
     companion object {
         @JvmStatic
-        fun parse(dbName: DatabaseName, str: String): TableRef {
+        fun parse(str: String): TableRef {
             val sym = Symbol.intern(str)
 
-            return TableRef(dbName, sym.namespace ?: "public", sym.name)
+            return TableRef(sym.namespace ?: "public", sym.name)
         }
     }
 }

--- a/core/src/main/clojure/xtdb/block_tables.clj
+++ b/core/src/main/clojure/xtdb/block_tables.clj
@@ -171,9 +171,9 @@
    "partition_count" (int (count partitions))})
 
 (defn- resolve-table-block
-  "Resolves a table-block file given db name, table name and block idx. Returns parsed map or nil."
-  [^BufferPool buffer-pool ^String db-name ^String table-name ^long block-idx]
-  (let [table-ref (table/->ref db-name table-name)
+  "Resolves a table-block file given table name and block idx. Returns parsed map or nil."
+  [^BufferPool buffer-pool ^String table-name ^long block-idx]
+  (let [table-ref (table/->ref table-name)
         table-path (Trie/getTablePath table-ref)
         obj-key (table-cat/->table-block-metadata-obj-key table-path block-idx)]
     (try
@@ -198,7 +198,7 @@
 
     (let [^BufferPool buffer-pool (.getBufferPool db)
           block-idx (<-lex-hex (str block-idx))
-          table-block (resolve-table-block buffer-pool (.getName db) (str table-name) block-idx)
+          table-block (resolve-table-block buffer-pool (str table-name) block-idx)
           rows (if table-block
                  [(table-block->row (str table-name) block-idx table-block)]
                  [])
@@ -253,7 +253,7 @@
     (let [^BufferPool buffer-pool (.getBufferPool db)
           block-idx-hex (str block-idx)
           block-idx (<-lex-hex block-idx-hex)
-          table-block (resolve-table-block buffer-pool (.getName db) (str table-name) block-idx)
+          table-block (resolve-table-block buffer-pool (str table-name) block-idx)
           rows (if table-block
                  (trie-details->rows (str table-name) block-idx-hex (:partitions table-block))
                  [])

--- a/core/src/main/clojure/xtdb/expression/pg.clj
+++ b/core/src/main/clojure/xtdb/expression/pg.clj
@@ -1,6 +1,5 @@
 (ns xtdb.expression.pg
-  (:require [clojure.set :as set]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
             [xtdb.information-schema :as info]
@@ -15,10 +14,13 @@
       (for [schema expr/search-path]
         (symbol schema needle)))))
 
+(defn- schema-key->table [k]
+  ;; table-info / schema keys are `[db-name table-ref]` qualified pairs; tolerate a bare ref/symbol too
+  (table/ref->schema+table (if (vector? k) (second k) k)))
+
 (defn tables [schema]
-  (->> (set/union (set (keys (info/table-info "xtdb")))
-                  (set (keys schema)))
-       (into #{} (map table/ref->schema+table))))
+  (into #{} (map schema-key->table)
+        (concat (keys (info/table-info "xtdb")) (keys schema))))
 
 (defn find-table [schema table-name]
   ;; TODO multi-db

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -138,7 +138,7 @@
           (fn [db-names]
             (->> (for [db-name db-names
                        [table fields] derived-tables]
-                   [(table/->ref db-name table) (set (keys fields))])
+                   [[db-name (table/->ref table)] (set (keys fields))])
                  (into {})))))
 
   (def ^:private ^Cache table-chains-cache
@@ -150,15 +150,16 @@
     (.get table-chains-cache [(into (sorted-set) db-names) default-db]
           (fn [[db-names default-db]]
             (->> (for [db-name db-names
-                       [table fields] derived-tables
-                       :let [^TableRef table-ref (table/->ref db-name table)
+                       [table _fields] derived-tables
+                       :let [^TableRef table-ref (table/->ref table)
+                             qualified [db-name table-ref]
                              db-sym (symbol db-name)
                              schema-name (symbol (.getSchemaName table-ref))
                              table-name (symbol (.getTableName table-ref))
                              default? (= db-name default-db)]]
-                   (cond-> [[[db-sym schema-name table-name] table-ref]]
-                     default? (conj [[schema-name table-name] table-ref])
-                     (and default? (= 'pg_catalog schema-name)) (conj [[table-name] table-ref])))
+                   (cond-> [[[db-sym schema-name table-name] qualified]]
+                     default? (conj [[schema-name table-name] qualified])
+                     (and default? (= 'pg_catalog schema-name)) (conj [[table-name] qualified])))
                  (into [] cat)))))
   (def meta-table-schemas
     (merge info-tables pg-catalog-tables))
@@ -185,9 +186,9 @@
                   :schema-name schema-name
                   :schema-owner "xtdb"})))))
 
-(defn tables [schema-info]
+(defn tables [db-name schema-info]
   (for [^TableRef table (keys schema-info)]
-    {:table-catalog (.getDbName table)
+    {:table-catalog db-name
      :table-name (.getTableName table)
      :table-schema (.getSchemaName table)
      :table-type (if (views (table/ref->schema+table table)) "VIEW" "BASE TABLE")}))
@@ -259,10 +260,10 @@
      :rngcanonical rngcanonical
      :rngsubdiff rngsubdiff}))
 
-(defn columns [col-rows]
+(defn columns [db-name col-rows]
   (for [{:keys [^TableRef table, ^VectorType vec-type, idx], col-name :name} col-rows
         :let [typname (.getTypname (PgType/fromVectorType vec-type))]]
-    {:table-catalog (.getDbName table)
+    {:table-catalog db-name
      :table-name (.getTableName table)
      :table-schema (.getSchemaName table)
      :column-name (.denormalize ^IKeyFn (identity #xt/key-fn :snake-case-string) (str col-name))
@@ -480,14 +481,14 @@
                             (update-keys (fn [k]
                                            (cond
                                              (instance? TableRef k) k
-                                             (symbol? k) (table/->ref db-name k)))))]
+                                             (symbol? k) (table/->ref k)))))]
 
         (util/with-close-on-catch [out-rel (Relation. ^BufferAllocator allocator
                                                       ^Map (update-keys derived-table-schema str))]
 
           (.writeRows out-rel (->> (case (table/ref->schema+table table)
-                                     information_schema/tables (tables schema-info)
-                                     information_schema/columns (columns (schema-info->col-rows schema-info))
+                                     information_schema/tables (tables db-name schema-info)
+                                     information_schema/columns (columns db-name (schema-info->col-rows schema-info))
                                      information_schema/schemata (schemas db-name)
                                      pg_catalog/pg_tables (pg-tables schema-info)
                                      pg_catalog/pg_type (pg-type)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -34,6 +34,7 @@
            (xtdb.trie Bucketer)
            (xtdb.util TemporalBounds TemporalDimension)))
 
+(s/def ::db-name string?)
 (s/def ::table ::table/ref)
 
 ;; TODO be good to just specify a single expression here and have the interpreter split it
@@ -43,16 +44,16 @@
 
 (defmethod lp/ra-expr :scan [_]
   (s/cat :op #{:scan}
-         :opts (s/keys :req-un [::table ::columns]
+         :opts (s/keys :req-un [::db-name ::table ::columns]
                        :opt-un [::lp/for-valid-time ::lp/for-system-time ::lp/clamp-valid-time?])))
 
 (definterface IScanEmitter
   (emitScan [^xtdb.query.IQuerySource$QueryCatalog db-cat scan-expr scan-vec-types param-types]))
 
 (defn ->scan-cols [{:keys [opts]}]
-  (let [{:keys [table columns]} opts]
+  (let [{:keys [db-name table columns]} opts]
     (for [[col-tag col-arg] columns]
-      [table
+      [db-name table
        (case col-tag
          :column col-arg
          :select (key (first col-arg)))])))
@@ -197,13 +198,12 @@
           (not (.isEmpty (.filterIidsForPath bucketer iid-set path))))))))
 
 (defn scan-vec-types [^IQuerySource$QueryCatalog db-catalog, snaps, scan-cols]
-  (letfn [(->vec-type [[^TableRef table col-name]]
+  (letfn [(->vec-type [[db-name ^TableRef table col-name]]
             (let [col-name (str col-name)]
               (or (types/temporal-vec-types col-name)
                   (-> (info-schema/derived-table table)
                       (get (symbol col-name)))
-                  (let [db-name (.getDbName table)
-                        state (.getQueryState (.databaseOrNull db-catalog db-name))
+                  (let [state (.getQueryState (.databaseOrNull db-catalog db-name))
                         table-catalog (.getTableCatalog state)
                         ^DatabaseSnapshot db-snap (get snaps db-name)
                         ;; TODO (#5557 unit 7) reduce types/merge-types over per-partition live
@@ -217,8 +217,7 @@
 (defn ->scan-emitter [info-schema]
   (reify IScanEmitter
     (emitScan [_ db-cat {:keys [opts]} scan-vec-types param-types]
-      (let [{:keys [^TableRef table columns] :as scan-opts} opts
-            db-name (.getDbName table)
+      (let [{:keys [db-name ^TableRef table columns] :as scan-opts} opts
             db (.databaseOrNull db-cat db-name)
             storage (.getStorage db)
             state (.getQueryState db)
@@ -233,7 +232,7 @@
             vec-types (->> col-names
                            (into {} (map (juxt identity
                                                (fn [col-name]
-                                                 (get scan-vec-types [table col-name]))))))
+                                                 (get scan-vec-types [db-name table col-name]))))))
 
             col-names (into #{} (map str) col-names)
 
@@ -260,7 +259,7 @@
 
         {:op :scan
          :children []
-         :explain {:table (->> [(.getDbName table) (.getSchemaName table) (.getTableName table)]
+         :explain {:table (->> [db-name (.getSchemaName table) (.getTableName table)]
                                (remove nil?)
                                (str/join "."))
                    :columns (vec col-names)
@@ -318,7 +317,7 @@
                              (let [filter-opts {:query-bounds temporal-bounds
                                                 :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
                                                 :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
-                                   ^ScanMetrics metrics (ScanMetrics. (.getDbName table)
+                                   ^ScanMetrics metrics (ScanMetrics. db-name
                                                                       (str (.getSchemaName table) "." (.getTableName table)))
                                    current-tries (cat/current-tries (.trieTableState snapshot table))
                                    filtered-tries (cat/filter-tries current-tries filter-opts)]

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -53,7 +53,6 @@
            xtdb.NodeBase
            xtdb.operator.scan.IScanEmitter
            (xtdb.query IQuerySource IQuerySource$Factory PrepareOpts PreparedQuery SqlStatement$Assert SqlStatement$CreateTable SqlStatement$Delete SqlStatement$Erase SqlStatement$GrantRole SqlStatement$Patch SqlStatement$Put SqlStatement$RevokeRole)
-           (xtdb.table TableRef)
            xtdb.util.RefCounter))
 
 (defn- wrap-result-types [^ICursor cursor, result-types]
@@ -355,7 +354,8 @@
                 (->> (.getDatabaseNames db-cat)
                      (into {} (mapcat (fn [db-name]
                                         (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat db-name))]
-                                          (update-vals (.tableInfo snap) set)))))))
+                                          (->> (.tableInfo snap)
+                                               (map (fn [[table-ref cols]] [[db-name table-ref] (set cols)])))))))))
 
               (plan-query* [table-info]
                 (-plan-query this parsed-query query-opts table-info))]
@@ -487,7 +487,8 @@
                            (.tableInfo snap))
                          (sql/xform-table-info [default-db] default-db))
           plan (-> (sql/plan-patch {:table-info table-info}
-                                   {:table table
+                                   {:db-name default-db
+                                    :table table
                                     :valid-from valid-from
                                     :valid-to valid-to
                                     :patch-rel (sql/->QueryExpr '[:table {:output-cols [_iid doc]

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -137,8 +137,8 @@
     (format "Ambiguous table reference: %s -> %s"
             (str/join "." table-chain)
             (->> table-chains
-                 (into #{} (map (fn [^TableRef table]
-                                  (symbol (format "%s.%s.%s" (.getDbName table) (.getSchemaName table) (.getTableName table))))))))))
+                 (into #{} (map (fn [[db-name ^TableRef table]]
+                                  (symbol (format "%s.%s.%s" db-name (.getSchemaName table) (.getTableName table))))))))))
 
 (defrecord ColumnNotFound [chain]
   PlanError
@@ -335,17 +335,17 @@
                    sys-time-col? (conj {(->col-sym '_system_time) (list 'period (->col-sym '_system_from) (->col-sym '_system_to))}))}
    plan])
 
-(defrecord BaseTable [env, ^TableRef table-ref
+(defrecord BaseTable [env, db-name, ^TableRef table-ref
                       for-valid-time clamp-valid-time? for-system-time
                       table-alias unique-table-alias cols
                       ^Map !reqd-cols]
   Scope
   (available-cols [_] cols)
 
-  (-find-cols [this [col-name table-name schema-name db-name] excl-cols]
+  (-find-cols [this [col-name table-name schema-name chain-db] excl-cols]
     (when (and (or (nil? table-name) (= table-name table-alias))
                (or (nil? schema-name) (= schema-name (symbol (.getSchemaName table-ref))))
-               (or (nil? db-name) (= db-name (symbol (.getDbName table-ref)))))
+               (or (nil? chain-db) (= chain-db (symbol db-name))))
       (for [col (if col-name
                   (when (or (contains? cols col-name) (types/temporal-col-name? col-name)
                             (temporal-period-column? col-name)
@@ -373,7 +373,8 @@
           for-st (or for-system-time sys-time-default)]
 
       [:rename {:prefix unique-table-alias}
-       (cond-> [:scan (cond-> {:table table-ref
+       (cond-> [:scan (cond-> {:db-name db-name
+                               :table table-ref
                                :columns scan-cols}
                         for-vt (assoc :for-valid-time for-vt)
                         clamp-valid-time? (assoc :clamp-valid-time? true)
@@ -712,6 +713,8 @@
                 _ (when more-matches
                     (add-err! env (->AmbiguousTableReference table-chain (cons table more-matches))))
 
+                [resolved-db resolved-ref] (or table [default-db (table/->ref "xt" "not_found")])
+
                 table-cols (get table-info table)
 
                 expr-visitor (->ExprPlanVisitor env (->NoColumnReferenceAllowed "No column reference allowed in table period specification: "))]
@@ -727,7 +730,7 @@
                 ;; `table` is nil only on the warning path (an unresolved internal-schema / `pg_*`
                 ;; table - see `system-table-chain?`); user tables have already erred. We scan the
                 ;; empty `xt.not_found` sentinel so those probes return no rows rather than blowing up.
-                (->BaseTable env (or table (table/->ref default-db "xt" "not_found"))
+                (->BaseTable env resolved-db resolved-ref
                              for-valid-time clamp-valid-time?
                              (<-table-time-period-specification (.querySystemTimePeriodSpecification ctx))
                              table-alias unique-table-alias
@@ -2949,7 +2952,8 @@
   PlanRelation
   (plan-rel [{{:keys [default-db]} :env}]
     [:rename {:prefix unique-table-alias}
-     [:scan (cond-> {:table (table/->ref default-db (symbol table-name))
+     [:scan (cond-> {:db-name default-db
+                     :table (table/->ref (symbol table-name))
                      :columns (vec (.keySet !reqd-cols))
                      :clamp-valid-time? true}
               for-valid-time (assoc :for-valid-time for-valid-time))]]))
@@ -3002,7 +3006,8 @@
   PlanRelation
   (plan-rel [{{:keys [default-db]} :env}]
     [:rename {:prefix unique-table-alias}
-     [:scan {:table (table/->ref default-db (symbol table-name))
+     [:scan {:db-name default-db
+             :table (table/->ref (symbol table-name))
              :for-system-time :all-time
              :for-valid-time :all-time
              :columns (vec (.keySet !reqd-cols))}]]))
@@ -3030,8 +3035,8 @@
   PlanError
   (error-string [_] (format "Cannot PATCH %s column" col)))
 
-(defn plan-patch [{:keys [table-info]} {:keys [table valid-from valid-to patch-rel]}]
-  (let [known-cols (mapv symbol (get table-info table))]
+(defn plan-patch [{:keys [table-info]} {:keys [db-name table valid-from valid-to patch-rel]}]
+  (let [known-cols (mapv symbol (get table-info [db-name table]))]
     (xt/template
      [:project {:projections [{_iid new/_iid}
                               {_valid_from (cast (coalesce old/_valid_from ~valid-from (current-timestamp))
@@ -3047,7 +3052,8 @@
          [:project {:projections [_iid _valid_from _valid_to
                                   {doc ~(into {} (map (juxt keyword identity)) known-cols)}]}
           [:order-by {:order-specs [[_iid] [_valid_from]]}
-           [:scan {:table ~table
+           [:scan {:db-name ~db-name
+                   :table ~table
                    :for-valid-time [:in ~valid-from ~valid-to]
                    :clamp-valid-time? true
                    :columns [_iid _valid_from _valid_to
@@ -3111,11 +3117,12 @@
       insert-plan))
 
   (visitPatchStatement [{{:keys [default-db]} :env, :as this} ctx]
-    (let [table (table/->ref default-db (identifier-sym (.targetTable ctx)))
+    (let [table (table/->ref (identifier-sym (.targetTable ctx)))
           [vf-expr vt-expr] (or (some-> (.patchStatementValidTimeExtents ctx)
                                         (.accept (->PatchValidTimeExtentsVisitor env scope)))
                                 ['(current-timestamp) time/end-of-time])]
-      (->QueryExpr (plan-patch env {:table table
+      (->QueryExpr (plan-patch env {:db-name default-db
+                                    :table table
                                     :valid-from vf-expr
                                     :valid-to vt-expr
                                     :patch-rel (.accept (.patchSource ctx) this)})
@@ -3137,7 +3144,7 @@
           table-name (identifier-sym (.targetTable ctx))
           table-alias (or (identifier-sym (.correlationName ctx)) (-> table-name name symbol))
           table-name (util/with-default-schema table-name)
-          table (table/->ref default-db table-name)
+          table (table/->ref table-name)
           unique-table-alias (symbol (str table-alias "." (swap! !id-count inc)))
           aliased-cols (mapv (fn [col] {col (->col-sym (str unique-table-alias) (str col))}) internal-cols)
 
@@ -3145,8 +3152,7 @@
                                                                           (.accept (->DmlValidTimeExtentsVisitor env scope)))
                                                                   default-vt-extents)
 
-          table-cols (if-let [cols (or (get table-info table)
-                                       (get table-info (table/ref->schema+table table)))]
+          table-cols (if-let [cols (get table-info [default-db table])]
                        cols
                        (do
                          (table-not-found! env [(namespace table-name) (name table-name)])
@@ -3205,7 +3211,7 @@
           table-name (identifier-sym (.targetTable ctx))
           table-alias (or (identifier-sym (.correlationName ctx)) (-> table-name name symbol))
           table-name (util/with-default-schema table-name)
-          table (table/->ref default-db table-name)
+          table (table/->ref table-name)
           unique-table-alias (symbol (str table-alias "." (swap! !id-count inc)))
           aliased-cols (mapv (fn [col] {col (->col-sym (str unique-table-alias) (str col))}) internal-cols)
 
@@ -3213,8 +3219,7 @@
                                                                           (.accept (->DmlValidTimeExtentsVisitor env scope)))
                                                                   default-vt-extents)
 
-          table-cols (if-let [cols (or (get table-info table)
-                                       (get table-info (table/ref->schema+table table)))]
+          table-cols (if-let [cols (get table-info [default-db table])]
                        cols
                        (do
                          (table-not-found! env [(namespace table-name) (name table-name)])
@@ -3248,11 +3253,10 @@
           table-alias (or (identifier-sym (.correlationName ctx)) (-> table-name name symbol))
           unique-table-alias (symbol (str table-alias "." (swap! !id-count inc)))
           table-name (util/with-default-schema table-name)
-          table (table/->ref default-db table-name)
+          table (table/->ref table-name)
           aliased-cols (mapv (fn [col] {col (->col-sym (str unique-table-alias) (str col))}) internal-cols)
 
-          table-cols (if-let [cols (or (get table-info table)
-                                       (get table-info (table/ref->schema+table table)))]
+          table-cols (if-let [cols (get table-info [default-db table])]
                        cols
                        (do
                          (table-not-found! env [(namespace table-name) (name table-name)])
@@ -3310,39 +3314,49 @@
 (defn xform-table-info [table-info db-names default-db]
   ;; this fn turned up in a profiler the last time I checked, particularly for low-latency queries.
   ;; plenty happening here that can be cached.
-  (into {}
-        (for [[table cns] (concat (info-schema/table-info db-names) table-info)]
-          [table (->> cns
-                      (map ->col-sym)
-                      (sort-by identity (fn [s1 s2]
-                                          (cond
-                                            (= '_id s1) -1
-                                            (= '_id s2) 1
-                                            :else (compare s1 s2))))
-                      ->insertion-ordered-set)])))
+  (letfn [(xform-cols [cns]
+            (->> cns
+                 (map ->col-sym)
+                 (sort-by identity (fn [s1 s2]
+                                     (cond
+                                       (= '_id s1) -1
+                                       (= '_id s2) 1
+                                       :else (compare s1 s2))))
+                 ->insertion-ordered-set))
+          ;; the caller's `table-info` is keyed by a bare ref/symbol, scoped to the default db -
+          ;; canonicalise to the `[db-name table-ref]` qualified key that `info-schema/table-info` uses.
+          (qualify [k]
+            (cond
+              (vector? k) k
+              (instance? TableRef k) [default-db k]
+              :else [default-db (table/->ref k)]))]
+    (into {}
+          (concat (for [[qualified cns] (info-schema/table-info db-names)]
+                    [qualified (xform-cols cns)])
+                  (for [[k cns] table-info]
+                    [(qualify k) (xform-cols cns)])))))
 
 (def ^:private ^Cache table-chains-cache
   (-> (Caffeine/newBuilder)
       (.maximumSize 4096)
       (.build)))
 
-(defn- ->table-chains [table-refs db-names default-db]
+(defn- ->table-chains [qualified-tables db-names default-db]
   ;; I suspect this'll light up a profiler too?
   (-> (into (info-schema/table-chains db-names default-db)
-            (mapcat (fn [table]
-                      (.get table-chains-cache [table default-db]
-                            (fn [[^TableRef table default-db]]
-                              (let [db-name (.getDbName table)
-                                    default-db? (= default-db db-name)
-                                    db-name (symbol db-name)
-                                    schema-name (symbol (.getSchemaName table))
+            (mapcat (fn [qualified]
+                      (.get table-chains-cache [qualified default-db]
+                            (fn [[[db-name ^TableRef table-ref :as qualified] default-db]]
+                              (let [default-db? (= default-db db-name)
+                                    db-sym (symbol db-name)
+                                    schema-name (symbol (.getSchemaName table-ref))
                                     search-path-schema? (= 'public schema-name)
-                                    table-name (symbol (.getTableName table))]
-                                (cond-> [[[db-name schema-name table-name] table]]
-                                  default-db? (conj [[schema-name table-name] table])
-                                  search-path-schema? (conj [[db-name table-name] table])
-                                  (and default-db? search-path-schema?) (conj [[table-name] table])))))))
-            table-refs)
+                                    table-name (symbol (.getTableName table-ref))]
+                                (cond-> [[[db-sym schema-name table-name] qualified]]
+                                  default-db? (conj [[schema-name table-name] qualified])
+                                  search-path-schema? (conj [[db-sym table-name] qualified])
+                                  (and default-db? search-path-schema?) (conj [[table-name] qualified])))))))
+            qualified-tables)
       (->> (group-by first))
       (update-vals #(into #{} (map second) %))))
 
@@ -3353,13 +3367,14 @@
 (defn ->env
   ([] (->env {}))
   ([{:keys [table-info default-db db-names], :or {default-db "xtdb"}}]
-   (let [db-names (or db-names [default-db])]
+   (let [db-names (or db-names [default-db])
+         table-info (xform-table-info table-info db-names default-db)]
      {:!errors (atom [])
       :!warnings (atom [])
       :!id-count (atom 0)
       :!param-count (atom 0)
       :default-db default-db
-      :table-info (xform-table-info table-info db-names default-db)
+      :table-info table-info
       :table-chains (->table-chains (keys table-info) db-names default-db)})))
 
 (defprotocol PlanExpr
@@ -3407,6 +3422,7 @@
   (-plan-query [ctx {:keys [default-db scope table-info db-names arg-fields]
                      :or {default-db "xtdb"}}]
     (let [db-names (or db-names [default-db])
+          table-info (xform-table-info table-info db-names default-db)
           !errors (atom [])
           !warnings (atom [])
           !param-count (atom 0)
@@ -3415,7 +3431,7 @@
                :!warnings !warnings
                :!id-count (atom 0)
                :!param-count !param-count
-               :table-info (xform-table-info table-info db-names default-db)
+               :table-info table-info
                :table-chains (->table-chains (keys table-info) db-names default-db)
                ;; NOTE this may not necessarily be provided
                ;; we get it through SQL DML, which is the main case we need it for #3656

--- a/core/src/main/clojure/xtdb/sql/parse.clj
+++ b/core/src/main/clojure/xtdb/sql/parse.clj
@@ -4,7 +4,7 @@
             [xtdb.table :as table])
   (:import (xtdb.antlr SqlVisitor)))
 
-(defrecord StatementVisitor [default-db]
+(defrecord StatementVisitor []
   SqlVisitor
   (visitQueryExpr [_ stmt]
     [:query {:stmt stmt}])
@@ -16,19 +16,19 @@
     [:show-clock-time])
 
   (visitInsertStatement [_ stmt]
-    [:insert {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt))) :stmt stmt}])
+    [:insert {:table (table/->ref (sql/identifier-sym (.targetTable stmt))) :stmt stmt}])
 
   (visitPatchStatement [_ stmt]
-    [:patch {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
+    [:patch {:table (table/->ref (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
 
   (visitUpdateStatement [_ stmt]
-    [:update {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
+    [:update {:table (table/->ref (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
 
   (visitDeleteStatement [_ stmt]
-    [:delete {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
+    [:delete {:table (table/->ref (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
 
   (visitEraseStatement [_ stmt]
-    [:erase {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
+    [:erase {:table (table/->ref (sql/identifier-sym (.targetTable stmt))), :stmt stmt}])
 
   (visitAssertStatement [_ stmt]
     [:assert {:stmt stmt, :message (some->> (.message stmt) (sql/accept-visitor sql/string-literal-visitor))}])
@@ -52,7 +52,7 @@
     [:revoke-role {:role (str (sql/identifier-sym (.roleName stmt))), :user (str (sql/identifier-sym (.userName stmt)))}])
 
   (visitCreateTableStatement [_ stmt]
-    [:create-table {:table (table/->ref default-db (sql/identifier-sym (.targetTable stmt)))
+    [:create-table {:table (table/->ref (sql/identifier-sym (.targetTable stmt)))
                     :col-names (some->> (.columnNameList stmt) (.columnName) (mapv (comp str sql/identifier-sym)))}]))
 
 (defn parse-statement [stmt opts]

--- a/core/src/main/clojure/xtdb/xtql/plan.clj
+++ b/core/src/main/clojure/xtdb/xtql/plan.clj
@@ -412,10 +412,10 @@
     1 {scan-col (first col-preds)}
     {scan-col (list* 'and col-preds)}))
 
-(defn- plan-from [{:keys [table for-valid-time for-system-time bindings project-all-cols?]}]
+(defn- plan-from [{:keys [db-name table for-valid-time for-system-time bindings project-all-cols?]}]
   (let [planned-bind-specs (concat (cond-> (mapv plan-out-spec bindings)
                                      project-all-cols?
-                                     (concat (->> (get *table-info* table)
+                                     (concat (->> (get *table-info* [db-name table])
                                                   (mapv symbol)
                                                   (mapv #(hash-map :l % :r %))))))
         distinct-scan-cols (distinct (replace-temporal-period-with-cols (mapv :l planned-bind-specs)))
@@ -424,7 +424,8 @@
                                       (map #(assoc % :pred (list '== (:l %) (:r %))))
                                       (group-by :l))
                                  (update-vals #(map :pred %)))]
-    (-> [:scan {:table table
+    (-> [:scan {:db-name db-name
+                :table table
                 :columns (mapv #(wrap-scan-col-preds % (get literal-preds-by-col %)) distinct-scan-cols)
                 :for-valid-time (plan-temporal-filter for-valid-time)
                 :for-system-time (plan-temporal-filter for-system-time)}]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -503,14 +503,14 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         override fun getTableSchema(catalog: String?, dbSchema: String?, tableName: String): Schema =
             openSnapshot().use { snap ->
-                getTableSchema(TableRef(catalog ?: dbName, dbSchema ?: "public", tableName), snap)
+                getTableSchema(catalog ?: dbName, TableRef(dbSchema ?: "public", tableName), snap)
             }
 
         fun getTableSchema(dbSchema: String, tableName: String, snap: DatabaseSnapshot): Schema =
-            getTableSchema(TableRef(dbName, dbSchema, tableName), snap)
+            getTableSchema(dbName, TableRef(dbSchema, tableName), snap)
 
-        private fun getTableSchema(table: TableRef, snap: DatabaseSnapshot): Schema {
-            val types = dbCat.databaseOrNull(table.dbName)?.getColumnTypes(table, snap) ?: return Schema(emptyList())
+        private fun getTableSchema(catalog: DatabaseName, table: TableRef, snap: DatabaseSnapshot): Schema {
+            val types = dbCat.databaseOrNull(catalog)?.getColumnTypes(table, snap) ?: return Schema(emptyList())
             return Schema(types.entries.map { (name, type) -> type.toField(name) })
         }
 

--- a/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
+++ b/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
@@ -42,7 +42,7 @@ object RoleMembership {
     @JvmStatic
     fun scanMemberships(querySource: IQuerySource, dbCat: IQuerySource.QueryCatalog): List<List<String>> {
         val primary = dbCat.databaseOrNull(PRIMARY_DB) ?: return emptyList()
-        val tableRef = TableRef(PRIMARY_DB, "xt", "role_membership")
+        val tableRef = TableRef("xt", "role_membership")
 
         val exists = primary.queryState.tableCatalog.getTypes(tableRef) != null ||
                 primary.openSnapshot().use { it.tableInfo().containsKey(tableRef) }

--- a/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
@@ -106,7 +106,7 @@ class BlockCatalog(
     val externalSourceToken: ExternalSourceToken?
         get() = latestBlock?.takeIf { it.hasExternalSourceToken() }?.externalSourceToken?.toByteArray()
 
-    val allTables: List<TableRef> get() = latestBlock?.tableNamesList.orEmpty().map { TableRef.parse(dbName, it) }
+    val allTables: List<TableRef> get() = latestBlock?.tableNamesList.orEmpty().map { TableRef.parse(it) }
 
     val secondaryDatabases: Map<String, DatabaseConfig> get() = latestBlock?.secondaryDatabasesMap.orEmpty()
 }

--- a/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
+++ b/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
@@ -279,7 +279,7 @@ private class LocalSegment(
 
 internal fun main() {
     val dir = "/tmp/downloads/compactor-error".asPath
-    val table = TableRef.parse("xtdb", "foo")
+    val table = TableRef.parse("foo")
     val trieKeys = listOf("l01-rc-b2c74", "l00-rc-b2c75")
 
     try {

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -120,7 +120,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
     private fun addTries(tries: List<TrieDetails>, logTimestamp: LogTimestamp) {
         tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
-            trieCatalog.addTries(TableRef.parse(dbState.name, tableName), tries, logTimestamp)
+            trieCatalog.addTries(TableRef.parse(tableName), tries, logTimestamp)
         }
     }
 
@@ -193,7 +193,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
             is ReplicaMessage.NoOp -> msg.srcMsgId?.let { watchers.notifyMsg(it) }
 
             is ReplicaMessage.TriesDeleted -> triesDeletedTimer.timed {
-                trieCatalog.deleteTries(TableRef.parse(dbState.name, msg.tableName), msg.trieKeys)
+                trieCatalog.deleteTries(TableRef.parse(msg.tableName), msg.trieKeys)
             }
         }
 

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -209,7 +209,7 @@ class LeaderLogProcessor(
             is SourceMessage.TriesAdded -> {
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch) {
                     msg.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
-                        trieCatalog.addTries(TableRef.parse(dbState.name, tableName), tries, record.logTimestamp)
+                        trieCatalog.addTries(TableRef.parse(tableName), tries, record.logTimestamp)
                     }
                 }
 

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -106,7 +106,7 @@ class LiveIndex private constructor(
         val stamp = snapLock.writeLock()
         try {
             for ((schemaAndTable, ipcBytes) in resolvedTx.tableData) {
-                val tableRef = TableRef.parse(dbName, schemaAndTable)
+                val tableRef = TableRef.parse(schemaAndTable)
                 val liveTable =
                     this@LiveIndex.tables.getOrPut(tableRef) {
                         LiveTable(

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -87,7 +87,7 @@ class OpenTx(
     // TODO add table(schemaAndTable), make table(TableRef) internal
     fun table(table: TableRef): Table = tableTxs.getOrPut(table) { Table(table) }
 
-    fun table(schemaName: SchemaName, tableName: TableName) = table(TableRef(dbState.name, schemaName, tableName))
+    fun table(schemaName: SchemaName, tableName: TableName) = table(TableRef(schemaName, tableName))
 
     internal val tables: Iterable<Map.Entry<TableRef, Table>> get() = tableTxs.entries
 
@@ -95,7 +95,7 @@ class OpenTx(
         val txId = txKey.txId
         val systemTimeMicros = txKey.systemTime.asMicros
 
-        val liveTable = table(TableRef(dbState.name, "xt", "txs"))
+        val liveTable = table(TableRef("xt", "txs"))
         val docWriter = liveTable.putDocWriter
 
         liveTable.writeId(txId)
@@ -320,7 +320,7 @@ class OpenTx(
             )
 
         val ts = currentTime.asMicros
-        val table = table(TableRef(dbState.name, "xt", "role_membership"))
+        val table = table(TableRef("xt", "role_membership"))
 
         table.writeIid(RoleMembership.membershipIid(user, role))
         table.writeValidTimeMicros(ts, MAX_LONG)

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
@@ -80,7 +80,7 @@ internal class SourceLogTxIndexer(
             val validToRdr = putLeg.vectorFor("_valid_to")
 
             val legName = docsRdr.getLeg(opIdx) ?: error("put-docs leg missing for op $opIdx")
-            val table = TableRef.parse(dbState.name, legName)
+            val table = TableRef.parse(legName)
             checkNotForbidden(table)
 
             val tableDocsRdr = docsRdr.vectorFor(legName)
@@ -153,7 +153,7 @@ internal class SourceLogTxIndexer(
             val validFromRdr = deleteLeg.vectorFor("_valid_from")
             val validToRdr = deleteLeg.vectorFor("_valid_to")
 
-            val table = TableRef.parse(dbState.name, tableRdr.getObject(opIdx) as String)
+            val table = TableRef.parse(tableRdr.getObject(opIdx) as String)
             checkNotForbidden(table)
 
             val openTxTable = table(table)
@@ -186,7 +186,7 @@ internal class SourceLogTxIndexer(
             val iidsRdr = eraseLeg.vectorFor("iids")
             val iidRdr = iidsRdr.listElements
 
-            val table = TableRef.parse(dbState.name, tableRdr.getObject(opIdx) as String)
+            val table = TableRef.parse(tableRdr.getObject(opIdx) as String)
             checkNotForbidden(table)
 
             val liveTable = table(table)
@@ -213,7 +213,7 @@ internal class SourceLogTxIndexer(
             val validToRdr = patchLeg.vectorFor("_valid_to")
 
             val legName = docsRdr.getLeg(opIdx) ?: error("patch-docs leg missing for op $opIdx")
-            val tableRef = TableRef.parse(dbState.name, legName)
+            val tableRef = TableRef.parse(legName)
             val tableDocsRdr = docsRdr.vectorFor(legName)
             val docRdr = tableDocsRdr.listElements
             val ks = docRdr.keyNames ?: emptySet()
@@ -249,7 +249,7 @@ internal class SourceLogTxIndexer(
                 tracer.withSpan(
                     "xtdb.transaction.patch-docs",
                     attributes = mapOf(
-                        "db" to tableRef.dbName, "schema" to tableRef.schemaName, "table" to tableRef.tableName,
+                        "db" to dbState.name, "schema" to tableRef.schemaName, "table" to tableRef.tableName,
                     ),
                 ) {
                     table(tableRef).patchDocs(docs, validFrom, validTo)

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -92,7 +92,7 @@ class TransitionLogProcessor(
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch) {
                     msg.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
                         trieCatalog.addTries(
-                            TableRef.parse(dbState.name, tableName),
+                            TableRef.parse(tableName),
                             tries,
                             record.logTimestamp
                         )
@@ -116,7 +116,7 @@ class TransitionLogProcessor(
             is ReplicaMessage.NoOp -> msg.srcMsgId?.let { watchers.notifyMsg(it) }
 
             is ReplicaMessage.TriesDeleted -> {
-                trieCatalog.deleteTries(TableRef.parse(dbState.name, msg.tableName), msg.trieKeys)
+                trieCatalog.deleteTries(TableRef.parse(msg.tableName), msg.trieKeys)
             }
         }
     }

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -164,7 +164,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun `l1 compaction followed by garbage collection`() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val l1Tries = L1TrieKeys.take(4).toList()
         val db = dbs[0]
@@ -217,7 +217,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun `gc during compaction preserves files`()  {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val l1Tries = L1TrieKeys.take(8).toList()
         val db = dbs[0]
@@ -285,7 +285,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun `gc collects old garbage while compaction runs`() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
         val blockCatalog = db.blockCatalog
@@ -363,7 +363,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @WithNumberOfSystems(2)
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     fun `multi-system compaction and gc`() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 
         // Add some old L1 tries and their corresponding L2s (already compacted, so L1s are garbage)
@@ -444,7 +444,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @WithNumberOfSystems(2)
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     fun `staggered system startup during active compaction`() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 
         // Add L1 tries that will be compacted
@@ -536,7 +536,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
     fun `l0 to l3 compaction and gc`() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
         val blockCatalog = db.blockCatalog
@@ -590,7 +590,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @WithNumberOfSystems(2)
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
     fun `l0 to 13 with concurrent compaction + gc`() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 
         val l0Tries = L0TrieKeys.take(16).toList()
@@ -677,7 +677,7 @@ class NodeSimulationTest : SimulationTestBase() {
     @WithNumberOfSystems(2)
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
     fun `multi system l3 to l4 compaction`() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
 
         // Using helper to generate 52 l3 tries

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -112,7 +112,7 @@ class CompactorMockDriverFactory(
                     LOGGER.debug("[channel msg received] systemId=$systemId received ${trieKeys.size} tries: $trieKeys")
                     yield() // force suspension mid-message processing
                     msg.triesAdded.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
-                        val tableRef = TableRef.parse(dbState.name, tableName)
+                        val tableRef = TableRef.parse(tableName)
                         addTriesToBufferPool(bufferPool, tableRef, tries)
                         trieCatalog.addTries(tableRef, tries, msg.msgTimestamp)
                     }
@@ -218,7 +218,7 @@ class CompactorMockDriverFactory(
             sharedFlow.emit(AppendMessage(triesAdded, logTimestamp, systemId))
             yield()
             triesAdded.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
-                val tableRef = TableRef.parse(dbState.name, tableName)
+                val tableRef = TableRef.parse(tableName)
                 addTriesToBufferPool(bufferPool, tableRef, tries)
                 trieCatalog.addTries(tableRef, tries, logTimestamp)
             }
@@ -355,7 +355,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun singleL0Compaction() {
-        val docsTable = TableRef("xtdb", "public", "docs")
+        val docsTable = TableRef("public", "docs")
         val l0Trie = buildTrieDetails(docsTable.tableName, L0TrieKeys.first())
         val db = dbs[0]
 
@@ -384,7 +384,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @RepeatableSimulationTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun multipleL0ToL1Compaction() {
-        val table = TableRef("xtdb", "public", "docs")
+        val table = TableRef("public", "docs")
         val db = dbs[0]
 
         db.withCompactor {
@@ -446,7 +446,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun biggerCompactorRun() {
-        val docsTable = TableRef("xtdb", "public", "docs")
+        val docsTable = TableRef("public", "docs")
         val l0tries = L0TrieKeys.take(100).map { buildTrieDetails(docsTable.tableName, it, 10L * 1024L * 1024L) }
         val db = dbs[0]
 
@@ -467,7 +467,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
     fun l1cToL2cCompaction() {
-        val docsTable = TableRef("xtdb", "public", "docs")
+        val docsTable = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
 
@@ -493,7 +493,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
     fun l1cToL2cWithPartialL2() {
-        val docsTable = TableRef("xtdb", "public", "docs")
+        val docsTable = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val rand = Random(currentSeed)
         val db = dbs[0]
@@ -533,7 +533,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = CURRENT)
     fun l2cGapFillingAndL3cCompaction() {
-        val docsTable = TableRef("xtdb", "public", "docs")
+        val docsTable = TableRef("public", "docs")
         val defaultFileTarget = 100L * 1024L * 1024L
         val db = dbs[0]
 
@@ -577,9 +577,9 @@ class CompactorSimulationTest : SimulationTestBase() {
     }
 
     private fun runConcurrentTableCompaction() {
-        val docsTable = TableRef("xtdb", "public", "docs")
-        val usersTable = TableRef("xtdb", "public", "users")
-        val ordersTable = TableRef("xtdb", "public", "orders")
+        val docsTable = TableRef("public", "docs")
+        val usersTable = TableRef("public", "users")
+        val ordersTable = TableRef("public", "orders")
         val l0FileSize = 100L * 1024L * 1024L
 
         // Start from L0 files to test the full compaction pipeline with multiple tables
@@ -633,7 +633,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @WithNumberOfSystems(2)
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     fun multiSystemSingleL0Compaction() {
-        val docsTable = TableRef("xtdb", "public", "docs")
+        val docsTable = TableRef("public", "docs")
         val l0Trie = buildTrieDetails(docsTable.tableName, L0TrieKeys.first())
 
         seedTries(docsTable, listOf(l0Trie))
@@ -665,7 +665,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @WithCompactorDriverConfig(temporalSplitting = BOTH)
     fun biggerMultiSystemCompactorRun() {
-        val docsTable = TableRef("xtdb", "public", "docs")
+        val docsTable = TableRef("public", "docs")
         val l0tries = L0TrieKeys.take(1000).map { buildTrieDetails(docsTable.tableName, it, 10L * 1024L * 1024L) }
 
         seedTries(docsTable, l0tries.toList())

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -175,7 +175,7 @@ class LeaderLogProcessorTest {
             trieMetadata = trieMetadata {},
             hllDeltas = emptyMap()
         )
-        val tableRef = TableRef.parse("test", "public/foo")
+        val tableRef = TableRef.parse("public/foo")
 
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
             every { finishBlock(any(), any()) } returns mapOf(tableRef to finishedBlock)

--- a/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
@@ -18,7 +18,7 @@ class LiveTableTest {
     @Test
     fun `importData appends rows to liveRelation and updates trie`() {
         RootAllocator().use { allocator ->
-            val table = TableRef("test", "public", "docs")
+            val table = TableRef("public", "docs")
             val rowCounter = RowCounter()
 
             LiveTable(allocator, table, 0L, rowCounter).use { liveTable ->
@@ -58,7 +58,7 @@ class LiveTableTest {
     @Test
     fun `importData accumulates with existing data`() {
         RootAllocator().use { allocator ->
-            val table = TableRef("test", "public", "docs")
+            val table = TableRef("public", "docs")
             val rowCounter = RowCounter()
 
             LiveTable(allocator, table, 0L, rowCounter).use { liveTable ->
@@ -120,7 +120,7 @@ class LiveTableTest {
         val n = 1000
 
         RootAllocator().use { allocator ->
-            LiveTable(allocator, TableRef("xtdb", "public", "docs"), 0L, RowCounter()) { iidVec ->
+            LiveTable(allocator, TableRef("public", "docs"), 0L, RowCounter()) { iidVec ->
                 MemoryHashTrie.builder(iidVec).setLogLimit(2).setPageLimit(4).build()
             }.use { liveTable ->
                 Trie.openLogDataWriter(allocator).use { sourceRel ->
@@ -159,7 +159,7 @@ class LiveTableTest {
 
         RootAllocator().use { allocator ->
             MemoryStorage(allocator, epoch = 0).use { bp ->
-                LiveTable(allocator, TableRef("xtdb", "public", "docs"), 0L, RowCounter()).use { liveTable ->
+                LiveTable(allocator, TableRef("public", "docs"), 0L, RowCounter()).use { liveTable ->
 
                     Trie.openLogDataWriter(allocator).use { sourceRel ->
                         writePut(sourceRel, uuid.toIidBytes(), 0, 0, 0)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -65,7 +65,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         nodeBase.close()
     }
 
-    private val docsTable = TableRef("test-db", "public", "docs")
+    private val docsTable = TableRef("public", "docs")
 
     private sealed interface SimAction {
         data class Commit(val rows: List<UUID>) : SimAction
@@ -227,10 +227,10 @@ class LogProcessorSimTest : SimulationTestBase() {
                 "block file missing for b$blockIdx"
             )
 
-            val tables = upload.tries.map { TableRef.parse(dbName, it.tableName) }.toSet()
+            val tables = upload.tries.map { TableRef.parse(it.tableName) }.toSet()
 
             for (trie in upload.tries) {
-                val table = TableRef.parse(dbName, trie.tableName)
+                val table = TableRef.parse(trie.tableName)
                 assertTrue(
                     table.dataFilePath(trie.trieKey) in storedPaths,
                     "data file missing for ${trie.tableName}/${trie.trieKey}"

--- a/modules/datasets/src/main/clojure/xtdb/datasets/tpch/ra.clj
+++ b/modules/datasets/src/main/clojure/xtdb/datasets/tpch/ra.clj
@@ -19,7 +19,7 @@
                                    {disc_price (* l_extendedprice (- 1 l_discount))}
                                    {charge (* (* l_extendedprice (- 1 l_discount))
                                               (+ 1 l_tax))}]}
-          [:scan {:table #xt/table lineitem, :columns [l_returnflag l_linestatus
+          [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_returnflag l_linestatus
             {l_shipdate (<= l_shipdate ?ship_date)}
             l_quantity l_extendedprice l_discount l_tax]}]]]]
       (with-args {:ship-date (LocalDate/parse "1998-09-02")})))
@@ -29,17 +29,17 @@
         [:join {:conditions [{s_suppkey ps_suppkey}]}
          [:join {:conditions [{n_nationkey s_nationkey}]}
           [:join {:conditions [{n_regionkey r_regionkey}]}
-           [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id n_name n_regionkey]}]]
-           [:rename {:columns {_id r_regionkey}} [:scan {:table #xt/table region, :columns [_id {r_name (== r_name ?region)}]}]]]
-          [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_nationkey s_acctbal s_name s_address s_phone s_comment]}]]]
-         [:scan {:table #xt/table partsupp, :columns [ps_suppkey ps_partkey ps_supplycost]}]]
+           [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name n_regionkey]}]]
+           [:rename {:columns {_id r_regionkey}} [:scan {:db-name "xtdb", :table #xt/table region, :columns [_id {r_name (== r_name ?region)}]}]]]
+          [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey s_acctbal s_name s_address s_phone s_comment]}]]]
+         [:scan {:db-name "xtdb", :table #xt/table partsupp, :columns [ps_suppkey ps_partkey ps_supplycost]}]]
         [:top {:limit 100}
          [:order-by {:order-specs [[s_acctbal {:direction :desc}] [n_name] [s_name] [p_partkey]]}
           [:project {:projections [s_acctbal s_name n_name p_partkey p_mfgr s_address s_phone s_comment]}
            [:join {:conditions [{ps_partkey ps_partkey} {ps_supplycost min_ps_supplycost}]}
             [:join {:conditions [{ps_partkey p_partkey}]}
              [:relation {:cte-id PartSupp :col-names [ps_partkey ps_supplycost]}]
-             [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id p_mfgr {p_size (== p_size ?size)} {p_type (like p_type "%BRASS")}]}]]]
+             [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id p_mfgr {p_size (== p_size ?size)} {p_type (like p_type "%BRASS")}]}]]]
             [:group-by {:columns [ps_partkey {min_ps_supplycost (min ps_supplycost)}]}
              [:relation {:cte-id PartSupp :col-names [ps_partkey ps_supplycost]}]]]]]]]
       (with-args {:region "EUROPE"
@@ -57,10 +57,10 @@
                                     {disc_price (* l_extendedprice (- 1 l_discount))}]}
            [:join {:conditions [{o_orderkey l_orderkey}]}
             [:join {:conditions [{c_custkey o_custkey}]}
-             [:rename {:columns {_id c_custkey}} [:scan {:table #xt/table customer, :columns [_id {c_mktsegment (== c_mktsegment ?segment)}]}]]
-             [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_custkey o_shippriority
+             [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id {c_mktsegment (== c_mktsegment ?segment)}]}]]
+             [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_custkey o_shippriority
                 {o_orderdate (< o_orderdate ?date)}]}]]]
-            [:scan {:table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount
+            [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount
               {l_shipdate (> l_shipdate ?date)}]}]]]]]]
       (with-args {:segment "BUILDING"
                   :date (LocalDate/parse "1995-03-15")})))
@@ -69,11 +69,11 @@
   (-> '[:order-by {:order-specs [[o_orderpriority]]}
         [:group-by {:columns [o_orderpriority {order_count (row-count)}]}
          [:semi-join {:conditions [{o_orderkey l_orderkey}]}
-          [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [o_orderpriority _id
+          [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [o_orderpriority _id
              {o_orderdate (and (>= o_orderdate ?start_date)
                                (< o_orderdate ?end_date))}]}]]
           [:select {:predicate (< l_commitdate l_receiptdate)}
-           [:scan {:table #xt/table lineitem, :columns [l_orderkey l_commitdate l_receiptdate]}]]]]]
+           [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_commitdate l_receiptdate]}]]]]]
       (with-args {:start-date (LocalDate/parse "1993-07-01")
                   ;; in the spec this is one date with `+ INTERVAL 3 MONTHS`
                   :end-date (LocalDate/parse "1993-10-01")})))
@@ -86,22 +86,22 @@
            [:join {:conditions [{s_nationkey c_nationkey}]}
             [:join {:conditions [{n_nationkey s_nationkey}]}
              [:join {:conditions [{r_regionkey n_regionkey}]}
-              [:rename {:columns {_id r_regionkey}} [:scan {:table #xt/table region, :columns [_id {r_name (== r_name "ASIA")}]}]]
-              [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id n_name n_regionkey]}]]]
-             [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]]
+              [:rename {:columns {_id r_regionkey}} [:scan {:db-name "xtdb", :table #xt/table region, :columns [_id {r_name (== r_name "ASIA")}]}]]
+              [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name n_regionkey]}]]]
+             [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey]}]]]
             [:join {:conditions [{o_custkey c_custkey}]}
-             [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_custkey
+             [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_custkey
                 {o_orderdate (and (>= o_orderdate ?start_date)
                                   (< o_orderdate ?end_date))}]}]]
-             [:rename {:columns {_id c_custkey}} [:scan {:table #xt/table customer, :columns [_id c_nationkey]}]]]]
-           [:scan {:table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey]}]]]]]
+             [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id c_nationkey]}]]]]
+           [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey]}]]]]]
       (with-args {:start-date (LocalDate/parse "1994-01-01")
                   :end-date (LocalDate/parse "1995-01-01")})))
 
 (def q6-forecasting-revenue-change
   (-> '[:group-by {:columns [{revenue (sum disc_price)}]}
         [:project {:projections [{disc_price (* l_extendedprice l_discount)}]}
-         [:scan {:table #xt/table lineitem, :columns [{l_shipdate (and (>= l_shipdate ?start_date)
+         [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [{l_shipdate (and (>= l_shipdate ?start_date)
                             (< l_shipdate ?end_date))}
            l_extendedprice
            {l_discount (and (>= l_discount ?min_discount)
@@ -125,16 +125,16 @@
                             (== n2/n_name ?nation1)))]}
             [:join {:conditions [{o_custkey c_custkey}]}
              [:join {:conditions [{n1/n_nationkey s_nationkey}]}
-              [:rename {:prefix n1} [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id {n_name (or (== n_name ?nation1) (== n_name ?nation2))}]}]]]
+              [:rename {:prefix n1} [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id {n_name (or (== n_name ?nation1) (== n_name ?nation2))}]}]]]
               [:join {:conditions [{o_orderkey l_orderkey}]}
-               [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_custkey]}]]
+               [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_custkey]}]]
                [:join {:conditions [{s_suppkey l_suppkey}]}
-                [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]
-                [:scan {:table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey
+                [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey]}]]
+                [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey
                   {l_shipdate (and (>= l_shipdate ?start_date)
                                    (<= l_shipdate ?end_date))}]}]]]]
-             [:rename {:columns {_id c_custkey}} [:scan {:table #xt/table customer, :columns [_id c_nationkey]}]]]
-            [:rename {:prefix n2} [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id {n_name (or (== n_name ?nation1) (== n_name ?nation2))}]}]]]]]]]]
+             [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id c_nationkey]}]]]
+            [:rename {:prefix n2} [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id {n_name (or (== n_name ?nation1) (== n_name ?nation2))}]}]]]]]]]]
       (with-args {:nation1 "FRANCE"
                   :nation2 "GERMANY"
                   :start-date (LocalDate/parse "1995-01-01")
@@ -156,17 +156,17 @@
                [:join {:conditions [{l_orderkey o_orderkey}]}
                 [:join {:conditions [{l_suppkey s_suppkey}]}
                  [:join {:conditions [{p_partkey l_partkey}]}
-                  [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id {p_type (== p_type ?type)}]}]]
-                  [:scan {:table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey l_partkey]}]]
-                 [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]]
-                [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_custkey
+                  [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id {p_type (== p_type ?type)}]}]]
+                  [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey l_partkey]}]]
+                 [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey]}]]]
+                [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_custkey
                    {o_orderdate (and (>= o_orderdate ?start_date)
                                      (<= o_orderdate ?end_date))}]}]]]
-               [:rename {:columns {_id c_custkey}} [:scan {:table #xt/table customer, :columns [_id c_nationkey]}]]]
+               [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id c_nationkey]}]]]
               [:join {:conditions [{r_regionkey n1/n_regionkey}]}
-               [:rename {:columns {_id r_regionkey}} [:scan {:table #xt/table region, :columns [_id {r_name (== r_name ?region)}]}]]
-               [:rename {:prefix n1} [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id n_name n_regionkey]}]]]]]
-             [:rename {:prefix n2} [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id n_name]}]]]]]]]]]
+               [:rename {:columns {_id r_regionkey}} [:scan {:db-name "xtdb", :table #xt/table region, :columns [_id {r_name (== r_name ?region)}]}]]
+               [:rename {:prefix n1} [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name n_regionkey]}]]]]]
+             [:rename {:prefix n2} [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]]]]]]]]
       (with-args {:nation "BRAZIL"
                   :region "AMERICA"
                   :type "ECONOMY ANODIZED STEEL"
@@ -185,12 +185,12 @@
              [:join {:conditions [{l_suppkey s_suppkey}]}
               [:join {:conditions [{l_partkey ps_partkey} {l_suppkey ps_suppkey}]}
                [:join {:conditions [{p_partkey l_partkey}]}
-                [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id {p_name (like p_name "%green%")}]}]]
-                [:scan {:table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey l_partkey l_quantity]}]]
-               [:scan {:table #xt/table partsupp, :columns [ps_partkey ps_suppkey ps_supplycost]}]]
-              [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]]
-             [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_orderdate]}]]]
-            [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id n_name]}]]]]]]]
+                [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id {p_name (like p_name "%green%")}]}]]
+                [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_extendedprice l_discount l_suppkey l_partkey l_quantity]}]]
+               [:scan {:db-name "xtdb", :table #xt/table partsupp, :columns [ps_partkey ps_suppkey ps_supplycost]}]]
+              [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey]}]]]
+             [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_orderdate]}]]]
+            [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]]]]]]
       #_(with-params {:color "green"})))
 
 (def q10-returned-item-reporting
@@ -203,12 +203,12 @@
            [:join {:conditions [{c_nationkey n_nationkey}]}
             [:join {:conditions [{o_orderkey l_orderkey}]}
              [:join {:conditions [{c_custkey o_custkey}]}
-              [:rename {:columns {_id c_custkey}} [:scan {:table #xt/table customer, :columns [_id c_name c_acctbal c_address c_phone c_comment c_nationkey]}]]
-              [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_custkey
+              [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id c_name c_acctbal c_address c_phone c_comment c_nationkey]}]]
+              [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_custkey
                  {o_orderdate (and (>= o_orderdate ?start_date)
                                    (< o_orderdate ?end_date))}]}]]]
-             [:scan {:table #xt/table lineitem, :columns [l_orderkey {l_returnflag (== l_returnflag "R")} l_extendedprice l_discount]}]]
-            [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id n_name]}]]]]]]]
+             [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey {l_returnflag (== l_returnflag "R")} l_extendedprice l_discount]}]]
+            [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]]]]]]
       (with-args {:start-date (LocalDate/parse "1993-10-01")
                   :end-date (LocalDate/parse "1994-01-01")})))
 
@@ -217,9 +217,9 @@
         [:project {:projections [ps_partkey {value (* ps_supplycost ps_availqty)}]}
          [:join {:conditions [{s_suppkey ps_suppkey}]}
           [:join {:conditions [{n_nationkey s_nationkey}]}
-           [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id {n_name (== n_name ?nation)}]}]]
-           [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_nationkey]}]]]
-          [:scan {:table #xt/table partsupp, :columns [ps_partkey ps_suppkey ps_supplycost ps_availqty]}]]]
+           [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id {n_name (== n_name ?nation)}]}]]
+           [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey]}]]]
+          [:scan {:db-name "xtdb", :table #xt/table partsupp, :columns [ps_partkey ps_suppkey ps_supplycost ps_availqty]}]]]
         [:order-by {:order-specs [[value {:direction :desc}]]}
          [:project {:projections [ps_partkey value]}
           [:join {:conditions [(> value total)]}
@@ -246,10 +246,10 @@
                                                1
                                                0)}]}
           [:join {:conditions [{o_orderkey l_orderkey}]}
-           [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_orderpriority]}]]
+           [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_orderpriority]}]]
            [:select {:predicate (and (< l_commitdate l_receiptdate)
                                      (< l_shipdate l_commitdate))}
-            [:scan {:table #xt/table lineitem, :columns [l_orderkey l_commitdate l_shipdate
+            [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_commitdate l_shipdate
               {l_shipmode (or (== l_shipmode ?ship_mode1)
                               (== l_shipmode ?ship_mode2))}
               {l_receiptdate (and (>= l_receiptdate ?start_date)
@@ -264,8 +264,8 @@
         [:group-by {:columns [c_count {custdist (row-count)}]}
          [:group-by {:columns [c_custkey {c_count (count o_comment)}]}
           [:left-outer-join {:conditions [{c_custkey o_custkey}]}
-           [:rename {:columns {_id c_custkey}} [:scan {:table #xt/table customer, :columns [_id]}]]
-           [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id {o_comment (not (like o_comment "%special%requests%"))} o_custkey]}]]]]]]
+           [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id]}]]
+           [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id {o_comment (not (like o_comment "%special%requests%"))} o_custkey]}]]]]]]
       #_(with-params {:word1 "special"
                       :word2 "requests"})))
 
@@ -278,8 +278,8 @@
                                                       0.0)}
                                   {disc_price (* l_extendedprice (- 1 l_discount))}]}
           [:join {:conditions [{p_partkey l_partkey}]}
-           [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id p_type]}]]
-           [:scan {:table #xt/table lineitem, :columns [l_partkey l_extendedprice l_discount
+           [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id p_type]}]]
+           [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_partkey l_extendedprice l_discount
              {l_shipdate (and (>= l_shipdate ?start_date)
                               (< l_shipdate ?end_date))}]}]]]]]
       (with-args {:start-date (LocalDate/parse "1995-09-01")
@@ -289,14 +289,14 @@
   (-> '[:let {:binding-sym Revenue}
         [:group-by {:columns [supplier_no {total_revenue (sum disc_price)}]}
          [:rename {:columns {l_suppkey supplier_no}} [:project {:projections [l_suppkey {disc_price (* l_extendedprice (- 1 l_discount))}]}
-           [:scan {:table #xt/table lineitem, :columns [l_suppkey l_extendedprice l_discount
+           [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_suppkey l_extendedprice l_discount
              {l_shipdate (and (>= l_shipdate ?start_date)
                               (< l_shipdate ?end_date))}]}]]]]
         [:project {:projections [s_suppkey s_name s_address s_phone total_revenue]}
          [:join {:conditions [{total_revenue max_total_revenue}]}
           [:join {:conditions [{supplier_no s_suppkey}]}
            [:relation {:cte-id Revenue :col-names [supplier_no total_revenue]}]
-           [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_name s_address s_phone]}]]]
+           [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_name s_address s_phone]}]]]
           [:group-by {:columns [{max_total_revenue (max total_revenue)}]}
            [:relation {:cte-id Revenue :col-names [supplier_no total_revenue]}]]]]]
       (with-args {:start-date (LocalDate/parse "1996-01-01")
@@ -309,11 +309,11 @@
           [:project {:projections [p_brand p_type p_size ps_suppkey]}
            [:join {:conditions [{p_partkey ps_partkey}]}
             [:semi-join {:conditions [{p_size p_size}]}
-             [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id {p_brand (<> p_brand ?brand)} {p_type (not (like p_type "MEDIUM POLISHED%"))} p_size]}]]
+             [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id {p_brand (<> p_brand ?brand)} {p_type (not (like p_type "MEDIUM POLISHED%"))} p_size]}]]
              [:table {:param ?sizes}]]
             [:anti-join {:conditions [{ps_suppkey s_suppkey}]}
-             [:scan {:table #xt/table partsupp, :columns [ps_partkey ps_suppkey]}]
-             [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id {s_comment (like s_comment "%Customer%Complaints%")}]}]]]]]]]]
+             [:scan {:db-name "xtdb", :table #xt/table partsupp, :columns [ps_partkey ps_suppkey]}]
+             [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id {s_comment (like s_comment "%Customer%Complaints%")}]}]]]]]]]]
       (with-args {:brand "Brand#45"
                   ;; :type "MEDIUM POLISHED%"
 
@@ -330,12 +330,12 @@
   (-> '[:project {:projections [{avg_yearly (/ sum_extendedprice 7)}]}
         [:group-by {:columns [{sum_extendedprice (sum l_extendedprice)}]}
          [:join {:conditions [{p_partkey l_partkey} (< l_quantity small_avg_qty)]}
-          [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id {p_brand (== p_brand ?brand)} {p_container (== p_container ?container)}]}]]
+          [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id {p_brand (== p_brand ?brand)} {p_container (== p_container ?container)}]}]]
           [:join {:conditions [{l_partkey l_partkey}]}
            [:project {:projections [l_partkey {small_avg_qty (* 0.2 avg_qty)}]}
             [:group-by {:columns [l_partkey {avg_qty (avg l_quantity)}]}
-             [:scan {:table #xt/table lineitem, :columns [l_partkey l_quantity]}]]]
-           [:scan {:table #xt/table lineitem, :columns [l_partkey l_quantity]}]]]]]
+             [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_partkey l_quantity]}]]]
+           [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_partkey l_quantity]}]]]]]
       (with-args {:brand "Brand#23"
                   :container "MED_BOX"})))
 
@@ -346,12 +346,12 @@
           [:join {:conditions [{o_orderkey l_orderkey}]}
            [:join {:conditions [{o_custkey c_custkey}]}
             [:semi-join {:conditions [{o_orderkey l_orderkey}]}
-             [:rename {:columns {_id o_orderkey}} [:scan {:table #xt/table orders, :columns [_id o_custkey o_orderdate o_totalprice]}]]
+             [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_custkey o_orderdate o_totalprice]}]]
              [:select {:predicate (> sum_qty ?qty)}
               [:group-by {:columns [l_orderkey {sum_qty (sum l_quantity)}]}
-               [:scan {:table #xt/table lineitem, :columns [l_orderkey l_quantity]}]]]]
-            [:rename {:columns {_id c_custkey}} [:scan {:table #xt/table customer, :columns [_id c_name]}]]]
-           [:scan {:table #xt/table lineitem, :columns [l_orderkey l_quantity]}]]]]]
+               [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_quantity]}]]]]
+            [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id c_name]}]]]
+           [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_quantity]}]]]]]
       (with-args {:qty 300})))
 
 (def q19-discounted-revenue
@@ -385,8 +385,8 @@
                                        (>= p_size 1)
                                        (<= p_size 15)))}
           [:join {:conditions [{p_partkey l_partkey}]}
-           [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id p_brand p_container p_size]}]]
-           [:scan {:table #xt/table lineitem, :columns [l_partkey l_extendedprice l_discount l_quantity
+           [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id p_brand p_container p_size]}]]
+           [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_partkey l_extendedprice l_discount l_quantity
              {l_shipmode (or (== l_shipmode "AIR") (== l_shipmode "AIR REG"))}
              {l_shipinstruct (== l_shipinstruct "DELIVER IN PERSON")}]}]]]]]
       (with-args {:qty1 1, :qty2 10, :qty3 20
@@ -397,15 +397,15 @@
         [:project {:projections [s_name s_address]}
          [:semi-join {:conditions [{s_suppkey ps_suppkey}]}
           [:join {:conditions [{n_nationkey s_nationkey}]}
-           [:rename {:columns {_id n_nationkey}} [:scan {:table #xt/table nation, :columns [_id {n_name (== n_name ?nation)}]}]]
-           [:rename {:columns {_id s_suppkey}} [:scan {:table #xt/table supplier, :columns [_id s_name s_address s_nationkey]}]]]
+           [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id {n_name (== n_name ?nation)}]}]]
+           [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_name s_address s_nationkey]}]]]
           [:join {:conditions [{ps_partkey l_partkey} {ps_suppkey l_suppkey} (> ps_availqty sum_qty)]}
            [:semi-join {:conditions [{ps_partkey p_partkey}]}
-            [:scan {:table #xt/table partsupp, :columns [ps_suppkey ps_partkey ps_availqty]}]
-            [:rename {:columns {_id p_partkey}} [:scan {:table #xt/table part, :columns [_id {p_name (like p_name "forest%")}]}]]]
+            [:scan {:db-name "xtdb", :table #xt/table partsupp, :columns [ps_suppkey ps_partkey ps_availqty]}]
+            [:rename {:columns {_id p_partkey}} [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id {p_name (like p_name "forest%")}]}]]]
            [:project {:projections [l_partkey l_suppkey {sum_qty (* 0.5 sum_qty)}]}
             [:group-by {:columns [l_partkey l_suppkey {sum_qty (sum l_quantity)}]}
-             [:scan {:table #xt/table lineitem, :columns [l_partkey l_suppkey l_quantity
+             [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_partkey l_suppkey l_quantity
                {l_shipdate (and (>= l_shipdate ?start_date)
                                 (< l_shipdate ?end_date))}]}]]]]]]]
       (with-args {;:color "forest"
@@ -419,12 +419,12 @@
          [:join {:conditions [{l1/l_suppkey s_suppkey}]}
           [:join {:conditions [{l1/l_orderkey o_orderkey}]}
            [:rename {:prefix l1} [:select {:predicate (> l_receiptdate l_commitdate)}
-             [:scan {:for-valid-time [:at :now], :table #xt/table lineitem, :columns [l_orderkey l_suppkey l_receiptdate l_commitdate]}]]]
-           [:rename {:columns {_id o_orderkey}} [:scan {:for-valid-time [:at :now], :table #xt/table orders, :columns [_id {o_orderstatus (== o_orderstatus "F")}]}]]]
+             [:scan {:db-name "xtdb", :for-valid-time [:at :now], :table #xt/table lineitem, :columns [l_orderkey l_suppkey l_receiptdate l_commitdate]}]]]
+           [:rename {:columns {_id o_orderkey}} [:scan {:db-name "xtdb", :for-valid-time [:at :now], :table #xt/table orders, :columns [_id {o_orderstatus (== o_orderstatus "F")}]}]]]
           [:semi-join {:conditions [{s_nationkey n_nationkey}]}
-           [:rename {:columns {_id s_suppkey}} [:scan {:for-valid-time [:at :now], :table #xt/table supplier, :columns [_id s_nationkey s_name]}]]
-           [:rename {:columns {_id n_nationkey}} [:scan {:for-valid-time [:at :now], :table #xt/table nation, :columns [_id {n_name (== n_name ?nation)}]}]]]]
-         [:rename {:prefix l2} [:scan {:for-valid-time [:at :now], :table #xt/table lineitem, :columns [l_orderkey l_suppkey]}]]]
+           [:rename {:columns {_id s_suppkey}} [:scan {:db-name "xtdb", :for-valid-time [:at :now], :table #xt/table supplier, :columns [_id s_nationkey s_name]}]]
+           [:rename {:columns {_id n_nationkey}} [:scan {:db-name "xtdb", :for-valid-time [:at :now], :table #xt/table nation, :columns [_id {n_name (== n_name ?nation)}]}]]]]
+         [:rename {:prefix l2} [:scan {:db-name "xtdb", :for-valid-time [:at :now], :table #xt/table lineitem, :columns [l_orderkey l_suppkey]}]]]
         [:top {:limit 100}
          [:order-by {:order-specs [[numwait {:direction :desc}] [s_name]]}
           [:group-by {:columns [s_name {numwait (row-count)}]}
@@ -435,14 +435,14 @@
               [:join {:conditions [{l1/l_orderkey l3/l_orderkey} (<> l3/l_suppkey l1/l_suppkey)]}
                [:relation {:cte-id L1 :col-names [l_orderkey l_suppkey l_receiptdate l_commitdate]}]
                [:select {:predicate (> l3/l_receiptdate l3/l_commitdate)}
-                [:rename {:prefix l3} [:scan {:table #xt/table lineitem, :columns [l_orderkey l_suppkey l_receiptdate l_commitdate]}]]]]]]]]]]]
+                [:rename {:prefix l3} [:scan {:db-name "xtdb", :table #xt/table lineitem, :columns [l_orderkey l_suppkey l_receiptdate l_commitdate]}]]]]]]]]]]]
       (with-args {:nation "SAUDI ARABIA"})))
 
 (def q22-global-sales-opportunity
   (-> '[:let {:binding-sym Customer}
         [:semi-join {:conditions [{cntrycode cntrycode}]}
          [:project {:projections [c_custkey {cntrycode (substring c_phone 1 2)} c_acctbal]}
-          [:rename {:columns {_id c_custkey}} [:scan {:for-valid-time [:at :now], :table #xt/table customer, :columns [_id c_phone c_acctbal]}]]]
+          [:rename {:columns {_id c_custkey}} [:scan {:db-name "xtdb", :for-valid-time [:at :now], :table #xt/table customer, :columns [_id c_phone c_acctbal]}]]]
          [:table {:param ?cntrycodes}]]
         [:order-by {:order-specs [[cntrycode]]}
          [:group-by {:columns [cntrycode {numcust (row-count)} {totacctbal (sum c_acctbal)}]}
@@ -452,7 +452,7 @@
             [:group-by {:columns [{avg_acctbal (avg c_acctbal)}]}
              [:select {:predicate (> c_acctbal 0.0)}
               [:relation {:cte-id Customer :col-names [c_custkey cntrycode c_acctbal]}]]]]
-           [:scan {:for-valid-time [:at :now], :table #xt/table orders, :columns [o_custkey]}]]]]]
+           [:scan {:db-name "xtdb", :for-valid-time [:at :now], :table #xt/table orders, :columns [o_custkey]}]]]]]
       (with-args {:cntrycodes [{:cntrycode "13"}
                                {:cntrycode "31"}
                                {:cntrycode "23"}

--- a/modules/datasets/src/main/clojure/xtdb/ts_devices.clj
+++ b/modules/datasets/src/main/clojure/xtdb/ts_devices.clj
@@ -87,7 +87,7 @@
   '[:top {:limit 10}
     [:order-by {:order-specs [[time {:direction :desc}]]}
      [:project {:projections [time device-id battery-temperature]}
-      [:scan {:table device-readings
+      [:scan {:db-name "xtdb", :table device-readings
               :columns [time device-id battery-temperature
                         {battery-status (= battery-status "discharging")}]}]]]])
 
@@ -105,11 +105,11 @@
     [:order-by {:order-specs [[cpu-avg-1min {:direction :desc}]
                 [time {:direction :desc}]]}
      [:join {:conditions [{device-id device-id}]}
-      [:scan {:table device-readings
+      [:scan {:db-name "xtdb", :table device-readings
               :columns [device-id time cpu-avg-1min
                         {battery-level (< battery-level 30)}
                         {battery-status (= battery-status "discharging")}]}]
-      [:scan {:table device-info
+      [:scan {:db-name "xtdb", :table device-info
               :columns [device-id model]}]]]])
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
@@ -132,9 +132,9 @@
       [:project {:projections [{hour (date-trunc "HOUR" time)}
                                 battery-level]}
        [:semi-join {device-id device-id}
-        [:scan {:table device-readings
+        [:scan {:db-name "xtdb", :table device-readings
                 :columns [device-id time battery-level]}]
-        [:scan {:table device-info
+        [:scan {:db-name "xtdb", :table device-info
                 :columns [device-id {model (or (= model "pinto")
                                                (= model "focus"))}]}]]]]]])
 

--- a/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
@@ -41,7 +41,7 @@ class DocsIndexer(
     ) : RecordIndexer.Factory {
 
         override fun open(dbName: String): RecordIndexer =
-            DocsIndexer(TableRef.parse(dbName, table))
+            DocsIndexer(TableRef.parse(table))
 
         class Registration : RecordIndexer.Registration<Factory> {
             override val protoTag: String

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/DirectMirror.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/DirectMirror.kt
@@ -34,7 +34,7 @@ class DirectMirror(private val dbName: String) : PgIndexer {
     }
 
     private fun writeOp(openTx: OpenTx, dbName: String, op: RowOp) {
-        val openTxTable = openTx.table(TableRef(dbName, op.schema, op.table))
+        val openTxTable = openTx.table(TableRef(op.schema, op.table))
 
         when (op) {
             is RowOp.Put -> {

--- a/src/test/clojure/xtdb/as_of_test.clj
+++ b/src/test/clojure/xtdb/as_of_test.clj
@@ -13,7 +13,7 @@
   (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id :my-doc, :last-updated "tx2"}]])
 
   (t/is (= #{{:last-updated "tx1"} {:last-updated "tx2"}}
-           (set (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time :all-time, :columns [last_updated]}]
+           (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time :all-time, :columns [last_updated]}]
                              {:node tu/*node*}))))
 
   (t/is (= #{{:last-updated "tx2"}}
@@ -21,7 +21,7 @@
 
   (t/testing "at tx1"
     (t/is (= #{{:last-updated "tx1"}}
-             (set (tu/query-ra '[:scan {:table #xt/table docs, :columns [last_updated]}]
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :columns [last_updated]}]
                                {:node tu/*node*, :snapshot-token (basis/->time-basis-str {"xtdb" [#inst "2020"]})}))))
 
     (t/is (= #{{:last-updated "tx1"}}
@@ -40,7 +40,7 @@
               :doc-with-app-time {:xt/id :doc-with-app-time,
                                   :xt/valid-from (time/->zdt #inst "2021")
                                   :xt/system-from system-time}}
-             (->> (tu/query-ra '[:scan {:table #xt/table docs,
+             (->> (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs,
                                         :columns [_id
                                                   _valid_from _valid_to
                                                   _system_from _system_to]}]

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -108,7 +108,7 @@
     (t/is (= [{:xt/id :foo, :version 0,
                :xt/valid-from (time/->zdt tt)
                :xt/system-from (time/->zdt tt)}]
-             (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id version
+             (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id version
                              _valid_from, _valid_to
                              _system_from, _system_to]}]
                           {:node tu/*node*})))
@@ -126,7 +126,7 @@
                  {:xt/id :foo, :version 1,
                   :xt/valid-from (time/->zdt tt2)
                   :xt/system-from (time/->zdt tt2)}}
-               (set (tu/query-ra '[:scan {:table #xt/table xt_docs,
+               (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs,
                                           :for-system-time :all-time,
                                           :for-valid-time :all-time, :columns [_id version
                                     _valid_from, _valid_to
@@ -136,7 +136,7 @@
       (t/is (= [{:xt/id :foo, :version 0,
                  :xt/valid-from (time/->zdt tt)
                  :xt/system-from (time/->zdt tt)}]
-               (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id version
+               (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id version
                                _valid_from, _valid_to
                                _system_from, _system_to]}]
                             {:node tu/*node*,

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -39,7 +39,7 @@
       (t/is (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]]))
 
       (t/is (= [{:xt/id :foo}]
-               (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id]}]
+               (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id]}]
                             {:node node}))))))
 
 (t/deftest ^:integration test-multi-db

--- a/src/test/clojure/xtdb/logical_plan_test.clj
+++ b/src/test/clojure/xtdb/logical_plan_test.clj
@@ -49,7 +49,7 @@
         {:projections [{~(sql/->col-sym '_valid_time)
                         (period ~(sql/->col-sym '_valid_from)
                                 ~(sql/->col-sym '_valid_to))}]}
-        [:scan {:table public/docs
+        [:scan {:db-name "xtdb", :table public/docs
                 :columns [~(sql/->col-sym '_valid_from) ~(sql/->col-sym '_valid_to)]}]]]))))
 
   (t/testing "only pushes past period constructors"
@@ -76,7 +76,7 @@
                           xtdb/end-of-time)))}
            [:project
             {:projections [{~(sql/->col-sym '_valid_time) (+ 1 ~(sql/->col-sym '_valid_from))}]}
-            [:scan {:table public/docs
+            [:scan {:db-name "xtdb", :table public/docs
                     :columns [~(sql/->col-sym '_valid_from) ~(sql/->col-sym '_valid_to)]}]]])))))
 
   (t/testing "scalar extends expressions are handled"
@@ -93,7 +93,7 @@
                          {~(sql/->col-sym '_valid_time)
                           (period ~(sql/->col-sym '_valid_from)
                                   ~(sql/->col-sym '_valid_to))}]}
-          [:scan {:table public/docs, :columns [~(sql/->col-sym '_bar)]}]]])))))
+          [:scan {:db-name "xtdb", :table public/docs, :columns [~(sql/->col-sym '_bar)]}]]])))))
 
   (t/testing "only push predicate if all columns referenced (aside from the new period) present in inner rel"
     (t/is
@@ -108,7 +108,7 @@
                          {~(sql/->col-sym '_valid_time)
                           (period ~(sql/->col-sym '_valid_from)
                                   ~(sql/->col-sym '_valid_to))}]}
-          [:scan {:table public/docs, :columns [~(sql/->col-sym '_bar)]}]]]))))))
+          [:scan {:db-name "xtdb", :table public/docs, :columns [~(sql/->col-sym '_bar)]}]]]))))))
 
 (t/deftest test-remove-redundant-period-constructors
   (t/is
@@ -179,34 +179,34 @@
           {:mode :cross-join, :columns {}}
           [:select
            {:predicate (== ~(sql/->col-sym 'x) 10)}
-           [:scan {:table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]]
-          [:scan {:table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]])
+           [:scan {:db-name "xtdb", :table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]]
+          [:scan {:db-name "xtdb", :table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]])
         (lp/push-selection-down-past-apply
          (xt/template
           [:select
            {:predicate (== ~(sql/->col-sym 'x) 10)}
            [:apply
             {:mode :cross-join, :columns {}}
-            [:scan {:table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
-            [:scan {:table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]])))))
+            [:scan {:db-name "xtdb", :table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
+            [:scan {:db-name "xtdb", :table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]])))))
 
   (t/testing "pushes selection down to dependent relation for cross-join"
     (t/is
      (= (xt/template
          [:apply
           {:mode :cross-join, :columns {}}
-          [:scan {:table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
+          [:scan {:db-name "xtdb", :table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
           [:select
            {:predicate (== ~(sql/->col-sym 'y) 20)}
-           [:scan {:table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]])
+           [:scan {:db-name "xtdb", :table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]])
         (lp/push-selection-down-past-apply
          (xt/template
           [:select
            {:predicate (== ~(sql/->col-sym 'y) 20)}
            [:apply
             {:mode :cross-join, :columns {}}
-            [:scan {:table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
-            [:scan {:table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]])))))
+            [:scan {:db-name "xtdb", :table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
+            [:scan {:db-name "xtdb", :table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]])))))
 
   (t/testing "does not push down to dependent relation for non-cross-join modes"
     (t/is
@@ -217,5 +217,5 @@
          {:predicate (== ~(sql/->col-sym 'bar/y) 20)}
          [:apply
           {:mode :semi-join, :columns {}}
-          [:scan {:table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
-          [:scan {:table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]]))))))
+          [:scan {:db-name "xtdb", :table #xt/table foo, :columns [~(sql/->col-sym 'x)]}]
+          [:scan {:db-name "xtdb", :table #xt/table bar, :columns [~(sql/->col-sym 'y)]}]]]))))))

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -41,22 +41,22 @@
   (c/compact-all! tu/*node* #xt/duration "PT1S")
 
   (t/is (= [{:num 1} {:num 1.0}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{num (== num 1)}]}]
                         {:node tu/*node*})))
 
   (t/is (= [{:num 2.0}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{num (== num 2)}]}]
                         {:node tu/*node*})))
 
   (t/is (= [{:num 4}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{num (== num ?x)}]}]
                         {:node tu/*node*, :args {:x (byte 4)}})))
 
   (t/is (= [{:num 3}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{num (== num ?x)}]}]
                         {:node tu/*node*, :args {:x (float 3)}}))))
 
@@ -73,21 +73,21 @@
   (t/is (= [{:timestamp #xt/date "2010-01-01"}
             {:timestamp #xt/zoned-date-time "2010-01-01T00:00Z"}
             {:timestamp #xt/date-time "2010-01-01T00:00:00"}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{timestamp (== timestamp #xt/zoned-date-time "2010-01-01T00:00:00Z")}]}]
                         {:node tu/*node*, :default-tz #xt/zone "Z"})))
 
   (t/is (= [{:timestamp #xt/date "2010-01-01"}
             {:timestamp #xt/zoned-date-time "2010-01-01T00:00Z"}
             {:timestamp #xt/date-time "2010-01-01T00:00:00"}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{timestamp (== timestamp ?x)}]}]
                         {:node tu/*node*, :default-tz #xt/zone "Z", :args {:x #xt/date "2010-01-01"}})))
 
   (t/is (= [{:timestamp #xt/date "2010-01-01"}
             {:timestamp #xt/zoned-date-time "2010-01-01T00:00Z"}
             {:timestamp #xt/date-time "2010-01-01T00:00:00"}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{timestamp (== timestamp #xt/date-time "2010-01-01T00:00:00")}]}]
                         {:node tu/*node*, :default-tz #xt/zone "Z"}))))
 
@@ -100,7 +100,7 @@
   (c/compact-all! tu/*node* #xt/duration "PT1S")
 
   (t/is (= [{:time #xt/time "04:05:06"}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                  :columns [{time (== time #xt/time "04:05:06")}]}]
                         {:node tu/*node*, :default-tz #xt/zone "Z"}))))
 
@@ -281,6 +281,6 @@
 
           (t/testing "Query returns correct results"
             (t/is (= [user3 user4]
-                     (sort-by :xt/id (tu/query-ra '[:scan {:table #xt/table xt_docs
+                     (sort-by :xt/id (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                                             :columns [_id {status (not (nil? status))}]}]
                                                    {:node node}))))))))))

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -371,8 +371,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
   (t/is (= [{:t2d {:foo {:bibble false}, :bar {:baz 1002}},
              :t1d {:foo {:bibble true}, :bar {:baz 1001}}}]
            (tu/query-ra '[:cross-join {}
-                          [:rename {:columns {data t2d}} [:scan {:table #xt/table t2, :columns [data]}]]
-                          [:rename {:columns {data t1d}} [:scan {:table #xt/table t1, :columns [data]}]]]
+                          [:rename {:columns {data t2d}} [:scan {:db-name "xtdb", :table #xt/table t2, :columns [data]}]]
+                          [:rename {:columns {data t1d}} [:scan {:db-name "xtdb", :table #xt/table t1, :columns [data]}]]]
                         {:node tu/*node*})
            #_(xt/q tu/*node* "SELECT t2.data t2d, t1.data t1d FROM t2, t1"))))
 
@@ -810,7 +810,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
   (t/is (= [{:col 904292726}]
            (tu/query-ra
-            '[:scan {:table #xt/table bar, :columns [{col (== col (cast "bar" #xt/type :regclass))}]}]
+            '[:scan {:db-name "xtdb", :table #xt/table bar, :columns [{col (== col (cast "bar" #xt/type :regclass))}]}]
             {:node tu/*node*}))
         "scan pred"))
 
@@ -996,8 +996,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
              (tu/query-ra '[:project {:projections [{bar _id} {foo foo/_id}]}
                             [:semi-join {:conditions [{_id vals/_column_1}]}
                              [:rename {:columns {bar/_id _id}} [:join {:conditions [{foo/_id bar/foo}]}
-                               [:rename {:prefix foo} [:scan {:table #xt/table foo, :columns [_id]}]]
-                               [:rename {:prefix bar} [:scan {:table #xt/table bar, :columns [_id foo]}]]]]
+                               [:rename {:prefix foo} [:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id]}]]
+                               [:rename {:prefix bar} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_id foo]}]]]]
                              [:rename {:prefix vals} [:table {:output-cols [_column_1], :rows [{:_column_1 "bar1"}]}]]]]
                           {:node node})))
 
@@ -1023,8 +1023,8 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
   (t/is (= [{:xt/id :toto, :col 3}]
            (tu/query-ra
             '[:join {:conditions [{col col}]}
-              [:scan {:table #xt/table xt_docs, :columns [_id {col (== col 3)}]}]
-              [:scan {:table #xt/table xt_docs, :columns [_id col]}]]
+              [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id {col (== col 3)}]}]
+              [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id col]}]]
             {:node tu/*node*}))))
 
 (deftest test-decimal-support
@@ -1087,7 +1087,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
                        bar #xt/type [:? :utf8]
                        foo #xt/type [:? :utf8]}}
              (tu/query-ra '[:order-by {:order-specs [[_id]]}
-                            [:scan {:table #xt/table device, :columns [_id foo bar]}]]
+                            [:scan {:db-name "xtdb", :table #xt/table device, :columns [_id foo bar]}]]
                           {:node tu/*node*
                            :with-types? true})))
 

--- a/src/test/clojure/xtdb/operator/join_test.clj
+++ b/src/test/clojure/xtdb/operator/join_test.clj
@@ -378,8 +378,8 @@
                  {:val "no-match-y", :m false}}
                (set (tu/query-ra
                      '[:mark-join {:mark-spec {m [{val val}]}}
-                       [:scan {:table #xt/table probe, :columns [val]}]
-                       [:scan {:table #xt/table build, :columns [val]}]]
+                       [:scan {:db-name "xtdb", :table #xt/table probe, :columns [val]}]
+                       [:scan {:db-name "xtdb", :table #xt/table build, :columns [val]}]]
                      {:node node})))))))
 
 (t/deftest test-left-equi-join
@@ -1247,8 +1247,8 @@
 
         (t/testing "inner"
           (let [join (set (tu/query-ra '[:join {:conditions [{foo bar}]}
-                                         [:rename {:columns {_id foo}} [:scan {:table #xt/table foo, :columns [_id]}]]
-                                         [:rename {:columns {_id bar}} [:scan {:table #xt/table bar, :columns [_id]}]]]
+                                         [:rename {:columns {_id foo}} [:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id]}]]
+                                         [:rename {:columns {_id bar}} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_id]}]]]
                                        {:node node}))]
             (t/is (= f-and-b (count join)))
 
@@ -1258,8 +1258,8 @@
 
         (t/testing "LOJ"
           (let [loj (set (tu/query-ra '[:left-outer-join {:conditions [{foo bar}]}
-                                        [:rename {:columns {_id foo}} [:scan {:table #xt/table foo, :columns [_id]}]]
-                                        [:rename {:columns {_id bar}} [:scan {:table #xt/table bar, :columns [_id]}]]]
+                                        [:rename {:columns {_id foo}} [:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id]}]]
+                                        [:rename {:columns {_id bar}} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_id]}]]]
                                       {:node node}))
                 foos (into #{} (map :foo) loj)
                 bars (into #{} (map :bar) loj)]
@@ -1274,8 +1274,8 @@
 
         (t/testing "LOJ flipped"
           (let [loj (set (tu/query-ra '[:left-outer-join {:conditions [{bar foo}]}
-                                        [:rename {:columns {_id bar}} [:scan {:table #xt/table bar, :columns [_id]}]]
-                                        [:rename {:columns {_id foo}} [:scan {:table #xt/table foo, :columns [_id]}]]]
+                                        [:rename {:columns {_id bar}} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_id]}]]
+                                        [:rename {:columns {_id foo}} [:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id]}]]]
                                       {:node node}))
                 foos (into #{} (map :foo) loj)
                 bars (into #{} (map :bar) loj)]
@@ -1290,8 +1290,8 @@
 
         (t/testing "FOJ"
           (let [foj (set (tu/query-ra '[:full-outer-join {:conditions [{foo bar}]}
-                                        [:rename {:columns {_id foo}} [:scan {:table #xt/table foo, :columns [_id]}]]
-                                        [:rename {:columns {_id bar}} [:scan {:table #xt/table bar, :columns [_id]}]]]
+                                        [:rename {:columns {_id foo}} [:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id]}]]
+                                        [:rename {:columns {_id bar}} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_id]}]]]
                                       {:node node}))
                 foos (into #{} (map :foo) foj)
                 bars (into #{} (map :bar) foj)]
@@ -1329,8 +1329,8 @@
       (t/is (= [{:foo id1, :bar id1, :a 1, :b 1} {:foo id2, :bar id2, :a 2, :b 2}]
                (tu/query-ra '[:order-by {:order-specs [[a]]}
                               [:join {:conditions [{foo bar}]}
-                               [:rename {:columns {_id foo}} [:scan {:table #xt/table foo, :columns [_id a]}]]
-                               [:rename {:columns {_id bar}} [:scan {:table #xt/table bar, :columns [_id b]}]]]]
+                               [:rename {:columns {_id foo}} [:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id a]}]]
+                               [:rename {:columns {_id bar}} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_id b]}]]]]
                             {:node node}))))))
 
 ;; Regression test for #5153 fix: semi-join IID pushdown for UUID columns

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -26,7 +26,7 @@
 
   (t/is (= #{{:xt/id :bar, :col1 "bar1", :col2 "bar2"}
              {:xt/id :foo, :col2 "baz2"}}
-           (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id col1 col2]}]
+           (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id col1 col2]}]
                              {:node tu/*node*})))))
 
 (t/deftest test-simple-scan-with-namespaced-attributes
@@ -36,14 +36,14 @@
 
   (t/is (= #{{:xt/id :bar, :the-ns/col1 "bar1", :col2 "bar2"}
              {:xt/id :foo}}
-           (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id the_ns$col1 col2]}]
+           (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id the_ns$col1 col2]}]
                              {:node tu/*node*})))))
 
 (t/deftest test-duplicates-in-scan-1
   (xt/submit-tx tu/*node* [[:put-docs :xt_docs {:xt/id :foo}]])
 
   (t/is (= [{:xt/id :foo}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id _id]}]
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id _id]}]
                         {:node tu/*node*}))))
 
 (t/deftest test-block-boundary
@@ -56,7 +56,7 @@
       (c/compact-all! node #xt/duration "PT1S"))
 
     (t/is (= (set (for [i (range 110)] {:xt/id i}))
-             (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id]}]
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id]}]
                                {:node node}))))))
 
 (t/deftest test-block-boundary-different-struct-types
@@ -70,7 +70,7 @@
     (t/is (= {{:bar 42} 20, {:bar "forty-two"} 20}
              (frequencies (tu/query-ra
                            '[:project {:projections [{bar (. foo :bar)}]}
-                             [:scan {:table #xt/table xt_docs, :columns [foo]}]]
+                             [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [foo]}]]
                            {:node node}))))
 
     (c/compact-all! node #xt/duration "PT1S")
@@ -78,7 +78,7 @@
     (t/is (= {{:bar 42} 20, {:bar "forty-two"} 20}
              (frequencies (tu/query-ra
                            '[:project {:projections [{bar (. foo :bar)}]}
-                             [:scan {:table #xt/table xt_docs, :columns [foo]}]]
+                             [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [foo]}]]
                            {:node node}))))))
 
 (t/deftest test-row-copying-different-struct-types-between-block-boundaries-3338
@@ -95,7 +95,7 @@
                                ;; the cross-join copies data from the underlying MultiVectorReader
                                '[:apply {:mode :cross-join, :columns {}}
                                  [:table {:rows [{}]}]
-                                 [:scan {:table #xt/table xt_docs, :columns [foo]}]]
+                                 [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [foo]}]]
                                {:node node})))))))
 
 (t/deftest test-smaller-page-limit
@@ -105,7 +105,7 @@
     (tu/flush-block! node)
 
     (t/is (= (into #{} (map #(hash-map :xt/id %)) (range 20))
-             (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id]}]
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id]}]
                                {:node node}))))))
 
 (t/deftest test-metadata
@@ -119,7 +119,7 @@
     (c/compact-all! node #xt/duration "PT1S")
 
     (t/is (= (set (concat (for [i (range 20)] {:xt/id i}) (for [i (range 80 100)] {:xt/id i})))
-             (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [{_id (or (< _id 20)
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [{_id (or (< _id 20)
                                                                          (>= _id 80))}]}]
                                {:node node})))
           "testing only getting some trie matches"))
@@ -132,12 +132,12 @@
     (c/compact-all! node #xt/duration "PT1S")
 
     (t/is (= []
-             (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [{_id (< _id 20)}]}]
+             (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [{_id (< _id 20)}]}]
                           {:node node}))
           "testing newer blocks relevant even if not matching")
 
     (t/is (= []
-             (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [toto]}]
+             (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [toto]}]
                           {:node node}))
           "testing nothing matches"))
 
@@ -147,7 +147,7 @@
     (tu/flush-block! tu/*node*)
 
     (t/is (= [{:boolean-or-int true}]
-             (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [{boolean_or_int (== boolean_or_int true)}]}]
+             (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [{boolean_or_int (== boolean_or_int true)}]}]
                           {:node tu/*node*})))))
 
 (t/deftest test-past-point-point-queries
@@ -166,28 +166,28 @@
 
   ;; valid-time
   (t/is (= {{:v 1, :xt/id :doc1} 1 {:v 1, :xt/id :doc2} 1}
-           (frequencies (tu/query-ra '[:scan {:table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :for-system-time nil, :columns [_id v]}]
+           (frequencies (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :for-system-time nil, :columns [_id v]}]
                                      {:node tu/*node*}))))
 
   (t/is (= {{:v 1, :xt/id :doc2} 1 {:v 2, :xt/id :doc1} 1}
-           (frequencies (tu/query-ra '[:scan {:table #xt/table xt_docs, :for-valid-time [:at :now], :for-system-time nil, :columns [_id v]}]
+           (frequencies (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at :now], :for-system-time nil, :columns [_id v]}]
                                      {:node tu/*node*}))))
 
   ;; system-time
   (t/is (= {{:v 1, :xt/id :doc1} 1 {:v 1, :xt/id :doc2} 1 {:v 1, :xt/id :doc3} 1}
-           (frequencies (tu/query-ra '[:scan {:table #xt/table xt_docs, :for-system-time [:at #inst "2020-01-01"], :columns [_id v]}]
+           (frequencies (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-system-time [:at #inst "2020-01-01"], :columns [_id v]}]
                                      {:node tu/*node*}))))
 
   (t/is (= {{:v 1, :xt/id :doc1} 1 {:v 1, :xt/id :doc2} 1}
-           (frequencies (tu/query-ra '[:scan {:table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :for-system-time [:at #inst "2020-01-01"], :columns [_id v]}]
+           (frequencies (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :for-system-time [:at #inst "2020-01-01"], :columns [_id v]}]
                                      {:node tu/*node*}))))
 
   (t/is (= {{:v 2, :xt/id :doc1} 1 {:v 1, :xt/id :doc2} 1}
-           (frequencies (tu/query-ra '[:scan {:table #xt/table xt_docs, :for-valid-time [:at :now], :for-system-time [:at #inst "2020-01-02"], :columns [_id v]}]
+           (frequencies (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at :now], :for-system-time [:at #inst "2020-01-02"], :columns [_id v]}]
                                      {:node tu/*node*}))))
 
   (t/is (= {{:v 2, :xt/id :doc1} 1 {:v 2, :xt/id :doc2} 1}
-           (frequencies (tu/query-ra '[:scan {:table #xt/table xt_docs
+           (frequencies (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs
                                               :for-valid-time [:at #inst "2100"]
                                               :for-system-time [:at #inst "2020-01-02"], :columns [_id v]}]
                                      {:node tu/*node*})))))
@@ -214,7 +214,7 @@
                 :xt/valid-from #xt/zoned-date-time "2015-01-01T00:00Z[UTC]",
                 :xt/valid-to #xt/zoned-date-time "2100-01-01T00:00Z[UTC]"}}
              (set (tu/query-ra '[:scan
-                                 {:table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :columns [_id v _valid_from _valid_to]}]
+                                 {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :columns [_id v _valid_from _valid_to]}]
                                {:node tu/*node*}))))
 
     (t/is (= #{{:v 2, :xt/id :doc1
@@ -224,7 +224,7 @@
                 :xt/valid-from #xt/zoned-date-time "2015-01-01T00:00Z[UTC]",
                 :xt/valid-to #xt/zoned-date-time "2100-01-01T00:00Z[UTC]"}}
              (set (tu/query-ra '[:scan
-                                 {:table #xt/table xt_docs, :for-valid-time [:at #inst "2023"], :columns [_id v _valid_from _valid_to]}]
+                                 {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2023"], :columns [_id v _valid_from _valid_to]}]
                                {:node tu/*node*}))))
     ;; system-time
     (t/is (= #{{:v 1, :xt/id :doc1,
@@ -233,14 +233,14 @@
                 :xt/valid-from #xt/zoned-date-time "2015-01-01T00:00Z[UTC]"}
                {:v 1, :xt/id :doc3,
                 :xt/valid-from #xt/zoned-date-time "2018-01-01T00:00Z[UTC]"}}
-             (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :for-valid-time [:at #inst "2023"], :for-system-time [:at #inst "2020"], :columns [_id v _valid_from _valid_to]}]
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2023"], :for-system-time [:at #inst "2020"], :columns [_id v _valid_from _valid_to]}]
                                {:node tu/*node*}))))
 
     (t/is (= #{{:v 1, :xt/id :doc1,
                 :xt/valid-from #xt/zoned-date-time "2015-01-01T00:00Z[UTC]"}
                {:v 1, :xt/id :doc2,
                 :xt/valid-from #xt/zoned-date-time "2015-01-01T00:00Z[UTC]"}}
-             (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :for-system-time [:at #inst "2020"], :columns [_id v _valid_from _valid_to]}]
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2017"], :for-system-time [:at #inst "2020"], :columns [_id v _valid_from _valid_to]}]
                                {:node tu/*node*}))))
 
     (t/is (= #{{:v 2, :xt/id :doc1,
@@ -249,7 +249,7 @@
                 :xt/valid-from #xt/zoned-date-time "2015-01-01T00:00Z[UTC]",
                 :xt/valid-to #xt/zoned-date-time "2100-01-01T00:00Z[UTC]",}}
              (set (tu/query-ra '[:scan
-                                 {:table #xt/table xt_docs, :for-valid-time [:at #inst "2023"], :for-system-time [:at #inst "2020-01-02"], :columns [_id v _valid_from _valid_to]}]
+                                 {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2023"], :for-system-time [:at #inst "2020-01-02"], :columns [_id v _valid_from _valid_to]}]
                                {:node tu/*node*}))))
 
     #_
@@ -258,14 +258,14 @@
                {:v 2, :xt/id :doc2,
                 :xt/valid-from #xt/zoned-date-time "2100-01-01T00:00Z[UTC]"}}
              (set (tu/query-ra '[:scan
-                                 {:table #xt/table xt_docs, :for-valid-time [:at #inst "2100"], :for-system-time [:at #inst "2020-01-02"], :columns [_id v _valid_from _valid_to]}]
+                                 {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time [:at #inst "2100"], :for-system-time [:at #inst "2020-01-02"], :columns [_id v _valid_from _valid_to]}]
                                {:node tu/*node*}))))))
 
 (t/deftest test-scanning-temporal-cols
   (xt/submit-tx tu/*node* [[:put-docs {:into :xt_docs, :valid-from #inst "2021", :valid-to #inst "3000"}
                             {:xt/id :doc}]])
 
-  (let [res (first (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id
+  (let [res (first (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id
                                    _valid_from _valid_to
                                    _system_from _system_to]}]
                                 {:node tu/*node*}))]
@@ -279,7 +279,7 @@
            (-> (first (tu/query-ra '[:project {:projections [_id
                                                              {app_time_start _valid_from}
                                                              {app_time_end _valid_to}]}
-                                     [:scan {:table #xt/table xt_docs, :columns [_id _valid_from _valid_to]}]]
+                                     [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id _valid_from _valid_to]}]]
                                    {:node tu/*node*}))
                (dissoc :xt/system-from :xt/system-to)))))
 
@@ -289,7 +289,7 @@
 
     (t/is (= #{{:xt/valid-from (time/->zdt tt)
                 :xt/system-from (time/->zdt tt)}}
-             (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_valid_from _valid_to
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_valid_from _valid_to
                                   _system_from _system_to]}]
                                {:node tu/*node*}))))))
 
@@ -311,7 +311,7 @@
               :xt/valid-from #xt/zoned-date-time "3001-01-01T00:00Z[UTC]",
               :xt/system-from #xt/zoned-date-time "3000-01-01T00:00Z[UTC]",
               :xt/system-to #xt/zoned-date-time "3001-01-01T00:00Z[UTC]"}}
-           (set (tu/query-ra '[:scan {:table #xt/table foo,
+           (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table foo,
                                       :for-system-time [:between #xt/zoned-date-time "2999-01-01T00:00Z" #xt/zoned-date-time "3002-01-01T00:00Z"]
                                       :for-valid-time :all-time, :columns [_system_from _system_to
                                 _valid_from _valid_to
@@ -327,20 +327,20 @@
     (xt/submit-tx tu/*node* [[:put-docs {:into :foo, :valid-from tt2}
                               {:xt/id 2, :version "version 2" :last_updated "tx2"}]])
     (t/is (= #{{:xt/id 1, :version "version 1"} {:xt/id 2, :version "version 2"}}
-             (set (tu/query-ra '[:scan {:table #xt/table foo,
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table foo,
                                         :for-valid-time [:between ?_start ?_end], :columns [_id version]}]
                                {:node tu/*node*
                                 :args {:_start (time/->instant tt1), :_end nil}}))))
     (t/is (= #{{:xt/id 1, :version "version 1"} {:xt/id 2, :version "version 2"}}
              (set
-              (tu/query-ra '[:scan {:table #xt/table foo,
+              (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table foo,
                                     :for-valid-time :all-time, :columns [_id version]}]
                            {:node tu/*node*}))))))
 
 (t/deftest test-scan-col-types
   (letfn [(->col-type [col]
             (:types
-             (tu/query-ra `[:scan {:table #xt/table xt_docs, :columns [~col]}]
+             (tu/query-ra `[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [~col]}]
                           {:node tu/*node*, :with-types? true})))]
 
     (xt/execute-tx tu/*node* [[:put-docs :xt_docs {:xt/id :doc}]])
@@ -360,7 +360,7 @@
                            [:put-docs :xt_docs {:xt/id :petr, :first-name "Petr", :last-name "Petrov"}]])
   (t/is (= [{:first-name "Ivan", :xt/id :ivan}]
            (tu/query-ra '[:scan
-                          {:table #xt/table xt_docs, :for-valid-time nil, :for-system-time nil, :columns [{first_name (== first_name "Ivan")} _id]}]
+                          {:db-name "xtdb", :table #xt/table xt_docs, :for-valid-time nil, :for-system-time nil, :columns [{first_name (== first_name "Ivan")} _id]}]
                         {:node tu/*node*}))))
 
 (t/deftest test-absent-columns
@@ -370,14 +370,14 @@
 
   ;; column not existent in all docs
   (t/is (= [{:col2 "bar2", :xt/id :bar}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id {col2 (== col2 "bar2")}]}]
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id {col2 (== col2 "bar2")}]}]
                         {:node tu/*node*})))
 
   #_
   ;; column not existent at all
   (t/is (= []
            (tu/query-ra
-            '[:scan {:table #xt/table xt_docs, :columns [_id {col-x (== col-x "toto")}]}]
+            '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id {col-x (== col-x "toto")}]}]
             {:node tu/*node*}))))
 
 (t/deftest test-iid-fast-path
@@ -414,20 +414,20 @@
                         iid-set))]
 
         (t/is (= [{:version 2, :xt/id search-uuid}]
-                 (tu/query-ra [:scan {:table #xt/table xt_docs, :columns ['version {'_id (list '== '_id search-uuid)}]}]
+                 (tu/query-ra [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns ['version {'_id (list '== '_id search-uuid)}]}]
                               {:node tu/*node*})))
 
         (t/is (= [{:version 2, :xt/id search-uuid}]
-                 (tu/query-ra [:scan {:table #xt/table xt_docs, :columns ['version {'_id (list '==  search-uuid '_id)}]}]
+                 (tu/query-ra [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns ['version {'_id (list '==  search-uuid '_id)}]}]
                               {:node tu/*node*})))
 
         (t/is (= [{:version 2, :xt/id search-uuid}]
-                 (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [version {_id (== _id ?search_uuid)}]}]
+                 (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [version {_id (== _id ?search_uuid)}]}]
                               {:node tu/*node*, :args {:search-uuid #uuid "80000000-0000-0000-0000-000000000000"}})))
 
         (t/is (= [{:version 2, :xt/id search-uuid}
                   {:version 1, :xt/id search-uuid}]
-                 (tu/query-ra [:scan {:table #xt/table xt_docs
+                 (tu/query-ra [:scan {:db-name "xtdb", :table #xt/table xt_docs
                                       :for-valid-time :all-time, :columns ['version {'_id (list '== '_id search-uuid)}]}]
                               {:node tu/*node*})))))))
 
@@ -478,7 +478,7 @@
                             (assert (> (.size iid-set) 1) "Should use MultiIidSelector"))
                           iid-set))]
           (t/is (= #{{:v 1, :xt/id uuid1} {:v 2, :xt/id uuid2}}
-                   (set (tu/query-ra [:scan {:table #xt/table xt_docs
+                   (set (tu/query-ra [:scan {:db-name "xtdb", :table #xt/table xt_docs
                                              :columns ['v {'_id (list 'or
                                                                       (list '== '_id uuid1)
                                                                       (list '== '_id uuid2))}]}]
@@ -499,11 +499,11 @@
            (mapv #(xt/submit-tx node %)))
 
       (t/is (= [{:version (last @!search-uuid-versions), :xt/id search-uuid}]
-               (tu/query-ra [:scan {:table #xt/table xt_docs, :columns ['version {'_id (list '== '_id search-uuid)}]}]
+               (tu/query-ra [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns ['version {'_id (list '== '_id search-uuid)}]}]
                             {:node node})))
 
       (t/is (=  (into #{} @!search-uuid-versions)
-                (->> (tu/query-ra [:scan {:table #xt/table xt_docs
+                (->> (tu/query-ra [:scan {:db-name "xtdb", :table #xt/table xt_docs
                                           :for-valid-time :all-time, :columns ['version {'_id (list '== '_id search-uuid)}]}]
                                   {:node node})
                      (map :version)
@@ -529,7 +529,7 @@
       (c/compact-all! node #xt/duration "PT1S")
 
       (t/is (= [{:xt/id search-uuid}]
-               (tu/query-ra (xt/template [:scan {:table #xt/table xt_docs, :columns [{~'_id (== ~'_id ~search-uuid)}]}])
+               (tu/query-ra (xt/template [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [{~'_id (== ~'_id ~search-uuid)}]}])
                             {:node node}))))))
 
 (deftest test-live-tries-with-multiple-leaves-are-loaded-correctly-2710
@@ -537,7 +537,7 @@
     (xt/execute-tx node (for [i (range 20)] [:put-docs :xt_docs {:xt/id i}]))
 
     (t/is (= (into #{} (map #(hash-map :xt/id %)) (range 20))
-             (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id]}]
+             (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id]}]
                                {:node node}))))))
 
 (deftest test-pushdown-blooms
@@ -550,8 +550,8 @@
   (c/compact-all! tu/*node* #xt/duration "PT1S")
 
   (let [ra-query '[:join {:conditions [{col col}]}
-                   [:scan {:table #xt/table xt_docs, :columns [col {col (== col "toto")}]}]
-                   [:scan {:table #xt/table xt_docs, :columns [col]}]]]
+                   [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [col {col (== col "toto")}]}]
+                   [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [col]}]]]
 
     (t/testing "results are correct"
       (t/is (= [{:col "toto"}]
@@ -572,9 +572,9 @@
                             [:put-docs :xt-docs {:xt/id :toto, :col "toto"}]])
 
   (let [ra-query '[:join {:conditions [{col renamed-col}]}
-                   [:scan {:table #xt/table xt_docs, :columns [col {col (== col "toto")}]}]
+                   [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [col {col (== col "toto")}]}]
                    [:project {:projections [{renamed-col col}]}
-                    [:scan {:table #xt/table xt_docs, :columns [col]}]]]]
+                    [:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [col]}]]]]
 
     (t/testing "results are correct"
       (t/is (= [{:renamed-col "toto", :col "toto"}]
@@ -601,12 +601,12 @@
         ;; first + second page
         (t/is (= 32
                  (count (tu/query-ra
-                         '[:scan {:table #xt/table docs, :columns [xt/id]}]
+                         '[:scan {:db-name "xtdb", :table #xt/table docs, :columns [xt/id]}]
                          {:node node}))))
 
         (t/is (= (into #{} (concat first-page second-page))
                  (into #{} (map :xt/id) (tu/query-ra
-                                         '[:scan {:table #xt/table docs, :columns [_id]}]
+                                         '[:scan {:db-name "xtdb", :table #xt/table docs, :columns [_id]}]
                                          {:node node}))))))))
 
 (deftest dont-use-fast-path-on-non-literals-2768
@@ -614,7 +614,7 @@
                            [:put-docs :xt-docs {:xt/id "bar-start" :v "bar-start"}]])
 
   (t/is (= [#:xt{:id "foo-start"}]
-           (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [{_id (== "foo" (substring _id 1 3))}]}]
+           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [{_id (== "foo" (substring _id 1 3))}]}]
                         {:node tu/*node*}))))
 
 (t/deftest test-iid-col-type-3016
@@ -624,7 +624,7 @@
             '_valid_from #xt/type :instant
             '_valid_to #xt/type [:? :instant]}
 
-           (:types (tu/query-ra '[:scan {:table #xt/table comments, :columns [_iid _valid_from _valid_to]}]
+           (:types (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table comments, :columns [_iid _valid_from _valid_to]}]
                                     {:node tu/*node*
                                      :with-types? true})))))
 
@@ -668,13 +668,13 @@
           ;; no filter, we should still get the latest entry (2025)
           (t/is (= [{:xt/id 1,
                      :xt/valid-from #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}]
-                   (tu/query-ra '[:scan {:table #xt/table docs, :columns [_id _valid_from]}] query-opts)))
+                   (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :columns [_id _valid_from]}] query-opts)))
 
           ;; one day earlier we still get the 2024 entry
           (t/is (= [{:xt/id 1,
                      :xt/valid-from #xt/zoned-date-time "2024-01-01T00:00Z[UTC]",
                      :xt/valid-to #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}]
-                   (tu/query-ra '[:scan {:table #xt/table docs, :columns [_id _valid_from _valid_to]}]
+                   (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :columns [_id _valid_from _valid_to]}]
                                 (assoc query-opts :current-time #xt/instant "2024-12-30T00:00:00Z"))))
 
           ;; two entries 2024 and 2025
@@ -683,21 +683,21 @@
                       :xt/valid-to #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}
                      {:xt/id 1,
                       :xt/valid-from #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}}
-                   (set (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time [:between #inst "2024" #inst "2026"], :columns [_id _valid_from _valid_to]}]
+                   (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time [:between #inst "2024" #inst "2026"], :columns [_id _valid_from _valid_to]}]
                                      query-opts))))
 
 
           ;; newest entry, basis at 2025
           (t/is (= [{:xt/id 1,
                      :xt/valid-from #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}]
-                   (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time [:between #inst "2026" nil], :columns [_id _valid_from _valid_to]}]
+                   (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time [:between #inst "2026" nil], :columns [_id _valid_from _valid_to]}]
                                 query-opts)))
           ;; everything
           (t/is (= (repeat 6 {:xt/id 1})
-                   (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time :all-time, :columns [_id]}] query-opts)))
+                   (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time :all-time, :columns [_id]}] query-opts)))
 
           (t/is (= (repeat 11 {:xt/id 1})
-                   (tu/query-ra '[:scan {:table #xt/table docs
+                   (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs
                                          :for-valid-time :all-time
                                          :for-system-time :all-time, :columns [_id]}] query-opts))))))))
 
@@ -728,7 +728,7 @@
             (t/is (= [{:xt/id 1,
                        :xt/valid-from #xt/zoned-date-time "2024-01-01T00:00Z[UTC]",
                        :xt/valid-to #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}]
-                     (tu/query-ra '[:scan {:table #xt/table docs, :columns [_id _valid_from _valid_to]}]
+                     (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :columns [_id _valid_from _valid_to]}]
                                   (assoc query-opts :current-time #xt/instant "2024-12-30T00:00:00Z"))))
             ;; two entries 2024 and 2025
             (t/is (= [{:xt/id 1,
@@ -737,7 +737,7 @@
                       {:xt/id 1,
                        :xt/valid-from #xt/zoned-date-time "2024-01-01T00:00Z[UTC]",
                        :xt/valid-to #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}]
-                     (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time [:between #inst "2024" #inst "2026"], :columns [_id _valid_from _valid_to]}]
+                     (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time [:between #inst "2024" #inst "2026"], :columns [_id _valid_from _valid_to]}]
                                   query-opts)))
 
 
@@ -745,12 +745,12 @@
             (t/is (= [{:xt/id 1,
                        :xt/valid-from #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"
                        :xt/valid-to #xt/zoned-date-time "2026-01-01T00:00Z[UTC]"}]
-                     (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time [:between #inst "2025-12-30" nil], :columns [_id _valid_from _valid_to]}]
+                     (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time [:between #inst "2025-12-30" nil], :columns [_id _valid_from _valid_to]}]
                                   query-opts)))
 
             ;; everything
             (t/is (= (repeat 6 {:xt/id 1})
-                     (tu/query-ra '[:scan {:table #xt/table docs
+                     (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs
                                            :for-valid-time :all-time
                                            :for-system-time :all-time, :columns [_id]}] query-opts)))
 
@@ -783,7 +783,7 @@
                             {:xt/id 1,
                              :xt/valid-from #xt/zoned-date-time "2024-01-01T00:00Z[UTC]",
                              :xt/valid-to #xt/zoned-date-time "2025-01-01T00:00Z[UTC]"}]
-                           (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time [:in #inst "2024" #inst "2026"], :columns [_id _valid_from _valid_to]}]
+                           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time [:in #inst "2024" #inst "2026"], :columns [_id _valid_from _valid_to]}]
                                         query-opts))))
 
                 (t/testing "earlier system times get ignored via the basis"
@@ -793,7 +793,7 @@
                                  :valid-from #xt/zoned-date-time "2026-01-01T00:00Z[UTC]",
                                  :id 1}]
 
-                           (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time [:between #inst "2026" #inst "3000"], :columns [_id _valid_from _valid_to]}]
+                           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time [:between #inst "2026" #inst "3000"], :columns [_id _valid_from _valid_to]}]
                                         query-opts))))
 
                 (t/testing "earlier system times bound the interval even when laying outside"
@@ -803,7 +803,7 @@
                             #:xt{:valid-to #xt/zoned-date-time "2027-01-01T00:00Z[UTC]",
                                  :valid-from #xt/zoned-date-time "2026-01-01T00:00Z[UTC]",
                                  :id 1}]
-                           (tu/query-ra '[:scan {:table #xt/table docs, :for-valid-time [:between #inst "2026" #inst "2027"], :columns [_id _valid_from _valid_to]}]
+                           (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table docs, :for-valid-time [:between #inst "2026" #inst "2027"], :columns [_id _valid_from _valid_to]}]
                                         (assoc query-opts :snapshot-token (basis/->time-basis-str {"xtdb" [(:system-time tx-key3)]}))))))))))))))
 
 (t/deftest ^:integration test-page-filtering

--- a/src/test/clojure/xtdb/operator/unnest_test.clj
+++ b/src/test/clojure/xtdb/operator/unnest_test.clj
@@ -131,7 +131,7 @@
                 {:columns {x1 unnest}, :ordinality-column o1}
                 [:map
                  {:projections [{unnest xs}]}
-                 [:scan {:table #xt/table r1, :columns [xs]}]]]]]
+                 [:scan {:db-name "xtdb", :table #xt/table r1, :columns [xs]}]]]]]
             {:node tu/*node*}))))
 
 (t/deftest unnest-issue-4441
@@ -146,7 +146,7 @@
            (tu/query-ra
             '[:unnest
               {:columns {x1 xs}}
-              [:scan {:table #xt/table r1, :columns [xs]}]]
+              [:scan {:db-name "xtdb", :table #xt/table r1, :columns [xs]}]]
             {:node tu/*node*}))))
 
 (t/deftest unnest-ordinality-join-issue-4131

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -41,11 +41,11 @@
     (let [block-cat (.getBlockCatalog (db/primary-db node))]
       (letfn [(test-query-ivan [expected]
                 (t/is (= expected
-                         (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id name {ordinal (> ordinal 1)}]}]
+                         (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id name {ordinal (> ordinal 1)}]}]
                                            {:node node}))))
 
                 (t/is (= expected
-                         (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [_id name {ordinal (> ordinal ?ordinal)}]}]
+                         (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id name {ordinal (> ordinal ?ordinal)}]}]
                                            {:node node, :args {:ordinal 1}})))))]
 
         (t/is (= 1 (.getCurrentBlockIndex block-cat)))
@@ -132,11 +132,11 @@
                   (t/is (true? (.test (.build param-sel page-metadata) 0)))))))))
 
       (t/is (= #{{:name "Ivan"}}
-               (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [{name (== name "Ivan")}]}]
+               (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [{name (== name "Ivan")}]}]
                                  {:node node}))))
 
       (t/is (= #{{:name "Ivan"}}
-               (set (tu/query-ra '[:scan {:table #xt/table xt_docs, :columns [{name (== name ?name)}]}]
+               (set (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [{name (== name ?name)}]}]
                                  {:node node, :args {:name "Ivan"}})))))))
 
 (t/deftest test-temporal-bounds
@@ -145,7 +145,7 @@
         tx2 (xt/execute-tx tu/*node* [[:put-docs :xt_docs {:xt/id :my-doc, :last-updated "tx2"}]])
         tt2 (.getSystemTime tx2)]
     (letfn [(q [& temporal-constraints]
-              (->> (tu/query-ra [:scan {:table #xt/table xt_docs, :for-system-time :all-time, :for-valid-time :all-time,
+              (->> (tu/query-ra [:scan {:db-name "xtdb", :table #xt/table xt_docs, :for-system-time :all-time, :for-valid-time :all-time,
                                         :columns (into '[last_updated] temporal-constraints)}]
                                 {:node tu/*node*, :args {:system-time1 tt1, :system-time2 tt2}})
                    (into #{} (map :last-updated))))]
@@ -362,17 +362,17 @@
 
       (t/is (= {:res [{:xt/id "xtdb-db"}],
                 :types '{_id #xt/type :utf8}}
-               (tu/query-ra '[:scan {:table #xt/table foo, :columns [_id]}]
+               (tu/query-ra '[:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id]}]
                             {:node node, :with-types? true})))
 
       (t/is (= {:res [{:xt/id :new-db}],
                 :types '{_id #xt/type :keyword}}
-               (tu/query-ra '[:scan {:table #xt/table [new_db foo], :columns [_id]}]
+               (tu/query-ra '[:scan {:db-name "new_db", :table #xt/table foo, :columns [_id]}]
                             {:node node, :default-db "new_db", :with-types? true})))
 
       (let [{:keys [res types]} (tu/query-ra '[:union-all {}
-                                               [:scan {:table #xt/table [xtdb foo], :columns [_id]}]
-                                               [:scan {:table #xt/table [new_db foo], :columns [_id]}]]
+                                               [:scan {:db-name "xtdb", :table #xt/table foo, :columns [_id]}]
+                                               [:scan {:db-name "new_db", :table #xt/table foo, :columns [_id]}]]
                                              {:node node, :with-types? true})]
         (t/is (= #{{:xt/id "xtdb-db"} {:xt/id :new-db}} (set res)))
 

--- a/src/test/clojure/xtdb/stats_test.clj
+++ b/src/test/clojure/xtdb/stats_test.clj
@@ -24,13 +24,13 @@
                            [:put-docs :bar {:xt/id "bar2"}]])
 
       (t/is (= {:row-count 3}
-               (:stats (lp/emit-expr '{:op :scan, :opts {:table #xt/table foo, :columns [[:column id]]}}
+               (:stats (lp/emit-expr '{:op :scan, :opts {:db-name "xtdb", :table #xt/table foo, :columns [[:column id]]}}
                                      {:scan-fields {['foo 'id] #xt/field {"id" :utf8}},
                                       :scan-emitter scan-emitter
                                       :db-cat db-cat}))))
 
       (t/is (= {:row-count 2}
-               (:stats (lp/emit-expr '{:op :scan, :opts {:table #xt/table bar, :columns [[:column id]]}}
+               (:stats (lp/emit-expr '{:op :scan, :opts {:db-name "xtdb", :table #xt/table bar, :columns [[:column id]]}}
                                      {:scan-fields {['bar 'id] #xt/field {"id" :utf8}},
                                       :scan-emitter scan-emitter
                                       :db-cat db-cat})))))))

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -10,13 +10,13 @@
   "system_time" [-2034527697 6.01764709272061],
   "committed" [1743138479 1.0004885993744506],
   "user_metadata" [1742602241 0.0],
-  "error" [468236000 1.0004885993744506]},
+  "error" [555293598 1.0004885993744506]},
  :partitions
  [{:level 0,
    :part [],
    :tries
    [{:trie-key "l00-rc-b00",
-     :data-file-size 3550,
+     :data-file-size 3534,
      :trie-metadata
      {:min-valid-from #xt/instant "2020-01-01T00:00:00Z",
       :max-valid-from #xt/instant "2020-01-06T00:00:00Z",

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/tables/xt$txs/blocks/b00.binpb.edn
@@ -10,13 +10,13 @@
   "system_time" [-1544051178 3.004403133222472],
   "committed" [1743138479 1.0004885993744506],
   "user_metadata" [1742602241 0.0],
-  "error" [395225469 1.0004885993744506]},
+  "error" [-558930497 1.0004885993744506]},
  :partitions
  [{:level 0,
    :part [],
    :tries
    [{:trie-key "l00-rc-b00",
-     :data-file-size 3358,
+     :data-file-size 3342,
      :trie-metadata
      {:min-valid-from #xt/instant "2020-01-01T00:00:00Z",
       :max-valid-from #xt/instant "2020-01-03T00:00:00Z",

--- a/src/test/resources/xtdb/sql/plan_test_expectations/all-as-expression-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/all-as-expression-in-select.edn
@@ -2,7 +2,7 @@
  {:projections [{_column_1 (not _sq_2)}]}
  [:mark-join
   {:mark-spec {_sq_2 [(> x.1/z z)]}}
-  [:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [z]}]]
+  [:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [z]}]]
   [:project
    {:projections [{z y.3/z}]}
-   [:rename {:prefix y.3} [:scan {:table #xt/table y, :columns [z]}]]]]]
+   [:rename {:prefix y.3} [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/all-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/all-in-where.edn
@@ -4,9 +4,9 @@
   {:projections [{_sq_2 true}]}
   [:anti-join
    {:conditions [(<= x.1/z z)]}
-   [:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y z]}]]
+   [:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y z]}]]
    [:project
     {:projections [{z y.3/z}]}
     [:rename
      {:prefix y.3}
-     [:scan {:table #xt/table y, :columns [z]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/any-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/any-in-where.edn
@@ -8,9 +8,9 @@
     {:projections [{_needle (== x.1/z 1)}]}
     [:rename
      {:prefix x.1}
-     [:scan {:table #xt/table x, :columns [y z]}]]]
+     [:scan {:db-name "xtdb", :table #xt/table x, :columns [y z]}]]]
    [:project
     {:projections [{z y.3/z}]}
     [:rename
      {:prefix y.3}
-     [:scan {:table #xt/table y, :columns [z]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/application-and-system-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/application-and-system-time-period-spec-between.edn
@@ -3,7 +3,7 @@
   [:rename
    {}
    [:scan
-    {:table t1,
+    {:db-name "xtdb", :table t1,
      :columns [],
      :for-valid-time
      [:between

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-1.edn
@@ -10,7 +10,7 @@
      {:projections [{_row_number_0 (row-number)}]}
      [:rename
       {:prefix tab0.1}
-      [:scan {:table #xt/table tab0, :columns [z]}]]]
+      [:scan {:db-name "xtdb", :table #xt/table tab0, :columns [z]}]]]
     [:rename
      {:prefix x.5}
      [:project

--- a/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/array-agg-decorrelation-2.edn
@@ -4,7 +4,7 @@
   {:mode :single-join, :columns {tab0.1/z ?_sq_z_3}}
   [:rename
    {:prefix tab0.1}
-   [:scan {:table #xt/table tab0, :columns [z]}]]
+   [:scan {:db-name "xtdb", :table #xt/table tab0, :columns [z]}]]
   [:project
    {:projections [{_sq_2 _array_agg_out6}]}
    [:group-by

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-1.edn
@@ -5,9 +5,9 @@
   [[:rename
     {:prefix si.1}
     [:scan
-     {:table #xt/table stars_in, :columns [star_name movie_title]}]]
+     {:db-name "xtdb", :table #xt/table stars_in, :columns [star_name movie_title]}]]
    [:rename
     {:prefix ms.2}
     [:scan
-     {:table #xt/table movie_star,
+     {:db-name "xtdb", :table #xt/table movie_star,
       :columns [{birthdate (== birthdate 1960)} name]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-10.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-10.edn
@@ -4,4 +4,4 @@
   {:columns [{_sum_out_2 (sum m.1/length)}]}
   [:rename
    {:prefix m.1}
-   [:scan {:table #xt/table movie, :columns [length]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table movie, :columns [length]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-11.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-11.edn
@@ -2,4 +2,4 @@
  {:projections [{name si.1/name}]}
  [:rename
   {:prefix si.1}
-  [:scan {:table #xt/table stars_in, :columns [name]}]]]
+  [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-12.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-12.edn
@@ -6,4 +6,4 @@
    {:columns {si.1/name bar}}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [name]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-13.edn
@@ -4,4 +4,4 @@
   {:prefix si.1}
   [:select
    {:predicate (== name lastname)}
-   [:scan {:table #xt/table stars_in, :columns [lastname name]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [lastname name]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-14.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-14.edn
@@ -4,4 +4,4 @@
   {}
   [:rename
    {:prefix si.1}
-   [:scan {:table #xt/table stars_in, :columns [movie_title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [movie_title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-15.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-15.edn
@@ -6,11 +6,11 @@
    {:projections [{name si.1/name}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [name]}]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]]
  [:distinct
   {}
   [:project
    {:projections [{name si.2/name}]}
    [:rename
     {:prefix si.2}
-    [:scan {:table #xt/table stars_in, :columns [name]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-16.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-16.edn
@@ -4,9 +4,9 @@
   {:projections [{name si.1/name}]}
   [:rename
    {:prefix si.1}
-   [:scan {:table #xt/table stars_in, :columns [name]}]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]
  [:project
   {:projections [{name si.2/name}]}
   [:rename
    {:prefix si.2}
-   [:scan {:table #xt/table stars_in, :columns [name]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-17.edn
@@ -6,9 +6,9 @@
    {:projections [{name si.1/name}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [name]}]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]
   [:project
    {:projections [{name si.2/name}]}
    [:rename
     {:prefix si.2}
-    [:scan {:table #xt/table stars_in, :columns [name]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [name]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-18.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-18.edn
@@ -2,7 +2,7 @@
  [:union-all {}
   [:project
    {:projections [{movie_title si.1/movie_title}]}
-   [:rename {:prefix si.1} [:scan {:table stars_in, :columns [movie_title]}]]]
+   [:rename {:prefix si.1} [:scan {:db-name "xtdb", :table stars_in, :columns [movie_title]}]]]
   [:rename {:columns {name movie_title}} [:project
     {:projections [{name si.2/name}]}
-    [:rename {:prefix si.2} [:scan {:table stars_in, :columns [name]}]]]]]]
+    [:rename {:prefix si.2} [:scan {:db-name "xtdb", :table stars_in, :columns [name]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-19.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-19.edn
@@ -4,7 +4,7 @@
   [:union-all {}
    [:project
     {:projections [{name si.1/name}]}
-    [:rename {:prefix si.1} [:scan {:table stars_in, :columns [name]}]]]
+    [:rename {:prefix si.1} [:scan {:db-name "xtdb", :table stars_in, :columns [name]}]]]
    [:project
     {:projections [{name si.2/name}]}
-    [:rename {:prefix si.2} [:scan {:table stars_in, :columns [name]}]]]]]]
+    [:rename {:prefix si.2} [:scan {:db-name "xtdb", :table stars_in, :columns [name]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-2.edn
@@ -5,11 +5,11 @@
   [[:rename
     {:prefix si.1}
     [:scan
-     {:table #xt/table stars_in, :columns [star_name movie_title]}]]
+     {:db-name "xtdb", :table #xt/table stars_in, :columns [star_name movie_title]}]]
    [:rename
     {:prefix ms.2}
     [:scan
-     {:table #xt/table movie_star,
+     {:db-name "xtdb", :table #xt/table movie_star,
       :columns
       [{birthdate (and (< birthdate 1960) (> birthdate 1950))}
        name]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-20.edn
@@ -4,4 +4,4 @@
   {:projections [{movie_title si.1/movie_title}]}
   [:rename
    {:prefix si.1}
-   [:scan {:table #xt/table stars_in, :columns [movie_title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [movie_title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-21.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-21.edn
@@ -4,4 +4,4 @@
   {:projections [{movie_title si.1/movie_title}]}
   [:rename
    {:prefix si.1}
-   [:scan {:table #xt/table stars_in, :columns [movie_title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [movie_title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-22.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-22.edn
@@ -4,4 +4,4 @@
   {:projections [{movie_title si.1/movie_title}]}
   [:rename
    {:prefix si.1}
-   [:scan {:table #xt/table stars_in, :columns [movie_title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [movie_title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-23.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-23.edn
@@ -5,4 +5,4 @@
    [[si.1/movie_title {:direction :asc, :null-ordering :nulls-last}]]}
   [:rename
    {:prefix si.1}
-   [:scan {:table #xt/table stars_in, :columns [movie_title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [movie_title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-24.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-24.edn
@@ -7,4 +7,4 @@
     [[si.1/movie_title {:direction :asc, :null-ordering :nulls-last}]]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [movie_title]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [movie_title]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-25.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-25.edn
@@ -6,4 +6,4 @@
      {:direction :desc, :null-ordering :nulls-first}]]}
   [:rename
    {:prefix si.1}
-   [:scan {:table #xt/table stars_in, :columns [movie_title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [movie_title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-26.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-26.edn
@@ -5,4 +5,4 @@
    [si.1/movie_title {:direction :asc, :null-ordering :nulls-last}]]}
   [:project
    {:projections [si.1/movie_title {_ob2 (== si.1/year "foo")}]}
-   [:rename {:prefix si.1} [:scan {:table stars_in, :columns [year movie_title]}]]]]]
+   [:rename {:prefix si.1} [:scan {:db-name "xtdb", :table stars_in, :columns [year movie_title]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-27.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-27.edn
@@ -6,4 +6,4 @@
    {:projections [{_ob2 si.1/year}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [year movie_title]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [year movie_title]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-28.edn
@@ -6,4 +6,4 @@
    {:projections [{_column_1 (== si.1/year "foo")}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [year]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [year]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-29.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-29.edn
@@ -6,4 +6,4 @@
    {:projections [{unnest si.1/films}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [films]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [films]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-3.edn
@@ -5,10 +5,10 @@
   [[:rename
     {:prefix si.1}
     [:scan
-     {:table #xt/table stars_in, :columns [star_name movie_title]}]]
+     {:db-name "xtdb", :table #xt/table stars_in, :columns [star_name movie_title]}]]
    [:rename
     {:prefix ms.2}
     [:scan
-     {:table #xt/table movie_star,
+     {:db-name "xtdb", :table #xt/table movie_star,
       :columns
       [{birthdate (< birthdate 1960)} {name (== name "Foo")}]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-30.edn
@@ -6,4 +6,4 @@
    {:projections [{unnest si.1/films}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [films]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [films]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-31.edn
@@ -10,4 +10,4 @@
    {:projections [{unnest si.1/films}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [films]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [films]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-34.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-34.edn
@@ -35,4 +35,4 @@
      555)}]}
  [:rename
   {:prefix t1.1}
-  [:scan {:table #xt/table t1, :columns [a e c b d]}]]]
+  [:scan {:db-name "xtdb", :table #xt/table t1, :columns [a e c b d]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-35.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-35.edn
@@ -2,4 +2,4 @@
  {:projections [{a t1.1/a}]}
  [:rename
   {:prefix t1.1}
-  [:scan {:table #xt/table t1, :columns [{a (nil? a)}]}]]]
+  [:scan {:db-name "xtdb", :table #xt/table t1, :columns [{a (nil? a)}]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-36.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-36.edn
@@ -2,4 +2,4 @@
  {:projections [{a t1.1/a}]}
  [:rename
   {:prefix t1.1}
-  [:scan {:table #xt/table t1, :columns [{a (not (nil? a))}]}]]]
+  [:scan {:db-name "xtdb", :table #xt/table t1, :columns [{a (not (nil? a))}]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-37.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-37.edn
@@ -1,3 +1,3 @@
 [:project
  {:projections [{_column_1 (nullif t1.1/a t1.1/b)}]}
- [:rename {:prefix t1.1} [:scan {:table #xt/table t1, :columns [a b]}]]]
+ [:rename {:prefix t1.1} [:scan {:db-name "xtdb", :table #xt/table t1, :columns [a b]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-4.edn
@@ -5,7 +5,7 @@
   [[:rename
     {:prefix si.1}
     [:scan
-     {:table #xt/table stars_in, :columns [star_name movie_title]}]]
+     {:db-name "xtdb", :table #xt/table stars_in, :columns [star_name movie_title]}]]
    [:rename
     {:prefix m.3}
     [:project
@@ -13,5 +13,5 @@
      [:rename
       {:prefix ms.2}
       [:scan
-       {:table #xt/table movie_star,
+       {:db-name "xtdb", :table #xt/table movie_star,
         :columns [{birthdate (== birthdate 1960)} name]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-5.edn
@@ -5,7 +5,7 @@
    [{m.1/title si.2/movie_title} {m.1/movie_year si.2/year}]}
   [[:rename
     {:prefix m.1}
-    [:scan {:table #xt/table movie, :columns [movie_year title]}]]
+    [:scan {:db-name "xtdb", :table #xt/table movie, :columns [movie_year title]}]]
    [:rename
     {:prefix si.2}
-    [:scan {:table #xt/table stars_in, :columns [year movie_title]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [year movie_title]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-6.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-6.edn
@@ -5,7 +5,7 @@
    [{m.1/title si.2/movie_title} {m.1/movie_year si.2/year}]}
   [:rename
    {:prefix m.1}
-   [:scan {:table #xt/table movie, :columns [movie_year title]}]]
+   [:scan {:db-name "xtdb", :table #xt/table movie, :columns [movie_year title]}]]
   [:rename
    {:prefix si.2}
-   [:scan {:table #xt/table stars_in, :columns [year movie_title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [year movie_title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-7.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-7.edn
@@ -4,7 +4,7 @@
   {:conditions [{m.1/title si.2/title}]}
   [[:rename
     {:prefix m.1}
-    [:scan {:table #xt/table movie, :columns [title]}]]
+    [:scan {:db-name "xtdb", :table #xt/table movie, :columns [title]}]]
    [:rename
     {:prefix si.2}
-    [:scan {:table #xt/table stars_in, :columns [title]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [title]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-8.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-8.edn
@@ -4,7 +4,7 @@
   {:conditions [{m.1/title si.2/title}]}
   [:rename
    {:prefix m.1}
-   [:scan {:table #xt/table movie, :columns [title]}]]
+   [:scan {:db-name "xtdb", :table #xt/table movie, :columns [title]}]]
   [:rename
    {:prefix si.2}
-   [:scan {:table #xt/table stars_in, :columns [title]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [title]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/basic-query-9.edn
@@ -11,8 +11,8 @@
     {:conditions [{me.1/cert m.2/producer}]}
     [[:rename
       {:prefix me.1}
-      [:scan {:table #xt/table movie_exec, :columns [name cert]}]]
+      [:scan {:db-name "xtdb", :table #xt/table movie_exec, :columns [name cert]}]]
      [:rename
       {:prefix m.2}
       [:scan
-       {:table #xt/table movie, :columns [producer year length]}]]]]]]]
+       {:db-name "xtdb", :table #xt/table movie, :columns [producer year length]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/correlated-scalar-subquery-in-select.edn
@@ -4,9 +4,9 @@
   {:mode :single-join, :columns {x.1/z ?_sq_z_3}}
   [:rename
    {:prefix x.1}
-   [:scan {:table #xt/table x, :columns [{y (== y 1)} z]}]]
+   [:scan {:db-name "xtdb", :table #xt/table x, :columns [{y (== y 1)} z]}]]
   [:project
    {:projections [{_sq_2 (== foo.3/bar ?_sq_z_3)}]}
    [:rename
     {:prefix foo.3}
-    [:scan {:table #xt/table foo, :columns [bar]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [bar]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/cross-join-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/cross-join-1.edn
@@ -4,7 +4,7 @@
   {:conditions []}
   [[:rename
     {:prefix a.1}
-    [:scan {:table #xt/table a, :columns [a2 a1]}]]
+    [:scan {:db-name "xtdb", :table #xt/table a, :columns [a2 a1]}]]
    [:rename
     {:prefix b.2}
-    [:scan {:table #xt/table b, :columns [b1]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table b, :columns [b1]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/cross-join-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/cross-join-2.edn
@@ -2,8 +2,8 @@
  {:projections [{c1 c.3/c1}]}
  [:mega-join
   {:conditions []}
-  [[:rename {:prefix a.1} [:scan {:table #xt/table a, :columns []}]]
-   [:rename {:prefix b.2} [:scan {:table #xt/table b, :columns []}]]
+  [[:rename {:prefix a.1} [:scan {:db-name "xtdb", :table #xt/table a, :columns []}]]
+   [:rename {:prefix b.2} [:scan {:db-name "xtdb", :table #xt/table b, :columns []}]]
    [:rename
     {:prefix c.3}
-    [:scan {:table #xt/table c, :columns [c1]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table c, :columns [c1]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-1.edn
@@ -13,8 +13,8 @@
       {:projections [{_row_number_0 (row-number)}]}
       [:rename
        {:prefix c.1}
-       [:scan {:table #xt/table customer, :columns [custkey]}]]]
+       [:scan {:db-name "xtdb", :table #xt/table customer, :columns [custkey]}]]]
      [:rename
       {:prefix o.3}
       [:scan
-       {:table #xt/table orders, :columns [custkey totalprice]}]]]]]]]
+       {:db-name "xtdb", :table #xt/table orders, :columns [custkey totalprice]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-2.edn
@@ -8,10 +8,10 @@
    [:rename
     {:prefix customers.1}
     [:scan
-     {:table #xt/table customers,
+     {:db-name "xtdb", :table #xt/table customers,
       :columns [{country (== country "Mexico")} custno]}]]
    [:project
     {:projections [{custno orders.3/custno}]}
     [:rename
      {:prefix orders.3}
-     [:scan {:table #xt/table orders, :columns [custno]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table orders, :columns [custno]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-3.edn
@@ -21,14 +21,14 @@
        [:rename
         {:prefix customers.1}
         [:scan
-         {:table #xt/table customers, :columns [country custno name]}]]
+         {:db-name "xtdb", :table #xt/table customers, :columns [country custno name]}]]
        [:project
         {:projections [{country salesp.3/country}]}
         [:rename
          {:prefix salesp.3}
-         [:scan {:table #xt/table salesp, :columns [country]}]]]]]]
+         [:scan {:db-name "xtdb", :table #xt/table salesp, :columns [country]}]]]]]]
     [:map
      {:projections [{_dep_countable_1 1}]}
      [:rename
       {:prefix orders.5}
-      [:scan {:table #xt/table orders, :columns [custno]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table orders, :columns [custno]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-4.edn
@@ -21,11 +21,11 @@
        {:conditions [{s.1/id e.2/sid}]}
        [[:rename
          {:prefix s.1}
-         [:scan {:table #xt/table students, :columns [name id]}]]
+         [:scan {:db-name "xtdb", :table #xt/table students, :columns [name id]}]]
         [:rename
          {:prefix e.2}
          [:scan
-          {:table #xt/table exams, :columns [sid grade course]}]]]]]
+          {:db-name "xtdb", :table #xt/table exams, :columns [sid grade course]}]]]]]
      [:rename
       {:prefix e2.4}
-      [:scan {:table #xt/table exams, :columns [sid grade]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table exams, :columns [sid grade]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/decorrelation-5.edn
@@ -27,7 +27,7 @@
        [[:rename
          {:prefix s.1}
          [:scan
-          {:table #xt/table students,
+          {:db-name "xtdb", :table #xt/table students,
            :columns
            [name
             year
@@ -36,9 +36,9 @@
         [:rename
          {:prefix e.2}
          [:scan
-          {:table #xt/table exams, :columns [sid grade course]}]]]]]
+          {:db-name "xtdb", :table #xt/table exams, :columns [sid grade course]}]]]]]
      [:rename
       {:prefix e2.4}
       [:scan
-       {:table #xt/table exams,
+       {:db-name "xtdb", :table #xt/table exams,
         :columns [sid date curriculum grade]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/deeply-nested-correlated-query.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/deeply-nested-correlated-query.edn
@@ -4,9 +4,9 @@
    {:mode :semi-join, :columns {x2 ?x13, x4 ?x14}}
    [:mega-join
     {:conditions []}
-    [[:rename {:columns {a x1, b x2}} [:scan {:table r, :columns [a b]}]]
-     [:rename {:columns {c x4}} [:scan {:table s, :columns [c]}]]]]
+    [[:rename {:columns {a x1, b x2}} [:scan {:db-name "xtdb", :table r, :columns [a b]}]]
+     [:rename {:columns {c x4}} [:scan {:db-name "xtdb", :table s, :columns [c]}]]]]
    [:semi-join
     {:conditions [(== x10 ?x14) {x7 x9}]}
-    [:rename {:columns {a x6, b x7}} [:scan {:table r, :columns [{a (== a ?x13)} b]}]]
-    [:rename {:columns {a x9, b x10}} [:scan {:table r, :columns [a b]}]]]]]]
+    [:rename {:columns {a x6, b x7}} [:scan {:db-name "xtdb", :table r, :columns [{a (== a ?x13)} b]}]]
+    [:rename {:columns {a x9, b x10}} [:scan {:db-name "xtdb", :table r, :columns [a b]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-1.edn
@@ -6,7 +6,7 @@
  [:rename
   {:prefix u.1}
   [:scan
-   {:table #xt/table t1,
+   {:db-name "xtdb", :table #xt/table t1,
     :columns [{col1 (== col1 30)} _valid_to _valid_from _iid],
     :clamp-valid-time? true,
     :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/delete-target-table-aliases-2.edn
@@ -6,7 +6,7 @@
  [:rename
   {:prefix t1.1}
   [:scan
-   {:table #xt/table t1,
+   {:db-name "xtdb", :table #xt/table t1,
     :columns [{col1 (== col1 30)} _valid_to _valid_from _iid],
     :clamp-valid-time? true,
     :for-valid-time [:in (current-timestamp) xtdb/end-of-time]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/exists-as-expression-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/exists-as-expression-in-select.edn
@@ -4,7 +4,7 @@
   {:mark-spec {_sq_2 [{x.1/y z}]}}
   [:rename
    {:prefix x.1}
-   [:scan {:table #xt/table x, :columns [y {z (== z 10)}]}]]
+   [:scan {:db-name "xtdb", :table #xt/table x, :columns [y {z (== z 10)}]}]]
   [:project
    {:projections [{z y.3/z}]}
-   [:rename {:prefix y.3} [:scan {:table #xt/table y, :columns [z]}]]]]]
+   [:rename {:prefix y.3} [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/exists-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/exists-in-where.edn
@@ -6,9 +6,9 @@
    {:conditions [{x.1/y z}]}
    [:rename
     {:prefix x.1}
-    [:scan {:table #xt/table x, :columns [y {z (== z 10.0)}]}]]
+    [:scan {:db-name "xtdb", :table #xt/table x, :columns [y {z (== z 10.0)}]}]]
    [:project
     {:projections [{z y.3/z}]}
     [:rename
      {:prefix y.3}
-     [:scan {:table #xt/table y, :columns [z]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/from-where-param-order-bug-4305.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/from-where-param-order-bug-4305.edn
@@ -3,6 +3,6 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [{_id (== _id ?_1)}],
     :for-valid-time [:at ?_0]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/in-in-where-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/in-in-where-select.edn
@@ -4,9 +4,9 @@
   {:projections [{_sq_2 true}]}
   [:semi-join
    {:conditions [{x.1/z z}]}
-   [:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y z]}]]
+   [:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y z]}]]
    [:project
     {:projections [{z y.3/z}]}
     [:rename
      {:prefix y.3}
-     [:scan {:table #xt/table y, :columns [z]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/in-in-where-set.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/in-in-where-set.edn
@@ -4,7 +4,7 @@
   {:projections [{_sq_2 true}]}
   [:semi-join
    {:conditions [{x.1/z xt.values.3/_column_1}]}
-   [:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y z]}]]
+   [:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y z]}]]
    [:rename
     {:prefix xt.values.3}
     [:table

--- a/src/test/resources/xtdb/sql/plan_test_expectations/join-lateral-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/join-lateral-1.edn
@@ -2,11 +2,11 @@
  {:projections [{y x.1/y} {z y.4/z}]}
  [:mega-join
   {:conditions [{x.1/y y.4/z}]}
-  [[:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y]}]]
+  [[:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y]}]]
    [:rename
     {:prefix y.4}
     [:project
      {:projections [{z z.2/z}]}
      [:rename
       {:prefix z.2}
-      [:scan {:table #xt/table z, :columns [z]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table z, :columns [z]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/join-lateral-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/join-lateral-2.edn
@@ -2,7 +2,7 @@
  {:projections [{y x.1/y} {z y.4/z}]}
  [:left-outer-join
   {:conditions [{x.1/y y.4/z}]}
-  [:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y]}]]
+  [:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y]}]]
   [:rename
    {:prefix y.4}
    [:project
@@ -11,4 +11,4 @@
      {:prefix z.2}
      [:select
       {:predicate true}
-      [:scan {:table #xt/table z, :columns [z]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table z, :columns [z]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/join-lateral-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/join-lateral-3.edn
@@ -2,11 +2,11 @@
  {:projections [{x x.1/x} {y x.1/y} {z y.4/z}]}
  [:mega-join
   {:conditions [{x.1/x y.4/x} {x.1/y y.4/z}]}
-  [[:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [x y]}]]
+  [[:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [x y]}]]
    [:rename
     {:prefix y.4}
     [:project
      {:projections [{x z.2/x} {z z.2/z}]}
      [:rename
       {:prefix z.2}
-      [:scan {:table #xt/table z, :columns [x z]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table z, :columns [x z]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/lateral-derived-table-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/lateral-derived-table-1.edn
@@ -2,11 +2,11 @@
  {:projections [{y x.1/y} {z y.4/z}]}
  [:mega-join
   {:conditions [{x.1/y y.4/z}]}
-  [[:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y]}]]
+  [[:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y]}]]
    [:rename
     {:prefix y.4}
     [:project
      {:projections [{z z.2/z}]}
      [:rename
       {:prefix z.2}
-      [:scan {:table #xt/table z, :columns [z]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table z, :columns [z]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/lateral-derived-table-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/lateral-derived-table-2.edn
@@ -6,4 +6,4 @@
    {:projections [{z z.1/z}]}
    [:rename
     {:prefix z.1}
-    [:scan {:table #xt/table z, :columns [{z (== z 1)}]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table z, :columns [{z (== z 1)}]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/limit-parens.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/limit-parens.edn
@@ -6,11 +6,11 @@
    {:projections [{_id bar.1/_id} {foo bar.1/foo}]}
    [:rename
     {:prefix bar.1}
-    [:scan {:table #xt/table bar, :columns [_id foo]}]]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_id foo]}]]]]
  [:top
   {:skip nil, :limit 1}
   [:project
    {:projections [{_id baz.2/_id} {foo baz.2/foo}]}
    [:rename
     {:prefix baz.2}
-    [:scan {:table #xt/table baz, :columns [_id foo]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table baz, :columns [_id foo]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/multiple-ins-in-where-clause.edn
@@ -10,7 +10,7 @@
      {:conditions [{f.1/a xt.values.3/_column_1}]}
      [:rename
       {:prefix f.1}
-      [:scan {:table #xt/table foo, :columns [{a (== a 42)} b]}]]
+      [:scan {:db-name "xtdb", :table #xt/table foo, :columns [{a (== a 42)} b]}]]
      [:rename
       {:prefix xt.values.3}
       [:table

--- a/src/test/resources/xtdb/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/multiple-references-to-temporal-cols.edn
@@ -14,7 +14,7 @@
      _valid_to
      {_valid_time (period _valid_from _valid_to)}]}
    [:scan
-    {:table #xt/table foo,
+    {:db-name "xtdb", :table #xt/table foo,
      :columns
      [{_valid_from
        (and

--- a/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-1.edn
@@ -5,7 +5,7 @@
   {:conditions [{m.1/title si.2/title}]}
   [[:rename
     {:prefix m.1}
-    [:scan {:table #xt/table movie, :columns [title length]}]]
+    [:scan {:db-name "xtdb", :table #xt/table movie, :columns [title length]}]]
    [:rename
     {:prefix si.2}
-    [:scan {:table #xt/table stars_in, :columns [title films]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [title films]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/natural-join-2.edn
@@ -5,7 +5,7 @@
   {:conditions [{si.2/title m.1/title}]}
   [:rename
    {:prefix si.2}
-   [:scan {:table #xt/table stars_in, :columns [title films]}]]
+   [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [title films]}]]
   [:rename
    {:prefix m.1}
-   [:scan {:table #xt/table movie, :columns [title length]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table movie, :columns [title length]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-1.edn
@@ -6,7 +6,7 @@
    {:mark-spec {_sq_2 [{f.1/a xt.values.3/_column_1}]}}
    [:rename
     {:prefix f.1}
-    [:scan {:table #xt/table foo, :columns [a b]}]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a b]}]]
    [:rename
     {:prefix xt.values.3}
     [:table

--- a/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/non-semi-join-subquery-optimizations-test-2.edn
@@ -4,9 +4,9 @@
   {:predicate (== true _sq_2)}
   [:mark-join
    {:mark-spec {_sq_2 [true]}}
-   [:rename {:prefix f.1} [:scan {:table #xt/table foo, :columns [a]}]]
+   [:rename {:prefix f.1} [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]
    [:project
     {:projections [{c foo.3/c}]}
     [:rename
      {:prefix foo.3}
-     [:scan {:table #xt/table foo, :columns [c]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table foo, :columns [c]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/not-exists-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/not-exists-in-where.edn
@@ -6,9 +6,9 @@
    {:conditions [{x.1/y z}]}
    [:rename
     {:prefix x.1}
-    [:scan {:table #xt/table x, :columns [y {z (== z 10)}]}]]
+    [:scan {:db-name "xtdb", :table #xt/table x, :columns [y {z (== z 10)}]}]]
    [:project
     {:projections [{z y.3/z}]}
     [:rename
      {:prefix y.3}
-     [:scan {:table #xt/table y, :columns [z]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/not-in-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/not-in-in-where.edn
@@ -4,9 +4,9 @@
   {:projections [{_sq_2 true}]}
   [:anti-join
    {:conditions [{x.1/z z}]}
-   [:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y z]}]]
+   [:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y z]}]]
    [:project
     {:projections [{z y.3/z}]}
     [:rename
      {:prefix y.3}
-     [:scan {:table #xt/table y, :columns [z]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table y, :columns [z]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/projects-that-matter-are-maintained.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/projects-that-matter-are-maintained.edn
@@ -6,7 +6,7 @@
    {:projections [{id customers.1/id}]}
    [:rename
     {:prefix customers.1}
-    [:scan {:table #xt/table customers, :columns [id]}]]]
+    [:scan {:db-name "xtdb", :table #xt/table customers, :columns [id]}]]]
   [:project
    {:projections [{id o.3/id}]}
    [:rename
@@ -15,4 +15,4 @@
      {:projections [{id orders.2/id} {product orders.2/product}]}
      [:rename
       {:prefix orders.2}
-      [:scan {:table #xt/table orders, :columns [product id]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table orders, :columns [product id]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/push-semi-and-anti-joins-down.edn
@@ -10,15 +10,15 @@
     {:conditions []}
     [[:rename
       {:prefix x.1}
-      [:scan {:table #xt/table x, :columns [foo]}]]
+      [:scan {:db-name "xtdb", :table #xt/table x, :columns [foo]}]]
      [:rename
       {:prefix y.2}
-      [:scan {:table #xt/table y, :columns [biz]}]]]]
+      [:scan {:db-name "xtdb", :table #xt/table y, :columns [biz]}]]]]
    [:project
     {:projections [{bar z.4/bar}]}
     [:rename
      {:prefix z.4}
      [:scan
-      {:table #xt/table z,
+      {:db-name "xtdb", :table #xt/table z,
        :columns
        [{baz (== baz ?_sq_biz_5)} {bar (== bar ?_sq_foo_4)}]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-1.edn
@@ -4,9 +4,9 @@
   {:conditions []}
   [:rename
    {:prefix x.1}
-   [:scan {:table #xt/table x, :columns [{y (== y 1)}]}]]
+   [:scan {:db-name "xtdb", :table #xt/table x, :columns [{y (== y 1)}]}]]
   [:project
    {:projections [{_sq_2 foo.3/bar}]}
    [:rename
     {:prefix foo.3}
-    [:scan {:table #xt/table foo, :columns [bar]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [bar]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-select-2.edn
@@ -4,11 +4,11 @@
   {:conditions []}
   [:rename
    {:prefix x.1}
-   [:scan {:table #xt/table x, :columns [{y (== y 1)}]}]]
+   [:scan {:db-name "xtdb", :table #xt/table x, :columns [{y (== y 1)}]}]]
   [:project
    {:projections [{_sq_2 _max_out_4}]}
    [:group-by
     {:columns [{_max_out_4 (max foo.3/bar)}]}
     [:rename
      {:prefix foo.3}
-     [:scan {:table #xt/table foo, :columns [bar]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table foo, :columns [bar]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/scalar-subquery-in-where.edn
@@ -4,11 +4,11 @@
   {:predicate (== x.1/y _sq_2)}
   [:single-join
    {:conditions []}
-   [:rename {:prefix x.1} [:scan {:table #xt/table x, :columns [y]}]]
+   [:rename {:prefix x.1} [:scan {:db-name "xtdb", :table #xt/table x, :columns [y]}]]
    [:project
     {:projections [{_sq_2 _max_out_4}]}
     [:group-by
      {:columns [{_max_out_4 (max foo.3/bar)}]}
      [:rename
       {:prefix foo.3}
-      [:scan {:table #xt/table foo, :columns [bar]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table foo, :columns [bar]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/select-from-schema-qualified-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/select-from-schema-qualified-table.edn
@@ -2,4 +2,4 @@
  {:projections [{_id bar.1/_id} {x bar.1/x}]}
  [:rename
   {:prefix bar.1}
-  [:scan {:table #xt/table foo/bar, :columns [x _id]}]]]
+  [:scan {:db-name "xtdb", :table #xt/table foo/bar, :columns [x _id]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-equality-subquery.edn
@@ -4,17 +4,17 @@
   {:conditions []}
   [[:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [a]}]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]
    [:select
     {:predicate (== bar.2/c _sq_3)}
     [:apply
      {:mode :single-join, :columns {bar.2/b ?_sq_b_4}}
      [:rename
       {:prefix bar.2}
-      [:scan {:table #xt/table bar, :columns [c b]}]]
+      [:scan {:db-name "xtdb", :table #xt/table bar, :columns [c b]}]]
      [:project
       {:projections [{_sq_3 foo.4/b}]}
       [:rename
        {:prefix foo.4}
        [:scan
-        {:table #xt/table foo, :columns [{a (== a ?_sq_b_4)} b]}]]]]]]]]
+        {:db-name "xtdb", :table #xt/table foo, :columns [{a (== a ?_sq_b_4)} b]}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-correlated-subquery.edn
@@ -4,7 +4,7 @@
   {:conditions []}
   [[:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [a]}]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]
    [:select
     {:predicate _sq_3}
     [:apply
@@ -13,10 +13,10 @@
       :mark-join-projection {_sq_3 (== ?_needle b)}}
      [:rename
       {:prefix bar.2}
-      [:scan {:table #xt/table bar, :columns [c b]}]]
+      [:scan {:db-name "xtdb", :table #xt/table bar, :columns [c b]}]]
      [:project
       {:projections [{b foo.4/b}]}
       [:rename
        {:prefix foo.4}
        [:scan
-        {:table #xt/table foo, :columns [{a (== a ?_sq_b_4)} b]}]]]]]]]]
+        {:db-name "xtdb", :table #xt/table foo, :columns [{a (== a ?_sq_b_4)} b]}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/subquery-in-join-uncorrelated-subquery.edn
@@ -4,16 +4,16 @@
   {:conditions []}
   [[:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [a]}]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]
    [:select
     {:predicate (== bar.2/c _sq_3)}
     [:single-join
      {:conditions []}
      [:rename
       {:prefix bar.2}
-      [:scan {:table #xt/table bar, :columns [c]}]]
+      [:scan {:db-name "xtdb", :table #xt/table bar, :columns [c]}]]
      [:project
       {:projections [{_sq_3 foo.4/b}]}
       [:rename
        {:prefix foo.4}
-       [:scan {:table #xt/table foo, :columns [b]}]]]]]]]]
+       [:scan {:db-name "xtdb", :table #xt/table foo, :columns [b]}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-as-of.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-as-of.edn
@@ -3,6 +3,6 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-system-time [:at #xt/ldt "2999-01-01T00:00"]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-lateraly-derived-table.edn
@@ -5,7 +5,7 @@
   [[:rename
     {:prefix x.1}
     [:scan
-     {:table #xt/table x,
+     {:db-name "xtdb", :table #xt/table x,
       :columns [y],
       :for-system-time [:at #xt/date "3001-01-01"]}]]
    [:rename
@@ -15,7 +15,7 @@
      [:rename
       {:prefix z.2}
       [:scan
-       {:table #xt/table z,
+       {:db-name "xtdb", :table #xt/table z,
         :columns [z],
         :for-system-time
         [:in #xt/date "3001-01-01" #xt/zdt "3002-01-01T00:00Z"]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-between-subquery.edn
@@ -2,13 +2,13 @@
  {:projections [{_column_1 _sq_2}]}
  [:single-join
   {:conditions []}
-  [:rename {:prefix t2.1} [:scan {:table #xt/table t2, :columns []}]]
+  [:rename {:prefix t2.1} [:scan {:db-name "xtdb", :table #xt/table t2, :columns []}]]
   [:project
    {:projections [{_sq_2 4}]}
    [:rename
     {:prefix t1.3}
     [:scan
-     {:table #xt/table t1,
+     {:db-name "xtdb", :table #xt/table t1,
       :columns [],
       :for-system-time
       [:between #xt/date "3001-01-01" #xt/zdt "3002-01-01T00:00Z"]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/system-time-from-a-to-b.edn
@@ -3,7 +3,7 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-system-time
     [:in #xt/date "2999-01-01" #xt/zdt "3000-01-01T00:00Z"]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-projection.edn
@@ -2,7 +2,7 @@
   {:projections [x7]}
   [:apply
    {:mode :single-join, :columns {x1 ?x8, x2 ?x9}}
-   [:rename {:columns {_valid_from x1, _valid_to x2}} [:scan {:table bar, :columns [_valid_from _valid_to]}]]
+   [:rename {:columns {_valid_from x1, _valid_to x2}} [:scan {:db-name "xtdb", :table bar, :columns [_valid_from _valid_to]}]]
    [:project
     {:projections [{x7 (and (< x4 ?x9) (> x5 ?x8))}]}
-    [:rename {:columns {_valid_from x4, _valid_to x5}} [:scan {:table foo, :columns [_valid_from _valid_to]}]]]]]]
+    [:rename {:columns {_valid_from x4, _valid_to x5}} [:scan {:db-name "xtdb", :table foo, :columns [_valid_from _valid_to]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-app-time-correlated-subquery-where.edn
@@ -2,10 +2,10 @@
   {:projections [x4]}
   [:apply
    {:mode :single-join, :columns {x1 ?x8, x2 ?x9}}
-   [:rename {:columns {_valid_from x1, _valid_to x2}} [:scan {:table bar, :columns [_valid_from _valid_to]}]]
+   [:rename {:columns {_valid_from x1, _valid_to x2}} [:scan {:db-name "xtdb", :table bar, :columns [_valid_from _valid_to]}]]
    [:project
     {:projections [x4]}
     [:rename {:columns {name x4, _valid_from x5, _valid_to x6}} [:scan
-      {:table foo, :columns [name
+      {:db-name "xtdb", :table foo, :columns [name
        {_valid_from (< _valid_from ?x9)}
        {_valid_to (> _valid_to ?x8)}]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-application-and-app-time-from-same-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-application-and-app-time-from-same-table.edn
@@ -2,4 +2,4 @@
   {:projections [x1]}
   [:rename {:columns {name x1, _valid_from x2, _valid_to x3}} [:select
     {:predicate (and (< _valid_from _valid_to) (> _valid_to _valid_from))}
-    [:scan {:table foo, :columns [name _valid_from _valid_to]}]]]]]
+    [:scan {:db-name "xtdb", :table foo, :columns [name _valid_from _valid_to]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-element-reference-107-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-element-reference-107-1.edn
@@ -1,3 +1,3 @@
 [:project
  {:projections [{first_el (nth u.1/a 0)}]}
- [:rename {:prefix u.1} [:scan {:table #xt/table u, :columns [a]}]]]
+ [:rename {:prefix u.1} [:scan {:db-name "xtdb", :table #xt/table u, :columns [a]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-element-reference-107-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-element-reference-107-2.edn
@@ -1,3 +1,3 @@
 [:project
  {:projections [{dyn_idx (nth u.1/b (- (nth u.1/a 0) 1))}]}
- [:rename {:prefix u.1} [:scan {:table #xt/table u, :columns [a b]}]]]
+ [:rename {:prefix u.1} [:scan {:db-name "xtdb", :table #xt/table u, :columns [a b]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery1.edn
@@ -4,11 +4,11 @@
   {:conditions []}
   [:rename
    {:prefix a.1}
-   [:scan {:table #xt/table a, :columns [{a (== a 42)}]}]]
+   [:scan {:db-name "xtdb", :table #xt/table a, :columns [{a (== a 42)}]}]]
   [:group-by
    {:columns [{_sq_2 (vec_agg b1)}]}
    [:project
     {:projections [{b1 b.3/b1}]}
     [:rename
      {:prefix b.3}
-     [:scan {:table #xt/table b, :columns [{b2 (== b2 42)} b1]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table b, :columns [{b2 (== b2 42)} b1]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-array-subquery2.edn
@@ -4,7 +4,7 @@
   {:mode :single-join, :columns {a.1/b ?_sq_b_3}}
   [:rename
    {:prefix a.1}
-   [:scan {:table #xt/table a, :columns [{a (== a 42)} b]}]]
+   [:scan {:db-name "xtdb", :table #xt/table a, :columns [{a (== a 42)} b]}]]
   [:group-by
    {:columns [{_sq_2 (vec_agg b1)}]}
    [:project
@@ -12,4 +12,4 @@
     [:rename
      {:prefix b.3}
      [:scan
-      {:table #xt/table b, :columns [{b2 (== b2 ?_sq_b_3)} b1]}]]]]]]
+      {:db-name "xtdb", :table #xt/table b, :columns [{b2 (== b2 ?_sq_b_3)} b1]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-current-time-111.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-current-time-111.edn
@@ -10,4 +10,4 @@
    {_column_8 (local-time 6)}
    {_column_9 (local-timestamp)}
    {_column_10 (local-timestamp 9)}]}
- [:rename {:prefix u.1} [:scan {:table #xt/table u, :columns [a]}]]]
+ [:rename {:prefix u.1} [:scan {:db-name "xtdb", :table #xt/table u, :columns [a]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-predicate.edn
@@ -19,5 +19,5 @@
      {_valid_time (period _valid_from _valid_to)}
      {_system_time (period _system_from _system_to)}]}
    [:scan
-    {:table #xt/table foo,
+    {:db-name "xtdb", :table #xt/table foo,
      :columns [_valid_from _valid_to _system_from _system_to]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-specs.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-derived-columns-with-periods-period-specs.edn
@@ -3,7 +3,7 @@
  [:rename
   {:prefix f.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-valid-time [:at (current-timestamp)],
     :for-system-time [:at (current-timestamp)]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-1.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo, :columns [a {c (== c ?_1)} {b (== b ?_0)}]}]]]
+   {:db-name "xtdb", :table #xt/table foo, :columns [a {c (== c ?_1)} {b (== b ?_0)}]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-2.edn
@@ -5,7 +5,7 @@
   [[:rename
     {:prefix foo.1}
     [:scan
-     {:table #xt/table foo,
+     {:db-name "xtdb", :table #xt/table foo,
       :columns [a {c (== c ?_2)} {b (== b ?_1)}]}]]
    [:rename
     {:prefix bar.3}
@@ -16,4 +16,4 @@
       [:rename
        {:prefix bar.2}
        [:scan
-        {:table #xt/table bar, :columns [{c (== c ?_0)} b]}]]]]]]]]
+        {:db-name "xtdb", :table #xt/table bar, :columns [{c (== c ?_0)} b]}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-subquery-project.edn
@@ -4,9 +4,9 @@
   {:conditions []}
   [:rename
    {:prefix t1.1}
-   [:scan {:table #xt/table t1, :columns [col1]}]]
+   [:scan {:db-name "xtdb", :table #xt/table t1, :columns [col1]}]]
   [:project
    {:projections [{_sq_2 ?_0}]}
    [:rename
     {:prefix bar.3}
-    [:scan {:table #xt/table bar, :columns [{col1 (== col1 4)}]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [{col1 (== col1 4)}]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-top-level-project.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-top-level-project.edn
@@ -2,4 +2,4 @@
  {:projections [{col1 t1.1/col1} {_column_2 ?_0}]}
  [:rename
   {:prefix t1.1}
-  [:scan {:table #xt/table t1, :columns [col1]}]]]
+  [:scan {:db-name "xtdb", :table #xt/table t1, :columns [col1]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-app-time.edn
@@ -8,7 +8,7 @@
  [:rename
   {:prefix u.1}
   [:scan
-   {:table #xt/table users,
+   {:db-name "xtdb", :table #xt/table users,
     :columns
     [_valid_to
      {id (== id ?_3)}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-103-update-set-value.edn
@@ -7,7 +7,7 @@
  [:rename
   {:prefix t1.1}
   [:scan
-   {:table #xt/table t1,
+   {:db-name "xtdb", :table #xt/table t1,
     :columns
     [{col1 (or (not (boolean (=== ?_0 col1))))}
      _valid_to

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of-system-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of-system-time.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo, :columns [bar], :for-system-time [:at ?_0]}]]]
+   {:db-name "xtdb", :table #xt/table foo, :columns [bar], :for-system-time [:at ?_0]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-as-of.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo, :columns [bar], :for-valid-time [:at ?_0]}]]]
+   {:db-name "xtdb", :table #xt/table foo, :columns [bar], :for-valid-time [:at ?_0]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-between.edn
@@ -3,6 +3,6 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-valid-time [:between ?_0 ?_1]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-from-to.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-dynamic-parameters-temporal-filters-3068-from-to.edn
@@ -3,6 +3,6 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-valid-time [:in ?_0 ?_1]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-expr-in-equi-join-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-expr-in-equi-join-1.edn
@@ -2,7 +2,7 @@
  {:projections [{a a.1/a}]}
  [:mega-join
   {:conditions [{(+ a.1/a 1) (+ b.2/b 1)}]}
-  [[:rename {:prefix a.1} [:scan {:table #xt/table a, :columns [a]}]]
+  [[:rename {:prefix a.1} [:scan {:db-name "xtdb", :table #xt/table a, :columns [a]}]]
    [:rename
     {:prefix b.2}
-    [:scan {:table #xt/table bar, :columns [b]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [b]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-expr-in-equi-join-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-expr-in-equi-join-2.edn
@@ -2,7 +2,7 @@
  {:projections [{a a.1/a}]}
  [:mega-join
   {:conditions [{a.1/a (+ b.2/b 1)}]}
-  [[:rename {:prefix a.1} [:scan {:table #xt/table a, :columns [a]}]]
+  [[:rename {:prefix a.1} [:scan {:db-name "xtdb", :table #xt/table a, :columns [a]}]]
    [:rename
     {:prefix b.2}
-    [:scan {:table #xt/table bar, :columns [b]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [b]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-system-time-404.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-system-time-404.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo, :columns [bar], :for-system-time :all-time}]]]
+   {:db-name "xtdb", :table #xt/table foo, :columns [bar], :for-system-time :all-time}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-delete.edn
@@ -6,7 +6,7 @@
  [:rename
   {:prefix users.1}
   [:scan
-   {:table #xt/table users,
+   {:db-name "xtdb", :table #xt/table users,
     :columns [_valid_to _valid_from _iid],
     :clamp-valid-time? true,
     :for-valid-time :all-time}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-query.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-query.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo, :columns [bar], :for-valid-time :all-time}]]]
+   {:db-name "xtdb", :table #xt/table foo, :columns [bar], :for-valid-time :all-time}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-for-all-valid-time-387-update.edn
@@ -7,7 +7,7 @@
  [:rename
   {:prefix users.1}
   [:scan
-   {:table #xt/table users,
+   {:db-name "xtdb", :table #xt/table users,
     :columns
     [_valid_to
      _valid_from

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-full-outer-join-uncorrelated.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-full-outer-join-uncorrelated.edn
@@ -4,7 +4,7 @@
   {:conditions [{d1.1/bar d2.2/foo}]}
   [:rename
    {:prefix d1.1}
-   [:scan {:table #xt/table d1, :columns [bar]}]]
+   [:scan {:db-name "xtdb", :table #xt/table d1, :columns [bar]}]]
   [:rename
    {:prefix d2.2}
-   [:scan {:table #xt/table d2, :columns [foo]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table d2, :columns [foo]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-alias.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-alias.edn
@@ -6,4 +6,4 @@
    {:projections [{cat (upper products.1/category)}]}
    [:rename
     {:prefix products.1}
-    [:scan {:table #xt/table products, :columns [category]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table products, :columns [category]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-having-non-pushable.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-having-non-pushable.edn
@@ -11,4 +11,4 @@
      {:projections [{cat (upper products.1/category)}]}
      [:rename
       {:prefix products.1}
-      [:scan {:table #xt/table products, :columns [category]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table products, :columns [category]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-having-pushable.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-having-pushable.edn
@@ -8,4 +8,4 @@
     {:projections [{cat (upper products.1/category)}]}
     [:rename
      {:prefix products.1}
-     [:scan {:table #xt/table products, :columns [category]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table products, :columns [category]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-not-in-select.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-not-in-select.edn
@@ -6,4 +6,4 @@
    {:projections [{_gb3 (upper products.1/category)}]}
    [:rename
     {:prefix products.1}
-    [:scan {:table #xt/table products, :columns [category]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table products, :columns [category]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-order-by.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expr-order-by.edn
@@ -10,4 +10,4 @@
      {:projections [{cat (upper products.1/category)}]}
      [:rename
       {:prefix products.1}
-      [:scan {:table #xt/table products, :columns [category]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table products, :columns [category]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expression.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-expression.edn
@@ -6,4 +6,4 @@
    {:projections [{cat (upper products.1/category)}]}
    [:rename
     {:prefix products.1}
-    [:scan {:table #xt/table products, :columns [category]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table products, :columns [category]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-mixed.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-mixed.edn
@@ -6,4 +6,4 @@
    {:projections [{ub (upper t.1/b)}]}
    [:rename
     {:prefix t.1}
-    [:scan {:table #xt/table t, :columns [a b]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table t, :columns [a b]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-projected-column-in-expr-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-projected-column-in-expr-2.edn
@@ -6,4 +6,4 @@
    {:projections [{_sum_in_3 (- foo.1/a 4)}]}
    [:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [a]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-projected-column-in-expr.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-projected-column-in-expr.edn
@@ -4,4 +4,4 @@
   {:columns [foo.1/a]}
   [:rename
    {:prefix foo.1}
-   [:scan {:table #xt/table foo, :columns [a]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-unresolved-column-reference.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-group-by-with-unresolved-column-reference.edn
@@ -8,4 +8,4 @@
     {:projections [{xt$missing_column4 nil}]}
     [:rename
      {:prefix docs.1}
-     [:scan {:table #xt/table docs, :columns [_id]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table docs, :columns [_id]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-having-with-unresolved-column-reference.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-having-with-unresolved-column-reference.edn
@@ -9,4 +9,4 @@
     {:projections [{_sum_in_3 nil}]}
     [:rename
      {:prefix docs.1}
-     [:scan {:table #xt/table docs, :columns [_id]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table docs, :columns [_id]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-limit-offset-params-3699.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-limit-offset-params-3699.edn
@@ -4,4 +4,4 @@
   {:projections [{a foo.1/a}]}
   [:rename
    {:prefix foo.1}
-   [:scan {:table #xt/table foo, :columns [a]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-many.edn
@@ -4,7 +4,7 @@
   {:mode :single-join, :columns {c.1/_id ?_sq__id_3}}
   [:rename
    {:prefix c.1}
-   [:scan {:table #xt/table customers, :columns [_id name]}]]
+   [:scan {:db-name "xtdb", :table #xt/table customers, :columns [_id name]}]]
   [:group-by
    {:columns [{_sq_2 (array_agg _sq_2)}]}
    [:project
@@ -14,6 +14,6 @@
      [:rename
       {:prefix o.3}
       [:scan
-       {:table #xt/table orders,
+       {:db-name "xtdb", :table #xt/table orders,
         :columns
         [{customer_id (== customer_id ?_sq__id_3)} _id value]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-nest-one.edn
@@ -4,7 +4,7 @@
   {:mode :single-join, :columns {o.1/customer_id ?_sq_customer_id_3}}
   [:rename
    {:prefix o.1}
-   [:scan {:table #xt/table orders, :columns [customer_id _id value]}]]
+   [:scan {:db-name "xtdb", :table #xt/table orders, :columns [customer_id _id value]}]]
   [:project
    {:projections [{_sq_2 {:name name}}]}
    [:project
@@ -12,5 +12,5 @@
     [:rename
      {:prefix c.3}
      [:scan
-      {:table #xt/table customers,
+      {:db-name "xtdb", :table #xt/table customers,
        :columns [{_id (== _id ?_sq_customer_id_3)} name]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-alias-in-expr.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-alias-in-expr.edn
@@ -8,4 +8,4 @@
     {:projections [{y (+ t.1/x 1)}]}
     [:rename
      {:prefix t.1}
-     [:scan {:table #xt/table t, :columns [x]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table t, :columns [x]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-null-handling-159-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-null-handling-159-1.edn
@@ -5,4 +5,4 @@
    [[foo.1/a {:direction :asc, :null-ordering :nulls-first}]]}
   [:rename
    {:prefix foo.1}
-   [:scan {:table #xt/table foo, :columns [a]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-null-handling-159-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-order-by-null-handling-159-2.edn
@@ -5,4 +5,4 @@
    [[foo.1/a {:direction :asc, :null-ordering :nulls-last}]]}
   [:rename
    {:prefix foo.1}
-   [:scan {:table #xt/table foo, :columns [a]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-cont.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-cont.edn
@@ -6,4 +6,4 @@
      (percentile_cont 0.5 [t.1/amount {:direction :asc}])}]}
   [:rename
    {:prefix t.1}
-   [:scan {:table #xt/table t, :columns [amount]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table t, :columns [amount]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-disc-desc.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-percentile-disc-desc.edn
@@ -6,4 +6,4 @@
      (percentile_disc 0.5 [t.1/amount {:direction :desc}])}]}
   [:rename
    {:prefix t.1}
-   [:scan {:table #xt/table t, :columns [amount]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table t, :columns [amount]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-contains-with-period-literal.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-contains-with-period-literal.edn
@@ -9,7 +9,7 @@
      _valid_to
      {_valid_time (period _valid_from _valid_to)}]}
    [:scan
-    {:table #xt/table foo,
+    {:db-name "xtdb", :table #xt/table foo,
      :columns
      [name
       {_valid_from (<= _valid_from #xt/zdt "2000-01-01T00:00Z")}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-infix-overlaps.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-infix-overlaps.edn
@@ -9,7 +9,7 @@
      _valid_to
      {_valid_time (period _valid_from _valid_to)}]}
    [:scan
-    {:table #xt/table foo,
+    {:db-name "xtdb", :table #xt/table foo,
      :columns
      [name
       {_valid_from

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-variadic-overlaps-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-variadic-overlaps-2.edn
@@ -18,7 +18,7 @@
       [_valid_from
        _valid_to
        {_valid_time (period _valid_from _valid_to)}]}
-     [:scan {:table #xt/table baz, :columns [_valid_from _valid_to]}]]]
+     [:scan {:db-name "xtdb", :table #xt/table baz, :columns [_valid_from _valid_to]}]]]
    [:rename
     {:prefix foo.1}
     [:project
@@ -28,7 +28,7 @@
        _valid_to
        {_valid_time (period _valid_from _valid_to)}]}
      [:scan
-      {:table #xt/table foo, :columns [name _valid_from _valid_to]}]]]
+      {:db-name "xtdb", :table #xt/table foo, :columns [name _valid_from _valid_to]}]]]
    [:rename
     {:prefix bar.2}
     [:project
@@ -37,4 +37,4 @@
        _valid_to
        {_valid_time (period _valid_from _valid_to)}]}
      [:scan
-      {:table #xt/table bar, :columns [_valid_from _valid_to]}]]]]]]
+      {:db-name "xtdb", :table #xt/table bar, :columns [_valid_from _valid_to]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-variadic-overlaps-3.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-predicate-optimisations-4054-variadic-overlaps-3.edn
@@ -16,7 +16,7 @@
        _valid_to
        {_valid_time (period _valid_from _valid_to)}]}
      [:scan
-      {:table #xt/table foo, :columns [name _valid_from _valid_to]}]]]
+      {:db-name "xtdb", :table #xt/table foo, :columns [name _valid_from _valid_to]}]]]
    [:rename
     {:prefix bar.2}
     [:project
@@ -25,4 +25,4 @@
        _valid_to
        {_valid_time (period _valid_from _valid_to)}]}
      [:scan
-      {:table #xt/table bar, :columns [_valid_from _valid_to]}]]]]]]
+      {:db-name "xtdb", :table #xt/table bar, :columns [_valid_from _valid_to]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-dml-subqueries-and-defaults-407.edn
@@ -28,6 +28,6 @@
       [:rename
        {:prefix prop_owner.1}
        [:scan
-        {:table #xt/table prop_owner,
+        {:db-name "xtdb", :table #xt/table prop_owner,
          :columns [_system_from {id (== id 1)}],
          :for-system-time :all-time}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-app-time.edn
@@ -7,6 +7,6 @@
    [:rename
     {:prefix foo.1}
     [:scan
-     {:table #xt/table foo,
+     {:db-name "xtdb", :table #xt/table foo,
       :columns [bar],
       :for-valid-time [:at (current-timestamp)]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-sys-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-sys-time.edn
@@ -1,3 +1,3 @@
 [:rename {:columns {x3 _column_1}} [:project
   {:projections [{x3 1}]}
-  [:rename {:columns {bar x1}} [:scan {:table foo, :for-system-time :all-time, :columns [bar]}]]]]
+  [:rename {:columns {bar x1}} [:scan {:db-name "xtdb", :table foo, :for-system-time :all-time, :columns [bar]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-system-time.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-period-specs-with-subqueries-407-system-time.edn
@@ -7,6 +7,6 @@
    [:rename
     {:prefix foo.1}
     [:scan
-     {:table #xt/table foo,
+     {:db-name "xtdb", :table #xt/table foo,
       :columns [bar],
       :for-system-time :all-time}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-push-predicate-down-past-period-constructor-scalar-extends.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-push-predicate-down-past-period-constructor-scalar-extends.edn
@@ -2,4 +2,4 @@
  {:projections [{_foo 4} {_valid_time (period _valid_from _valid_to)}]}
  [:select
   {:predicate '(== (period _valid_from _valid_to) 1)}
-  [:scan {:table public/docs, :columns [_bar]}]]]
+  [:scan {:db-name "xtdb", :table public/docs, :columns [_bar]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-push-predicate-down-past-period-constructor-valid.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-push-predicate-down-past-period-constructor-valid.edn
@@ -16,4 +16,4 @@
                    #xt/zoned-date-time "2000-01-01T00:00Z"
                    #xt/zoned-date-time "2001-01-01T00:00Z"))
                  xtdb/end-of-time)))}
-  [:scan {:table public/docs, :columns [_valid_from _valid_to]}]]]
+  [:scan {:db-name "xtdb", :table public/docs, :columns [_valid_from _valid_to]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-push-selection-down-past-unnest-inner-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-push-selection-down-past-unnest-inner-col-ref.edn
@@ -6,4 +6,4 @@
    {:projections [{unnest f.1/vs}]}
    [:rename
     {:prefix f.1}
-    [:scan {:table #xt/table foo, :columns [vs {_id (< _id 2)}]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [vs {_id (< _id 2)}]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-push-selection-down-past-unnest-ord-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-push-selection-down-past-unnest-ord-col-ref.edn
@@ -8,4 +8,4 @@
     {:projections [{unnest f.1/vs}]}
     [:rename
      {:prefix f.1}
-     [:scan {:table #xt/table foo, :columns [vs _id]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table foo, :columns [vs _id]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-push-selection-down-past-unnest-unnested-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-push-selection-down-past-unnest-unnested-col-ref.edn
@@ -8,4 +8,4 @@
     {:projections [{unnest f.1/vs}]}
     [:rename
      {:prefix f.1}
-     [:scan {:table #xt/table foo, :columns [vs _id]}]]]]]]
+     [:scan {:db-name "xtdb", :table #xt/table foo, :columns [vs _id]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-qc-array-expr.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-qc-array-expr.edn
@@ -6,5 +6,5 @@
    {:conditions [{foo.1/a _qc_expr_3}]}
    [:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [a]}]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a]}]]
    [:table {:column {_qc_expr_3 (current-schemas true)}}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-aliased-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-aliased-table.edn
@@ -3,5 +3,5 @@
  [:rename
   {:prefix f.1}
   [:scan
-   {:table #xt/table information_schema/columns,
+   {:db-name "xtdb", :table #xt/table information_schema/columns,
     :columns [column_name]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-field.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-field.edn
@@ -1,3 +1,3 @@
 [:rename {:columns {x3 my_field}} [:project
   {:projections [{x3 (. x1 :my_field)}]}
-  [:rename {:columns {column_name x1}} [:scan {:table information_schema$columns, :columns [column_name]}]]]]
+  [:rename {:columns {column_name x1}} [:scan {:db-name "xtdb", :table information_schema$columns, :columns [column_name]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-fully-qualified.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-fully-qualified.edn
@@ -3,5 +3,5 @@
  [:rename
   {:prefix columns.1}
   [:scan
-   {:table #xt/table information_schema/columns,
+   {:db-name "xtdb", :table #xt/table information_schema/columns,
     :columns [column_name]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-implict-pg_catalog.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-implict-pg_catalog.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix pg_attribute.1}
   [:scan
-   {:table #xt/table pg_catalog/pg_attribute, :columns [attname]}]]]
+   {:db-name "xtdb", :table #xt/table pg_catalog/pg_attribute, :columns [attname]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-qualified-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-qualified-col-ref.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix pg_attribute.1}
   [:scan
-   {:table #xt/table pg_catalog/pg_attribute, :columns [attname]}]]]
+   {:db-name "xtdb", :table #xt/table pg_catalog/pg_attribute, :columns [attname]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-unqualified-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-schema-qualified-names-unqualified-col-ref.edn
@@ -3,4 +3,4 @@
  [:rename
   {:prefix pg_attribute.1}
   [:scan
-   {:table #xt/table pg_catalog/pg_attribute, :columns [attname]}]]]
+   {:db-name "xtdb", :table #xt/table pg_catalog/pg_attribute, :columns [attname]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-semi-and-anti-joins-are-pushed-down.edn
@@ -12,7 +12,7 @@
        {:conditions [{t3.3/c1 xt.values.9/_column_1}]}
        [:rename
         {:prefix t3.3}
-        [:scan {:table #xt/table t3, :columns [c1]}]]
+        [:scan {:db-name "xtdb", :table #xt/table t3, :columns [c1]}]]
        [:rename
         {:prefix xt.values.9}
         [:table
@@ -22,7 +22,7 @@
        {:conditions [{t1.1/b1 xt.values.5/_column_1}]}
        [:rename
         {:prefix t1.1}
-        [:scan {:table #xt/table t1, :columns [a1 b1]}]]
+        [:scan {:db-name "xtdb", :table #xt/table t1, :columns [a1 b1]}]]
        [:rename
         {:prefix xt.values.5}
         [:table
@@ -32,7 +32,7 @@
        {:conditions [{t2.2/b1 xt.values.7/_column_1}]}
        [:rename
         {:prefix t2.2}
-        [:scan {:table #xt/table t2, :columns [a2 b1]}]]
+        [:scan {:db-name "xtdb", :table #xt/table t2, :columns [a2 b1]}]]
        [:rename
         {:prefix xt.values.7}
         [:table

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-delete-plan.edn
@@ -6,7 +6,7 @@
  [:rename
   {:prefix u.1}
   [:scan
-   {:table #xt/table users,
+   {:db-name "xtdb", :table #xt/table users,
     :columns [_valid_to {id (== id ?_0)} _valid_from _iid],
     :clamp-valid-time? true,
     :for-valid-time [:in #xt/date "2020-05-01" nil]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-erase-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-erase-plan.edn
@@ -5,7 +5,7 @@
   [:rename
    {:prefix u.1}
    [:scan
-    {:table #xt/table users,
+    {:db-name "xtdb", :table #xt/table users,
      :for-system-time :all-time,
      :for-valid-time :all-time,
      :columns [{id (== id ?_0)} _iid]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-from-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-from-subquery.edn
@@ -6,4 +6,4 @@
    {:projections [{a foo.1/a} {b foo.1/b}]}
    [:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [a b]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [a b]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-subquery.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk-subquery.edn
@@ -7,12 +7,12 @@
    {:conditions []}
    [[:rename
      {:prefix foo.1}
-     [:scan {:table #xt/table foo, :columns [lastname name]}]]
+     [:scan {:db-name "xtdb", :table #xt/table foo, :columns [lastname name]}]]
     [:rename
      {:prefix bar.2}
-     [:scan {:table #xt/table bar, :columns []}]]]]
+     [:scan {:db-name "xtdb", :table #xt/table bar, :columns []}]]]]
   [:project
    {:projections [{_sq_3 baz.4/frame}]}
    [:rename
     {:prefix baz.4}
-    [:scan {:table #xt/table baz, :columns [frame]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table baz, :columns [frame]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-asterisk.edn
@@ -8,7 +8,7 @@
   {:conditions []}
   [[:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [lastname name]}]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [lastname name]}]]
    [:rename
     {:prefix bar.2}
-    [:scan {:table #xt/table bar, :columns [lastjame jame]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [lastjame jame]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-col-ref.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-col-ref.edn
@@ -2,4 +2,4 @@
  {:projections [{name foo.1/name}]}
  [:rename
   {:prefix foo.1}
-  [:scan {:table #xt/table foo, :columns [name]}]]]
+  [:scan {:db-name "xtdb", :table #xt/table foo, :columns [name]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-qualified-asterisk.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-over-scanning-qualified-asterisk.edn
@@ -5,7 +5,7 @@
   {:conditions []}
   [[:rename
     {:prefix foo.1}
-    [:scan {:table #xt/table foo, :columns [lastname name]}]]
+    [:scan {:db-name "xtdb", :table #xt/table foo, :columns [lastname name]}]]
    [:rename
     {:prefix bar.2}
-    [:scan {:table #xt/table bar, :columns [jame]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [jame]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-column-references.edn
@@ -11,7 +11,7 @@
   [:select
    {:predicate (or (not (boolean (=== baz bar))))}
    [:scan
-    {:table #xt/table foo,
+    {:db-name "xtdb", :table #xt/table foo,
      :columns [_valid_to bar baz quux _valid_from _iid],
      :clamp-valid-time? true,
      :for-valid-time :all-time}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan-with-period-references.edn
@@ -29,7 +29,7 @@
           (lower _valid_time)))
         bar))))}
    [:scan
-    {:table #xt/table foo,
+    {:db-name "xtdb", :table #xt/table foo,
      :columns
      [_valid_to bar baz _system_time _valid_from _valid_time _iid],
      :clamp-valid-time? true,

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-sql-update-plan.edn
@@ -9,7 +9,7 @@
  [:rename
   {:prefix u.1}
   [:scan
-   {:table #xt/table users,
+   {:db-name "xtdb", :table #xt/table users,
     :columns
     [_valid_to
      last_name

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-system-time-period-predicate-full-plan.edn
@@ -17,7 +17,7 @@
        _system_to
        {_system_time (period _system_from _system_to)}]}
      [:scan
-      {:table #xt/table foo,
+      {:db-name "xtdb", :table #xt/table foo,
        :columns [name _system_from _system_to]}]]]
    [:rename
     {:prefix bar.2}
@@ -28,5 +28,5 @@
        _system_to
        {_system_time (period _system_from _system_to)}]}
      [:scan
-      {:table #xt/table bar,
+      {:db-name "xtdb", :table #xt/table bar,
        :columns [name _system_from _system_to]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-table-period-specification-ordering-2260-s-v.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-table-period-specification-ordering-2260-s-v.edn
@@ -3,7 +3,7 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-valid-time :all-time,
     :for-system-time :all-time}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-table-period-specification-ordering-2260-v-s.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-table-period-specification-ordering-2260-v-s.edn
@@ -3,7 +3,7 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-valid-time :all-time,
     :for-system-time :all-time}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-projection.edn
@@ -9,7 +9,7 @@
      [_valid_from
       _valid_to
       {_valid_time (period _valid_from _valid_to)}]}
-    [:scan {:table #xt/table bar, :columns [_valid_from _valid_to]}]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_valid_from _valid_to]}]]]
   [:project
    {:projections
     [{_sq_2
@@ -28,4 +28,4 @@
        _valid_to
        {_valid_time (period _valid_from _valid_to)}]}
      [:scan
-      {:table #xt/table foo, :columns [_valid_from _valid_to]}]]]]]]
+      {:db-name "xtdb", :table #xt/table foo, :columns [_valid_from _valid_to]}]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-where.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-valid-time-correlated-subquery-where.edn
@@ -9,7 +9,7 @@
      [_valid_from
       _valid_to
       {_valid_time (period _valid_from _valid_to)}]}
-    [:scan {:table #xt/table bar, :columns [_valid_from _valid_to]}]]]
+    [:scan {:db-name "xtdb", :table #xt/table bar, :columns [_valid_from _valid_to]}]]]
   [:project
    {:projections [{_sq_2 foo.3/name}]}
    [:rename
@@ -21,7 +21,7 @@
        _valid_to
        {_valid_time (period _valid_from _valid_to)}]}
      [:scan
-      {:table #xt/table foo,
+      {:db-name "xtdb", :table #xt/table foo,
        :columns
        [name
         {_valid_from

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-where-with-unresolved-column-reference.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-where-with-unresolved-column-reference.edn
@@ -4,4 +4,4 @@
   {:prefix docs.1}
   [:select
    {:predicate (> nil 1)}
-   [:scan {:table #xt/table docs, :columns [_id]}]]]]
+   [:scan {:db-name "xtdb", :table #xt/table docs, :columns [_id]}]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/test-window-with-partition-and-order-by.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/test-window-with-partition-and-order-by.edn
@@ -13,4 +13,4 @@
    {:projections [{_ob4 docs.1/z}]}
    [:rename
     {:prefix docs.1}
-    [:scan {:table #xt/table docs, :columns [y z]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table docs, :columns [y z]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q01.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q01.edn
@@ -46,7 +46,7 @@
      [:rename
       {:prefix l.1}
       [:scan
-       {:table #xt/table lineitem,
+       {:db-name "xtdb", :table #xt/table lineitem,
         :columns
         [l_linestatus
          l_tax

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q02.edn
@@ -58,22 +58,22 @@
           [[:rename
             {:prefix r.5}
             [:scan
-             {:table #xt/table region,
+             {:db-name "xtdb", :table #xt/table region,
               :columns [_id {r_name (== r_name "EUROPE")}]}]]
            [:rename
             {:prefix n.4}
             [:scan
-             {:table #xt/table nation,
+             {:db-name "xtdb", :table #xt/table nation,
               :columns [_id n_name n_regionkey]}]]
            [:rename
             {:prefix ps.3}
             [:scan
-             {:table #xt/table partsupp,
+             {:db-name "xtdb", :table #xt/table partsupp,
               :columns [ps_partkey ps_supplycost ps_suppkey]}]]
            [:rename
             {:prefix p.1}
             [:scan
-             {:table #xt/table part,
+             {:db-name "xtdb", :table #xt/table part,
               :columns
               [_id
                {p_size (== p_size 15)}
@@ -82,7 +82,7 @@
            [:rename
             {:prefix s.2}
             [:scan
-             {:table #xt/table supplier,
+             {:db-name "xtdb", :table #xt/table supplier,
               :columns
               [s_comment
                s_name
@@ -99,19 +99,19 @@
          [[:rename
            {:prefix r.10}
            [:scan
-            {:table #xt/table region,
+            {:db-name "xtdb", :table #xt/table region,
              :columns [_id {r_name (== r_name "EUROPE")}]}]]
           [:rename
            {:prefix n.9}
            [:scan
-            {:table #xt/table nation, :columns [_id n_regionkey]}]]
+            {:db-name "xtdb", :table #xt/table nation, :columns [_id n_regionkey]}]]
           [:rename
            {:prefix ps.7}
            [:scan
-            {:table #xt/table partsupp,
+            {:db-name "xtdb", :table #xt/table partsupp,
              :columns [ps_partkey ps_supplycost ps_suppkey]}]]
           [:rename
            {:prefix s.8}
            [:scan
-            {:table #xt/table supplier,
+            {:db-name "xtdb", :table #xt/table supplier,
              :columns [_id s_nationkey]}]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q03.edn
@@ -26,7 +26,7 @@
        [[:rename
          {:prefix l.3}
          [:scan
-          {:table #xt/table lineitem,
+          {:db-name "xtdb", :table #xt/table lineitem,
            :columns
            [l_orderkey
             {l_shipdate (> l_shipdate #xt/date "1995-03-15")}
@@ -35,13 +35,13 @@
         [:rename
          {:prefix c.1}
          [:scan
-          {:table #xt/table customer,
+          {:db-name "xtdb", :table #xt/table customer,
            :columns
            [_id {c_mktsegment (== c_mktsegment "BUILDING")}]}]]
         [:rename
          {:prefix o.2}
          [:scan
-          {:table #xt/table orders,
+          {:db-name "xtdb", :table #xt/table orders,
            :columns
            [_id
             {o_orderdate (< o_orderdate #xt/date "1995-03-15")}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q04.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q04.edn
@@ -16,7 +16,7 @@
       [:rename
        {:prefix o.1}
        [:scan
-        {:table #xt/table orders,
+        {:db-name "xtdb", :table #xt/table orders,
          :columns
          [o_orderpriority
           _id
@@ -52,7 +52,7 @@
         [:select
          {:predicate (< l_commitdate l_receiptdate)}
          [:scan
-          {:table #xt/table lineitem,
+          {:db-name "xtdb", :table #xt/table lineitem,
            :columns
            [l_linestatus
             l_receiptdate

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q05.edn
@@ -21,29 +21,29 @@
       [[:rename
         {:prefix r.6}
         [:scan
-         {:table #xt/table region,
+         {:db-name "xtdb", :table #xt/table region,
           :columns [_id {r_name (== r_name "ASIA")}]}]]
        [:rename
         {:prefix n.5}
         [:scan
-         {:table #xt/table nation, :columns [_id n_name n_regionkey]}]]
+         {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name n_regionkey]}]]
        [:rename
         {:prefix s.4}
         [:scan
-         {:table #xt/table supplier, :columns [_id s_nationkey]}]]
+         {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey]}]]
        [:rename
         {:prefix l.3}
         [:scan
-         {:table #xt/table lineitem,
+         {:db-name "xtdb", :table #xt/table lineitem,
           :columns [l_orderkey l_extendedprice l_suppkey l_discount]}]]
        [:rename
         {:prefix c.1}
         [:scan
-         {:table #xt/table customer, :columns [c_nationkey _id]}]]
+         {:db-name "xtdb", :table #xt/table customer, :columns [c_nationkey _id]}]]
        [:rename
         {:prefix o.2}
         [:scan
-         {:table #xt/table orders,
+         {:db-name "xtdb", :table #xt/table orders,
           :columns
           [_id
            {o_orderdate

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q06.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q06.edn
@@ -7,7 +7,7 @@
    [:rename
     {:prefix l.1}
     [:scan
-     {:table #xt/table lineitem,
+     {:db-name "xtdb", :table #xt/table lineitem,
       :columns
       [{l_shipdate
         (and

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q07.edn
@@ -39,25 +39,25 @@
          {s.1/_id l.2/l_suppkey}]}
        [[:rename
          {:prefix n2.6}
-         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+         [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]
         [:rename
          {:prefix n1.5}
-         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+         [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]
         [:rename
          {:prefix c.4}
          [:scan
-          {:table #xt/table customer, :columns [c_nationkey _id]}]]
+          {:db-name "xtdb", :table #xt/table customer, :columns [c_nationkey _id]}]]
         [:rename
          {:prefix o.3}
-         [:scan {:table #xt/table orders, :columns [_id o_custkey]}]]
+         [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_custkey]}]]
         [:rename
          {:prefix s.1}
          [:scan
-          {:table #xt/table supplier, :columns [_id s_nationkey]}]]
+          {:db-name "xtdb", :table #xt/table supplier, :columns [_id s_nationkey]}]]
         [:rename
          {:prefix l.2}
          [:scan
-          {:table #xt/table lineitem,
+          {:db-name "xtdb", :table #xt/table lineitem,
            :columns
            [l_orderkey
             {l_shipdate

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q08.edn
@@ -37,23 +37,23 @@
         [[:rename
           {:prefix r.8}
           [:scan
-           {:table #xt/table region,
+           {:db-name "xtdb", :table #xt/table region,
             :columns [_id {r_name (== r_name "AMERICA")}]}]]
          [:rename
           {:prefix n2.7}
-          [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+          [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]
          [:rename
           {:prefix n1.6}
           [:scan
-           {:table #xt/table nation, :columns [_id n_regionkey]}]]
+           {:db-name "xtdb", :table #xt/table nation, :columns [_id n_regionkey]}]]
          [:rename
           {:prefix c.5}
           [:scan
-           {:table #xt/table customer, :columns [c_nationkey _id]}]]
+           {:db-name "xtdb", :table #xt/table customer, :columns [c_nationkey _id]}]]
          [:rename
           {:prefix o.4}
           [:scan
-           {:table #xt/table orders,
+           {:db-name "xtdb", :table #xt/table orders,
             :columns
             [_id
              {o_orderdate
@@ -65,7 +65,7 @@
          [:rename
           {:prefix l.3}
           [:scan
-           {:table #xt/table lineitem,
+           {:db-name "xtdb", :table #xt/table lineitem,
             :columns
             [l_orderkey
              l_extendedprice
@@ -75,11 +75,11 @@
          [:rename
           {:prefix p.1}
           [:scan
-           {:table #xt/table part,
+           {:db-name "xtdb", :table #xt/table part,
             :columns
             [_id {p_type (== p_type "ECONOMY ANODIZED STEEL")}]}]]
          [:rename
           {:prefix s.2}
           [:scan
-           {:table #xt/table supplier,
+           {:db-name "xtdb", :table #xt/table supplier,
             :columns [_id s_nationkey]}]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q09.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q09.edn
@@ -34,19 +34,19 @@
          {p.1/_id l.3/l_partkey}]}
        [[:rename
          {:prefix n.6}
-         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+         [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]
         [:rename
          {:prefix o.5}
-         [:scan {:table #xt/table orders, :columns [_id o_orderdate]}]]
+         [:scan {:db-name "xtdb", :table #xt/table orders, :columns [_id o_orderdate]}]]
         [:rename
          {:prefix ps.4}
          [:scan
-          {:table #xt/table partsupp,
+          {:db-name "xtdb", :table #xt/table partsupp,
            :columns [ps_partkey ps_supplycost ps_suppkey]}]]
         [:rename
          {:prefix l.3}
          [:scan
-          {:table #xt/table lineitem,
+          {:db-name "xtdb", :table #xt/table lineitem,
            :columns
            [l_orderkey
             l_extendedprice
@@ -57,10 +57,10 @@
         [:rename
          {:prefix p.1}
          [:scan
-          {:table #xt/table part,
+          {:db-name "xtdb", :table #xt/table part,
            :columns [_id {p_name (like p_name "%green%")}]}]]
         [:rename
          {:prefix s.2}
          [:scan
-          {:table #xt/table supplier,
+          {:db-name "xtdb", :table #xt/table supplier,
            :columns [_id s_nationkey]}]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q10.edn
@@ -35,11 +35,11 @@
          {c.1/_id o.2/o_custkey}]}
        [[:rename
          {:prefix n.4}
-         [:scan {:table #xt/table nation, :columns [_id n_name]}]]
+         [:scan {:db-name "xtdb", :table #xt/table nation, :columns [_id n_name]}]]
         [:rename
          {:prefix l.3}
          [:scan
-          {:table #xt/table lineitem,
+          {:db-name "xtdb", :table #xt/table lineitem,
            :columns
            [l_orderkey
             {l_returnflag (== l_returnflag "R")}
@@ -48,7 +48,7 @@
         [:rename
          {:prefix c.1}
          [:scan
-          {:table #xt/table customer,
+          {:db-name "xtdb", :table #xt/table customer,
            :columns
            [c_phone
             c_acctbal
@@ -60,7 +60,7 @@
         [:rename
          {:prefix o.2}
          [:scan
-          {:table #xt/table orders,
+          {:db-name "xtdb", :table #xt/table orders,
            :columns
            [_id
             {o_orderdate

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q11.edn
@@ -24,18 +24,18 @@
         [[:rename
           {:prefix n.3}
           [:scan
-           {:table #xt/table nation,
+           {:db-name "xtdb", :table #xt/table nation,
             :columns [_id {n_name (== n_name "GERMANY")}]}]]
          [:rename
           {:prefix ps.1}
           [:scan
-           {:table #xt/table partsupp,
+           {:db-name "xtdb", :table #xt/table partsupp,
             :columns
             [ps_partkey ps_supplycost ps_availqty ps_suppkey]}]]
          [:rename
           {:prefix s.2}
           [:scan
-           {:table #xt/table supplier,
+           {:db-name "xtdb", :table #xt/table supplier,
             :columns [_id s_nationkey]}]]]]]]
      [:project
       {:projections [{_sq_6 (* _sum_out_10 1.0E-4)}]}
@@ -50,15 +50,15 @@
          [[:rename
            {:prefix n.9}
            [:scan
-            {:table #xt/table nation,
+            {:db-name "xtdb", :table #xt/table nation,
              :columns [_id {n_name (== n_name "GERMANY")}]}]]
           [:rename
            {:prefix ps.7}
            [:scan
-            {:table #xt/table partsupp,
+            {:db-name "xtdb", :table #xt/table partsupp,
              :columns [ps_supplycost ps_availqty ps_suppkey]}]]
           [:rename
            {:prefix s.8}
            [:scan
-            {:table #xt/table supplier,
+            {:db-name "xtdb", :table #xt/table supplier,
              :columns [_id s_nationkey]}]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q12.edn
@@ -37,7 +37,7 @@
        [[:rename
          {:prefix o.1}
          [:scan
-          {:table #xt/table orders, :columns [o_orderpriority _id]}]]
+          {:db-name "xtdb", :table #xt/table orders, :columns [o_orderpriority _id]}]]
         [:semi-join
          {:conditions [{l.2/l_shipmode xt.values.4/_column_1}]}
          [:rename
@@ -48,7 +48,7 @@
              (< l_commitdate l_receiptdate)
              (< l_shipdate l_commitdate))}
            [:scan
-            {:table #xt/table lineitem,
+            {:db-name "xtdb", :table #xt/table lineitem,
              :columns
              [{l_receiptdate
                (and

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q13.edn
@@ -18,9 +18,9 @@
          (not (like o.2/o_comment "%special%requests%"))]}
        [:rename
         {:prefix c.1}
-        [:scan {:table #xt/table customer, :columns [_id]}]]
+        [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id]}]]
        [:rename
         {:prefix o.2}
         [:scan
-         {:table #xt/table orders,
+         {:db-name "xtdb", :table #xt/table orders,
           :columns [_id o_comment o_custkey]}]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q14.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q14.edn
@@ -16,7 +16,7 @@
     [[:rename
       {:prefix l.1}
       [:scan
-       {:table #xt/table lineitem,
+       {:db-name "xtdb", :table #xt/table lineitem,
         :columns
         [{l_shipdate
           (and
@@ -31,4 +31,4 @@
          l_partkey]}]]
      [:rename
       {:prefix p.2}
-      [:scan {:table #xt/table part, :columns [_id p_type]}]]]]]]]
+      [:scan {:db-name "xtdb", :table #xt/table part, :columns [_id p_type]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q15.edn
@@ -11,7 +11,7 @@
     [:rename
      {:prefix l.1}
      [:scan
-      {:table #xt/table lineitem,
+      {:db-name "xtdb", :table #xt/table lineitem,
        :columns
        [{l_shipdate
          (and
@@ -45,7 +45,7 @@
        [[:rename
          {:prefix s.5}
          [:scan
-          {:table #xt/table supplier,
+          {:db-name "xtdb", :table #xt/table supplier,
            :columns [s_name s_address s_phone _id]}]]
         [:rename
          {:prefix revenue.6}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q16.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q16.edn
@@ -29,14 +29,14 @@
          [:rename
           {:prefix ps.1}
           [:scan
-           {:table #xt/table partsupp,
+           {:db-name "xtdb", :table #xt/table partsupp,
             :columns [ps_partkey ps_suppkey]}]]
          [:project
           {:projections [{_id s.6/_id}]}
           [:rename
            {:prefix s.6}
            [:scan
-            {:table #xt/table supplier,
+            {:db-name "xtdb", :table #xt/table supplier,
              :columns
              [{s_comment (like s_comment "%Customer%Complaints%")}
               _id]}]]]]
@@ -45,7 +45,7 @@
          [:rename
           {:prefix p.2}
           [:scan
-           {:table #xt/table part,
+           {:db-name "xtdb", :table #xt/table part,
             :columns
             [_id
              {p_brand (<> p_brand "Brand#45")}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q17.edn
@@ -25,12 +25,12 @@
         [[:rename
           {:prefix l.1}
           [:scan
-           {:table #xt/table lineitem,
+           {:db-name "xtdb", :table #xt/table lineitem,
             :columns [l_extendedprice l_quantity l_partkey]}]]
          [:rename
           {:prefix p.2}
           [:scan
-           {:table #xt/table part,
+           {:db-name "xtdb", :table #xt/table part,
             :columns
             [_id
              {p_brand (== p_brand "Brand#23")}
@@ -38,5 +38,5 @@
       [:rename
        {:prefix l.4}
        [:scan
-        {:table #xt/table lineitem,
+        {:db-name "xtdb", :table #xt/table lineitem,
          :columns [l_quantity l_partkey]}]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q18.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q18.edn
@@ -30,17 +30,17 @@
        [[:rename
          {:prefix l.3}
          [:scan
-          {:table #xt/table lineitem,
+          {:db-name "xtdb", :table #xt/table lineitem,
            :columns [l_orderkey l_quantity]}]]
         [:rename
          {:prefix c.1}
-         [:scan {:table #xt/table customer, :columns [_id c_name]}]]
+         [:scan {:db-name "xtdb", :table #xt/table customer, :columns [_id c_name]}]]
         [:semi-join
          {:conditions [{o.2/_id l_orderkey}]}
          [:rename
           {:prefix o.2}
           [:scan
-           {:table #xt/table orders,
+           {:db-name "xtdb", :table #xt/table orders,
             :columns [o_totalprice _id o_orderdate o_custkey]}]]
          [:project
           {:projections [{l_orderkey l.5/l_orderkey}]}
@@ -52,5 +52,5 @@
             [:rename
              {:prefix l.5}
              [:scan
-              {:table #xt/table lineitem,
+              {:db-name "xtdb", :table #xt/table lineitem,
                :columns [l_orderkey l_quantity]}]]]]]]]]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q19.edn
@@ -60,7 +60,7 @@
            [[:rename
              {:prefix l.1}
              [:scan
-              {:table #xt/table lineitem,
+              {:db-name "xtdb", :table #xt/table lineitem,
                :columns
                [l_extendedprice
                 l_quantity
@@ -71,7 +71,7 @@
             [:rename
              {:prefix p.2}
              [:scan
-              {:table #xt/table part,
+              {:db-name "xtdb", :table #xt/table part,
                :columns [_id p_brand p_size p_container]}]]]]
           [:rename
            {:prefix xt.values.10}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q20.edn
@@ -12,7 +12,7 @@
       [:rename
        {:prefix s.1}
        [:scan
-        {:table #xt/table supplier,
+        {:db-name "xtdb", :table #xt/table supplier,
          :columns [s_name s_address _id s_nationkey]}]]
       [:project
        {:projections [{ps_suppkey ps.4/ps_suppkey}]}
@@ -40,12 +40,12 @@
               [:rename
                {:prefix ps.4}
                [:scan
-                {:table #xt/table partsupp,
+                {:db-name "xtdb", :table #xt/table partsupp,
                  :columns [ps_partkey ps_availqty ps_suppkey]}]]]
              [:rename
               {:prefix l.8}
               [:scan
-               {:table #xt/table lineitem,
+               {:db-name "xtdb", :table #xt/table lineitem,
                 :columns
                 [{l_shipdate
                   (and
@@ -63,10 +63,10 @@
           [:rename
            {:prefix p.6}
            [:scan
-            {:table #xt/table part,
+            {:db-name "xtdb", :table #xt/table part,
              :columns [_id {p_name (like p_name "forest%")}]}]]]]]]]
      [:rename
       {:prefix n.2}
       [:scan
-       {:table #xt/table nation,
+       {:db-name "xtdb", :table #xt/table nation,
         :columns [_id {n_name (== n_name "CANADA")}]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q21.edn
@@ -22,17 +22,17 @@
         [[:rename
           {:prefix n.4}
           [:scan
-           {:table #xt/table nation,
+           {:db-name "xtdb", :table #xt/table nation,
             :columns [_id {n_name (== n_name "SAUDI ARABIA")}]}]]
          [:rename
           {:prefix o.3}
           [:scan
-           {:table #xt/table orders,
+           {:db-name "xtdb", :table #xt/table orders,
             :columns [{o_orderstatus (== o_orderstatus "F")} _id]}]]
          [:rename
           {:prefix s.1}
           [:scan
-           {:table #xt/table supplier,
+           {:db-name "xtdb", :table #xt/table supplier,
             :columns [s_name _id s_nationkey]}]]
          [:semi-join
           {:conditions
@@ -47,7 +47,7 @@
             [:select
              {:predicate (> l_receiptdate l_commitdate)}
              [:scan
-              {:table #xt/table lineitem,
+              {:db-name "xtdb", :table #xt/table lineitem,
                :columns
                [l_receiptdate l_commitdate l_orderkey l_suppkey]}]]]
            [:project
@@ -74,7 +74,7 @@
              [:select
               {:predicate (> l_receiptdate l_commitdate)}
               [:scan
-               {:table #xt/table lineitem,
+               {:db-name "xtdb", :table #xt/table lineitem,
                 :columns
                 [l_linestatus
                  l_receiptdate
@@ -115,7 +115,7 @@
            [:rename
             {:prefix l2.6}
             [:scan
-             {:table #xt/table lineitem,
+             {:db-name "xtdb", :table #xt/table lineitem,
               :columns
               [l_linestatus
                l_receiptdate

--- a/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q22.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/tpch/q22.edn
@@ -37,7 +37,7 @@
              [:rename
               {:prefix c.1}
               [:scan
-               {:table #xt/table customer,
+               {:db-name "xtdb", :table #xt/table customer,
                 :columns [c_phone c_acctbal _id]}]]
              [:project
               {:projections
@@ -53,7 +53,7 @@
               [:rename
                {:prefix o.10}
                [:scan
-                {:table #xt/table orders,
+                {:db-name "xtdb", :table #xt/table orders,
                  :columns
                  [o_orderpriority
                   o_clerk
@@ -89,7 +89,7 @@
              [:rename
               {:prefix c.5}
               [:scan
-               {:table #xt/table customer,
+               {:db-name "xtdb", :table #xt/table customer,
                 :columns [c_phone {c_acctbal (> c_acctbal 0.0)}]}]]]
             [:rename
              {:prefix xt.values.7}

--- a/src/test/resources/xtdb/sql/plan_test_expectations/unnest-query-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/unnest-query-1.edn
@@ -7,4 +7,4 @@
    {:projections [{unnest si.1/films}]}
    [:rename
     {:prefix si.1}
-    [:scan {:table #xt/table stars_in, :columns [films]}]]]]]
+    [:scan {:db-name "xtdb", :table #xt/table stars_in, :columns [films]}]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-1.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-1.edn
@@ -7,7 +7,7 @@
  [:rename
   {:prefix u.1}
   [:scan
-   {:table #xt/table t1,
+   {:db-name "xtdb", :table #xt/table t1,
     :columns
     [{col1 (or (not (boolean (=== 30 col1))))}
      _valid_to

--- a/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-2.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/update-target-table-aliases-2.edn
@@ -7,7 +7,7 @@
  [:rename
   {:prefix t1.1}
   [:scan
-   {:table #xt/table t1,
+   {:db-name "xtdb", :table #xt/table t1,
     :columns
     [{col1 (or (not (boolean (=== 30 col1))))}
      _valid_to

--- a/src/test/resources/xtdb/sql/plan_test_expectations/use-parent-left-scope-in-nested-join-table.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/use-parent-left-scope-in-nested-join-table.edn
@@ -6,10 +6,10 @@
    {:conditions []}
    [[:rename
      {:prefix r1.1}
-     [:scan {:table #xt/table r1, :columns [xs]}]]
+     [:scan {:db-name "xtdb", :table #xt/table r1, :columns [xs]}]]
     [:rename
      {:prefix r2.2}
-     [:scan {:table #xt/table r2, :columns [xs]}]]]]
+     [:scan {:db-name "xtdb", :table #xt/table r2, :columns [xs]}]]]]
   [:mega-join
    {:conditions [{u1.4/i1 u2.6/i2}]}
    [[:map

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-and-system-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-and-system-time-period-spec-between.edn
@@ -3,7 +3,7 @@
  [:rename
   {:prefix t1.1}
   [:scan
-   {:table #xt/table t1,
+   {:db-name "xtdb", :table #xt/table t1,
     :columns [],
     :for-valid-time
     [:between #xt/zdt "3001-01-01T00:00Z" #xt/date "3000-01-01"],

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-as-of.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-as-of.edn
@@ -3,6 +3,6 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-valid-time [:at #xt/ldt "2999-01-01T00:00"]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-between.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-between.edn
@@ -3,7 +3,7 @@
  [:rename
   {:prefix t1.1}
   [:scan
-   {:table #xt/table t1,
+   {:db-name "xtdb", :table #xt/table t1,
     :columns [],
     :for-valid-time
     [:between #xt/zdt "3000-01-01T00:00Z" #xt/date "3001-01-01"]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-from-to.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/valid-time-period-spec-from-to.edn
@@ -3,7 +3,7 @@
  [:rename
   {:prefix foo.1}
   [:scan
-   {:table #xt/table foo,
+   {:db-name "xtdb", :table #xt/table foo,
     :columns [bar],
     :for-valid-time
     [:in #xt/date "2999-01-01" #xt/zdt "3000-01-01T00:00Z"]}]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-clause.edn
@@ -4,7 +4,7 @@
   {:conditions []}
   [[:rename {:prefix foo.3} [:project
      {:projections [{_id bar.1/_id}]}
-     [:rename {:prefix bar.1} [:scan {:table #xt/table bar, :columns [{_id (== _id 5)}]}]]]]
+     [:rename {:prefix bar.1} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [{_id (== _id 5)}]}]]]]
    [:rename {:prefix baz.4} [:project
      {:projections [{_id bar.1/_id}]}
-     [:rename {:prefix bar.1} [:scan {:table #xt/table bar, :columns [{_id (== _id 5)}]}]]]]]]]
+     [:rename {:prefix bar.1} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [{_id (== _id 5)}]}]]]]]]]

--- a/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-mat-clause.edn
+++ b/src/test/resources/xtdb/sql/plan_test_expectations/with/test-with-mat-clause.edn
@@ -2,7 +2,7 @@
  {:binding-sym foo.2}
  [:project
   {:projections [{_id bar.1/_id}]}
-  [:rename {:prefix bar.1} [:scan {:table #xt/table bar, :columns [{_id (== _id 5)}]}]]]
+  [:rename {:prefix bar.1} [:scan {:db-name "xtdb", :table #xt/table bar, :columns [{_id (== _id 5)}]}]]]
  [:project
   {:projections [{foo_id foo.3/_id} {baz_id baz.4/_id}]}
   [:mega-join


### PR DESCRIPTION
## Summary

`TableRef` carried a `dbName` field, making it a globally-qualified `(dbName, schemaName, tableName)` identity. This drops it: `TableRef` is now db-relative — `(schemaName, tableName)`, "a table within a database". Where the database genuinely matters, it travels *alongside* a db-relative ref rather than inside the identity. Behaviour is preserved — this is a refactor.

There is no surrounding issue; this PR carries its own context.

## Motivation

The database is ambient context almost everywhere `TableRef` is used. The per-database state and indexing layers (`OpenTx`, `LiveIndex`, `BlockCatalog`, `TableCatalog`, `Snapshot`, `TrieCatalog`) stamped the db onto the ref from the `dbState` they already hold, purely to satisfy the type, then used the full ref only as a redundant key in a map that is itself per-database. The db was never read back for logic — the one read was a telemetry attribute. Scan execution consumed it once to resolve a `Database` and then worked off that object. The cost showed up at construction sites that don't naturally have a db (and there are many), which had to invent one.

## Where the database rides now

- Scan logical-plan nodes carry a required `:db-name` key; `emitScan` resolves the `Database` from it, and the scan-col / scan-vec-type map keys gain the db so they don't collide across databases.
- The SQL and XTQL planners key `table-info` and `table-chains` by `[db-name table-ref]` pairs. These are the genuinely cross-database maps — `query.clj`'s `->table-info` folds every attached database's table info into one map, so a db-relative key alone would collide when two databases share a `schema/table`. The db-relative-to-qualified conversion happens at the `(.tableInfo snap)` boundaries, where the db name is in hand.
- Per-db indexing layers simply stop stamping the db on; the db is the `dbState`/`dbName` they already carry.

A composite/wrapper type for the pair was considered and deliberately not introduced — the pairing is confined to that bounded planner surface, and a bare `[db-name table-ref]` vector reads idiomatically there.

## Behaviour preserved

Cross-database queries, the SQL-standard `information_schema.table_catalog` column (now sourced from the per-db cursor's ambient db name), and the full unit suite all behave exactly as before.

## Wire-format change — worth a reviewer's eye

The `#xt/table` reader literal drops its `[db table]` vector form, and the transit and JSON-LD (`xt:table`) encodings drop `db`. `TableRef` does not appear in SQL result sets, so this is internal plumbing rather than a result-set contract — but it is a wire-format narrowing. If you read the JSON-LD surface as a public API, this is the line to consider a `breaking change` label against.

## Notes

Two `xt$txs` golden block files are regenerated. They were already stale on the base — a prior error-enrichment change merges `{:table, :tx-key, :tx-op-idx}` into every stored anomaly but didn't regenerate these goldens. The change surfaces here because that enriched error embeds a `:table` ref, now db-relative (~16 bytes smaller); the regenerated goldens differ from the actual only in the `error` column's HLL digest and data-file size.

## Test plan

- Full unit suite green (`./gradlew test`, 1554 tests).
- A code-review pass over the diff found no correctness issues; producer/consumer key shapes across the planner were verified consistent, and three minor robustness/tidy items (a dead field, two defensive `:else` guards against silent `nil`) were folded in.