### PR TITLE
feat(indexer): split external-source indexTx into executeTx + fire-and-forget submitTx

### DIFF
--- a/core/src/main/kotlin/xtdb/database/ExternalSource.kt
+++ b/core/src/main/kotlin/xtdb/database/ExternalSource.kt
@@ -8,7 +8,6 @@ import xtdb.error.Unsupported
 import xtdb.indexer.TxIndexer
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
-import xtdb.database.proto.DatabaseConfig
 import java.util.*
 import com.google.protobuf.Any as ProtoAny
 
@@ -20,7 +19,7 @@ typealias ExternalSourceToken = ByteArray
  * instead of XTDB's own DML.
  *
  * The source owns the read side of its upstream: it receives events (via polling or other methods),
- * maps each to a transaction, and submits it * through [TxIndexer.indexTx].
+ * maps each to a transaction, and submits it through [TxIndexer.executeTx].
  *
  * XTDB drives the source via [onPartitionAssigned] and persists the per-tx [ExternalSourceToken]
  * so the source can resume after the last indexed event.

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -140,8 +140,10 @@ class LeaderLogProcessor(
     // works, bounding lookahead to ~2 batches. Backpressure falls out of a full channel suspending the send.
     private val sourceLogCh =
         Channel<SourceLogTask>(capacity = 1, onUndeliveredElement = { it.onComplete.cancel() })
+    // capacity 1 so a fire-and-forget `submitTx` caller can queue one tx ahead while the persister works the
+    // current one (bounding lookahead to ~2). `executeTx` still blocks on the result regardless of capacity.
     private val extSourceCh =
-        Channel<ExtSourceTask>(onUndeliveredElement = { it.onComplete.cancel() })
+        Channel<ExtSourceTask>(capacity = 1, onUndeliveredElement = { it.onComplete.cancel() })
     private val gcCh =
         Channel<GcTask>(onUndeliveredElement = { it.onComplete.cancel() })
 
@@ -290,13 +292,16 @@ class LeaderLogProcessor(
         trieCatalog.deleteTries(task.tableName, task.trieKeys)
     }
 
-    private suspend fun submit(task: PersisterTask) {
+    // Hand the task to the persister and return its completion handle. The caller decides whether to
+    // await it: `executeTx`, GC and `processRecords` await (they need the work done before returning);
+    // `submitTx` doesn't (fire-and-forget). Suspends only on the channel send (backpressure).
+    private suspend fun enqueue(task: PersisterTask): Deferred<Unit> {
         when (task) {
             is SourceLogTask -> sourceLogCh.send(task)
             is ExtSourceTask -> extSourceCh.send(task)
             is GcTask -> gcCh.send(task)
         }
-        task.onComplete.await()
+        return task.onComplete
     }
 
     internal val trieGc = nodeBase.config.garbageCollector.let { cfg ->
@@ -317,7 +322,7 @@ class LeaderLogProcessor(
         // The table-block file uploaded at (2) is now a persistent snapshot of state that
         // disagrees with the replica log it claims to be a snapshot of.
         val commitTriesDeleted: suspend (TableRef, Set<TrieKey>) -> Unit = { tableName, trieKeys ->
-            submit(GcTask.TriesDeleted(tableName, trieKeys))
+            enqueue(GcTask.TriesDeleted(tableName, trieKeys)).await()
         }
 
         TrieGarbageCollector(
@@ -336,8 +341,10 @@ class LeaderLogProcessor(
         // supervisorScope so an ext-source crash doesn't kill the persister.
         supervisorScope {
             launch {
-                // Close the channels with the failure cause so a subsequent `processRecords` send
-                // (no longer awaited per-record) throws it rather than a bare ClosedSendChannelException.
+                // Close the channels with the failure cause so a subsequent `enqueue` send throws it rather
+                // than a bare ClosedSendChannelException. An awaiting caller (`executeTx`, GC, `processRecords`)
+                // sees the cause through its `await`; this close-with-cause is the safety net for fire-and-forget
+                // `submitTx`, and for any caller's next send once the persister loop has exited.
                 var cause: Throwable? = null
                 try {
                     while (true) {
@@ -402,13 +409,23 @@ class LeaderLogProcessor(
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
         OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer)
 
-    override suspend fun indexTx(
+    override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
         writer: suspend (OpenTx) -> TxResult,
     ): TxResult =
         ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer)
-            .also { submit(it) }
+            .also { enqueue(it).await() }
             .result.await()
+
+    override suspend fun submitTx(
+        externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
+        writer: suspend (OpenTx) -> TxResult,
+    ) {
+        // Fire-and-forget: enqueue and return without awaiting the completion handle. The task's
+        // `result`/`onComplete` are completed by the persister but go unawaited here — an unrecoverable
+        // failure closes the channel with its cause, so the next `enqueue` (this or `executeTx`) throws it.
+        enqueue(ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer))
+    }
 
     private suspend fun maybeFlushBlock() {
         if (blockFlusher.checkBlockTimeout(blockCatalog, liveIndex)) {
@@ -587,7 +604,7 @@ class LeaderLogProcessor(
         // run a leader/follower transition under `runBlocking` — the persister is quiescent, so a
         // concurrent DETACH/shutdown that must cancel-join the term doesn't wedge against in-flight
         // import work on a starved dispatcher (#5741).
-        if (records.isNotEmpty()) submit(SourceLogTask.Batch(records))
+        if (records.isNotEmpty()) enqueue(SourceLogTask.Batch(records)).await()
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -47,7 +47,7 @@ import kotlin.Long.Companion.MIN_VALUE as MIN_LONG
 private val LOG = OpenTx::class.logger
 
 /**
- * The per-transaction write/read handle passed to an external-source [writer][TxIndexer.indexTx].
+ * The per-transaction write/read handle passed to an external-source [writer][TxIndexer.executeTx].
  *
  * Stage writes per table via [table]; [openQuery] / [executeSql] run SQL against the live index with
  * read-your-writes visibility into those staged writes. [TxIndexer] owns opening, committing and closing the

--- a/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
@@ -9,12 +9,13 @@ import java.time.Instant
  * indicating success or failure (with optional `userMetadata` — the source can decide metadata
  * after writing, not before).
  *
- * [indexTx] owns the full lifecycle: smoothing, opening the OpenTx, running the writer,
- * adding the `xt/txs` row, publishing the resulting tx, and closing the OpenTx.
+ * [executeTx] and [submitTx] own the full lifecycle: smoothing, opening the OpenTx, running the writer,
+ * adding the `xt/txs` row, publishing the resulting tx, and closing the OpenTx. They differ only in
+ * whether the caller waits for the result.
  */
 interface TxIndexer {
 
-    /** The outcome a [writer][indexTx] returns: commit or abort, plus optional `userMetadata` recorded on the `xt/txs` row. */
+    /** The outcome a [writer] returns: commit or abort, plus optional `userMetadata` recorded on the `xt/txs` table. */
     sealed interface TxResult {
         val userMetadata: Map<*, *>?
 
@@ -26,12 +27,28 @@ interface TxIndexer {
      * Indexes one external-source transaction: opens an [OpenTx], runs [writer] to populate it, then commits
      * or aborts per the returned [TxResult].
      *
-     * [externalSourceToken] is persisted with the tx so the source can resume after it. [txId] / [systemTime]
-     * default to the next monotonic tx id / the current time.
+     * [externalSourceToken] is persisted with the tx so the source can resume after it. [systemTime]
+     * default to the next monotonic time.
      */
-    suspend fun indexTx(
+    suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?,
         systemTime: Instant? = null,
         writer: suspend (OpenTx) -> TxResult,
     ): TxResult
+
+    /**
+     * Like [executeTx], but hands the transaction off and returns without waiting for its [TxResult] — for a
+     * high-volume source that only needs ingestion to stay healthy, not each individual result, so it can keep
+     * submitting while the indexer works through the backlog.
+     *
+     * The hand-off buffer is bounded, so [submitTx] still suspends under backpressure; it just doesn't block on
+     * the result. An unrecoverable ingestion failure surfaces on a subsequent [submitTx] or [executeTx] — the call
+     * throws the failure cause — so a caller can't keep submitting into a dead indexer and have its transactions
+     * silently vanish.
+     */
+    suspend fun submitTx(
+        externalSourceToken: ExternalSourceToken?,
+        systemTime: Instant? = null,
+        writer: suspend (OpenTx) -> TxResult,
+    )
 }

--- a/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
@@ -43,7 +43,7 @@ private class CountingExternalSource(
     override suspend fun onPartitionAssigned(partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer) {
         leaderFor.add(dbName)
         repeat(rowsToIndex) {
-            txIndexer.indexTx(externalSourceToken = null) { TxResult.Committed() }
+            txIndexer.executeTx(externalSourceToken = null) { TxResult.Committed() }
             indexed.countDown()
         }
     }

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -2,6 +2,8 @@ package xtdb.database
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -67,10 +69,14 @@ class ExternalSourceTest {
 
     /**
      * Simple in-memory ExternalSource for testing.
-     * Send signals to [channel]; each signal submits a tx via [xtdb.indexer.TxIndexer.indexTx].
+     * Send signals to [channel]; each signal submits a tx via [index] (by default the blocking
+     * [xtdb.indexer.TxIndexer.executeTx]; pass a `submit`-based [index] to drive the fire-and-forget path).
      */
     class InMemoryExternalSource(
         val channel: Channel<ExternalSourceToken?> = Channel(100),
+        private val index: suspend TxIndexer.(ExternalSourceToken?) -> Unit = {
+            executeTx(it) { TxResult.Committed() }
+        },
     ) : ExternalSource {
 
         override suspend fun onPartitionAssigned(
@@ -79,9 +85,7 @@ class ExternalSourceTest {
             txIndexer: TxIndexer
         ) {
             for (token in channel) {
-                txIndexer.indexTx(token) { _ ->
-                    TxResult.Committed()
-                }
+                txIndexer.index(token)
             }
         }
 
@@ -120,7 +124,7 @@ class ExternalSourceTest {
     }
 
     @Test
-    fun `indexTx appends ResolvedTx to replica log`() = runTest {
+    fun `execute appends ResolvedTx to replica log`() = runTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val extSource = InMemoryExternalSource()
 
@@ -191,7 +195,7 @@ class ExternalSourceTest {
     }
 
     @Test
-    fun `indexTx threads resumeToken to watchers`() = runTest {
+    fun `execute threads resumeToken to watchers`() = runTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
         val extSource = InMemoryExternalSource()
         leaderProc(watchers = watchers, extSource = extSource)
@@ -240,6 +244,67 @@ class ExternalSourceTest {
         extSource.channel.send(null)
         delay(500.milliseconds)
         assertNotNull(watchers.exception, "watchers should be in failed state")
+    }
+
+    @Test
+    fun `submit applies txs fire-and-forget with monotonic txIds`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val extSource = InMemoryExternalSource(index = { submitTx(it) { TxResult.Committed() } })
+
+        leaderProc(replicaLog = replicaLog, extSource = extSource)
+
+        extSource.channel.send(null)
+        extSource.channel.send(null)
+        delay(500.milliseconds)
+
+        val resolvedTxs = mutableListOf<ReplicaMessage.ResolvedTx>()
+        backgroundScope.launch {
+            replicaLog.tailAll(-1) { records ->
+                records.forEach { (it.message as? ReplicaMessage.ResolvedTx)?.let(resolvedTxs::add) }
+            }
+        }
+        delay(200.milliseconds)
+
+        assertEquals(listOf(0L, 1L), resolvedTxs.map { it.txId })
+        assertTrue(resolvedTxs.all { it.committed }, "both fire-and-forget txs should commit")
+    }
+
+    @Test
+    fun `submit surfaces an unrecoverable failure to the caller on a later submit`() = runTest {
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { importTx(any()) } throws RuntimeException("commit pipeline fault")
+        }
+
+        val caught = CompletableDeferred<Throwable>()
+        val failingSource = object : ExternalSource {
+            override suspend fun onPartitionAssigned(
+                partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer
+            ) {
+                try {
+                    while (true) {
+                        txIndexer.submitTx(null) { TxResult.Committed() }
+                        delay(10.milliseconds)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    caught.complete(e)
+                    throw e
+                }
+            }
+
+            override fun close() {}
+        }
+
+        leaderProc(watchers = watchers, liveIndex = liveIndex, extSource = failingSource)
+
+        val caughtError = caught.await()
+        assertEquals(
+            "commit pipeline fault", caughtError.message,
+            "the fire-and-forget caller sees the original failure cause"
+        )
+        assertNotNull(watchers.exception, "watchers should also be in failed state")
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -32,7 +32,6 @@ import xtdb.storage.MemoryStorage
 import xtdb.table.TableRef
 import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.metaFilePath
-import xtdb.util.asIid
 import xtdb.util.debug
 import xtdb.util.logger
 import java.nio.ByteBuffer
@@ -83,7 +82,7 @@ class LogProcessorSimTest : SimulationTestBase() {
     /**
      * Test-side `ExternalSource`. Holds a pre-built sequence of `SimAction`s; its
      * `onPartitionAssigned` drains the iterator through whichever node is currently leader,
-     * calling `txIndexer.indexTx { … }` from inside the leader's coroutine scope.
+     * calling `txIndexer.execute { … }` from inside the leader's coroutine scope.
      *
      * A single instance is shared across all `SimNode`s in a test. Leadership transitions
      * surface as fresh `onPartitionAssigned` invocations on the same instance — the iterator
@@ -91,13 +90,13 @@ class LogProcessorSimTest : SimulationTestBase() {
      * `close()` is a no-op so the per-`LeaderLogProcessor` `extSource.close()` doesn't tear
      * down the shared instance.
      *
-     * Putting `indexTx` inside `onPartitionAssigned` (rather than calling it from the test
+     * Putting `execute` inside `onPartitionAssigned` (rather than calling it from the test
      * driver against a stale `TxIndexer` reference) is what keeps the leader's allocator
-     * accounting clean across rebalances: `indexTx` allocates an `OpenTx` from the
+     * accounting clean across rebalances: `execute` allocates an `OpenTx` from the
      * leader's allocator; if the leader term's scope were cancelled while that `OpenTx` is
      * still live, the leader's `allocator.close()` would throw on the
      * outstanding allocation. Holding the call inside `onPartitionAssigned` ties its lifetime
-     * to the leader's scope — cancelling that scope propagates cancellation through `indexTx`'s
+     * to the leader's scope — cancelling that scope propagates cancellation through `execute`'s
      * inner catch, which closes the `OpenTx` before the allocator does.
      */
     private inner class SimExtSource(private val actions: List<SimAction>) : ExternalSource {
@@ -123,7 +122,7 @@ class LogProcessorSimTest : SimulationTestBase() {
                 val action = actions[actionIdx]
 
                 val externalSourceToken = ByteArray(Integer.BYTES).also { ByteBuffer.wrap(it).putInt(actionIdx) }
-                txIndexer.indexTx(externalSourceToken = externalSourceToken) { openTx ->
+                txIndexer.executeTx(externalSourceToken = externalSourceToken) { openTx ->
                     when (action) {
                         is SimAction.Commit -> {
                             val table = openTx.table(docsTable)

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -851,9 +851,13 @@ rule ExternalSourceAssigned {
 }
 
 rule ExternalSourceIndexesTx {
-    -- Per-tx entry point. The external source calls TxIndexer.indexTx with
-    -- an opaque resume token, optional system_time, and a writer that
-    -- populates an OpenTx with the transformed row data.
+    -- Per-tx entry point. The external source calls TxIndexer.executeTx
+    -- (synchronous, returns the TxResult) or TxIndexer.submitTx
+    -- (fire-and-forget, returns without awaiting) with an opaque resume
+    -- token, optional system_time, and a writer that populates an OpenTx
+    -- with the transformed row data. The per-tx indexing behaviour below is
+    -- identical for both; they differ only in whether the caller awaits the
+    -- result, which is caller-side and below this spec's abstraction level.
     --
     -- Unlike the client-driven leader, tx_id here is assigned by the
     -- processor as live_index.latest_completed_tx.tx_id + 1, NOT taken

--- a/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
@@ -65,7 +65,10 @@ class DocsIndexer(private val table: TableRef) : RecordIndexer {
             val token = kafkaConnectSourceToken { offset = rec.kafkaOffset() }.toByteArray()
             val systemTime = rec.timestamp()?.let { Instant.ofEpochMilli(it) }
 
-            txIndexer.indexTx(token, systemTime = systemTime) { openTx ->
+            // Fire-and-forget: resume is anchored to XTDB's per-tx import token (the consumer re-seeks from
+            // it on restart and never commits offsets back to Kafka), so a crash replays from the last
+            // *imported* offset — handing off without awaiting the result can't lose or skip a record.
+            txIndexer.submitTx(token, systemTime = systemTime) { openTx ->
                 try {
                     writeRecord(openTx, rec)
                     TxResult.Committed()

--- a/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/IngestNodeIntegrationTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/IngestNodeIntegrationTest.kt
@@ -90,7 +90,7 @@ class IngestNodeIntegrationTest {
 
         override suspend fun indexRecords(records: List<SinkRecord>, txIndexer: TxIndexer) {
             for (rec in records) {
-                txIndexer.indexTx(externalSourceToken = null) {
+                txIndexer.executeTx(externalSourceToken = null) {
                     seenKeys.add(rec.key() as String)
                     TxResult.Committed()
                 }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -261,7 +261,7 @@ class PostgresSource(
                         snapshotCompleted = false
                     }.toByteArray()
 
-                    txIndexer.indexTx(token) { openTx ->
+                    txIndexer.executeTx(token) { openTx ->
                         // snapshot has no upstream commit time — use the tx's system-time
                         val snapshotTx = PostgresDriver.Transaction(snapshot.slotLsn, openTx.txKey.systemTime, batch)
                         indexer.indexTx(snapshotTx, openTx)
@@ -275,7 +275,7 @@ class PostgresSource(
                 }.toByteArray()
 
                 LOG.debug { "[$dbName] Writing snapshot-complete marker" }
-                txIndexer.indexTx(completeToken) {
+                txIndexer.executeTx(completeToken) {
                     TxResult.Committed()
                 }
             }
@@ -295,7 +295,12 @@ class PostgresSource(
                             snapshotCompleted = true
                         }.toByteArray()
 
-                        txIndexer.indexTx(token, systemTime = tx.commitTime) { openTx ->
+                        // Stays `execute`, NOT fire-and-forget `submit`: `nextTransaction` advances the
+                        // replication slot (`acknowledgeLsn`) as soon as this returns, letting Postgres recycle
+                        // WAL. Blocking until the tx is durably imported is what keeps that ack honest — handing
+                        // off early would ack before durability and lose the tx on a crash. Going async here
+                        // needs the slot ack moved behind durable import first.
+                        txIndexer.executeTx(token, systemTime = tx.commitTime) { openTx ->
                             indexer.indexTx(tx, openTx)
                             TxResult.Committed()
                         }


### PR DESCRIPTION
Resolves #5738. Builds on #5739 (which moved source-log resolution onto the persister thread and added the channel-close-with-cause teardown this PR reuses).

## Summary

External sources fed the leader through a single per-tx entry point that blocked the caller for the whole persister round-trip — resolve, append to the replica log (a synchronous Kafka transaction commit), import, notify — and returned the `TxResult`. A high-volume source streaming many small transactions paid that latency serially for a result it never used. This splits the entry point into `execute` (the blocking path, for callers that need the result) and `submit` (fire-and-forget, for callers that only need ingestion to stay healthy).

## Approach

`execute(token, systemTime, writer): TxResult` is the old behaviour, renamed from `indexTx`. `submit(token, systemTime, writer)` hands the transaction to the persister and returns without awaiting the result. The writer still runs on the persister thread, so the caller is free to fetch and build its next transaction while the current one is in flight. `submit` still suspends under backpressure — `extSourceCh` is bounded to capacity 1, so a caller can queue one transaction ahead (peak lookahead ~2), no more. `execute` is unchanged; it awaits the result regardless of channel capacity.

The `indexTx` → `execute` rename touches the `TxIndexer` SPI, but the external-source SPI isn't published yet, so this isn't a breaking change.

## Error propagation

A fire-and-forget caller still has to learn of an unrecoverable failure, or it could feed a dead indexer and have its transactions silently vanish. This reuses the teardown from #5739: when the persister loop dies it closes the channels with the failure cause, so the next `send` throws that cause rather than a bare `ClosedSendChannelException`. A caller looping on `submit` therefore hits the error on its next call.

## Kafka migrates, Postgres deliberately doesn't

The two in-tree streaming callers look symmetric but aren't, and the reason Postgres stays synchronous is durability, not just metrics ordering.

The Kafka connect source moves to `submit`. Resume is anchored to XTDB's per-tx import token — the consumer re-seeks from the last *imported* offset on restart and never commits offsets back to Kafka — so a crash mid-flight replays the un-imported records rather than dropping them.

`PostgresSource.streamChanges` stays on `execute`. `nextTransaction` advances the replication slot (`acknowledgeLsn` → `setFlushedLSN`/`setAppliedLSN`/`forceUpdateStatus`) the moment the writer block returns, letting Postgres recycle WAL. Blocking until the transaction is durably imported is what keeps that ack honest — handing off early would ack before durability and lose the transaction on a crash. A comment in `streamChanges` records this so nobody flips it naively.

## Out of scope

Making the Postgres stream fire-and-forget needs the slot ack moved behind durable import first — tracked as a follow-up on #5738. Replica-log transaction batching (#5507) and block-boundary double-buffering (#4495) are separate cards on the same pipelining effort.

## Test plan

Two new `ExternalSourceTest` cases: `submit applies txs fire-and-forget with monotonic txIds`, and `submit surfaces an unrecoverable failure to the caller on a later submit` (importTx throws → the fire-and-forget source's next `submit` throws the original cause). Core indexer / external-source suites green, both module suites green (`:modules:xtdb-kafka:test` including `DocsIndexerTest`, `:modules:xtdb-postgres-source:test`), and the full `./gradlew test` is green. A code-review pass over the diff surfaced no material findings. Docker-gated integration tests (`IngestNodeIntegrationTest`, `PostgresSourceIndexerTest`) run in CI; the one behavioural module change has unit coverage.