### PR TITLE
fix(indexer): await source-log batches through the persister

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -580,9 +580,14 @@ class LeaderLogProcessor(
     override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
         maybeFlushBlock()
 
-        // Fire the batch onto the persister and return, freeing the (shared) consumer poll thread.
-        // The persister resolves + imports; clients observe completion via the watchers, not this return.
-        if (records.isNotEmpty()) sourceLogCh.send(SourceLogTask.Batch(records))
+        // Await the batch through the persister rather than firing and returning. The persister still
+        // resolves + imports on its own thread (the heavy work is off the poll thread), but blocking
+        // here until it's done keeps the shared consumer's poll loop and the persister in lock-step:
+        // whenever the poll thread is back in `poll()` — where Kafka runs rebalance callbacks, which
+        // run a leader/follower transition under `runBlocking` — the persister is quiescent, so a
+        // concurrent DETACH/shutdown that must cancel-join the term doesn't wedge against in-flight
+        // import work on a starved dispatcher (#5741).
+        if (records.isNotEmpty()) submit(SourceLogTask.Batch(records))
     }
 
     override fun close() {


### PR DESCRIPTION
Closes #5741.

## Summary

Closes the intermittent DETACH / node-shutdown teardown deadlock by re-serialising the shared consumer's source-log poll loop with the persister. One line: `processRecords` awaits the batch through the persister again, rather than firing it and returning.

## Root cause

The shared group-consumer poll loop is the only place that processes subscription `Unregister` commands, but Kafka runs its rebalance callbacks synchronously on that poll thread inside `consumer.poll()`, and those callbacks drive a leader/follower transition under `runBlocking`. While the poll thread is in that `runBlocking`, a concurrent teardown that must cancel-join the term's persister blocks on in-flight import work, and on a parallelism-constrained dispatcher the two thread-parking operations starve each other into a deadlock. (Full investigation, including why lifting the teardown scope tree in #5742 was necessary but not sufficient, is on #5741.)

## The fix

#5739 turned `processRecords` into fire-and-return — it sent the poll batch onto the persister channel and came straight back, so the persister resolved and imported concurrently with the poll loop. That concurrency is what lets a teardown race in-flight import work. Awaiting the batch through the persister again puts the poll loop and the persister back in lock-step: whenever the poll thread is back in `poll()` (where the rebalance callbacks fire), the persister is quiescent, so a transition or teardown that cancel-joins the term finds nothing in flight to wait on.

## Tradeoff (deliberate)

This is a minimal backout. It reverses #5739's poll-thread-freeing benefit on the source-log path — a database's heavy indexing again occupies its consumer's poll loop for the duration of resolve + import — but keeps the rest of #5739 (resolution runs on the persister thread, not the poll thread). The load-bearing cause is running the full transition under `runBlocking` inside Kafka's synchronous rebalance callback; moving that off the callback would let the poll loop stay free and the await be dropped again. That is a larger Kafka-consumer change, left as a follow-up.

## Relationship to #5742

Independent. #5742 lifts the teardown scope tree to `DatabaseCatalog` (a behaviour-preserving cleanup that removes the per-database teardown `runBlocking`); this PR is the actual deadlock fix and stands alone off `main`. Both reference #5741.

## Test plan

KafkaClusterTest: six real `--rerun-tasks` runs (58–70s each), all green and no hangs, where the unfixed branch hung on the first run.

`LeaderLogProcessorTest` + `LogProcessorTest`: pass (the await makes `processRecords` synchronous again).

Full `./gradlew test`: 1,561 tests, 0 failures, no reflection or boxed-math warnings.