### PR TITLE
refactor(database): lift the teardown scope tree to DatabaseCatalog

### DIFF
--- a/core/src/main/kotlin/xtdb/api/IngestNode.kt
+++ b/core/src/main/kotlin/xtdb/api/IngestNode.kt
@@ -1,5 +1,10 @@
 package xtdb.api
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.cache.DiskCache
@@ -9,7 +14,6 @@ import xtdb.database.DatabaseName
 import xtdb.error.Incorrect
 import xtdb.util.closeAll
 import xtdb.util.closeOnCatch
-import xtdb.util.safeMapValues
 import java.util.UUID.randomUUID
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -25,13 +29,16 @@ import java.util.concurrent.atomic.AtomicBoolean
 class IngestNode internal constructor(
     private val base: NodeBase,
     private val databases: Map<DatabaseName, Database>,
+    private val rootJob: Job,
 ) : AutoCloseable {
     private val closing = AtomicBoolean(false)
 
     override fun close() {
         if (closing.compareAndSet(false, true)) {
-            // close the databases (each owns its own LogProcessor / external source) before the base,
-            // which owns the allocator they're children of.
+            // One cancel stops every database's job tree (Phase 1 — the single thread-parking bridge,
+            // at node shutdown); then free the databases (each owns its LogProcessor / external source)
+            // before the base, which owns the allocator they're children of.
+            runBlocking { rootJob.cancelAndJoin() }
             databases.closeAll()
             base.close()
         }
@@ -106,10 +113,24 @@ class IngestNode internal constructor(
             // db never calls back into a catalog, so the ingest node needs neither the DatabaseCatalog
             // nor its "xtdb" primary. Each db joins leader election and runs its source only when leader.
             return NodeBase.openBase(toBaseConfig()).closeOnCatch { base ->
-                val dbs = databases.safeMapValues { dbName, dbConfig ->
-                    Database.open(base, dbName, dbConfig, base.compactor)
+                // The ingest node owns its databases' job tree directly (no DatabaseCatalog). A
+                // SupervisorJob so one database's failure doesn't cancel its siblings; `close`
+                // cancels it once to stop every database in one go.
+                val rootJob = SupervisorJob()
+                val rootScope = CoroutineScope(rootJob)
+                val openedDbs = LinkedHashMap<DatabaseName, Database>()
+                try {
+                    for ((dbName, dbConfig) in databases)
+                        openedDbs[dbName] = Database.open(base, dbName, dbConfig, base.compactor, rootScope)
+                } catch (t: Throwable) {
+                    // Cancel the job tree (Phase 1) before freeing the already-opened databases
+                    // (Phase 2) — closing them while their coroutines still run would free
+                    // allocator-backed state out from under live work.
+                    runBlocking { rootJob.cancelAndJoin() }
+                    openedDbs.values.closeAll()
+                    throw t
                 }
-                IngestNode(base, dbs)
+                IngestNode(base, openedDbs, rootJob)
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -129,11 +129,16 @@ class Database(
 
     override fun hashCode() = Objects.hash(name)
 
+    // Phase 1: cancel-join this database's job tree. A suspend (not `runBlocking`) so DETACH's closer
+    // coroutine needn't park a thread. `close` MUST follow a returned `cancelAndJoin` — see the
+    // SubSystem precedent in LogProcessor. Node shutdown cancels the whole catalog tree at once
+    // instead, so its owner cancel-joins on its behalf and only `close` runs per database.
+    suspend fun cancelAndJoin() = job?.cancelAndJoin()
+
     override fun close() {
+        // Phase 2: the job tree has already been cancel-joined (by `cancelAndJoin` above, or by the
+        // owner cancelling the catalog root). Free state, children before the database allocator.
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
-        // Everything runs under `job`, so one cancel stops the tree; then free, children before the
-        // database allocator.
-        runBlocking { job?.cancelAndJoin() }
         (partitions.values + listOf(storage, allocator)).closeAll()
     }
 
@@ -230,6 +235,7 @@ class Database(
             dbName: DatabaseName,
             dbConfig: Config,
             compactor: Compactor,
+            parentScope: CoroutineScope,
             dbCatalog: Catalog? = null,
         ): Database = safelyOpening {
             val indexerConfig = base.config.indexer
@@ -260,10 +266,17 @@ class Database(
 
             val crashLogger = CrashLogger(allocator, storage.bufferPool, base.config.nodeId)
 
-            val job = Job()
+            // SupervisorJob child of the catalog's root job: the owner's single cancel still cascades
+            // down to this database's whole tree (term, compactor, source-log subscription), but a
+            // failure *within* the database (e.g. the source-log subscription) surfaces through this
+            // scope's CoroutineExceptionHandler — `watchers.notifyError` — rather than propagating
+            // up. A CoroutineExceptionHandler only fires for a root coroutine or a direct child of a
+            // SupervisorJob, so this must be a SupervisorJob (cf. LogProcessor.openTerm). Sibling-
+            // database isolation is a separate concern, provided by the parent dbJob being a Supervisor.
+            val job = SupervisorJob(parentScope.coroutineContext.job)
 
-            // Child of the database `job`; `close`'s single `job.cancelAndJoin()` stops and joins it
-            // along with the rest of the tree.
+            // Child of the database `job`; the owner's cancel stops and joins it along with the rest
+            // of the tree.
             val compactorScope = CoroutineScope(Job(job))
 
             // For open-failure unwinding, each coroutine-owning resource registers a closeable that

--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -3,9 +3,12 @@ package xtdb.database
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import xtdb.NodeBase
 import xtdb.compactor.Compactor
 import xtdb.database.proto.DatabaseConfig
@@ -32,8 +35,15 @@ class DatabaseCatalog @JvmOverloads constructor(
     private val databases = ConcurrentHashMap<DatabaseName, Database>()
     private val dormantDatabases = ConcurrentHashMap<DatabaseName, DatabaseConfig>()
 
-    // Closing databases stay in `databases` until their close completes — see #5613.
-    private val closerJob = SupervisorJob()
+    // Parent of every database's job tree. A SupervisorJob so one database's failure is contained
+    // here (on the common parent) rather than cancelling its siblings; node shutdown cancels this
+    // once to stop every database's indexing/compaction in one go.
+    private val dbJob = SupervisorJob()
+    private val dbScope = CoroutineScope(dbJob)
+
+    // Detaching databases tear down off the caller's thread on this scope, and stay in `databases`
+    // until that completes — see #5613. Nested under `dbJob` so node shutdown's single cancel covers it.
+    private val closerJob = SupervisorJob(dbJob)
     private val closerScope = CoroutineScope(closerJob + closerDispatcher)
 
     override val databaseNames: Collection<DatabaseName>
@@ -75,7 +85,7 @@ class DatabaseCatalog @JvmOverloads constructor(
         val readOnlyConfig = if (base.config.readOnlyDatabases) dbConfig.mode(Database.Mode.READ_ONLY) else dbConfig
 
         val db = try {
-            Database.open(base, dbName, readOnlyConfig, compactor, this.takeIf { dbName == "xtdb" })
+            Database.open(base, dbName, readOnlyConfig, compactor, dbScope, this.takeIf { dbName == "xtdb" })
         } catch (t: Throwable) {
             LOG.debug { "Failed to open database: db-name=$dbName, exception=${t.javaClass}, message=${t.message}" }
             t.cause?.let { LOG.debug { "Cause: class=${it.javaClass}, message=${it.message}" } }
@@ -100,23 +110,34 @@ class DatabaseCatalog @JvmOverloads constructor(
         if (db.isClosing)
             throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
 
-        // Close off the persister's stack — see #5613.
+        // Close off the persister's stack — see #5613. `cancelAndJoin` suspends rather than parking a
+        // thread in `runBlocking`, so the detach can't deadlock against another thread-parking
+        // teardown on a constrained dispatcher.
         db.isClosing = true
         closerScope.launch {
-            try {
-                db.close()
-            } catch (t: Throwable) {
-                LOG.error(t) { "Failed to close detaching database '$dbName'" }
-            } finally {
-                databases.remove(dbName, db)
+            // NonCancellable: once teardown starts it must run to completion. Node shutdown cancels
+            // `dbJob` (this coroutine's ancestor); without the shield a detach caught mid-cancelAndJoin
+            // would skip `db.close()` yet still remove the database from the map — leaking its state.
+            withContext(NonCancellable) {
+                try {
+                    db.cancelAndJoin()
+                    db.close()
+                } catch (t: Throwable) {
+                    LOG.error(t) { "Failed to close detaching database '$dbName'" }
+                } finally {
+                    databases.remove(dbName, db)
+                }
             }
         }
     }
 
     override fun close() {
-        // Join without cancelling — cancelling would interrupt each db.close() mid-teardown.
-        runBlocking { closerJob.children.toList().forEach { it.join() } }
-        closerJob.cancel()
+        runBlocking {
+            // In-flight detaches own their database's teardown — let them finish before we cancel.
+            closerJob.children.toList().forEach { it.join() }
+            // One cancel stops every remaining database's job tree (Phase 1); free synchronously below.
+            dbJob.cancelAndJoin()
+        }
         databases.values.closeAll()
     }
 

--- a/core/src/test/kotlin/xtdb/database/DatabaseCatalogTest.kt
+++ b/core/src/test/kotlin/xtdb/database/DatabaseCatalogTest.kt
@@ -1,13 +1,13 @@
 package xtdb.database
 
 import clojure.lang.Keyword
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.Dispatchers
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xtdb.NodeBase
 import xtdb.error.Conflict
+import java.util.concurrent.TimeUnit.SECONDS
 
 class DatabaseCatalogTest {
 
@@ -17,13 +17,12 @@ class DatabaseCatalogTest {
 
     @Test
     fun `reattach during detach returns transient conflict (#5613)`() {
-        val scheduler = TestCoroutineScheduler()
-        val dispatcher = StandardTestDispatcher(scheduler)
-
         NodeBase.openBase(openMeterRegistry = false).use { base ->
-            DatabaseCatalog.open(base, dispatcher).use { catalog ->
+            // Unconfined runs the detach inline up to its first real suspension — the suspend
+            // cancelAndJoin of the database's job tree — so the database is still mid-teardown
+            // (isClosing, not yet removed) when we observe the conflict, with no scheduler poking.
+            DatabaseCatalog.open(base, Dispatchers.Unconfined).use { catalog ->
                 catalog.attach("test_db", Database.Config())
-                // close is enqueued on the paused dispatcher
                 catalog.detach("test_db")
 
                 val ex = assertThrows<Conflict> {
@@ -31,9 +30,17 @@ class DatabaseCatalogTest {
                 }
                 assertEquals("xtdb/db-being-detached", ex.errCode())
 
-                // drain the closer, then re-attach succeeds
-                scheduler.advanceUntilIdle()
-                catalog.attach("test_db", Database.Config())
+                // Teardown finishes on the database's own dispatcher in the background; the conflict
+                // is transient, so the name frees up and re-attach eventually succeeds.
+                val deadline = System.nanoTime() + SECONDS.toNanos(10)
+                while (true) {
+                    try {
+                        catalog.attach("test_db", Database.Config()); break
+                    } catch (e: Conflict) {
+                        check(System.nanoTime() < deadline) { "detach did not complete within 10s" }
+                        Thread.sleep(10)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Refs #5741 — a step toward it, not the fix (see "Out of scope").

## Summary

A behaviour-preserving restructure of database and node teardown: the coroutine job tree that owns a database's indexing/compaction work is now rooted at `DatabaseCatalog` rather than at each independent `Database`, and teardown follows the same two-phase (cancel-then-free) model the rest of the codebase already uses. Same observable teardown, with no per-database `runBlocking`.

## Context

Each database used to cancel its own job tree with `runBlocking { job.cancelAndJoin() }` — in `Database.close` on the DETACH path, and once per database at node shutdown. Each call parks a dispatcher thread for the duration of the cancel-join, and under a parallelism-constrained dispatcher those parked threads can starve the coroutines they are waiting on. That is the shape behind the #5741 teardown deadlock.

## Implementation

`DatabaseCatalog` owns a root `dbJob` (a `SupervisorJob`); each `Database`'s job is opened as a child of it (`Database.open` now takes the catalog's scope), and the existing detach `closerJob` nests under the same root.

`Database.close()` becomes Phase-2-only (free state); a new `suspend fun cancelAndJoin()` is the Phase-1 half — mirroring the `SubSystem` pattern already in `LogProcessor`. DETACH runs `cancelAndJoin(); close()` on the closer scope as a suspend join, so it no longer parks a thread; node shutdown cancels `dbJob` once and then frees synchronously.

Each database's own job is itself a `SupervisorJob`, so a failure within it (e.g. the source-log subscription) surfaces through the scope's `CoroutineExceptionHandler` (`watchers.notifyError`) rather than propagating up — a handler fires only for a root coroutine or a direct child of a `SupervisorJob`. Sibling-database isolation is the separate concern of the catalog's `dbJob` being a `SupervisorJob`. The detach teardown runs under `NonCancellable` so a concurrent node shutdown cannot interrupt it mid-flight and leak a half-closed database.

`IngestNode` is the other database owner — it bypasses the catalog — so it grows the same shape: its own root `SupervisorJob`, threaded into `Database.open`, cancelled once at shutdown and, on a partial-open failure, cancelled before the opened databases are freed.

## Out of scope

This does not on its own resolve #5741. The deadlock's load-bearing `runBlocking` is the Kafka rebalance callback running the follower→leader transition on the poll thread; lifting the scope tree only removes the per-database teardown `runBlocking`. The minimal fix — re-adding the per-batch `processRecords` await that #5739 removed, which re-serialises the poll loop with the persister — is a separate follow-up.

## Test plan

Full `./gradlew test`: 1,561 tests, 0 failures, no reflection or boxed-math warnings.

Simulations (`NodeSimulationTest`, `CompactorSimulationTest`, `LogProcessorSimTest`): 488 iterations, 0 failures, no `UncompletedCoroutinesError`, no allocator leaks, no hangs.

`DatabaseCatalogTest` (the #5613 reattach-during-detach test) was reworked off the virtual-time dispatcher onto `Dispatchers.Unconfined` plus a real re-attach poll, since the suspend-based detach now spans the database's real dispatcher and can't be drained by `advanceUntilIdle()`.

A concurrency-focused review pass produced three findings — `CoroutineExceptionHandler` firing, `IngestNode` open-failure ordering, and `NonCancellable` detach teardown — all folded into the commit.