### PR TITLE
refactor: move the connection transaction off pgwire onto Xtdb.Connection

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -324,11 +324,11 @@
   If the status is omitted, the status is determined from whether a transaction is currently open."
   ([conn]
    ;; it would be good to look at ready status being automatically driven by pure conn state, this is a bit messy.
-   (if-some [transaction (:transaction @(:conn-state conn))]
-     (if (:failed transaction)
-       (cmd-send-ready conn :failed-transaction)
-       (cmd-send-ready conn :transaction))
-     (cmd-send-ready conn :idle)))
+   (let [cs @(:conn-state conn)]
+     (cond
+       (.getTxFailed ^Xtdb$Connection (:node-conn cs)) (cmd-send-ready conn :failed-transaction)
+       (:transaction cs) (cmd-send-ready conn :transaction)
+       :else (cmd-send-ready conn :idle))))
   ([conn status]
    (pgio/cmd-write-msg conn pgio/msg-ready {:status status})))
 
@@ -599,8 +599,8 @@
 
 (defn cmd-commit [{:keys [conn-state tx-error-counter tx-latency-timer tx-submit-timer tx-execute-timer] :as conn}]
   (let [{:keys [transaction ^Xtdb$Connection node-conn]} @conn-state
-        {:keys [failed async?]} transaction]
-    (if failed
+        {:keys [async?]} transaction]
+    (if (.getTxFailed node-conn)
       (throw (pgio/err-protocol-violation "transaction failed"))
 
       (try
@@ -714,10 +714,10 @@
 (defmethod handle-msg* :msg-sync [{:keys [conn-state] :as conn} _]
   ;; Sync commands are sent by the client to commit transactions
   ;; and to clear the error state of a :extended mode series of commands (e.g the parse/bind/execute dance)
-  (let [{:keys [implicit? failed]} (:transaction @conn-state)]
+  (let [{:keys [implicit?]} (:transaction @conn-state)]
     (try
       (when implicit?
-        (if failed
+        (if (.getTxFailed ^Xtdb$Connection (:node-conn @conn-state))
           (cmd-rollback conn)
           (cmd-commit conn)))
       (catch Throwable t
@@ -1151,7 +1151,7 @@
   (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET SESSION CHARACTERISTICS"}))
 
 (defn- cmd-exec-dml [{:keys [node conn-state tx-error-counter ^BufferAllocator allocator] :as conn} {:keys [^ParsedStatement$Dml parsed args param-oids]}]
-  (when (get-in @conn-state [:transaction :failed])
+  (when (.getTxFailed ^Xtdb$Connection (:node-conn @conn-state))
     (throw (pgio/err-protocol-violation "current transaction is aborted, commands ignored until ROLLBACK is received")))
 
   (let [query (.getOriginalSql parsed)]
@@ -1227,7 +1227,7 @@
                        :as _portal}]
   ;; Create an implicit transaction if one hasn't already been started
   (let [transaction (get-in @conn-state [:transaction])]
-    (when (:failed transaction)
+    (when (.getTxFailed ^Xtdb$Connection (:node-conn @conn-state))
       (throw (pgio/err-protocol-violation "current transaction is aborted, commands ignored until ROLLBACK is received")))
 
     (when-not (or transaction (instance? ParsedStatement$ShowVariable parsed))
@@ -1490,13 +1490,13 @@
           (when-let [{:keys [implicit?]} (:transaction @conn-state)]
             (if implicit?
               (cmd-rollback conn)
-              (swap! conn-state util/maybe-update :transaction assoc :failed true, :err e)))
+              (.failTx ^Xtdb$Connection (:node-conn @conn-state) e)))
 
           (send-ex conn e))))
 
-    (let [{:keys [implicit? failed]} (:transaction @conn-state)]
+    (let [{:keys [implicit?]} (:transaction @conn-state)]
       (when implicit?
-        (if failed
+        (if (.getTxFailed ^Xtdb$Connection (:node-conn @conn-state))
           (cmd-rollback conn)
           (cmd-commit conn))))
 
@@ -1644,14 +1644,14 @@
 
     (catch Throwable e
       (log/debug e "error processing message: " (ex-message e))
+      ;; error seen while in :extended mode, start skipping messages until sync received
       (swap! conn-state
-             (fn [{:keys [transaction protocol] :as cs}]
+             (fn [{:keys [protocol] :as cs}]
                (cond-> cs
-                 ;; error seen while in :extended mode, start skipping messages until sync received
-                 (= :extended protocol) (assoc :skip-until-sync? true)
+                 (= :extended protocol) (assoc :skip-until-sync? true))))
 
-                 ;; mark a transaction (if open as failed), for now we will consider all errors to do this
-                 transaction (update :transaction assoc :failed true, :err e))))
+      ;; mark any open tx as failed (no-op if none) — all errors abort the tx for now
+      (.failTx ^Xtdb$Connection (:node-conn @conn-state) e)
 
       (send-ex conn e))))
 

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -578,14 +578,15 @@
                                            (->> (into {} (filter (comp some? val))))))
                                  (assoc :await-token await-token)))))))))
 
-  ;; mirror the write-side opts onto the connection's tx, so executeDml buffers and commit submits with them.
-  ;; the read basis (current-time/snapshot/await-token) still flows via the :transaction map + bind-stmt — that's C′.
+  ;; mirror the tx onto the connection: it pins the read basis (a read-only tx's queries read it via openQuery) and
+  ;; the commit metadata (a read-write tx's submit uses it).
   (let [{:keys [^Xtdb$Connection node-conn session]
-         {:keys [access-mode default-tz system-time user-metadata async?]} :transaction} @conn-state]
+         {:keys [access-mode current-time snapshot-token snapshot-time await-token
+                 default-tz system-time user-metadata async?]} :transaction} @conn-state]
     ;; pgwire's swap above already decided whether a (re-)begin is allowed (it throws on a double explicit BEGIN).
     ;; an explicit BEGIN is preceded by an empty implicit auto-begin (msg-simple-query) — discard it and re-begin.
     (.rollback node-conn)
-    (.beginTx node-conn nil nil nil nil
+    (.beginTx node-conn current-time snapshot-token (some-> snapshot-time time/->instant) await-token
               default-tz system-time (get-in session [:parameters "user"]) user-metadata
               (boolean async?)
               (case access-mode :read-only true :read-write false nil))))
@@ -947,21 +948,27 @@
         {:keys [^Clock clock], session-params :parameters} session
         await-token (:await-token transaction (.getAwaitToken node-conn))
 
-        query-opts (QueryOpts. (or (some-> (or (:current-time stmt) (:current-time transaction))
-                                            (time/->instant))
-                                   (.instant clock))
-                              (or (:default-tz transaction) (.getDefaultTz node-conn))
-                              (:snapshot-token stmt (:snapshot-token transaction))
-                              (some-> (or (:snapshot-time stmt) (:snapshot-time transaction))
-                                      (time/->instant))
-                              query-tracer)
+        ;; current-time/snapshot are the read basis: tx-less reads fall back to the session clock here, an open
+        ;; read-only tx's pinned basis is overlaid by the connection's openQuery. tz is NOT basis — it's session
+        ;; state (begin-initialised, SET TIME ZONE-mutable), so it stays pgwire-side and rides through here.
+        query-opts (QueryOpts. (.instant clock)
+                               (or (:default-tz transaction) (.getDefaultTz node-conn))
+                               nil nil query-tracer)
 
         xt-args (xtify-args conn args stmt)]
 
-    (letfn [(->cursor ^xtdb.ResultCursor [xt-args]
+    (letfn [;; meta-reads (SHOW, EXECUTE's arg evaluation) open the prepared query directly — they mustn't pin a
+            ;; basis or resolve the connection's tx access-mode (an EXECUTE-of-DML evaluates its args first).
+            (->cursor ^xtdb.ResultCursor [xt-args]
               (with-auth-check conn
                 (util/with-close-on-catch [args-rel (vw/open-args allocator xt-args)]
                   (.openQuery prepared-query args-rel query-opts))))
+
+            ;; genuine user queries go through the connection, which overlays an open read-only tx's pinned basis
+            (->tx-cursor ^xtdb.ResultCursor [xt-args]
+              (with-auth-check conn
+                (util/with-close-on-catch [args-rel (vw/open-args allocator xt-args)]
+                  (.openQuery node-conn prepared-query args-rel query-opts))))
 
             (->pg-cols [prepared-pg-cols ^ResultCursor cursor]
               (let [resolved-pg-cols (mapv (fn [[col-name vec-type]] (type->pg-col col-name vec-type)) (.getResultTypes cursor))]
@@ -982,7 +989,7 @@
         (.accept parsed
                (reify ParsedStatement$Visitor
                  (visitQuery [_ _]
-                   (util/with-close-on-catch [cursor (->cursor xt-args)]
+                   (util/with-close-on-catch [cursor (->tx-cursor xt-args)]
                      (-> stmt
                          (assoc :cursor cursor,
                                 :pg-cols (->pg-cols (:pg-cols stmt) cursor)))))
@@ -1035,7 +1042,7 @@
                          (cond
                            (instance? ParsedStatement$Query inner-parsed)
                            (with-auth-check conn
-                             (util/with-close-on-catch [inner-cursor (.openQuery inner-pq args-rel query-opts)]
+                             (util/with-close-on-catch [inner-cursor (.openQuery node-conn inner-pq args-rel query-opts)]
                                (-> inner
                                    (assoc :cursor inner-cursor
                                           :pg-cols (-> (->pg-cols (:pg-cols inner) inner-cursor)

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -54,7 +54,7 @@
                        ParsedStatement ParsedStatement$Visitor ParsedStatement$TxOptions
                        ParsedStatement$Query ParsedStatement$Dml ParsedStatement$ShowVariable
                        ParsedStatement$CopyIn ParsedStatement$Execute)
-           (xtdb.tx PutDocs PutRel Sql TxOpts)))
+           (xtdb.tx PutDocs PutRel TxOp$Sql)))
 
 ;; references
 ;; https://www.postgresql.org/docs/current/protocol-flow.html
@@ -376,7 +376,10 @@
                  (.databaseOrNull db-cat db-name))
                (throw (err-invalid-catalog db-name)))
         user (get startup-opts "user")
-        node-conn (xtp/open-connection node db-name)
+        node-conn (doto ^Xtdb$Connection (xtp/open-connection node db-name)
+                        ;; pgwire drives tx boundaries itself (implicit + explicit), so the connection
+                        ;; stays in manual mode for its whole life — executeDml buffers, we commit explicitly
+                        (.setAutoCommit false))
         conn (assoc conn :node node, :authn authn, :db db)
         _ (swap! (:conn-state conn) assoc :node-conn node-conn)]
     (if authn
@@ -573,51 +576,49 @@
                                            (update :snapshot-time #(some-> % (apply-args args)))
                                            (update :user-metadata #(some-> % (apply-args args)))
                                            (->> (into {} (filter (comp some? val))))))
-                                 (assoc :await-token await-token))))))))))
+                                 (assoc :await-token await-token)))))))))
+
+  ;; mirror the write-side opts onto the connection's tx, so executeDml buffers and commit submits with them.
+  ;; the read basis (current-time/snapshot/await-token) still flows via the :transaction map + bind-stmt — that's C′.
+  (let [{:keys [^Xtdb$Connection node-conn session]
+         {:keys [access-mode default-tz system-time user-metadata async?]} :transaction} @conn-state]
+    ;; pgwire's swap above already decided whether a (re-)begin is allowed (it throws on a double explicit BEGIN).
+    ;; an explicit BEGIN is preceded by an empty implicit auto-begin (msg-simple-query) — discard it and re-begin.
+    (.rollback node-conn)
+    (.beginTx node-conn nil nil nil nil
+              default-tz system-time (get-in session [:parameters "user"]) user-metadata
+              (boolean async?)
+              (case access-mode :read-only true :read-write false nil))))
 
 (defn close-transaction [{:keys [conn-state] :as conn}]
+  ;; discard any open connection-side tx (no-op after a successful commit, which already cleared it)
+  (.rollback ^Xtdb$Connection (:node-conn @conn-state))
   (swap! conn-state dissoc :transaction)
   (close-all-portals conn))
 
-(defn cmd-commit [{:keys [conn-state ^BufferAllocator allocator, tx-error-counter, tx-latency-timer, tx-submit-timer, tx-execute-timer] :as conn}]
-  (let [{:keys [transaction session ^Xtdb$Connection node-conn]} @conn-state
-        {:keys [failed dml-buf system-time access-mode default-tz async? user-metadata]} transaction
-        {:keys [parameters]} session]
+(defn cmd-commit [{:keys [conn-state tx-error-counter tx-latency-timer tx-submit-timer tx-execute-timer] :as conn}]
+  (let [{:keys [transaction ^Xtdb$Connection node-conn]} @conn-state
+        {:keys [failed async?]} transaction]
     (if failed
       (throw (pgio/err-protocol-violation "transaction failed"))
 
       (try
-        (when (= :read-write access-mode)
-          (metrics/record-callable! tx-latency-timer
-                                    (let [tx-opts (TxOpts. default-tz
-                                                           (some-> system-time (time/->instant {:default-tz default-tz}))
-                                                           (get parameters "user")
-                                                           user-metadata)]
-                                      (util/with-open [tx-ops (->> dml-buf
-                                                                   (mapcat (fn [op]
-                                                                             (or (when (instance? Sql op)
-                                                                                   (let [^Sql op op]
-                                                                                     (seq (sql/sql->static-ops (.getSql op) (.getArgRows op)))))
-                                                                                 [op])))
-                                                                   (util/safe-mapv #(xt-log/open-tx-op % allocator {:default-tz default-tz})))]
-                                        (if async?
-                                          (let [^Xtdb$SubmittedTx tx-id (with-auth-check conn
-                                                                          (metrics/record-callable! tx-submit-timer
-                                                                                                    (.submitTx node-conn tx-ops tx-opts)))
-                                                msg-id (.getTxId tx-id)]
-                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id}))
-
-                                          (let [^Xtdb$ExecutedTx tx (with-auth-check conn
-                                                                      (metrics/record-callable! tx-execute-timer
-                                                                                                (.executeTx node-conn tx-ops tx-opts)))
-                                                msg-id (.getTxId tx)]
-                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id
-                                                                                          :system-time (.getSystemTime tx)
-                                                                                          :committed? (.getCommitted tx)
-                                                                                          :error (.getError tx)})
-
-                                            (when-let [error (.getError tx)]
-                                              (throw error))))))))
+        ;; the connection drains its buffer, plans/submits, and advances its await-token. it hands us back the
+        ;; SubmittedTx (async) / ExecutedTx (sync) — or nil for a read-only/empty tx — to report as latest-submitted.
+        (metrics/record-callable! tx-latency-timer
+          (let [commit! #(with-auth-check conn (.commitTx node-conn))]
+            (when-let [tx (if async?
+                            (metrics/record-callable! tx-submit-timer (commit!))
+                            (metrics/record-callable! tx-execute-timer (commit!)))]
+              (if (instance? Xtdb$ExecutedTx tx)
+                (let [^Xtdb$ExecutedTx tx tx]
+                  (swap! conn-state assoc :latest-submitted-tx {:tx-id (.getTxId tx)
+                                                                :system-time (.getSystemTime tx)
+                                                                :committed? (.getCommitted tx)
+                                                                :error (.getError tx)})
+                  (when-let [error (.getError tx)]
+                    (throw error)))
+                (swap! conn-state assoc :latest-submitted-tx {:tx-id (.getTxId ^Xtdb$SubmittedTx tx)})))))
         (catch Throwable t
           (metrics/inc-counter! tx-error-counter)
           (throw t))
@@ -1142,7 +1143,7 @@
   (swap! conn-state update-in [:session :characteristics] (fnil into {}) session-characteristics)
   (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET SESSION CHARACTERISTICS"}))
 
-(defn- cmd-exec-dml [{:keys [node conn-state tx-error-counter] :as conn} {:keys [^ParsedStatement$Dml parsed args param-oids]}]
+(defn- cmd-exec-dml [{:keys [node conn-state tx-error-counter ^BufferAllocator allocator] :as conn} {:keys [^ParsedStatement$Dml parsed args param-oids]}]
   (when (get-in @conn-state [:transaction :failed])
     (throw (pgio/err-protocol-violation "current transaction is aborted, commands ignored until ROLLBACK is received")))
 
@@ -1179,15 +1180,11 @@
     (when-not (:transaction @conn-state)
       (cmd-begin conn {:implicit? true, :access-mode :read-write} {}))
 
-    (swap! conn-state update-in [:transaction :dml-buf]
-           (fnil (fn [dml-ops]
-                   (or (when-let [^Sql last-op (peek dml-ops)]
-                         (when (and (instance? Sql last-op)
-                                    (= (.getSql last-op) query))
-                           (conj (pop dml-ops)
-                                 (Sql. query (conj (or (.getArgRows last-op) []) args)))))
-                       (conj dml-ops (Sql. query [args]))))
-                 []))
+    ;; hand the row to the connection — it coalesces consecutive same-SQL ops into one multi-row op and submits
+    ;; at commit. args are already xtified (bind-stmt). open-args always yields ≥1 row (even with no params), so
+    ;; static expansion and the indexer see arg-idx 0 and run the param-count check — matching pre-connection pgwire.
+    (.executeDml ^Xtdb$Connection (:node-conn @conn-state)
+                 (TxOp$Sql. query (vw/open-args allocator args)))
 
     ;; oid is always 0 (legacy pg); row count is 0 because we're async
     (pgio/cmd-write-msg conn pgio/msg-command-complete
@@ -1510,7 +1507,7 @@
                                             (throw (err/incorrect ::copy-not-in-progress "COPY IN not in progress, cannot write data")))]
     (.write write-ch (ByteBuffer/wrap data))))
 
-(defn- copy-transit-batch ^long [{:keys [conn-state] :as conn} {:keys [format, ^Path copy-file]}]
+(defn- copy-transit-batch ^long [{:keys [conn-state ^BufferAllocator allocator] :as conn} {:keys [format, ^Path copy-file]}]
   (let [started-tx? (when-not (:transaction @conn-state)
                       (cmd-begin conn {:implicit? true, :access-mode :read-write} {})
                       true)]
@@ -1522,12 +1519,11 @@
                                                              :transit-msgpack :msgpack)
                                                            {:handlers serde/transit-read-handler-map}))))]
 
-        (swap! conn-state
-               (fn [{:keys [copy], :as conn-state}]
-                 (-> conn-state
-                     (update-in [:transaction :dml-buf] (fnil conj [])
-                                (PutDocs. (:table-name copy) docs nil nil))
-                     (dissoc :copy))))
+        (let [^Xtdb$Connection node-conn (:node-conn @conn-state)]
+          (.executeDml node-conn
+                       (xt-log/open-tx-op (PutDocs. (get-in @conn-state [:copy :table-name]) docs nil nil)
+                                          allocator {:default-tz (.getDefaultTz node-conn)})))
+        (swap! conn-state dissoc :copy)
 
         (when started-tx?
           (cmd-commit conn))
@@ -1546,11 +1542,10 @@
                                              :arrow-file (Relation/loader allocator copy-file))
                      rel (Relation. allocator (.getSchema ldr))]
       (letfn [(add-batch! []
-                (swap! conn-state
-                       (fn [{:keys [copy], :as conn-state}]
-                         (-> conn-state
-                             (update-in [:transaction :dml-buf] (fnil conj [])
-                                        (PutRel. (:table-name copy) (.getAsArrowStream rel)))))))]
+                (let [^Xtdb$Connection node-conn (:node-conn @conn-state)]
+                  (.executeDml node-conn
+                               (xt-log/open-tx-op (PutRel. (get-in @conn-state [:copy :table-name]) (.getAsArrowStream rel))
+                                                  allocator {:default-tz (.getDefaultTz node-conn)}))))]
 
         (if-let [{:keys [access-mode]} (:transaction @conn-state)]
           (do

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -47,7 +47,7 @@
            org.apache.arrow.vector.types.pojo.Field
            (xtdb ICursor ResultCursor ResultCursor$ErrorTrackingCursor PagesCursor)
            (xtdb.antlr Sql$DirectlyExecutableStatementContext)
-           (xtdb.api.query IKeyFn)
+           (xtdb.api.query IKeyFn IKeyFn$KeyFn)
            (xtdb.arrow RelationReader VectorReader VectorType)
            (xtdb.indexer DatabaseSnapshot Snapshot)
            xtdb.NodeBase
@@ -480,6 +480,23 @@
             (throw (err/incorrect ::invalid-sql-tx-op
                                   "Invalid SQL query sent as transaction operation"
                                   {:query sql})))))))
+
+  (sqlToStaticOps [_ sql args allocator default-tz]
+    ;; row-major bridge to the existing (row-major) expander: read args back to arg-rows, then open the deferred
+    ;; ClientTxOps into eager TxOps against the connection allocator. requiring-resolve breaks a
+    ;; query->log->node->query cycle. nil → not statically expandable; caller submits the raw SQL op.
+    ;; Read by `?_N` name, NOT vector position: open-args builds the row via `(into {} …)`, so ≥9 params land in
+    ;; hash order, not `?_0..?_n` — `->param-row` re-keys by position and would otherwise swap them. SNAKE_CASE_STRING
+    ;; keys so record-valued args carry the string keys the PutDocs/PatchDocs writers look up.
+    (let [arg-rows (when-let [^RelationReader args args]
+                     (let [cols (count (.getVectors args))]
+                       (vec (for [row-idx (range (.getRowCount args))]
+                              (vec (for [col-idx (range cols)]
+                                     (when-let [^VectorReader v (.vectorForOrNull args (str "?_" col-idx))]
+                                       (.getObject v row-idx IKeyFn$KeyFn/SNAKE_CASE_STRING))))))))]
+      (when-let [tx-ops (seq (sql/sql->static-ops sql arg-rows))]
+        (let [open-tx-op (requiring-resolve 'xtdb.log/open-tx-op)]
+          (util/safe-mapv #(open-tx-op % allocator {:default-tz default-tz}) tx-ops)))))
 
   (preparePatchDocsQuery [this table valid-from valid-to db-cat opts]
     (let [default-db (:default-db opts)

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -36,6 +36,7 @@ import xtdb.api.module.XtdbModule
 import xtdb.api.storage.Storage
 import xtdb.arrow.Relation
 import xtdb.arrow.RelationReader
+import xtdb.arrow.RelationWriter
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.arrow.unsupported
@@ -138,7 +139,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         private val awaitTimeout: Duration = Duration.ofMinutes(1)
 
         private var autoCommit = true
-        private val pendingOps = mutableListOf<TxOp>()
+        private var tx: Transaction? = null
 
         private fun db(dbName: DatabaseName): Database =
             dbCat.databaseOrNull(dbName)
@@ -321,29 +322,96 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             }
         }
 
+        // Manual-tx DML buffer: consecutive same-SQL ops coalesce, their args appended into the last op's own
+        // relation, so a prepared INSERT in a loop becomes one multi-row op.
+        private class DmlBuffer(private val al: BufferAllocator) : AutoCloseable {
+            private val ops = mutableListOf<TxOp>()
+
+            fun add(op: TxOp) {
+                if (op !is TxOp.Sql || op.args == null) {
+                    ops.add(op)
+                    return
+                }
+
+                val target = (ops.lastOrNull() as? TxOp.Sql)?.takeIf { it.sql == op.sql }?.args as? RelationWriter
+                if (target != null) {
+                    op.args.use(target::append)
+                } else {
+                    val rel = Relation(al)
+                    rel.closeOnCatch { op.args.use(rel::append) }
+                    ops.add(TxOp.Sql(op.sql, rel))
+                }
+            }
+
+            fun drain(): List<TxOp> = ops.toList().also { ops.clear() }
+
+            override fun close() = ops.forEach { it.close() }
+        }
+
+        private class Basis(val currentTime: Instant?, val snapshotToken: String?, val snapshotTime: Instant?)
+
+        // a "read-write" tx is write-only in XTDB (queries are rejected in a DML tx), so only ReadOnly carries a basis
+        private sealed interface AccessMode : AutoCloseable {
+            class ReadOnly(val basis: Basis) : AccessMode {
+                override fun close() {}
+            }
+
+            class ReadWrite(
+                val buffer: DmlBuffer,
+                val systemTime: Instant? = null,
+                val userMetadata: Map<*, *>? = null,
+                val async: Boolean = false,
+            ) : AccessMode {
+                override fun close() = buffer.close()
+            }
+        }
+
+        private class Transaction(var mode: AccessMode? = null, var failed: Throwable? = null) : AutoCloseable {
+            override fun close() { mode?.close() }
+        }
+
+        private fun commitTx() {
+            val tx = tx ?: return
+            this.tx = null
+            val ops = (tx.mode as? AccessMode.ReadWrite)?.buffer?.drain()
+            if (!ops.isNullOrEmpty()) ops.useAll { executeTx(it) }
+        }
+
         internal fun executeDml(op: TxOp) {
             if (autoCommit) {
                 listOf(op).useAll { ops -> executeTx(ops) }
-            } else {
-                pendingOps.add(op)
+                return
+            }
+            val tx = tx ?: Transaction().also { tx = it }
+            when (val mode = tx.mode) {
+                is AccessMode.ReadWrite -> mode.buffer.add(op)
+                null -> AccessMode.ReadWrite(DmlBuffer(allocator)).also { tx.mode = it }.buffer.add(op)
+                is AccessMode.ReadOnly -> {
+                    op.close()
+                    throw Incorrect("Cannot write in a read-only transaction", "xtdb/read-only-tx")
+                }
             }
         }
 
         override fun setAutoCommit(autoCommit: Boolean) {
+            if (this.autoCommit == autoCommit) return
+            if (autoCommit) commitTx()
             this.autoCommit = autoCommit
         }
 
         override fun commit() {
-            val ops = pendingOps.toList()
-            pendingOps.clear()
-            if (ops.isNotEmpty()) {
-                ops.useAll { executeTx(it) }
-            }
+            if (autoCommit) throw Incorrect("Cannot commit when autoCommit is enabled", "xtdb.adbc/commit-in-autocommit")
+            commitTx()
+        }
+
+        private fun discardTx() {
+            tx?.close()
+            tx = null
         }
 
         override fun rollback() {
-            pendingOps.forEach { it.close() }
-            pendingOps.clear()
+            if (autoCommit) throw Incorrect("Cannot rollback when autoCommit is enabled", "xtdb.adbc/rollback-in-autocommit")
+            discardTx()
         }
 
         override fun bulkIngest(targetTableName: String, mode: BulkIngestMode): Statement {
@@ -652,7 +720,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         override fun getCurrentDbSchema(): String = "public"
 
         override fun close() {
-            rollback()
+            discardTx()
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -223,8 +223,25 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             )
         }
 
+        // Reads go through here so an open read-only transaction supplies its pinned basis: the tx's basis wins,
+        // falling back to whatever the caller pinned per-statement (vestigial today) and then its default. With no
+        // tx the caller's opts pass through untouched. The first read also resolves an undecided tx to read-only.
+        fun openQuery(pq: PreparedQuery, args: RelationReader?, opts: QueryOpts): ResultCursor {
+            val tx = tx
+            val merged = if (tx != null && tx.mode !is AccessMode.ReadWrite) {
+                if (tx.mode == null) tx.mode = AccessMode.ReadOnly
+                opts.copy(
+                    currentTime = tx.basis.currentTime ?: opts.currentTime,
+                    snapshotToken = tx.basis.snapshotToken ?: opts.snapshotToken,
+                    snapshotTime = tx.basis.snapshotTime ?: opts.snapshotTime,
+                    defaultTz = tx.defaultTz ?: opts.defaultTz,
+                )
+            } else opts
+            return pq.openQuery(args, merged)
+        }
+
         fun openSqlQuery(sql: String): ResultCursor =
-            prepareSql(sql).openQuery(null, QueryOpts(null, defaultTz))
+            openQuery(prepareSql(sql), null, QueryOpts(null, defaultTz))
 
         fun openSnapshot(): DatabaseSnapshot {
             val db = db(dbName)
@@ -300,7 +317,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 val queryArgs = openQueryArgs()
                 val cursor = try {
-                    prepared?.openQuery(queryArgs, QueryOpts()) ?: openSqlQuery(sql)
+                    prepared?.let { openQuery(it, queryArgs, QueryOpts()) } ?: openSqlQuery(sql)
                 } catch (t: Throwable) {
                     queryArgs?.close()
                     throw t
@@ -350,31 +367,67 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         private class Basis(val currentTime: Instant?, val snapshotToken: String?, val snapshotTime: Instant?)
 
-        // a "read-write" tx is write-only in XTDB (queries are rejected in a DML tx), so only ReadOnly carries a basis
+        // resolved on the first statement: a query makes it read-only, DML makes it read-write. A "read-write" tx
+        // is write-only in XTDB — queries are rejected in a DML tx — so only ReadOnly reads a basis.
         private sealed interface AccessMode : AutoCloseable {
-            class ReadOnly(val basis: Basis) : AccessMode {
+            data object ReadOnly : AccessMode {
                 override fun close() {}
             }
 
-            class ReadWrite(
-                val buffer: DmlBuffer,
-                val systemTime: Instant? = null,
-                val userMetadata: Map<*, *>? = null,
-                val async: Boolean = false,
-            ) : AccessMode {
+            class ReadWrite(val buffer: DmlBuffer) : AccessMode {
                 override fun close() = buffer.close()
             }
         }
 
-        private class Transaction(var mode: AccessMode? = null, var failed: Throwable? = null) : AutoCloseable {
+        // Begin-time state, pinned before the mode is known: [basis] serves a read-only tx's reads, the commit
+        // metadata a read-write tx's submit. ADBC starts one lazily with defaults; pgwire's beginTx fills it.
+        private class Transaction(
+            val basis: Basis = Basis(null, null, null),
+            val awaitToken: String? = null,
+            val defaultTz: ZoneId? = null,
+            val systemTime: Instant? = null,
+            val user: String? = null,
+            val userMetadata: Map<*, *>? = null,
+            val async: Boolean = false,
+            var mode: AccessMode? = null,
+            var failed: Throwable? = null,
+        ) : AutoCloseable {
             override fun close() { mode?.close() }
         }
+
+        // Start an explicit transaction, pinning its basis and commit metadata. readOnly fixes the mode up front
+        // (BEGIN READ ONLY / READ WRITE); left null, the first statement resolves it.
+        fun beginTx(
+            currentTime: Instant? = null, snapshotToken: String? = null, snapshotTime: Instant? = null,
+            awaitToken: String? = null, defaultTz: ZoneId? = null,
+            systemTime: Instant? = null, user: String? = null, userMetadata: Map<*, *>? = null,
+            async: Boolean = false, readOnly: Boolean? = null,
+        ) {
+            if (tx != null) throw Incorrect("transaction already started", "xtdb/tx-already-open")
+            tx = Transaction(
+                Basis(currentTime, snapshotToken, snapshotTime),
+                awaitToken, defaultTz, systemTime, user, userMetadata, async,
+                mode = when (readOnly) {
+                    true -> AccessMode.ReadOnly
+                    false -> AccessMode.ReadWrite(DmlBuffer(allocator))
+                    null -> null
+                }
+            )
+        }
+
+        val txOpen get() = tx != null
+        val txFailed get() = tx?.failed != null
+        val txReadOnly get() = tx?.mode is AccessMode.ReadOnly
+
+        fun failTx(cause: Throwable) { tx?.let { it.failed = cause } }
 
         private fun commitTx() {
             val tx = tx ?: return
             this.tx = null
-            val ops = (tx.mode as? AccessMode.ReadWrite)?.buffer?.drain()
-            if (!ops.isNullOrEmpty()) ops.useAll { executeTx(it) }
+            val ops = (tx.mode as? AccessMode.ReadWrite)?.buffer?.drain() ?: return
+            if (ops.isEmpty()) return
+            val opts = TxOpts(tx.defaultTz, tx.systemTime, tx.user, tx.userMetadata)
+            ops.useAll { if (tx.async) submitTx(it, opts) else executeTx(it, opts) }
         }
 
         internal fun executeDml(op: TxOp) {

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -57,6 +57,7 @@ import xtdb.query.QueryOpts
 import xtdb.table.TableRef
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
+import xtdb.util.closeAll
 import xtdb.util.closeOnCatch
 import xtdb.util.useAll
 import java.util.concurrent.ExecutionException
@@ -421,16 +422,32 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         fun failTx(cause: Throwable) { tx?.let { it.failed = cause } }
 
-        private fun commitTx() {
-            val tx = tx ?: return
+        // returns the SubmittedTx (async) / ExecutedTx (sync) for the frontend to report, or null if nothing buffered.
+        // INSERT/PATCH ops are statically expanded to PutDocs/PatchDocs via qSrc (shared with pgwire); everything
+        // else submits raw. `drained` owns the buffered originals, `expanded` the freshly-opened expansion relations;
+        // both close once in finally (disjoint), while submit/execute only read them.
+        fun commitTx(): Any? {
+            val tx = tx ?: return null
             this.tx = null
-            val ops = (tx.mode as? AccessMode.ReadWrite)?.buffer?.drain() ?: return
-            if (ops.isEmpty()) return
+            val drained = (tx.mode as? AccessMode.ReadWrite)?.buffer?.drain() ?: return null
+            if (drained.isEmpty()) return null
             val opts = TxOpts(tx.defaultTz, tx.systemTime, tx.user, tx.userMetadata)
-            ops.useAll { if (tx.async) submitTx(it, opts) else executeTx(it, opts) }
+            val tz = tx.defaultTz ?: defaultTz
+            val expanded = mutableListOf<TxOp>()
+            try {
+                val toSubmit = drained.flatMap { op ->
+                    (op as? TxOp.Sql)?.let { qSrc.sqlToStaticOps(it.sql, it.args, allocator, tz) }
+                        ?.also { expanded += it }
+                        ?: listOf(op)
+                }
+                return if (tx.async) submitTx(toSubmit, opts) else executeTx(toSubmit, opts)
+            } finally {
+                drained.closeAll()
+                expanded.closeAll()
+            }
         }
 
-        internal fun executeDml(op: TxOp) {
+        fun executeDml(op: TxOp) {
             if (autoCommit) {
                 listOf(op).useAll { ops -> executeTx(ops) }
                 return

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -231,11 +231,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             val tx = tx
             val merged = if (tx != null && tx.mode !is AccessMode.ReadWrite) {
                 if (tx.mode == null) tx.mode = AccessMode.ReadOnly
+                // only the read basis is pinned at begin; tz is session-live (PG SET TIME ZONE is immediate), so
+                // it's left to the caller's opts rather than overridden from the tx.
                 opts.copy(
                     currentTime = tx.basis.currentTime ?: opts.currentTime,
                     snapshotToken = tx.basis.snapshotToken ?: opts.snapshotToken,
                     snapshotTime = tx.basis.snapshotTime ?: opts.snapshotTime,
-                    defaultTz = tx.defaultTz ?: opts.defaultTz,
                 )
             } else opts
             return pq.openQuery(args, merged)

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -2,12 +2,15 @@ package xtdb.query
 
 import io.micrometer.core.instrument.MeterRegistry
 import org.apache.arrow.memory.BufferAllocator
+import xtdb.arrow.RelationReader
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.indexer.DatabaseSnapshot
 import xtdb.table.TableRef
+import xtdb.tx.TxOp
 import java.time.Instant
+import java.time.ZoneId
 
 interface IQuerySource : AutoCloseable {
 
@@ -23,6 +26,13 @@ interface IQuerySource : AutoCloseable {
 
     fun prepareQuery(query: Any, dbs: QueryCatalog, opts: Any?): PreparedQuery
     fun prepareTxSql(sql: String, dbs: QueryCatalog, opts: Any?): SqlStatement
+
+    /**
+     * Statically expands an INSERT/PATCH into eager PutDocs/PatchDocs ops at submit time, opened against
+     * [allocator]; null when the statement isn't statically expandable (UPDATE/DELETE/etc, or a planning error),
+     * in which case the caller submits the raw SQL op instead.
+     */
+    fun sqlToStaticOps(sql: String, args: RelationReader?, allocator: BufferAllocator, defaultTz: ZoneId?): List<TxOp>?
     fun preparePatchDocsQuery(table: TableRef, validFrom: Instant?, validTo: Instant?, dbs: QueryCatalog, opts: Any?): PreparedQuery
 
     fun interface Factory {

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -32,8 +32,7 @@
            (xtdb JsonSerde JsonLdSerde)
            (xtdb.api DataSource$ConnectionBuilder PasswordHash)
            xtdb.api.log.SourceMessage$FlushBlock
-           xtdb.pgwire.Server
-           xtdb.tx.Sql))
+           xtdb.pgwire.Server))
 
 (set! *warn-on-reflection* false) ; gagh! lazy. don't do this.
 (set! *unchecked-math* false)
@@ -1791,26 +1790,25 @@
       (jdbc/execute! tx ["INSERT INTO foo RECORDS {_id: ?, a: ?}" 3, "three"])
       (jdbc/execute! tx ["INSERT INTO foo RECORDS ?" {:xt/id 4, :a "four"}])
 
-      ;; HACK - leaning into internal state
-      (let [dml-buf (-> @(:server-state *server*)
-                        (get-in [:connections 1 :conn-state])
-                        deref
-                        (get-in [:transaction :dml-buf]))]
-        (t/is (= ["INSERT INTO foo RECORDS $1"
-                   "INSERT INTO foo RECORDS {_id: $1, a: $2}"
-                   "INSERT INTO foo RECORDS $1"]
-                  (mapv Sql/.getSql dml-buf)))
-        (t/is (= [[[{:_id 1, :a "one"}]
-                   [{:_id 2, :a "two"}]]
-                  [[3 "three"]]
-                  [[{:_id 4, :a "four"}]]]
-                  (mapv Sql/.getArgRows dml-buf)))))
+      ;; op-coalescing moved into the connection's DmlBuffer (pgwire's :transaction :dml-buf is gone); it's verified
+      ;; directly in InProcessAdbcTest. Here we just check the combined writes all land.
+      )
 
     (t/is (= [{:xt/id 1, :a "one"}
               {:xt/id 2, :a "two"}
               {:xt/id 3, :a "three"}
               {:xt/id 4, :a "four"}]
              (q conn ["SELECT * FROM foo ORDER BY _id"])))))
+
+(t/deftest test-static-ops-arg-order-over-8-params
+  ;; >8 params: open-args builds the arg row via `(into {} …)`, which promotes to a hash-ordered map, so the
+  ;; relation's columns aren't `?_0..?_n` in order. Static expansion must read args back by name, else the
+  ;; column values get permuted. (≤8 params stay an array-map and wouldn't catch this.)
+  (with-open [conn (jdbc-conn)]
+    (jdbc/execute! conn ["INSERT INTO foo (_id, c1, c2, c3, c4, c5, c6, c7, c8) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                         0 1 2 3 4 5 6 7 8])
+    (t/is (= [{:xt/id 0, :c1 1, :c2 2, :c3 3, :c4 4, :c5 5, :c6 6, :c7 7, :c8 8}]
+             (q conn ["SELECT * FROM foo"])))))
 
 (deftest test-java-sql-timestamp
   (testing "java.sql.Timestamp"

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -189,4 +189,148 @@ class InProcessAdbcTest {
             }
         }
     }
+
+    private fun allRows(stmt: AdbcStatement): List<Map<*, *>> {
+        val res = mutableListOf<Map<*, *>>()
+        stmt.executeQuery().reader.use { rdr ->
+            while (rdr.loadNextBatch())
+                Relation.fromRoot(al, rdr.vectorSchemaRoot).use { res.addAll(it.toMaps(SNAKE_CASE_STRING)) }
+        }
+        return res
+    }
+
+    private fun Xtdb.Connection.select(sql: String) =
+        createStatement().use { stmt -> stmt.setSqlQuery(sql); allRows(stmt) }
+
+    private fun Xtdb.Connection.update(sql: String) =
+        createStatement().use { stmt -> stmt.setSqlQuery(sql); stmt.executeUpdate() }
+
+    @Test
+    fun `commit and rollback are illegal in autocommit mode`() {
+        xtdb.connect().use { conn ->
+            assertThrows(Incorrect::class.java) { conn.commit() }
+            assertThrows(Incorrect::class.java) { conn.rollback() }
+        }
+    }
+
+    @Test
+    fun `manual-mode writes are buffered until commit`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "the buffered write is not yet committed"
+            )
+
+            conn.commit()
+            assertEquals(
+                listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "visible once committed"
+            )
+        }
+    }
+
+    @Test
+    fun `rollback discards buffered writes`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.rollback()
+
+            assertEquals(listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"))
+        }
+    }
+
+    @Test
+    fun `switching to autocommit commits the open transaction`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.setAutoCommit(true)
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id")
+            )
+        }
+    }
+
+    @Test
+    fun `consecutive prepared inserts coalesce and every row lands on commit`() {
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                for (id in 1L..5L) {
+                    bindLongParam(stmt, id)
+                    stmt.executeUpdate()
+                }
+            }
+            conn.commit()
+
+            assertEquals(
+                (1L..5L).map { mapOf("_id" to it) },
+                conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "every row of the coalesced run lands as a distinct insert"
+            )
+        }
+    }
+
+    @Test
+    fun `a different statement seals the run, then a fresh run resumes`() {
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                bindLongParam(stmt, 1L); stmt.executeUpdate()
+                bindLongParam(stmt, 2L); stmt.executeUpdate()
+            }
+
+            conn.update("INSERT INTO bar RECORDS {_id: 10}")
+
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                bindLongParam(stmt, 3L); stmt.executeUpdate()
+            }
+
+            conn.commit()
+
+            assertEquals((1L..3L).map { mapOf("_id" to it) }, conn.select("SELECT _id FROM foo ORDER BY _id"))
+            assertEquals(listOf(mapOf("_id" to 10L)), conn.select("SELECT _id FROM bar"))
+        }
+    }
+
+    @Test
+    fun `rollback discards a buffered coalescing run`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("INSERT INTO foo (_id) VALUES (?)")
+                stmt.prepare()
+                for (id in 1L..3L) {
+                    bindLongParam(stmt, id)
+                    stmt.executeUpdate()
+                }
+            }
+            conn.rollback()
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "the buffered run is discarded; the run relation is freed (tearDown's allocator close would fail on a leak)"
+            )
+        }
+    }
 }


### PR DESCRIPTION
Part of the SHOW-into-engine arc. Builds on #5736 — review that one first. Until it merges this PR's diff shows both changes; it collapses to just the pgwire migration once #5736 lands on `main`.

**Draft / work in progress.** The connection-side API has landed (commit 1); the pgwire migration that consumes it (commits 2–3) is in progress. Raised early for visibility into the shape.

## Summary

#5736 gave `Xtdb.Connection` a coalescing DML buffer and wired ADBC onto it. This retires pgwire's *own* transaction machinery so the connection becomes the single home for transaction state, leaving `pgwire.clj` with pg-protocol concerns only.

## Context

pgwire keeps everything about a transaction in its `:transaction` conn-state map: the DML buffer (`:dml-buf` plus a coalescing swap-fn), the read basis (`:current-time`/`:snapshot-token`/`:snapshot-time`, pinned at `BEGIN` and consumed when binding a query), the commit options (`:system-time`/`:user-metadata`/`:async?`), and protocol flags (`:implicit?`, `:failed`, `:access-mode`). ADBC, since #5736, keeps the same notion on the connection. That's two competing homes for one concept, and the duplicated commit path is where they drift — pgwire assembles `TxOpts` and chooses sync-vs-async submission itself, reimplementing what the connection now does.

So this moves the whole notion at once rather than half-migrating into a state with two tx homes.

## Approach

The connection owns tx *content* — existence, access-mode, the pinned read basis, the DML buffer, commit metadata, and the failed flag. pgwire owns protocol *lifecycle* only — the parse/bind/execute/sync loop, implicit-transaction (auto-begin) tracking, auto-commit at `Sync`, `ReadyForQuery` status, the pg-specific permissibility and aborted-tx errors, command tags, and COPY framing. pgwire *drives* the connection's transaction and *queries* it for status to shape its protocol responses; the connection never learns what an implicit transaction is.

The read basis is the semantic crux. The connection's `openQuery` becomes transaction-aware: when a read-only tx is active it supplies that tx's pinned basis, so pgwire stops threading basis through its query options. The merge rule is "active read-only tx's basis wins, else the caller's per-statement options, else the connection default". This is behaviour-preserving: pgwire's per-statement basis overrides are vestigial (always nil today), so "tx wins" matches current behaviour, and the clock-split is respected — pgwire still supplies current-time from its session clock for tx-less reads and at `BEGIN`. ADBC opens no read-only tx, so `openQuery` sees no active tx and behaves exactly as before.

## Out of scope

A genuine `SETTING SNAPSHOT_TOKEN` per-statement override channel — noted, not built; the merge rule leaves room for it. Begin-time snapshot isolation for ADBC/Flight SQL, and gating session-state setters mid-transaction (the original motivation for all this), are separate later increments.

## Test plan

The full pgwire suite (`xtdb.pgwire-test`, `xtdb.pgwire.*`) plus `xtdb.sql-test` are the behaviour-preservation oracle, exercising both protocols, PREPARE/EXECUTE, COPY, BEGIN/COMMIT/ROLLBACK, implicit transactions, aborted-tx rejection, and snapshot/basis reads. The ADBC/Connection/Flight SQL suites must stay green since the shared `openQuery`/buffer changed. No reflection or boxed-math warnings.