### PR TITLE
refactor(postgres-source)!: require an explicit indexer, no !DirectMirror default

### DIFF
--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -118,7 +118,7 @@ class PostgresSource(
         val remote: RemoteAlias,
         val slotName: String,
         val publicationName: String,
-        val indexer: PgIndexer.Factory = DirectMirror.Factory(),
+        val indexer: PgIndexer.Factory,
     ) : ExternalSource.Factory {
 
         override fun open(
@@ -169,9 +169,7 @@ class PostgresSource(
                     remote = config.remote,
                     slotName = config.slotName,
                     publicationName = config.publicationName,
-                    // absent on configs persisted before pluggable indexers landed
-                    indexer = if (config.hasIndexer()) PgIndexer.Factory.fromProto(config.indexer)
-                              else DirectMirror.Factory(),
+                    indexer = PgIndexer.Factory.fromProto(config.indexer),
                 )
             }
 

--- a/modules/postgres-source/src/main/proto/postgres_source.proto
+++ b/modules/postgres-source/src/main/proto/postgres_source.proto
@@ -13,7 +13,6 @@ message PostgresSourceConfig {
 
     // Carried as Any so the proto stays decoupled from specific indexer config shapes —
     // mirrors KafkaConnectSourceConfig.indexer and DatabaseConfig.external_source.
-    // Absent on configs persisted before pluggable indexers landed — decoded as !DirectMirror.
     google.protobuf.Any indexer = 4;
 }
 

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
@@ -19,6 +19,7 @@ class PostgresSourceFactoryTest {
             remote = "pg",
             slotName = "my_slot",
             publicationName = "my_pub",
+            indexer = DirectMirror.Factory(),
         )
 
         val restored = protoRoundTrip(original)
@@ -26,27 +27,20 @@ class PostgresSourceFactoryTest {
         assertEquals("pg", restored.remote)
         assertEquals("my_slot", restored.slotName)
         assertEquals("my_pub", restored.publicationName)
+        assertTrue(restored.indexer is DirectMirror.Factory)
     }
 
+    // fix: DETACH the database, then re-ATTACH with an indexer in the config
     @Test
-    fun `indexer defaults to DirectMirror`() {
-        val factory = PostgresSource.Factory(remote = "pg", slotName = "s", publicationName = "p")
-        assertTrue(factory.indexer is DirectMirror.Factory)
-
-        assertTrue(protoRoundTrip(factory).indexer is DirectMirror.Factory, "survives proto round-trip")
-    }
-
-    @Test
-    fun `config persisted before pluggable indexers decodes to DirectMirror`() {
-        // an older PostgresSourceConfig carries no `indexer` field; the absent Any must decode as the default
+    fun `config persisted without an indexer is rejected`() {
         val legacy = xtdb.postgres.proto.postgresSourceConfig {
             remote = "pg"; slotName = "s"; publicationName = "p"
         }
         val any = com.google.protobuf.Any.pack(legacy, "proto.xtdb.com")
 
-        val factory = PostgresSource.Factory.Registration().fromProto(any)
-
-        assertTrue(factory.indexer is DirectMirror.Factory)
+        assertThrows(IllegalStateException::class.java) {
+            PostgresSource.Factory.Registration().fromProto(any)
+        }
     }
 
     @Test
@@ -56,6 +50,7 @@ class PostgresSourceFactoryTest {
               remote: pg
               slotName: my_slot
               publicationName: my_pub
+              indexer: !DirectMirror {}
         """.trimIndent()
 
         val config = Database.Config.fromYaml(yaml)
@@ -64,6 +59,7 @@ class PostgresSourceFactoryTest {
         assertEquals("pg", factory.remote)
         assertEquals("my_slot", factory.slotName)
         assertEquals("my_pub", factory.publicationName)
+        assertTrue(factory.indexer is DirectMirror.Factory)
     }
 
     @Test
@@ -122,6 +118,7 @@ class PostgresSourceFactoryTest {
               remote: pg
               slotName: s
               publicationName: p
+              indexer: !DirectMirror {}
         """.trimIndent()
 
         val nodeRemote = nodeConfig(nodeYaml).remotes["pg"]

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -121,6 +121,7 @@ class PostgresSourceIntegrationTest {
                           remote: pg
                           slotName: $slotName
                           publicationName: $publicationName
+                          indexer: !DirectMirror {}
                     $$""".trimIndent()
                 )
             }
@@ -150,6 +151,7 @@ class PostgresSourceIntegrationTest {
                           remote: pg
                           slotName: $slotName
                           publicationName: $publicationName
+                          indexer: !DirectMirror {}
                     $$""".trimIndent()
                 )
             }

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
@@ -80,6 +80,7 @@ abstract class PostgresSourceTestBase {
                           remote: pg
                           slotName: $slot
                           publicationName: $pub
+                          indexer: !DirectMirror {}
                     $$""".trimIndent()
                 )
             }


### PR DESCRIPTION
Part of #5725.

## Summary

Make the `indexer` field of a `!Postgres` external source a required field — it previously defaulted to `!DirectMirror`.

## Motivation

`!DirectMirror` mirrors the upstream as-is, which isn't the right behaviour for every Postgres source, and we want to leave room for other indexers rather than treat it as the obvious choice. Defaulting to it lets a config author omit the field and silently get mirror-as-is semantics they never chose.

We'd rather every `!Postgres` source state its indexer outright. We may settle on a default later, but we're deferring that decision rather than baking in `!DirectMirror` by inertia.

This also brings `!Postgres` into line with the sibling `!KafkaConnect` external source, which already requires its indexer with no default.

## Breaking change

A `!Postgres` external source that was valid without an `indexer` no longer is.

- New configs must name an indexer:

  \`\`\`yaml
  externalSource: !Postgres
    remote: pg
    slotName: my_slot
    publicationName: my_pub
    indexer: !DirectMirror {}
  \`\`\`

- For an already-attached database, the upgrade path is to DETACH and re-ATTACH with an explicit indexer.
- A persisted config without an indexer is now rejected at the indexer SPI lookup rather than decoded as `!DirectMirror`.

## Test plan

- `PostgresSourceFactoryTest` (6/6) passing — exercises the required field via the constructor, a proto round-trip, YAML deserialization, and rejection of a persisted config with no indexer.
- The Docker-backed integration and simulation tests inherit the updated `ATTACH DATABASE` YAML; not run locally — CI will exercise them.