### PR TITLE
refactor(adbc): consolidate the connection transaction onto a coalescing DML buffer

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -36,6 +36,7 @@ import xtdb.api.module.XtdbModule
 import xtdb.api.storage.Storage
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
+import xtdb.arrow.RelationWriter
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.unsupported
@@ -138,7 +139,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         private val awaitTimeout: Duration = Duration.ofMinutes(1)
 
         private var autoCommit = true
-        private val pendingOps = mutableListOf<TxOp>()
+        private var tx: Transaction? = null
 
         private fun db(dbName: DatabaseName): Database =
             dbCat.databaseOrNull(dbName)
@@ -321,29 +322,95 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             }
         }
 
+        // Manual-tx DML buffer: consecutive same-SQL ops coalesce, their args appended into the last op's own
+        // relation, so a prepared INSERT in a loop becomes one multi-row op.
+        private class DmlBuffer(private val al: BufferAllocator) : AutoCloseable {
+            private val ops = mutableListOf<TxOp>()
+
+            fun add(op: TxOp) {
+                if (op !is TxOp.Sql || op.args == null) {
+                    ops.add(op)
+                    return
+                }
+
+                val target = (ops.lastOrNull() as? TxOp.Sql)?.takeIf { it.sql == op.sql }?.args as? RelationWriter
+                if (target != null) {
+                    op.args.use(target::append)
+                } else {
+                    val rel = Relation(al)
+                    rel.closeOnCatch { op.args.use(rel::append) }
+                    ops.add(TxOp.Sql(op.sql, rel))
+                }
+            }
+
+            fun drain(): List<TxOp> = ops.toList().also { ops.clear() }
+
+            override fun close() = ops.forEach { it.close() }
+        }
+
+        // resolved on the first statement: a query makes it read-only, DML makes it read-write. In XTDB a
+        // "read-write" tx is write-only — queries are rejected in a DML tx, DML in a read-only one.
+        private sealed interface AccessMode : AutoCloseable {
+            data object ReadOnly : AccessMode {
+                override fun close() {}
+            }
+
+            class ReadWrite(
+                val buffer: DmlBuffer,
+                val systemTime: Instant? = null,
+                val userMetadata: Map<*, *>? = null,
+                val async: Boolean = false,
+            ) : AccessMode {
+                override fun close() = buffer.close()
+            }
+        }
+
+        private class Transaction(var mode: AccessMode? = null, var failed: Throwable? = null) : AutoCloseable {
+            override fun close() { mode?.close() }
+        }
+
+        private fun commitTx() {
+            val tx = tx ?: return
+            this.tx = null
+            val ops = (tx.mode as? AccessMode.ReadWrite)?.buffer?.drain()
+            if (!ops.isNullOrEmpty()) ops.useAll { executeTx(it) }
+        }
+
         internal fun executeDml(op: TxOp) {
             if (autoCommit) {
                 listOf(op).useAll { ops -> executeTx(ops) }
-            } else {
-                pendingOps.add(op)
+                return
+            }
+            val tx = tx ?: Transaction().also { tx = it }
+            when (val mode = tx.mode) {
+                is AccessMode.ReadWrite -> mode.buffer.add(op)
+                null -> AccessMode.ReadWrite(DmlBuffer(allocator)).also { tx.mode = it }.buffer.add(op)
+                is AccessMode.ReadOnly -> {
+                    op.close()
+                    throw Incorrect("Cannot write in a read-only transaction", "xtdb/read-only-tx")
+                }
             }
         }
 
         override fun setAutoCommit(autoCommit: Boolean) {
+            if (this.autoCommit == autoCommit) return
+            if (autoCommit) commitTx()
             this.autoCommit = autoCommit
         }
 
         override fun commit() {
-            val ops = pendingOps.toList()
-            pendingOps.clear()
-            if (ops.isNotEmpty()) {
-                ops.useAll { executeTx(it) }
-            }
+            if (autoCommit) throw Incorrect("Cannot commit when autoCommit is enabled", "xtdb.adbc/commit-in-autocommit")
+            commitTx()
+        }
+
+        private fun discardTx() {
+            tx?.close()
+            tx = null
         }
 
         override fun rollback() {
-            pendingOps.forEach { it.close() }
-            pendingOps.clear()
+            if (autoCommit) throw Incorrect("Cannot rollback when autoCommit is enabled", "xtdb.adbc/rollback-in-autocommit")
+            discardTx()
         }
 
         override fun bulkIngest(targetTableName: String, mode: BulkIngestMode): Statement {
@@ -652,7 +719,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         override fun getCurrentDbSchema(): String = "public"
 
         override fun close() {
-            rollback()
+            discardTx()
         }
     }
 

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -189,4 +189,148 @@ class InProcessAdbcTest {
             }
         }
     }
+
+    private fun allRows(stmt: AdbcStatement): List<Map<*, *>> {
+        val res = mutableListOf<Map<*, *>>()
+        stmt.executeQuery().reader.use { rdr ->
+            while (rdr.loadNextBatch())
+                Relation.fromRoot(al, rdr.vectorSchemaRoot).use { res.addAll(it.toMaps(SNAKE_CASE_STRING)) }
+        }
+        return res
+    }
+
+    private fun Xtdb.Connection.select(sql: String) =
+        createStatement().use { stmt -> stmt.setSqlQuery(sql); allRows(stmt) }
+
+    private fun Xtdb.Connection.update(sql: String) =
+        createStatement().use { stmt -> stmt.setSqlQuery(sql); stmt.executeUpdate() }
+
+    @Test
+    fun `commit and rollback are illegal in autocommit mode`() {
+        xtdb.connect().use { conn ->
+            assertThrows(Incorrect::class.java) { conn.commit() }
+            assertThrows(Incorrect::class.java) { conn.rollback() }
+        }
+    }
+
+    @Test
+    fun `manual-mode writes are buffered until commit`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "the buffered write is not yet committed"
+            )
+
+            conn.commit()
+            assertEquals(
+                listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "visible once committed"
+            )
+        }
+    }
+
+    @Test
+    fun `rollback discards buffered writes`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.rollback()
+
+            assertEquals(listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"))
+        }
+    }
+
+    @Test
+    fun `switching to autocommit commits the open transaction`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.setAutoCommit(true)
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id")
+            )
+        }
+    }
+
+    @Test
+    fun `consecutive prepared inserts coalesce and every row lands on commit`() {
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                for (id in 1L..5L) {
+                    bindLongParam(stmt, id)
+                    stmt.executeUpdate()
+                }
+            }
+            conn.commit()
+
+            assertEquals(
+                (1L..5L).map { mapOf("_id" to it) },
+                conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "every row of the coalesced run lands as a distinct insert"
+            )
+        }
+    }
+
+    @Test
+    fun `a different statement seals the run, then a fresh run resumes`() {
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                bindLongParam(stmt, 1L); stmt.executeUpdate()
+                bindLongParam(stmt, 2L); stmt.executeUpdate()
+            }
+
+            conn.update("INSERT INTO bar RECORDS {_id: 10}")
+
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                bindLongParam(stmt, 3L); stmt.executeUpdate()
+            }
+
+            conn.commit()
+
+            assertEquals((1L..3L).map { mapOf("_id" to it) }, conn.select("SELECT _id FROM foo ORDER BY _id"))
+            assertEquals(listOf(mapOf("_id" to 10L)), conn.select("SELECT _id FROM bar"))
+        }
+    }
+
+    @Test
+    fun `rollback discards a buffered coalescing run`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                for (id in 1L..3L) {
+                    bindLongParam(stmt, id)
+                    stmt.executeUpdate()
+                }
+            }
+            conn.rollback()
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "the buffered run is discarded; the run relation is freed (tearDown's allocator close would fail on a leak)"
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary

The unified `Xtdb.Connection` is becoming the SQL front door for every frontend (pgwire, ADBC, Flight SQL): session state, prepare, and query execution already route through it. This moves the connection's *transaction* there too, starting with ADBC, and reshapes how buffered DML is held so that coalescing — previously a pgwire-only trick — becomes a property of the connection that all frontends share.

This is the first of two increments: it wires ADBC onto the new model; a follow-up ports pgwire onto the same buffer (see *Out of scope*).

## Context

Per-frontend transaction machinery is the largest remaining duplication between pgwire and ADBC. pgwire keeps tx-state in a Clojure map and coalesces consecutive same-SQL DML into one multi-row op; ADBC buffered manual-mode DML as a flat list of eagerly-opened `TxOp`s — one per `executeUpdate`. So a prepared `INSERT` run in a loop produced N separate ops on the ADBC path, each holding its own Arrow buffers and planned independently at commit, where pgwire would have folded them into one.

## Approach

The connection now owns the DML buffer. It keeps its ops in a list and coalesces in place: a DML op whose SQL matches the last buffered op appends its argument rows into that op's own relation, so a prepared `INSERT` run in a loop becomes one multi-row `TxOp.Sql` rather than N ops. Other ops, and SQL with no arguments, stay standalone and ordered. The op carries a growing relation from its first row, so there is no separate seal step or deferred/eager conversion — at commit the list is already the submittable op list.

`maybePromote` on the relation writer absorbs arguments whose types differ across executes, so the buffer needs no up-front schema — it widens as rows arrive, the same way pgwire's commit-time `sql->static-ops` merges types across rows.

The transaction is modelled as a sealed `AccessMode`: a read-only tx carries the read basis, a read-write tx carries the buffer and its commit metadata. In XTDB a "read-write" transaction is effectively write-only — queries are rejected inside a DML tx and DML inside a read-only one — so a read basis on a write tx is now unrepresentable rather than merely unused.

## Behaviour

This is behaviour-preserving for results: a coalesced multi-row op applies each row exactly as N single-row ops would, which is the semantics pgwire has always relied on. The one deliberate change is JDBC correctness — `commit`/`rollback` now key off the sticky autocommit flag and throw when autocommit is on, rather than silently flushing.

Arrow lifecycle is single-owner throughout: each incoming argument batch is appended into the op's relation and the incoming reader closed; `drain` hands the ops to the committer and empties the buffer so a later close cannot double-free. A throw mid-append (e.g. OOM opening a relation) closes the arguments and leaves the buffer consistent.

## Out of scope

pgwire keeps its own buffer for now; porting it onto this connection-owned one — feeding rows a row at a time — is the next increment, and will populate the `systemTime`/`userMetadata`/`async` and `failed` fields the model carries for that migration. ADBC/Flight SQL begin-time snapshot isolation, and gating session-state setters mid-transaction, are separate later increments.

## Test plan

`InProcessAdbcTest` gains real-node cases: coalescing (a prepared insert looped five times lands every row), seal-on-SQL-change (a run, an interleaved statement, then a fresh run all commit in order), and rollback discarding a buffered run without leaking. The full ADBC / Connection / Flight SQL suites and the pgwire suite stay green — pgwire is unaffected, as it submits through `executeTx`/`submitTx`, not `executeDml` — with no reflection or boxed-math warnings.
