### PR TITLE
feat(adbc): transaction & session control on the connection (ADBC parity)

### DIFF
--- a/api/src/main/kotlin/xtdb/database/Basis.kt
+++ b/api/src/main/kotlin/xtdb/database/Basis.kt
@@ -2,14 +2,20 @@
 
 package xtdb.database
 
+import com.google.protobuf.Timestamp
 import xtdb.api.log.MessageId
 import xtdb.error.Incorrect
 import xtdb.proto.basis.*
+import java.time.Instant
 import kotlin.io.encoding.Base64
 import kotlin.math.max
 
 typealias DatabaseName = String
 typealias TxBasisToken = Map<DatabaseName, List<MessageId>>
+
+// a read snapshot's upper bound: per database, the latest-completed system-time of each partition
+// (null where a partition has completed no transactions).
+typealias TimeBasisToken = Map<DatabaseName, List<Instant?>>
 
 fun TxBasisToken.encodeTxBasisToken(): String =
     txBasis {
@@ -32,6 +38,39 @@ fun String.decodeTxBasisToken(): TxBasisToken =
         .let { basis ->
             basis.databasesMap.entries
                 .associate { it.key to it.value.messageIdsList }
+        }
+
+fun TimeBasisToken.encodeTimeBasisToken(): String =
+    timeBasis {
+        entries.forEach { (dbName, sysTimes) ->
+            databases.put(dbName, systemTimes {
+                systemTimes.addAll(sysTimes.map {
+                    it?.let { Timestamp.newBuilder().setSeconds(it.epochSecond).setNanos(it.nano).build() }
+                        ?: Timestamp.getDefaultInstance()
+                })
+            })
+        }
+    }
+        .toByteArray()
+        .let { Base64.encode(it) }
+
+fun String.decodeTimeBasisToken(): TimeBasisToken =
+    runCatching { TimeBasis.parseFrom(Base64.decode(this)) }
+        .getOrElse {
+            throw Incorrect(
+                message = "Invalid basis: ${it.message}",
+                errorCode = "xtdb.basis/invalid-basis",
+                cause = it
+            )
+        }
+        .let { basis ->
+            basis.databasesMap.entries
+                .associate { (dbName, sysTimes) ->
+                    dbName to sysTimes.systemTimesList.map {
+                        if (it == Timestamp.getDefaultInstance()) null
+                        else Instant.ofEpochSecond(it.seconds, it.nanos.toLong())
+                    }
+                }
         }
 
 fun mergeTxBasisTokens(l: String?, r: String): String {

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -19,6 +19,7 @@
   (:import io.micrometer.core.instrument.composite.CompositeMeterRegistry
            io.micrometer.core.instrument.Counter
            (java.io Closeable Writer)
+           (java.time Clock)
            (java.util HashMap)
            [java.util.concurrent.atomic AtomicReference]
            (org.apache.arrow.memory BufferAllocator)
@@ -85,7 +86,7 @@
 (defn- ->node-connection ^Xtdb$Connection [^Database$Catalog db-cat ^BufferAllocator allocator
                                            ^IQuerySource q-src ^SqlPlanner sql-planner default-tz ^Counter tx-error-counter
                                            tx-await-timer tx-submit-timer tx-execute-timer db-name]
-  (Xtdb$Connection. allocator db-cat q-src sql-planner default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
+  (Xtdb$Connection. allocator db-cat q-src sql-planner (Clock/systemDefaultZone) default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
 
 (defrecord Node [^BufferAllocator allocator, ^Database$Catalog db-cat
                  ^IQuerySource q-src ^SqlPlanner sql-planner

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -11,6 +11,7 @@
             [xtdb.protocols :as xtp]
             [xtdb.query :as q]
             [xtdb.serde :as serde]
+            [xtdb.sql :as sql]
             [xtdb.time :as time]
             [xtdb.tracer]
             [xtdb.util :as util]
@@ -27,7 +28,7 @@
            xtdb.api.module.XtdbModule$Factory
            (xtdb.database Database Database$Catalog DatabasePartition)
            xtdb.error.Anomaly
-           (xtdb.query IQuerySource PreparedQuery QueryOpts)))
+           (xtdb.query IQuerySource PreparedQuery QueryOpts SqlPlanner)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -82,12 +83,12 @@
            :error error}))))
 
 (defn- ->node-connection ^Xtdb$Connection [^Database$Catalog db-cat ^BufferAllocator allocator
-                                           ^IQuerySource q-src default-tz ^Counter tx-error-counter
+                                           ^IQuerySource q-src ^SqlPlanner sql-planner default-tz ^Counter tx-error-counter
                                            tx-await-timer tx-submit-timer tx-execute-timer db-name]
-  (Xtdb$Connection. allocator db-cat q-src default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
+  (Xtdb$Connection. allocator db-cat q-src sql-planner default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
 
 (defrecord Node [^BufferAllocator allocator, ^Database$Catalog db-cat
-                 ^IQuerySource q-src
+                 ^IQuerySource q-src ^SqlPlanner sql-planner
                  ^CompositeMeterRegistry metrics-registry
                  default-tz, ^AtomicReference !await-token
                  system, close-fn,
@@ -115,7 +116,7 @@
       (.createConnectionBuilder data-source)))
 
   (connect [_]
-    (->node-connection db-cat allocator q-src default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer "xtdb"))
+    (->node-connection db-cat allocator q-src sql-planner default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer "xtdb"))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))
@@ -177,7 +178,7 @@
           (throw e)))))
 
   (open-connection [_ db-name]
-    (->node-connection db-cat allocator q-src default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
+    (->node-connection db-cat allocator q-src sql-planner default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
 
   xtp/PStatus
   (latest-completed-txs [_]
@@ -264,6 +265,7 @@
                             (dissoc :base)
                             (assoc :allocator (.getAllocator base)
                                    :q-src (.getQuerySource base)
+                                   :sql-planner (sql/->sql-planner)
                                    :metrics-registry metrics-registry
                                    :default-tz (.getDefaultTz (.getConfig base))
                                    :!await-token (AtomicReference. nil))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -84,9 +84,9 @@
            :error error}))))
 
 (defn- ->node-connection ^Xtdb$Connection [^Database$Catalog db-cat ^BufferAllocator allocator
-                                           ^IQuerySource q-src ^SqlPlanner sql-planner default-tz ^Counter tx-error-counter
+                                           ^IQuerySource q-src ^SqlPlanner sql-planner query-tracer default-tz ^Counter tx-error-counter
                                            tx-await-timer tx-submit-timer tx-execute-timer db-name]
-  (Xtdb$Connection. allocator db-cat q-src sql-planner (Clock/systemDefaultZone) default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
+  (Xtdb$Connection. allocator db-cat q-src sql-planner (Clock/systemDefaultZone) query-tracer default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
 
 (defrecord Node [^BufferAllocator allocator, ^Database$Catalog db-cat
                  ^IQuerySource q-src ^SqlPlanner sql-planner
@@ -94,7 +94,7 @@
                  default-tz, ^AtomicReference !await-token
                  system, close-fn,
                  query-timer, ^Counter query-error-counter, ^Counter tx-error-counter
-                 tx-await-timer tx-submit-timer tx-execute-timer]
+                 tx-await-timer tx-submit-timer tx-execute-timer query-tracer]
   Xtdb
   (getAllocator [_] allocator)
 
@@ -117,7 +117,7 @@
       (.createConnectionBuilder data-source)))
 
   (connect [_]
-    (->node-connection db-cat allocator q-src sql-planner default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer "xtdb"))
+    (->node-connection db-cat allocator q-src sql-planner query-tracer default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer "xtdb"))
 
   (addMeterRegistry [_ reg]
     (.add metrics-registry reg))
@@ -179,7 +179,7 @@
           (throw e)))))
 
   (open-connection [_ db-name]
-    (->node-connection db-cat allocator q-src sql-planner default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
+    (->node-connection db-cat allocator q-src sql-planner query-tracer default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
 
   xtp/PStatus
   (latest-completed-txs [_]
@@ -279,7 +279,11 @@
                                    :tx-submit-timer (metrics/add-timer metrics-registry "node.tx.submit"
                                                                        {:description "Time spent in submitTx (async-path log append + ack), across all frontends."})
                                    :tx-execute-timer (metrics/add-timer metrics-registry "node.tx.execute"
-                                                                        {:description "Time spent in executeTx (sync-path log append + indexer await), across all frontends."}))))]
+                                                                        {:description "Time spent in executeTx (sync-path log append + indexer await), across all frontends."})
+                                   ;; query tracer gated by config, threaded into every connection's reads — the
+                                   ;; connection owns query tracing, so it applies across all frontends alike
+                                   :query-tracer (when (.getQueryTracing (.getTracer (.getConfig base)))
+                                                   (.getTracer base)))))]
     node))
 
 (defmethod ig/halt-key! :xtdb/node [_ node]

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -8,6 +8,7 @@
             [xtdb.api :as xt]
             [xtdb.error :as err]
             [xtdb.information-schema :as info-schema]
+            [xtdb.log :as xt-log]
             [xtdb.logical-plan :as lp]
             [xtdb.table :as table]
             [xtdb.time :as time]
@@ -3418,11 +3419,18 @@
           (throw (err/incorrect :xtdb/missing-arg (str "missing arg: " expr) {}))))
     expr))
 
+(declare sql->static-ops)
+
 (defn ->sql-planner ^SqlPlanner []
   (reify SqlPlanner
     (evalLiteral [_ expr args]
       (-> (plan-expr expr (->env))
-          (apply-args args)))))
+          (apply-args args)))
+
+    ;; the adapter opens sql->static-ops' client ops up into core TxOps (via safe-mapv, closing partials on throw)
+    (toStaticOps [_ sql args al default-tz]
+      (when-let [client-ops (seq (sql->static-ops sql args))]
+        (util/safe-mapv #(xt-log/open-tx-op % al {:default-tz default-tz}) client-ops)))))
 
 (defprotocol PlanQuery
   (-plan-query [query opts]))

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -328,6 +328,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
             override fun executeQuery(): QueryResult {
                 val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
+                resolveForQuery()
                 if (prepared == null && args != null)
                     throw Incorrect(
                         "call prepare() before executeQuery() when parameters are bound",
@@ -518,6 +519,21 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     op.close()
                     throw Incorrect("Cannot write in a read-only transaction", "xtdb/read-only-tx")
                 }
+            }
+        }
+
+        // The read counterpart of executeDml's access-mode resolution: a query resolves an unresolved tx to
+        // read-only, and is rejected in a read-write (DML) tx — in XTDB a write tx is write-only. With no open
+        // tx (autocommit, or none begun) the query reads latest, unchanged.
+        private fun resolveForQuery() {
+            val tx = tx ?: return
+            when (tx.mode) {
+                is ReadWrite -> throw Incorrect(
+                    "Queries are unsupported in a DML transaction", "xtdb/queries-in-read-write-tx"
+                )
+
+                is ReadOnly -> {}
+                null -> tx.mode = ReadOnly
             }
         }
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -2,20 +2,15 @@
 
 package xtdb.api
 
+import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
-import io.micrometer.core.instrument.Counter
-import io.micrometer.core.instrument.Timer
-import org.apache.arrow.adbc.core.AdbcConnection
+import org.apache.arrow.adbc.core.*
 import org.apache.arrow.adbc.core.AdbcConnection.GetObjectsDepth
-import org.apache.arrow.adbc.core.AdbcDatabase
-import org.apache.arrow.adbc.core.AdbcInfoCode
-import org.apache.arrow.adbc.core.AdbcStatement
 import org.apache.arrow.adbc.core.AdbcStatement.QueryResult
 import org.apache.arrow.adbc.core.AdbcStatement.UpdateResult
-import org.apache.arrow.adbc.core.BulkIngestMode
-import org.apache.arrow.adbc.core.StandardSchemas
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.UInt4Vector
 import org.apache.arrow.vector.VectorLoader
@@ -34,12 +29,8 @@ import xtdb.api.metrics.HealthzConfig
 import xtdb.api.metrics.TracerConfig
 import xtdb.api.module.XtdbModule
 import xtdb.api.storage.Storage
-import xtdb.arrow.Relation
-import xtdb.arrow.RelationReader
-import xtdb.arrow.RelationWriter
-import xtdb.arrow.VectorType
+import xtdb.arrow.*
 import xtdb.arrow.VectorType.Companion.ofType
-import xtdb.arrow.unsupported
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.database.Database
@@ -50,25 +41,20 @@ import xtdb.error.Anomaly
 import xtdb.error.Fault
 import xtdb.error.Incorrect
 import xtdb.indexer.DatabaseSnapshot
-import xtdb.query.IQuerySource
-import xtdb.query.PrepareOpts
-import xtdb.query.PreparedQuery
-import xtdb.query.QueryOpts
+import xtdb.query.*
 import xtdb.table.TableRef
+import xtdb.time.asInstant
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
 import xtdb.util.closeOnCatch
-import xtdb.util.useAll
-import java.util.concurrent.ExecutionException
 import xtdb.util.requiringResolve
+import xtdb.util.useAll
 import java.nio.file.Files
 import java.nio.file.Path
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import java.time.ZoneOffset
+import java.time.*
+import java.util.Date
 import java.util.UUID.randomUUID
+import java.util.concurrent.ExecutionException
 import kotlin.io.path.extension
 
 private fun parseSkipDbsEnv(skipDbs: String): Set<String> =
@@ -126,6 +112,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         private val allocator: BufferAllocator,
         private val dbCat: Database.Catalog,
         private val qSrc: IQuerySource,
+        private val sqlPlanner: SqlPlanner,
         var defaultTz: ZoneId,
         private val txErrorCounter: Counter?,
         private val txAwaitTimer: Timer?,
@@ -360,8 +347,20 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
             override fun executeUpdate(): UpdateResult {
                 val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-                val op = TxOp.Sql(sql, openQueryArgs())
-                executeDml(op)
+
+                val stmt = parseStatements(sql).singleOrNull()
+                    ?: throw Incorrect(
+                        "executeUpdate expects exactly one SQL statement",
+                        "xtdb.adbc/expected-single-statement",
+                        mapOf("sql" to sql)
+                    )
+                when (stmt) {
+                    is ParsedStatement.Begin -> beginParsedTx(stmt.txOptions, sql)
+
+                    is ParsedStatement.Commit -> commitTx()
+                    is ParsedStatement.Rollback -> rollbackTx()
+                    else -> executeDml(TxOp.Sql(sql, openQueryArgs()))
+                }
                 return UpdateResult(-1)
             }
 
@@ -399,42 +398,123 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         // resolved on the first statement: a query makes it read-only, DML makes it read-write. In XTDB a
         // "read-write" tx is write-only — queries are rejected in a DML tx, DML in a read-only one.
-        private sealed interface AccessMode : AutoCloseable {
-            data object ReadOnly : AccessMode {
-                override fun close() {}
-            }
+        private sealed interface AccessMode : AutoCloseable
 
-            class ReadWrite(
-                val buffer: DmlBuffer,
-                val systemTime: Instant? = null,
-                val userMetadata: Map<*, *>? = null,
-                val async: Boolean = false,
-            ) : AccessMode {
-                override fun close() = buffer.close()
+        private data object ReadOnly : AccessMode {
+            override fun close() {}
+        }
+
+        private inner class ReadWrite(
+            val systemTime: Instant? = null,
+            val userMetadata: Map<*, *>? = null,
+            val async: Boolean = false,
+        ) : AccessMode {
+            val buffer = DmlBuffer(allocator)
+
+            override fun close() = buffer.close()
+        }
+
+        private class Transaction(var mode: AccessMode? = null) : AutoCloseable {
+            var failed: Throwable? = null
+
+            override fun close() {
+                mode?.close()
             }
         }
 
-        private class Transaction(var mode: AccessMode? = null, var failed: Throwable? = null) : AutoCloseable {
-            override fun close() { mode?.close() }
+        // Open an explicit transaction (SQL BEGIN). [readOnly] fixes the access mode — READ ONLY rejects writes,
+        // READ WRITE buffers them; a bare BEGIN leaves it unresolved until the first statement resolves it.
+        // Coexists with autoCommit — an open tx captures subsequent DML (see executeDml) until COMMIT/ROLLBACK.
+        private fun beginTx(accessMode: AccessMode?) {
+            if (tx != null) throw Incorrect("transaction already started", "xtdb/tx-already-open")
+            tx = Transaction(accessMode)
         }
 
-        private fun commitTx() {
+        fun beginTx() = beginTx(null)
+
+        fun beginReadOnly() = beginTx(ReadOnly)
+
+        fun beginWriteOnly(systemTime: Instant? = null, userMetadata: Map<*, *>? = null, async: Boolean = false) =
+            beginTx(ReadWrite(systemTime, userMetadata, async))
+
+        // Coerce a planned BEGIN-option value to an Instant, mirroring xtdb.time/->instant so the connection and
+        // pgwire agree on the system-time a SQL temporal literal resolves to. SqlPlanner plans `TIMESTAMP '…'`
+        // to a java.time temporal (ZonedDateTime when zoned, else LocalDateTime); a bare string falls back to
+        // the SQL-timestamp parse. LocalDate/LocalDateTime are anchored in [defaultTz], as pgwire does.
+        private fun coerceInstant(value: Any?): Instant? = when (value) {
+            null -> null
+            is Instant -> value
+            is ZonedDateTime -> value.toInstant()
+            is OffsetDateTime -> value.toInstant()
+            is LocalDateTime -> value.atZone(defaultTz).toInstant()
+            is LocalDate -> value.atStartOfDay(defaultTz).toInstant()
+            is Date -> value.toInstant()
+            is String -> value.asInstant(defaultTz)
+            else -> throw Incorrect(
+                "cannot coerce SYSTEM_TIME option to an instant",
+                "xtdb.adbc/invalid-system-time",
+                mapOf("value" to value, "type" to value::class.java.name)
+            )
+        }
+
+        // Begin an explicit tx from parsed WITH options, evaluating each option expression via the injected
+        // SqlPlanner. BEGIN options carry no bound params, so args is null.
+        private fun beginParsedTx(opts: ParsedStatement.TxOptions, sql: String) {
+            fun rejectOpt(): Nothing = throw Incorrect(
+                "BEGIN ... WITH option is not yet supported here",
+                "xtdb.adbc/unsupported-tx-option",
+                mapOf("sql" to sql)
+            )
+
+            when (opts.accessMode) {
+                ParsedStatement.AccessMode.READ_WRITE -> {
+                    if (opts.defaultTz != null) throw Incorrect(
+                        "BEGIN READ WRITE WITH (TIMEZONE …) is not yet supported",
+                        "xtdb.adbc/unsupported-tx-option",
+                        mapOf("sql" to sql)
+                    )
+
+                    val systemTime = coerceInstant(opts.systemTime?.let { sqlPlanner.evalLiteral(it, null) })
+                    val userMetadata = opts.userMetadata?.let { sqlPlanner.evalLiteral(it, null) } as Map<*, *>?
+                    val async = (opts.async?.let { sqlPlanner.evalLiteral(it, null) } as Boolean?) ?: false
+
+                    beginWriteOnly(systemTime, userMetadata, async)
+                }
+
+                ParsedStatement.AccessMode.READ_ONLY -> {
+                    // the read basis is not implemented yet, so reject any WITH option
+                    if (opts != ParsedStatement.TxOptions(accessMode = opts.accessMode)) rejectOpt()
+                    beginReadOnly()
+                }
+
+                null -> beginTx()
+            }
+        }
+
+        fun commitTx() {
             val tx = tx ?: return
             this.tx = null
-            val ops = (tx.mode as? AccessMode.ReadWrite)?.buffer?.drain()
-            if (!ops.isNullOrEmpty()) ops.useAll { executeTx(it) }
+            // a ReadWrite tx commits even when its buffer is empty — an explicit write tx records a transaction
+            // (and advances the await-token); a ReadOnly / still-unresolved tx is a no-op.
+            val mode = tx.mode as? ReadWrite ?: return
+            // defaultTz/user left null: doSubmit fills defaultTz via withFallbackTz, and there's no connection user yet.
+            val opts = TxOpts(systemTime = mode.systemTime, userMetadata = mode.userMetadata)
+            mode.buffer.drain().useAll { ops -> if (mode.async) submitTx(ops, opts) else executeTx(ops, opts) }
         }
 
         internal fun executeDml(op: TxOp) {
-            if (autoCommit) {
+            // auto-execute only when no explicit tx is open; an open tx (from beginTx) buffers even under autoCommit.
+            if (autoCommit && tx == null) {
                 listOf(op).useAll { ops -> executeTx(ops) }
                 return
             }
+
             val tx = tx ?: Transaction().also { tx = it }
+
             when (val mode = tx.mode) {
-                is AccessMode.ReadWrite -> mode.buffer.add(op)
-                null -> AccessMode.ReadWrite(DmlBuffer(allocator)).also { tx.mode = it }.buffer.add(op)
-                is AccessMode.ReadOnly -> {
+                is ReadWrite -> mode.buffer.add(op)
+                null -> ReadWrite().also { tx.mode = it }.buffer.add(op)
+                is ReadOnly -> {
                     op.close()
                     throw Incorrect("Cannot write in a read-only transaction", "xtdb/read-only-tx")
                 }
@@ -448,18 +528,24 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         override fun commit() {
-            if (autoCommit) throw Incorrect("Cannot commit when autoCommit is enabled", "xtdb.adbc/commit-in-autocommit")
+            if (autoCommit)
+                throw Incorrect("Cannot commit when autoCommit is enabled", "xtdb.adbc/commit-in-autocommit")
+
             commitTx()
         }
 
-        private fun discardTx() {
+        // SQL ROLLBACK: discards the open tx regardless of autoCommit (unlike [rollback], which rejects rollback in
+        // autocommit). The explicit-tx mechanism the SQL tx-control path drives.
+        private fun rollbackTx() {
             tx?.close()
             tx = null
         }
 
         override fun rollback() {
-            if (autoCommit) throw Incorrect("Cannot rollback when autoCommit is enabled", "xtdb.adbc/rollback-in-autocommit")
-            discardTx()
+            if (autoCommit)
+                throw Incorrect("Cannot rollback when autoCommit is enabled", "xtdb.adbc/rollback-in-autocommit")
+
+            rollbackTx()
         }
 
         override fun bulkIngest(targetTableName: String, mode: BulkIngestMode): Statement {
@@ -768,7 +854,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         override fun getCurrentDbSchema(): String = "public"
 
         override fun close() {
-            discardTx()
+            rollbackTx()
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -113,6 +113,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         private val dbCat: Database.Catalog,
         private val qSrc: IQuerySource,
         private val sqlPlanner: SqlPlanner,
+        private val clock: Clock,
         var defaultTz: ZoneId,
         private val txErrorCounter: Counter?,
         private val txAwaitTimer: Timer?,
@@ -260,7 +261,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         fun openSqlQuery(sql: String): ResultCursor =
-            prepareSql(sql).openQuery(null, QueryOpts(null, defaultTz))
+            prepareSql(sql).openQuery(null, queryOpts())
 
         fun openSnapshot(): DatabaseSnapshot {
             val db = db(dbName)
@@ -337,7 +338,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 val queryArgs = openQueryArgs()
                 val cursor = try {
-                    prepared?.openQuery(queryArgs, QueryOpts()) ?: openSqlQuery(sql)
+                    prepared?.openQuery(queryArgs, queryOpts()) ?: openSqlQuery(sql)
                 } catch (t: Throwable) {
                     queryArgs?.close()
                     throw t
@@ -415,7 +416,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             override fun close() = buffer.close()
         }
 
-        private class Transaction(var mode: AccessMode? = null) : AutoCloseable {
+        // The read basis pinned at BEGIN and observed by every query in the transaction — the lever for
+        // cross-query snapshot isolation. Carried by an unresolved tx and a ReadOnly one (resolving the
+        // former to the latter inherits it unchanged); a ReadWrite tx has none — writes don't read.
+        private class ReadBasis(val snapshotToken: String?, val snapshotTime: Instant?, val currentTime: Instant)
+
+        private class Transaction(var mode: AccessMode? = null, val readBasis: ReadBasis? = null) : AutoCloseable {
             var failed: Throwable? = null
 
             override fun close() {
@@ -423,20 +429,32 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             }
         }
 
-        // Open an explicit transaction (SQL BEGIN). [readOnly] fixes the access mode — READ ONLY rejects writes,
-        // READ WRITE buffers them; a bare BEGIN leaves it unresolved until the first statement resolves it.
-        // Coexists with autoCommit — an open tx captures subsequent DML (see executeDml) until COMMIT/ROLLBACK.
-        private fun beginTx(accessMode: AccessMode?) {
-            if (tx != null) throw Incorrect("transaction already started", "xtdb/tx-already-open")
-            tx = Transaction(accessMode)
+        // Pin the begin-time read basis: await this connection's own writes, then snapshot the data
+        // (latest-completed system-times) and the clock. A READ ONLY WITH clause overrides any of the three.
+        private fun pinReadBasis(
+            snapshotToken: String? = null, snapshotTime: Instant? = null, currentTime: Instant? = null
+        ): ReadBasis {
+            dbCat.awaitAll(awaitToken, awaitTimeout)
+            return ReadBasis(snapshotToken ?: dbCat.snapshotToken(), snapshotTime, currentTime ?: clock.instant())
         }
 
-        fun beginTx() = beginTx(null)
+        // Open an explicit transaction (SQL BEGIN). [accessMode] fixes the mode — READ ONLY rejects writes,
+        // READ WRITE buffers them; a bare BEGIN leaves it unresolved until the first statement resolves it.
+        // [readBasis] pins the begin-time read snapshot (null for an explicit READ WRITE — writes don't read).
+        // Coexists with autoCommit — an open tx captures subsequent DML (see executeDml) until COMMIT/ROLLBACK.
+        private fun beginTx(accessMode: AccessMode?, readBasis: ReadBasis?) {
+            if (tx != null) throw Incorrect("transaction already started", "xtdb/tx-already-open")
+            tx = Transaction(accessMode, readBasis)
+        }
 
-        fun beginReadOnly() = beginTx(ReadOnly)
+        // a bare BEGIN pins a basis even while unresolved: if a query resolves it to read-only the basis is
+        // inherited; if DML resolves it to read-write the basis is simply ignored.
+        fun beginTx() = beginTx(null, pinReadBasis())
+
+        fun beginReadOnly() = beginTx(ReadOnly, pinReadBasis())
 
         fun beginWriteOnly(systemTime: Instant? = null, userMetadata: Map<*, *>? = null, async: Boolean = false) =
-            beginTx(ReadWrite(systemTime, userMetadata, async))
+            beginTx(ReadWrite(systemTime, userMetadata, async), null)
 
         // Coerce a planned BEGIN-option value to an Instant, mirroring xtdb.time/->instant so the connection and
         // pgwire agree on the system-time a SQL temporal literal resolves to. SqlPlanner plans `TIMESTAMP '…'`
@@ -483,9 +501,15 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 }
 
                 ParsedStatement.AccessMode.READ_ONLY -> {
-                    // the read basis is not implemented yet, so reject any WITH option
-                    if (opts != ParsedStatement.TxOptions(accessMode = opts.accessMode)) rejectOpt()
-                    beginReadOnly()
+                    // SNAPSHOT_TOKEN / SNAPSHOT_TIME / CLOCK_TIME override the begin-time auto-pin. AWAIT_TOKEN
+                    // (the only other READ ONLY option in the grammar) isn't wired through yet — reject it fail-closed.
+                    if (opts.awaitToken != null) rejectOpt()
+
+                    val snapshotToken = opts.snapshotToken?.let { sqlPlanner.evalLiteral(it, null) } as String?
+                    val snapshotTime = coerceInstant(opts.snapshotTime?.let { sqlPlanner.evalLiteral(it, null) })
+                    val currentTime = coerceInstant(opts.clockTime?.let { sqlPlanner.evalLiteral(it, null) })
+
+                    beginTx(ReadOnly, pinReadBasis(snapshotToken, snapshotTime, currentTime))
                 }
 
                 null -> beginTx()
@@ -523,10 +547,16 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         // The read counterpart of executeDml's access-mode resolution: a query resolves an unresolved tx to
-        // read-only, and is rejected in a read-write (DML) tx — in XTDB a write tx is write-only. With no open
-        // tx (autocommit, or none begun) the query reads latest, unchanged.
+        // read-only, and is rejected in a read-write (DML) tx — in XTDB a write tx is write-only.
         private fun resolveForQuery() {
-            val tx = tx ?: return
+            val tx = tx
+            if (tx == null) {
+                // manual mode mirrors executeDml's lazy open: a query opens a read-only tx pinning the
+                // begin-time basis, so subsequent reads share its snapshot. Under autocommit there is no open
+                // tx — the query reads latest at the connection's current basis, unchanged.
+                if (!autoCommit) this.tx = Transaction(ReadOnly, pinReadBasis())
+                return
+            }
             when (tx.mode) {
                 is ReadWrite -> throw Incorrect(
                     "Queries are unsupported in a DML transaction", "xtdb/queries-in-read-write-tx"
@@ -535,6 +565,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 is ReadOnly -> {}
                 null -> tx.mode = ReadOnly
             }
+        }
+
+        // QueryOpts for a user read: an open tx's pinned basis (snapshot isolation), else null fields so the
+        // planner defaults to latest data and the wall-clock now (autocommit / no open tx).
+        private fun queryOpts() = tx?.readBasis.let { b ->
+            QueryOpts(b?.currentTime, defaultTz, b?.snapshotToken, b?.snapshotTime)
         }
 
         override fun setAutoCommit(autoCommit: Boolean) {

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -5,6 +5,7 @@ package xtdb.api
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import io.micrometer.tracing.Tracer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import org.apache.arrow.adbc.core.*
@@ -119,6 +120,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         private val qSrc: IQuerySource,
         private val sqlPlanner: SqlPlanner,
         private val clock: Clock,
+        // the query tracer, gated by the node's query-tracing config (null = off); threaded into every read's
+        // QueryOpts so the connection — not each frontend — owns query tracing.
+        private val tracer: Tracer?,
         var defaultTz: ZoneId,
         private val txErrorCounter: Counter?,
         private val txAwaitTimer: Timer?,
@@ -275,7 +279,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         fun openSqlQuery(sql: String): ResultCursor =
-            prepareSql(sql).openQuery(null, queryOpts())
+            openQuery(prepareSql(sql), null)
 
         fun openSnapshot(): DatabaseSnapshot {
             val db = db(dbName)
@@ -357,7 +361,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 val queryArgs = openQueryArgs()
                 val cursor = try {
-                    prepared?.openQuery(queryArgs, queryOpts()) ?: openSqlQuery(sql)
+                    prepared?.let { openQuery(it, queryArgs) } ?: openSqlQuery(sql)
                 } catch (t: Throwable) {
                     queryArgs?.close()
                     throw t
@@ -667,8 +671,13 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // QueryOpts for a user read: an open tx's pinned basis (snapshot isolation), else null fields so the
         // planner defaults to latest data and the wall-clock now (autocommit / no open tx).
         private fun queryOpts() = tx.let { t ->
-            QueryOpts(t?.readBasis?.currentTime, t?.txDefaultTz ?: defaultTz, t?.readBasis?.snapshotToken, t?.readBasis?.snapshotTime)
+            QueryOpts(t?.readBasis?.currentTime, t?.txDefaultTz ?: defaultTz, t?.readBasis?.snapshotToken, t?.readBasis?.snapshotTime, tracer)
         }
+
+        // Open a cursor on an already-prepared query at this connection's current basis, tz and tracer. The
+        // one place a frontend opens a read — it owns the cursor for wire serialization, but the QueryOpts
+        // (basis/tz/tracer) stay the connection's, so no callsite reconstructs them.
+        fun openQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor = pq.openQuery(args, queryOpts())
 
         // Answer a SHOW from connection state. SHOW LATEST_SUBMITTED_TX reports this connection's own last write;
         // SHOW AWAIT_TOKEN reads the connection's await-token; SHOW of any other identifier reads a session

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -352,7 +352,6 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 if (prepared == null)
                     (parseStatements(sql).singleOrNull() as? ParsedStatement.ShowVariable)
                         ?.let { return showVariable(it.variable) }
-                resolveForQuery()
                 if (prepared == null && args != null)
                     throw Incorrect(
                         "call prepare() before executeQuery() when parameters are bound",
@@ -361,7 +360,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 val queryArgs = openQueryArgs()
                 val cursor = try {
-                    prepared?.let { openQuery(it, queryArgs) } ?: openSqlQuery(sql)
+                    prepared?.let { openQuery(it, queryArgs) } ?: openQuery(prepareSql(sql), null)
                 } catch (t: Throwable) {
                     queryArgs?.close()
                     throw t
@@ -674,10 +673,14 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             QueryOpts(t?.readBasis?.currentTime, t?.txDefaultTz ?: defaultTz, t?.readBasis?.snapshotToken, t?.readBasis?.snapshotTime, tracer)
         }
 
-        // Open a cursor on an already-prepared query at this connection's current basis, tz and tracer. The
-        // one place a frontend opens a read — it owns the cursor for wire serialization, but the QueryOpts
-        // (basis/tz/tracer) stay the connection's, so no callsite reconstructs them.
-        fun openQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor = pq.openQuery(args, queryOpts())
+        // Open a cursor on an already-prepared query: first resolves the tx's access mode and basis (rejecting
+        // a read in a write tx, resolving an unresolved tx to read-only), then opens at the connection's basis,
+        // tz and tracer. A frontend owns the cursor for wire serialization, but the gate and the QueryOpts stay
+        // the connection's — no callsite reconstructs them, nor decides the gate.
+        fun openQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor {
+            resolveForQuery()
+            return pq.openQuery(args, queryOpts())
+        }
 
         // Answer a SHOW from connection state. SHOW LATEST_SUBMITTED_TX reports this connection's own last write;
         // SHOW AWAIT_TOKEN reads the connection's await-token; SHOW of any other identifier reads a session

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -119,7 +119,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         private val dbCat: Database.Catalog,
         private val qSrc: IQuerySource,
         private val sqlPlanner: SqlPlanner,
-        private val clock: Clock,
+        // mutable so a frontend can seed it (pgwire pushes the server clock at startup); current-time only,
+        // and only really exercised by tests pinning a fixed instant.
+        var clock: Clock,
         // the query tracer, gated by the node's query-tracing config (null = off); threaded into every read's
         // QueryOpts so the connection — not each frontend — owns query tracing.
         private val tracer: Tracer?,
@@ -614,15 +616,20 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             }
         }
 
-        fun commitTx() {
-            val tx = tx ?: return
+        // Returns the executed tx (committed flag + system-time + error) so a frontend can both react to an
+        // abort and surface it via SHOW LATEST_SUBMITTED_TX. null when there's nothing to commit (no tx, or a
+        // ReadOnly / still-unresolved one) and for an async submit, which isn't awaited so has no outcome yet.
+        fun commitTx(): ExecutedTx? {
+            val tx = tx ?: return null
             this.tx = null
             defaultTz = tx.sessionDefaultTz   // a mid-tx SET TIME ZONE persists; a WITH (TIMEZONE) override doesn't
             // a ReadWrite tx commits even when its buffer is empty — an explicit write tx records a transaction
             // (and advances the await-token); a ReadOnly / still-unresolved tx is a no-op.
-            val mode = tx.mode as? ReadWrite ?: return
+            val mode = tx.mode as? ReadWrite ?: return null
             val opts = TxOpts(systemTime = mode.systemTime, user = user, userMetadata = mode.userMetadata, defaultTz = tx.txDefaultTz)
-            expandStaticOps(mode.buffer.drain(), tx.txDefaultTz).useAll { ops -> if (mode.async) submitTx(ops, opts) else executeTx(ops, opts) }
+            return expandStaticOps(mode.buffer.drain(), tx.txDefaultTz).useAll { ops ->
+                if (mode.async) { submitTx(ops, opts); null } else executeTx(ops, opts)
+            }
         }
 
         private fun expandStaticOps(ops: List<TxOp>, tz: ZoneId): List<TxOp> =

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -47,6 +47,8 @@ import xtdb.table.TableRef
 import xtdb.time.asInstant
 import xtdb.tx.TxOp
 import xtdb.tx.TxOpts
+import xtdb.util.closeAll
+import xtdb.util.closeAllOnCatch
 import xtdb.util.closeOnCatch
 import xtdb.util.requiringResolve
 import xtdb.util.useAll
@@ -593,13 +595,32 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             val mode = tx.mode as? ReadWrite ?: return
             // defaultTz/user left null: doSubmit fills defaultTz via withFallbackTz, and there's no connection user yet.
             val opts = TxOpts(systemTime = mode.systemTime, userMetadata = mode.userMetadata)
-            mode.buffer.drain().useAll { ops -> if (mode.async) submitTx(ops, opts) else executeTx(ops, opts) }
+            expandStaticOps(mode.buffer.drain()).useAll { ops -> if (mode.async) submitTx(ops, opts) else executeTx(ops, opts) }
         }
+
+        private fun expandStaticOps(ops: List<TxOp>): List<TxOp> =
+            mutableListOf<TxOp>().closeAllOnCatch { out ->
+                ops.forEachIndexed { idx, op ->
+                    val expanded = try {
+                        (op as? TxOp.Sql)?.let { sqlPlanner.toStaticOps(it.sql, it.args, allocator, defaultTz) }
+                    } catch (t: Throwable) {
+                        ops.subList(idx, ops.size).closeAll()
+                        throw t
+                    }
+
+                    if (expanded != null) {
+                        op.close()
+                        out.addAll(expanded)
+                    } else out.add(op)
+                }
+
+                out
+            }
 
         internal fun executeDml(op: TxOp) {
             // auto-execute only when no explicit tx is open; an open tx (from beginTx) buffers even under autoCommit.
             if (autoCommit && tx == null) {
-                listOf(op).useAll { ops -> executeTx(ops) }
+                expandStaticOps(listOf(op)).useAll { ops -> executeTx(ops) }
                 return
             }
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -19,6 +19,7 @@ import org.apache.arrow.vector.VectorUnloader
 import org.apache.arrow.vector.complex.DenseUnionVector
 import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.Schema
+import xtdb.ICursor
 import xtdb.ResultCursor
 import xtdb.ZoneIdSerde
 import xtdb.antlr.Sql
@@ -53,6 +54,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.*
 import java.util.Date
+import java.util.SequencedMap
+import java.util.function.Consumer
 import java.util.UUID.randomUUID
 import java.util.concurrent.ExecutionException
 import kotlin.io.path.extension
@@ -149,6 +152,14 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         private var autoCommit = true
         private var tx: Transaction? = null
+
+        // session parameters (SET <param> = <value>) — stored raw; param-specific interpretation (e.g.
+        // pgwire's fallback_output_format) stays with the consumer. SHOW <param> reads back from here.
+        private val sessionParameters = mutableMapOf<String, String?>()
+
+        // the default access mode for a subsequently-opened bare BEGIN, set by SET SESSION CHARACTERISTICS;
+        // null leaves a bare BEGIN unresolved (resolved by its first statement).
+        private var defaultAccessMode: ParsedStatement.AccessMode? = null
 
         private fun db(dbName: DatabaseName): Database =
             dbCat.databaseOrNull(dbName)
@@ -329,6 +340,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
             override fun executeQuery(): QueryResult {
                 val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
+                // SHOW is answered from connection state, ahead of the access-mode gate — it is session
+                // introspection, valid in any transaction (pgwire's verify-permissibility doesn't gate it).
+                if (prepared == null)
+                    (parseStatements(sql).singleOrNull() as? ParsedStatement.ShowVariable)
+                        ?.let { return showVariable(it.variable) }
                 resolveForQuery()
                 if (prepared == null && args != null)
                     throw Incorrect(
@@ -361,6 +377,15 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                     is ParsedStatement.Commit -> commitTx()
                     is ParsedStatement.Rollback -> rollbackTx()
+
+                    is ParsedStatement.SetSessionParameter ->
+                        sessionParameters[stmt.name] = sqlPlanner.evalLiteral(stmt.value, null)?.toString()
+                    is ParsedStatement.SetTimeZone -> setTimeZone(coerceZoneId(sqlPlanner.evalLiteral(stmt.zone, null)))
+                    is ParsedStatement.SetAwaitToken -> _awaitToken = coerceAwaitToken(sqlPlanner.evalLiteral(stmt.token, null))
+                    is ParsedStatement.SetSessionCharacteristics -> defaultAccessMode = stmt.accessMode
+                    is ParsedStatement.SetTransaction -> {} // isolation is always serializable — accepted, no-op
+                    is ParsedStatement.SetRole -> {} // accepted, no-op (as pgwire)
+
                     else -> executeDml(TxOp.Sql(sql, openQueryArgs()))
                 }
                 return UpdateResult(-1)
@@ -376,6 +401,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // relation, so a prepared INSERT in a loop becomes one multi-row op.
         private class DmlBuffer(private val al: BufferAllocator) : AutoCloseable {
             private val ops = mutableListOf<TxOp>()
+
+            val isEmpty get() = ops.isEmpty()
 
             fun add(op: TxOp) {
                 if (op !is TxOp.Sql || op.args == null) {
@@ -421,7 +448,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // former to the latter inherits it unchanged); a ReadWrite tx has none — writes don't read.
         private class ReadBasis(val snapshotToken: String?, val snapshotTime: Instant?, val currentTime: Instant)
 
-        private class Transaction(var mode: AccessMode? = null, val readBasis: ReadBasis? = null) : AutoCloseable {
+        // [enteredTz] is the connection's time zone as it was at BEGIN; ROLLBACK restores it, discarding any
+        // mid-transaction SET TIME ZONE (Postgres semantics — a plain SET in an aborted tx is rolled back).
+        private class Transaction(
+            var mode: AccessMode? = null, val readBasis: ReadBasis? = null, val enteredTz: ZoneId
+        ) : AutoCloseable {
             var failed: Throwable? = null
 
             override fun close() {
@@ -444,12 +475,17 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // Coexists with autoCommit — an open tx captures subsequent DML (see executeDml) until COMMIT/ROLLBACK.
         private fun beginTx(accessMode: AccessMode?, readBasis: ReadBasis?) {
             if (tx != null) throw Incorrect("transaction already started", "xtdb/tx-already-open")
-            tx = Transaction(accessMode, readBasis)
+            tx = Transaction(accessMode, readBasis, defaultTz)
         }
 
-        // a bare BEGIN pins a basis even while unresolved: if a query resolves it to read-only the basis is
-        // inherited; if DML resolves it to read-write the basis is simply ignored.
-        fun beginTx() = beginTx(null, pinReadBasis())
+        // a bare BEGIN takes the session default access mode (SET SESSION CHARACTERISTICS); with none set it
+        // stays unresolved, pinning a basis anyway — a query resolving it to read-only inherits the basis, DML
+        // resolving it to read-write ignores it.
+        fun beginTx() = when (defaultAccessMode) {
+            ParsedStatement.AccessMode.READ_ONLY -> beginReadOnly()
+            ParsedStatement.AccessMode.READ_WRITE -> beginWriteOnly()
+            null -> beginTx(null, pinReadBasis())
+        }
 
         fun beginReadOnly() = beginTx(ReadOnly, pinReadBasis())
 
@@ -474,6 +510,39 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 "xtdb.adbc/invalid-system-time",
                 mapOf("value" to value, "type" to value::class.java.name)
             )
+        }
+
+        private fun coerceZoneId(value: Any?): ZoneId = when (value) {
+            is ZoneId -> value
+            is String -> ZoneId.of(value)
+            else -> throw Incorrect(
+                "cannot coerce TIME ZONE to a zone",
+                "xtdb.adbc/invalid-time-zone",
+                mapOf("value" to value)
+            )
+        }
+
+        private fun coerceAwaitToken(value: Any?): String? = when (value) {
+            null -> null
+            is String -> value
+            else -> throw Incorrect(
+                "AWAIT_TOKEN must be a string",
+                "xtdb.adbc/invalid-await-token",
+                mapOf("value" to value)
+            )
+        }
+
+        // SET TIME ZONE. Session-level when no tx is open. Inside a tx it's tx-local — [Transaction.enteredTz]
+        // preserves the pre-tx zone for ROLLBACK to restore. Rejected once a write tx has buffered ops: those
+        // ops captured temporal literals under the old zone, so changing it mid-buffer would be inconsistent.
+        private fun setTimeZone(zone: ZoneId) {
+            (tx?.mode as? ReadWrite)?.let {
+                if (!it.buffer.isEmpty) throw Incorrect(
+                    "Cannot SET TIME ZONE in a read-write transaction with buffered writes",
+                    "xtdb/set-tz-in-write-tx"
+                )
+            }
+            defaultTz = zone
         }
 
         // Begin an explicit tx from parsed WITH options, evaluating each option expression via the injected
@@ -534,7 +603,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 return
             }
 
-            val tx = tx ?: Transaction().also { tx = it }
+            val tx = tx ?: Transaction(enteredTz = defaultTz).also { tx = it }
 
             when (val mode = tx.mode) {
                 is ReadWrite -> mode.buffer.add(op)
@@ -554,7 +623,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 // manual mode mirrors executeDml's lazy open: a query opens a read-only tx pinning the
                 // begin-time basis, so subsequent reads share its snapshot. Under autocommit there is no open
                 // tx — the query reads latest at the connection's current basis, unchanged.
-                if (!autoCommit) this.tx = Transaction(ReadOnly, pinReadBasis())
+                if (!autoCommit) this.tx = Transaction(ReadOnly, pinReadBasis(), defaultTz)
                 return
             }
             when (tx.mode) {
@@ -573,6 +642,37 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             QueryOpts(b?.currentTime, defaultTz, b?.snapshotToken, b?.snapshotTime)
         }
 
+        // Answer a SHOW from connection state. SHOW AWAIT_TOKEN reads the connection's await-token; SHOW of any
+        // other identifier reads a session parameter. (SHOW TIME ZONE / SNAPSHOT_TOKEN / CLOCK_TIME are grammar
+        // `showVariable`s — classified as Query and answered by the engine from the basis, not here.) The
+        // node-level status SHOWs (latest_completed_txs, …) stay in pgwire for now.
+        private fun showVariable(variable: String): QueryResult =
+            showResult(variable, if (variable == "await_token") awaitToken else sessionParameters[variable])
+
+        // A one-row, single-(nullable-utf8)-column result built directly from a value — the SHOW counterpart of
+        // the query engine's cursor, so executeQuery can return session state as an Arrow result set.
+        private fun showResult(col: String, value: String?): QueryResult {
+            val types: SequencedMap<String, VectorType> = linkedMapOf(col to VectorType.maybe(VectorType.UTF8))
+            val rel = Relation(allocator, types).closeOnCatch { it.writeRow(mapOf(col to value)); it }
+            val cursor = object : ResultCursor {
+                override val resultTypes get() = types
+                override val cursorType get() = "show"
+                override val childCursors get() = emptyList<ICursor>()
+
+                private var done = false
+                override fun tryAdvance(c: Consumer<in RelationReader>): Boolean {
+                    if (done) return false
+                    done = true
+                    c.accept(rel)
+                    return true
+                }
+
+                override fun close() = rel.close()
+            }
+            val schema = Schema(cursor.resultTypes.map { (name, type) -> type.toField(name) })
+            return QueryResult(-1, cursorToArrowReader(cursor, schema))
+        }
+
         override fun setAutoCommit(autoCommit: Boolean) {
             if (this.autoCommit == autoCommit) return
             if (autoCommit) commitTx()
@@ -589,6 +689,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // SQL ROLLBACK: discards the open tx regardless of autoCommit (unlike [rollback], which rejects rollback in
         // autocommit). The explicit-tx mechanism the SQL tx-control path drives.
         private fun rollbackTx() {
+            tx?.let { defaultTz = it.enteredTz }   // discard any mid-tx SET TIME ZONE
             tx?.close()
             tx = null
         }

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -160,8 +160,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         private val sessionParameters = mutableMapOf<String, String?>()
 
         // the default access mode for a subsequently-opened bare BEGIN, set by SET SESSION CHARACTERISTICS;
-        // null leaves a bare BEGIN unresolved (resolved by its first statement).
-        private var defaultAccessMode: ParsedStatement.AccessMode? = null
+        // null leaves a bare BEGIN unresolved (resolved by its first statement). Readable for the frontend.
+        var defaultAccessMode: ParsedStatement.AccessMode? = null
+            private set
 
         private fun db(dbName: DatabaseName): Database =
             dbCat.databaseOrNull(dbName)

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -450,10 +450,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // former to the latter inherits it unchanged); a ReadWrite tx has none — writes don't read.
         private class ReadBasis(val snapshotToken: String?, val snapshotTime: Instant?, val currentTime: Instant)
 
-        // [enteredTz] is the connection's time zone as it was at BEGIN; ROLLBACK restores it, discarding any
-        // mid-transaction SET TIME ZONE (Postgres semantics — a plain SET in an aborted tx is rolled back).
+        // [txDefaultTz] anchors this tx's DML and reads; [sessionDefaultTz] is copied back to the connection on
+        // COMMIT. SET TIME ZONE writes both (a session operator); `WITH (TIMEZONE)` writes only [txDefaultTz], so
+        // the override stays tx-scoped. The connection's defaultTz is untouched while a tx is open.
         private class Transaction(
-            var mode: AccessMode? = null, val readBasis: ReadBasis? = null, val enteredTz: ZoneId
+            var mode: AccessMode? = null, val readBasis: ReadBasis? = null,
+            var txDefaultTz: ZoneId, var sessionDefaultTz: ZoneId
         ) : AutoCloseable {
             var failed: Throwable? = null
 
@@ -475,38 +477,44 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // READ WRITE buffers them; a bare BEGIN leaves it unresolved until the first statement resolves it.
         // [readBasis] pins the begin-time read snapshot (null for an explicit READ WRITE — writes don't read).
         // Coexists with autoCommit — an open tx captures subsequent DML (see executeDml) until COMMIT/ROLLBACK.
-        private fun beginTx(accessMode: AccessMode?, readBasis: ReadBasis?) {
+        private fun beginTx(accessMode: AccessMode?, readBasis: ReadBasis?, tz: ZoneId = defaultTz) {
             if (tx != null) throw Incorrect("transaction already started", "xtdb/tx-already-open")
-            tx = Transaction(accessMode, readBasis, defaultTz)
+            tx = Transaction(accessMode, readBasis, txDefaultTz = tz, sessionDefaultTz = defaultTz)
         }
 
         // a bare BEGIN takes the session default access mode (SET SESSION CHARACTERISTICS); with none set it
         // stays unresolved, pinning a basis anyway — a query resolving it to read-only inherits the basis, DML
         // resolving it to read-write ignores it.
-        fun beginTx() = when (defaultAccessMode) {
-            ParsedStatement.AccessMode.READ_ONLY -> beginReadOnly()
-            ParsedStatement.AccessMode.READ_WRITE -> beginWriteOnly()
-            null -> beginTx(null, pinReadBasis())
+        // @JvmOverloads: a frontend (pgwire) calls these reflectively with the shorter arities, taking the
+        // default session tz — the defaulted `tz` param alone wouldn't emit those JVM overloads.
+        @JvmOverloads
+        fun beginTx(tz: ZoneId = defaultTz) = when (defaultAccessMode) {
+            ParsedStatement.AccessMode.READ_ONLY -> beginReadOnly(tz)
+            ParsedStatement.AccessMode.READ_WRITE -> beginWriteOnly(tz = tz)
+            null -> beginTx(null, pinReadBasis(), tz)
         }
 
-        fun beginReadOnly() = beginTx(ReadOnly, pinReadBasis())
+        @JvmOverloads
+        fun beginReadOnly(tz: ZoneId = defaultTz) = beginTx(ReadOnly, pinReadBasis(), tz)
 
-        fun beginWriteOnly(systemTime: Instant? = null, userMetadata: Map<*, *>? = null, async: Boolean = false) =
-            beginTx(ReadWrite(systemTime, userMetadata, async), null)
+        @JvmOverloads
+        fun beginWriteOnly(systemTime: Instant? = null, userMetadata: Map<*, *>? = null, async: Boolean = false,
+                           tz: ZoneId = defaultTz) =
+            beginTx(ReadWrite(systemTime, userMetadata, async), null, tz)
 
         // Coerce a planned BEGIN-option value to an Instant, mirroring xtdb.time/->instant so the connection and
         // pgwire agree on the system-time a SQL temporal literal resolves to. SqlPlanner plans `TIMESTAMP '…'`
         // to a java.time temporal (ZonedDateTime when zoned, else LocalDateTime); a bare string falls back to
-        // the SQL-timestamp parse. LocalDate/LocalDateTime are anchored in [defaultTz], as pgwire does.
-        private fun coerceInstant(value: Any?): Instant? = when (value) {
+        // the SQL-timestamp parse. LocalDate/LocalDateTime are anchored in [tz] (the tx's zone), as pgwire does.
+        private fun coerceInstant(value: Any?, tz: ZoneId): Instant? = when (value) {
             null -> null
             is Instant -> value
             is ZonedDateTime -> value.toInstant()
             is OffsetDateTime -> value.toInstant()
-            is LocalDateTime -> value.atZone(defaultTz).toInstant()
-            is LocalDate -> value.atStartOfDay(defaultTz).toInstant()
+            is LocalDateTime -> value.atZone(tz).toInstant()
+            is LocalDate -> value.atStartOfDay(tz).toInstant()
             is Date -> value.toInstant()
-            is String -> value.asInstant(defaultTz)
+            is String -> value.asInstant(tz)
             else -> throw Incorrect(
                 "cannot coerce SYSTEM_TIME option to an instant",
                 "xtdb.adbc/invalid-system-time",
@@ -534,17 +542,18 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             )
         }
 
-        // SET TIME ZONE. Session-level when no tx is open. Inside a tx it's tx-local — [Transaction.enteredTz]
-        // preserves the pre-tx zone for ROLLBACK to restore. Rejected once a write tx has buffered ops: those
-        // ops captured temporal literals under the old zone, so changing it mid-buffer would be inconsistent.
-        private fun setTimeZone(zone: ZoneId) {
+        // SET TIME ZONE — a session operator. Mid-tx it writes both the tx zone and the session zone it commits to,
+        // so it persists on COMMIT and reverts on ROLLBACK (which just drops the tx). Rejected once a write tx has
+        // buffered ops: those ops captured temporal literals under the old zone, so changing it mid-buffer would be
+        // inconsistent.
+        fun setTimeZone(zone: ZoneId) {
             (tx?.mode as? ReadWrite)?.let {
                 if (!it.buffer.isEmpty) throw Incorrect(
                     "Cannot SET TIME ZONE in a read-write transaction with buffered writes",
                     "xtdb/set-tz-in-write-tx"
                 )
             }
-            defaultTz = zone
+            tx?.let { it.txDefaultTz = zone; it.sessionDefaultTz = zone } ?: run { defaultTz = zone }
         }
 
         // Begin an explicit tx from parsed WITH options, evaluating each option expression via the injected
@@ -556,19 +565,16 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 mapOf("sql" to sql)
             )
 
+            // WITH (TIMEZONE) overrides the tx zone for its duration (tx-scoped — it doesn't touch the session).
+            val tz = opts.defaultTz?.let { coerceZoneId(sqlPlanner.evalLiteral(it, null)) } ?: defaultTz
+
             when (opts.accessMode) {
                 ParsedStatement.AccessMode.READ_WRITE -> {
-                    if (opts.defaultTz != null) throw Incorrect(
-                        "BEGIN READ WRITE WITH (TIMEZONE …) is not yet supported",
-                        "xtdb.adbc/unsupported-tx-option",
-                        mapOf("sql" to sql)
-                    )
-
-                    val systemTime = coerceInstant(opts.systemTime?.let { sqlPlanner.evalLiteral(it, null) })
+                    val systemTime = coerceInstant(opts.systemTime?.let { sqlPlanner.evalLiteral(it, null) }, tz)
                     val userMetadata = opts.userMetadata?.let { sqlPlanner.evalLiteral(it, null) } as Map<*, *>?
                     val async = (opts.async?.let { sqlPlanner.evalLiteral(it, null) } as Boolean?) ?: false
 
-                    beginWriteOnly(systemTime, userMetadata, async)
+                    beginWriteOnly(systemTime, userMetadata, async, tz)
                 }
 
                 ParsedStatement.AccessMode.READ_ONLY -> {
@@ -577,32 +583,32 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     if (opts.awaitToken != null) rejectOpt()
 
                     val snapshotToken = opts.snapshotToken?.let { sqlPlanner.evalLiteral(it, null) } as String?
-                    val snapshotTime = coerceInstant(opts.snapshotTime?.let { sqlPlanner.evalLiteral(it, null) })
-                    val currentTime = coerceInstant(opts.clockTime?.let { sqlPlanner.evalLiteral(it, null) })
+                    val snapshotTime = coerceInstant(opts.snapshotTime?.let { sqlPlanner.evalLiteral(it, null) }, tz)
+                    val currentTime = coerceInstant(opts.clockTime?.let { sqlPlanner.evalLiteral(it, null) }, tz)
 
-                    beginTx(ReadOnly, pinReadBasis(snapshotToken, snapshotTime, currentTime))
+                    beginTx(ReadOnly, pinReadBasis(snapshotToken, snapshotTime, currentTime), tz)
                 }
 
-                null -> beginTx()
+                null -> beginTx(tz)
             }
         }
 
         fun commitTx() {
             val tx = tx ?: return
             this.tx = null
+            defaultTz = tx.sessionDefaultTz   // a mid-tx SET TIME ZONE persists; a WITH (TIMEZONE) override doesn't
             // a ReadWrite tx commits even when its buffer is empty — an explicit write tx records a transaction
             // (and advances the await-token); a ReadOnly / still-unresolved tx is a no-op.
             val mode = tx.mode as? ReadWrite ?: return
-            // defaultTz/user left null: doSubmit fills defaultTz via withFallbackTz, and there's no connection user yet.
-            val opts = TxOpts(systemTime = mode.systemTime, userMetadata = mode.userMetadata)
-            expandStaticOps(mode.buffer.drain()).useAll { ops -> if (mode.async) submitTx(ops, opts) else executeTx(ops, opts) }
+            val opts = TxOpts(systemTime = mode.systemTime, userMetadata = mode.userMetadata, defaultTz = tx.txDefaultTz)
+            expandStaticOps(mode.buffer.drain(), tx.txDefaultTz).useAll { ops -> if (mode.async) submitTx(ops, opts) else executeTx(ops, opts) }
         }
 
-        private fun expandStaticOps(ops: List<TxOp>): List<TxOp> =
+        private fun expandStaticOps(ops: List<TxOp>, tz: ZoneId): List<TxOp> =
             mutableListOf<TxOp>().closeAllOnCatch { out ->
                 ops.forEachIndexed { idx, op ->
                     val expanded = try {
-                        (op as? TxOp.Sql)?.let { sqlPlanner.toStaticOps(it.sql, it.args, allocator, defaultTz) }
+                        (op as? TxOp.Sql)?.let { sqlPlanner.toStaticOps(it.sql, it.args, allocator, tz) }
                     } catch (t: Throwable) {
                         ops.subList(idx, ops.size).closeAll()
                         throw t
@@ -620,11 +626,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         internal fun executeDml(op: TxOp) {
             // auto-execute only when no explicit tx is open; an open tx (from beginTx) buffers even under autoCommit.
             if (autoCommit && tx == null) {
-                expandStaticOps(listOf(op)).useAll { ops -> executeTx(ops) }
+                expandStaticOps(listOf(op), defaultTz).useAll { ops -> executeTx(ops) }
                 return
             }
 
-            val tx = tx ?: Transaction(enteredTz = defaultTz).also { tx = it }
+            val tx = tx ?: Transaction(txDefaultTz = defaultTz, sessionDefaultTz = defaultTz).also { tx = it }
 
             when (val mode = tx.mode) {
                 is ReadWrite -> mode.buffer.add(op)
@@ -644,7 +650,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 // manual mode mirrors executeDml's lazy open: a query opens a read-only tx pinning the
                 // begin-time basis, so subsequent reads share its snapshot. Under autocommit there is no open
                 // tx — the query reads latest at the connection's current basis, unchanged.
-                if (!autoCommit) this.tx = Transaction(ReadOnly, pinReadBasis(), defaultTz)
+                if (!autoCommit) this.tx = Transaction(ReadOnly, pinReadBasis(), txDefaultTz = defaultTz, sessionDefaultTz = defaultTz)
                 return
             }
             when (tx.mode) {
@@ -659,8 +665,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         // QueryOpts for a user read: an open tx's pinned basis (snapshot isolation), else null fields so the
         // planner defaults to latest data and the wall-clock now (autocommit / no open tx).
-        private fun queryOpts() = tx?.readBasis.let { b ->
-            QueryOpts(b?.currentTime, defaultTz, b?.snapshotToken, b?.snapshotTime)
+        private fun queryOpts() = tx.let { t ->
+            QueryOpts(t?.readBasis?.currentTime, t?.txDefaultTz ?: defaultTz, t?.readBasis?.snapshotToken, t?.readBasis?.snapshotTime)
         }
 
         // Answer a SHOW from connection state. SHOW LATEST_SUBMITTED_TX reports this connection's own last write;
@@ -731,7 +737,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // SQL ROLLBACK: discards the open tx regardless of autoCommit (unlike [rollback], which rejects rollback in
         // autocommit). The explicit-tx mechanism the SQL tx-control path drives.
         private fun rollbackTx() {
-            tx?.let { defaultTz = it.enteredTz }   // discard any mid-tx SET TIME ZONE
+            // defaultTz was never touched while the tx was open, so dropping the tx reverts any mid-tx SET TIME ZONE
             tx?.close()
             tx = null
         }

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -663,18 +663,39 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             QueryOpts(b?.currentTime, defaultTz, b?.snapshotToken, b?.snapshotTime)
         }
 
-        // Answer a SHOW from connection state. SHOW AWAIT_TOKEN reads the connection's await-token; SHOW of any
-        // other identifier reads a session parameter. (SHOW TIME ZONE / SNAPSHOT_TOKEN / CLOCK_TIME are grammar
-        // `showVariable`s — classified as Query and answered by the engine from the basis, not here.) The
-        // node-level status SHOWs (latest_completed_txs, …) stay in pgwire for now.
+        // Answer a SHOW from connection state. SHOW LATEST_SUBMITTED_TX reports this connection's own last write;
+        // SHOW AWAIT_TOKEN reads the connection's await-token; SHOW of any other identifier reads a session
+        // parameter. (SHOW TIME ZONE / SNAPSHOT_TOKEN / CLOCK_TIME are grammar `showVariable`s — classified as
+        // Query and answered by the engine from the basis, not here.) The node-level status SHOWs
+        // (latest_completed_txs, …) are node introspection, not connection state — they stay in pgwire for now.
         private fun showVariable(variable: String): QueryResult =
-            showResult(variable, if (variable == "await_token") awaitToken else sessionParameters[variable])
+            when (variable) {
+                // 0 rows until this connection has submitted a tx (matches the `tx_id IS NOT NULL` filter);
+                // system-time/committed/error are null for a fire-and-forget submit. error is a Throwable → transit.
+                "latest_submitted_tx" -> showResult(
+                    linkedMapOf("tx_id" to VectorType.maybe(VectorType.I64),
+                                "system_time" to VectorType.maybe(VectorType.INSTANT),
+                                "committed" to VectorType.maybe(VectorType.BOOL),
+                                "error" to VectorType.maybe(VectorType.TRANSIT),
+                                "await_token" to VectorType.maybe(VectorType.UTF8)),
+                    lastSubmittedTx?.let {
+                        listOf(mapOf("tx_id" to it.txId, "system_time" to it.systemTime,
+                                     "committed" to it.committed, "error" to it.error,
+                                     "await_token" to awaitToken))
+                    } ?: emptyList())
 
-        // A one-row, single-(nullable-utf8)-column result built directly from a value — the SHOW counterpart of
-        // the query engine's cursor, so executeQuery can return session state as an Arrow result set.
-        private fun showResult(col: String, value: String?): QueryResult {
-            val types: SequencedMap<String, VectorType> = linkedMapOf(col to VectorType.maybe(VectorType.UTF8))
-            val rel = Relation(allocator, types).closeOnCatch { it.writeRow(mapOf(col to value)); it }
+                "await_token" -> showResult(variable, awaitToken)
+                else -> showResult(variable, sessionParameters[variable])
+            }
+
+        // A one-row, single-(nullable-utf8)-column result — the common SHOW shape.
+        private fun showResult(col: String, value: String?): QueryResult =
+            showResult(linkedMapOf(col to VectorType.maybe(VectorType.UTF8)), listOf(mapOf(col to value)))
+
+        // A SHOW result of arbitrary typed columns and 0-or-more rows — the SHOW counterpart of the query
+        // engine's cursor, so executeQuery can return connection state as an Arrow result set.
+        private fun showResult(types: SequencedMap<String, VectorType>, rows: List<Map<String, Any?>>): QueryResult {
+            val rel = Relation(allocator, types).closeOnCatch { r -> rows.forEach { r.writeRow(it) }; r }
             val cursor = object : ResultCursor {
                 override val resultTypes get() = types
                 override val cursorType get() = "show"

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -152,6 +152,10 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         var lastSubmittedTx: LastSubmittedTx? = null
             private set
 
+        // the authenticated user, threaded into every write's [TxOpts] for the audit trail. Established by the
+        // frontend at connect-time (pgwire's startup handshake); null until a frontend sets it.
+        var user: String? = null
+
         // how long to wait for this connection's writes to become visible before giving up, shared by every
         // read this connection prepares or snapshots
         private val awaitTimeout: Duration = Duration.ofMinutes(1)
@@ -161,7 +165,10 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         // session parameters (SET <param> = <value>) — stored raw; param-specific interpretation (e.g.
         // pgwire's fallback_output_format) stays with the consumer. SHOW <param> reads back from here.
-        private val sessionParameters = mutableMapOf<String, String?>()
+        private val _sessionParameters = mutableMapOf<String, String?>()
+
+        // read view for the frontend (pgwire's serialization env / ParameterStatus echo); writes go through SET.
+        val sessionParameters: Map<String, String?> get() = _sessionParameters
 
         // the default access mode for a subsequently-opened bare BEGIN, set by SET SESSION CHARACTERISTICS;
         // null leaves a bare BEGIN unresolved (resolved by its first statement). Readable for the frontend.
@@ -385,7 +392,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     is ParsedStatement.Rollback -> rollbackTx()
 
                     is ParsedStatement.SetSessionParameter ->
-                        sessionParameters[stmt.name] = sqlPlanner.evalLiteral(stmt.value, null)?.toString()
+                        _sessionParameters[stmt.name] = sqlPlanner.evalLiteral(stmt.value, null)?.toString()
                     is ParsedStatement.SetTimeZone -> setTimeZone(coerceZoneId(sqlPlanner.evalLiteral(stmt.zone, null)))
                     is ParsedStatement.SetAwaitToken -> _awaitToken = coerceAwaitToken(sqlPlanner.evalLiteral(stmt.token, null))
                     is ParsedStatement.SetSessionCharacteristics -> defaultAccessMode = stmt.accessMode
@@ -506,6 +513,16 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                            tz: ZoneId = defaultTz) =
             beginTx(ReadWrite(systemTime, userMetadata, async), null, tz)
 
+        // tx status for the frontend's ready-state + commit/abort decisions. A failed tx rejects further work
+        // until ROLLBACK (Postgres' "current transaction is aborted").
+        val isTxOpen: Boolean get() = tx != null
+        val isTxFailed: Boolean get() = tx?.failed != null
+
+        // mark the open tx failed (first error wins), driven by the frontend when a statement throws mid-tx.
+        fun failTx(cause: Throwable) {
+            tx?.let { it.failed = it.failed ?: cause }
+        }
+
         // Coerce a planned BEGIN-option value to an Instant, mirroring xtdb.time/->instant so the connection and
         // pgwire agree on the system-time a SQL temporal literal resolves to. SqlPlanner plans `TIMESTAMP '…'`
         // to a java.time temporal (ZonedDateTime when zoned, else LocalDateTime); a bare string falls back to
@@ -604,7 +621,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             // a ReadWrite tx commits even when its buffer is empty — an explicit write tx records a transaction
             // (and advances the await-token); a ReadOnly / still-unresolved tx is a no-op.
             val mode = tx.mode as? ReadWrite ?: return
-            val opts = TxOpts(systemTime = mode.systemTime, userMetadata = mode.userMetadata, defaultTz = tx.txDefaultTz)
+            val opts = TxOpts(systemTime = mode.systemTime, user = user, userMetadata = mode.userMetadata, defaultTz = tx.txDefaultTz)
             expandStaticOps(mode.buffer.drain(), tx.txDefaultTz).useAll { ops -> if (mode.async) submitTx(ops, opts) else executeTx(ops, opts) }
         }
 
@@ -630,7 +647,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         internal fun executeDml(op: TxOp) {
             // auto-execute only when no explicit tx is open; an open tx (from beginTx) buffers even under autoCommit.
             if (autoCommit && tx == null) {
-                expandStaticOps(listOf(op), defaultTz).useAll { ops -> executeTx(ops) }
+                expandStaticOps(listOf(op), defaultTz).useAll { ops -> executeTx(ops, TxOpts(user = user)) }
                 return
             }
 
@@ -647,7 +664,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         // The read counterpart of executeDml's access-mode resolution: a query resolves an unresolved tx to
-        // read-only, and is rejected in a read-write (DML) tx — in XTDB a write tx is write-only.
+        // read-only, and is rejected in a read-write (DML) tx — in XTDB a write tx is write-only. Applied by
+        // openQuery, so every read gates through one place.
         private fun resolveForQuery() {
             val tx = tx
             if (tx == null) {
@@ -754,8 +772,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         // SQL ROLLBACK: discards the open tx regardless of autoCommit (unlike [rollback], which rejects rollback in
-        // autocommit). The explicit-tx mechanism the SQL tx-control path drives.
-        private fun rollbackTx() {
+        // autocommit). The explicit-tx mechanism the SQL tx-control path (and the pgwire frontend) drives.
+        fun rollbackTx() {
             // defaultTz was never touched while the tx was open, so dropping the tx reverts any mid-tx SET TIME ZONE
             tx?.close()
             tx = null

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -682,6 +682,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             return pq.openQuery(args, queryOpts())
         }
 
+        // Open a read WITHOUT the access-mode gate — for a frontend's driver-compatibility probe that must be
+        // permitted in any transaction (pgwire allows the pgjdbc type-metadata query inside a write tx, where
+        // the gate would otherwise reject it). Reads at the connection's current basis; inside a write tx that
+        // is latest-committed data, not the tx's buffered writes.
+        fun openUncheckedQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor = pq.openQuery(args, queryOpts())
+
         // Answer a SHOW from connection state. SHOW LATEST_SUBMITTED_TX reports this connection's own last write;
         // SHOW AWAIT_TOKEN reads the connection's await-token; SHOW of any other identifier reads a session
         // parameter. (SHOW TIME ZONE / SNAPSHOT_TOKEN / CLOCK_TIME are grammar `showVariable`s — classified as

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -527,6 +527,19 @@ class Database(
 
         val primary: Database get() = databaseOrNull("xtdb")!!
 
+        // a read snapshot pinned to now: each database's latest-completed system-time per partition,
+        // encoded as a time-basis token. The Kotlin twin of the node's PStatus/snapshot-token, so a
+        // connection can pin a begin-time read basis without reaching into Clojure.
+        fun snapshotToken(): String =
+            databaseNames.mapNotNull { dbName ->
+                // databaseNames and databaseOrNull are read separately, so a concurrent detach can drop a db
+                // between them — skip it, as the sibling awaitAll0/syncAll0 do, rather than NPE.
+                databaseOrNull(dbName)?.let { db ->
+                    dbName to db.partitions.entries.sortedBy { it.key }
+                        .map { it.value.liveIndex.latestCompletedTx?.systemTime }
+                }
+            }.toMap().encodeTimeBasisToken()
+
         fun attach(dbName: DatabaseName, config: Config?)
         fun detach(dbName: DatabaseName)
 

--- a/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
+++ b/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
@@ -1,6 +1,10 @@
 package xtdb.query
 
 import org.antlr.v4.runtime.ParserRuleContext
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.arrow.RelationReader
+import xtdb.tx.TxOp
+import java.time.ZoneId
 
 interface SqlPlanner {
     /**
@@ -10,4 +14,13 @@ interface SqlPlanner {
      * [expr] is the parsed expression context — a `Sql.ExprContext` or `Sql.LiteralContext`.
      */
     fun evalLiteral(expr: ParserRuleContext, args: List<*>?): Any?
+
+    /**
+     * Eager-expand a DML statement into core [TxOp]s (e.g. INSERT/PATCH RECORDS → PutDocs/PatchDocs),
+     * reading positional params (?_0, ?_1, …) column-major from [args].
+     *
+     * Returns null when the statement isn't statically expandable — the caller submits the raw SQL op and
+     * lets the indexer expand it at index time.
+     */
+    fun toStaticOps(sql: String, args: RelationReader?, al: BufferAllocator, defaultTz: ZoneId?): List<TxOp>?
 }

--- a/dev/doc/tx.allium
+++ b/dev/doc/tx.allium
@@ -157,6 +157,13 @@ enum BeginAccessMode {
     read_only | read_write | none
 }
 
+enum SessionAccessMode {
+    -- The connection's session-level default access mode, set by SET SESSION CHARACTERISTICS
+    -- AS TRANSACTION READ ONLY / READ WRITE. When set, a bare BEGIN (access_mode = none) takes
+    -- this default; absent (null), a bare BEGIN stays Unresolved.
+    read_only | read_write
+}
+
 ---- Entities and Variants
 
 entity Connection {
@@ -166,6 +173,7 @@ entity Connection {
     auto_commit: Boolean
     default_tz: ZoneId
     await_token: TxBasisToken?       -- advanced by every write, threaded through every read
+    default_access_mode: SessionAccessMode?  -- set by SET SESSION CHARACTERISTICS; null leaves a bare BEGIN unresolved
 
     -- At most one open transaction. Singular relationship: the value is the open
     -- Transaction, or null when none is open.
@@ -187,6 +195,7 @@ entity Transaction {
     connection: Connection
     mode: Unresolved | ReadOnly | ReadWrite
     failed: Boolean
+    entered_tz: ZoneId               -- the connection's default_tz as at BEGIN; ROLLBACK restores it
 }
 
 variant Unresolved : Transaction {
@@ -255,6 +264,7 @@ rule BeginReadOnly {
         ReadOnly.created(
             connection: connection,
             failed: false,
+            entered_tz: connection.default_tz,
             read_basis: ReadBasis(
                 snapshot_token: read_basis?.snapshot_token ?? Database.snapshotToken,
                 snapshot_time: read_basis?.snapshot_time,
@@ -282,6 +292,7 @@ rule BeginReadWrite {
         ReadWrite.created(
             connection: connection,
             failed: false,
+            entered_tz: connection.default_tz,
             buffer: buffer,
             commit_opts: commit_opts ?? CommitOpts(
                 system_time: null,
@@ -293,23 +304,49 @@ rule BeginReadWrite {
 }
 
 rule BeginUnresolved {
-    -- BEGIN with no explicit access mode. The read basis is pinned NOW (begin-time) even
-    -- though the mode is not yet known; if the tx resolves to ReadOnly this basis is
-    -- inherited unchanged. Access mode resolves on the first statement.
+    -- Bare BEGIN (no explicit access mode). The session default access mode decides the
+    -- variant: a connection with default_access_mode set (via SET SESSION CHARACTERISTICS)
+    -- opens ReadOnly / ReadWrite directly; with no default set it stays Unresolved, resolved
+    -- on the first statement (the common case). Either way the read basis is pinned NOW
+    -- (begin-time): an Unresolved or ReadOnly tx inherits it; a ReadWrite tx discards it.
     when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
     requires: connection.tx = null
     requires: access_mode = none
 
     ensures:
-        Unresolved.created(
-            connection: connection,
-            failed: false,
-            read_basis: ReadBasis(
-                snapshot_token: Database.snapshotToken,
-                snapshot_time: null,
-                clock_time: now
-            )
+        let begin_basis = ReadBasis(
+            snapshot_token: Database.snapshotToken,
+            snapshot_time: null,
+            clock_time: now
         )
+        if connection.default_access_mode = read_only:
+            ReadOnly.created(
+                connection: connection,
+                failed: false,
+                entered_tz: connection.default_tz,
+                read_basis: begin_basis
+            )
+        else if connection.default_access_mode = read_write:
+            let buffer = DmlBuffer.created(ops: {})
+            ReadWrite.created(
+                connection: connection,
+                failed: false,
+                entered_tz: connection.default_tz,
+                buffer: buffer,
+                commit_opts: CommitOpts(
+                    system_time: null,
+                    user_metadata: null,
+                    async: false,
+                    tz_override: null
+                )
+            )
+        else:
+            Unresolved.created(
+                connection: connection,
+                failed: false,
+                entered_tz: connection.default_tz,
+                read_basis: begin_basis
+            )
 }
 
 rule BeginWhileOpenRejected {
@@ -414,6 +451,7 @@ rule ManualLazyOpenDml {
         ReadWrite.created(
             connection: connection,
             failed: false,
+            entered_tz: connection.default_tz,
             buffer: buffer,
             commit_opts: CommitOpts(
                 system_time: null,
@@ -440,6 +478,7 @@ rule ManualLazyOpenQuery {
         let opened = ReadOnly.created(
             connection: connection,
             failed: false,
+            entered_tz: connection.default_tz,
             read_basis: ReadBasis(
                 snapshot_token: connection.await_token,
                 snapshot_time: null,
@@ -600,10 +639,14 @@ rule CommitNoOp {
 rule Rollback {
     -- Rollback discards the open transaction (and its buffer, if any), submitting
     -- nothing. Valid even on a failed transaction — this is how a failed tx is cleared.
+    -- Restores the connection's default_tz to the value captured at BEGIN, discarding any
+    -- mid-transaction SET TIME ZONE (Postgres semantics — a plain SET in an aborted tx is
+    -- rolled back; COMMIT keeps the new zone).
     when: RollbackTransaction(frontend, connection)
     requires: connection.tx != null
 
     ensures:
+        connection.default_tz = connection.tx.entered_tz
         not exists connection.tx
 }
 

--- a/dev/doc/tx.allium
+++ b/dev/doc/tx.allium
@@ -99,16 +99,25 @@ value TxBasisToken {
     -- it; each read threads it through. See: database/encodeTxBasisToken.
 }
 
+value TimeBasisToken {
+    -- An opaque snapshot token: per-database latest-completed system-times, the upper bound
+    -- on the data a read observes. Captured from the Database catalog at BEGIN to pin a
+    -- transaction's snapshot. See: database/encodeTimeBasisToken, Database.Catalog.snapshotToken.
+}
+
 value ReadBasis {
     -- The pinned point-in-time a transaction's reads observe, fixed AT BEGIN for every
-    -- transaction (begin-time snapshot isolation). The begin-time pin sets snapshot_token
-    -- to the connection's await_token and clock_time to the current-time at begin; a
-    -- BEGIN READ ONLY WITH (...) clause overrides individual fields. The WITH options are
-    -- grammar-scoped to READ ONLY (readOnlyTxOption in the SQL grammar).
-    --   snapshot_token — an opaque basis token (as TxBasisToken).
+    -- transaction (begin-time snapshot isolation). The begin-time pin awaits the connection's
+    -- await_token (so the snapshot reflects this connection's own writes), then sets
+    -- snapshot_token to the resulting latest-completed snapshot and clock_time to the
+    -- current-time at begin; a BEGIN READ ONLY WITH (...) clause overrides individual fields.
+    -- The WITH options are grammar-scoped to READ ONLY (readOnlyTxOption in the SQL grammar).
+    --   snapshot_token — the data snapshot's upper bound, a TimeBasisToken (per-database
+    --                    latest-completed system-times). Distinct from the await_token, which
+    --                    is a TxBasisToken of message-ids the read awaits before snapshotting.
     --   snapshot_time  — observe state as of a wall-clock instant.
     --   clock_time     — pin the transaction's notion of "now".
-    snapshot_token: TxBasisToken?
+    snapshot_token: TimeBasisToken?
     snapshot_time: Timestamp?
     clock_time: Timestamp?
 }
@@ -219,8 +228,9 @@ entity DmlBuffer {
 -- An explicit SQL BEGIN opens a transaction regardless of auto_commit; the flag is left
 -- untouched and the explicit transaction coexists with it.
 --
--- Every BEGIN pins a read basis NOW, at begin-time — the connection's current await_token
--- as the snapshot token and the current-time as the clock_time. This gives begin-time
+-- Every BEGIN pins a read basis NOW, at begin-time — awaiting the connection's await_token
+-- then capturing the latest-completed snapshot as the snapshot token, and the current-time as
+-- the clock_time. This gives begin-time
 -- snapshot isolation: a transaction's notion of visible data and "now" is fixed at BEGIN,
 -- before the access mode is known. The variant opened depends on the access mode carried
 -- on the BEGIN event (READ_ONLY | READ_WRITE | none — see BeginAccessMode):
@@ -233,9 +243,10 @@ entity DmlBuffer {
 -- begin-time basis.
 
 rule BeginReadOnly {
-    -- BEGIN READ ONLY [WITH (snapshot-token | snapshot-time | clock-time)]. The basis is
-    -- the begin-time pin (connection await_token + current-time); any field supplied in
-    -- the WITH clause overrides the corresponding pinned default.
+    -- BEGIN READ ONLY [WITH (snapshot-token | snapshot-time | clock-time)]. The basis is the
+    -- begin-time pin — the latest-completed snapshot (Database.snapshotToken, captured after
+    -- awaiting the connection's await_token) plus the current-time; any field supplied in the
+    -- WITH clause overrides the corresponding pinned default.
     when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
     requires: connection.tx = null
     requires: access_mode = read_only
@@ -245,7 +256,7 @@ rule BeginReadOnly {
             connection: connection,
             failed: false,
             read_basis: ReadBasis(
-                snapshot_token: read_basis?.snapshot_token ?? connection.await_token,
+                snapshot_token: read_basis?.snapshot_token ?? Database.snapshotToken,
                 snapshot_time: read_basis?.snapshot_time,
                 clock_time: read_basis?.clock_time ?? now
             )
@@ -260,7 +271,8 @@ rule BeginReadWrite {
     -- The commit-opts values (system_time, user_metadata, async) are obtained by evaluating
     -- their WITH-clause expressions through the SqlPlanner — it plans each option expression
     -- (e.g. SYSTEM_TIME's `TIMESTAMP '…'`) and substitutes positional params to a runtime
-    -- value. The READ ONLY read-basis options are evaluated likewise, once that increment lands.
+    -- value. The READ ONLY read-basis options (SNAPSHOT_TOKEN / SNAPSHOT_TIME / CLOCK_TIME) are
+    -- evaluated likewise.
     when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
     requires: connection.tx = null
     requires: access_mode = read_write
@@ -293,7 +305,7 @@ rule BeginUnresolved {
             connection: connection,
             failed: false,
             read_basis: ReadBasis(
-                snapshot_token: connection.await_token,
+                snapshot_token: Database.snapshotToken,
                 snapshot_time: null,
                 clock_time: now
             )

--- a/dev/doc/tx.allium
+++ b/dev/doc/tx.allium
@@ -1,0 +1,728 @@
+-- allium: 3
+-- tx.allium
+--
+-- The connection-level transaction model of XTDB: the client-facing transaction
+-- lifecycle that sits ABOVE db.allium. Where db.allium begins at submitTx/executeTx
+-- (the Database boundary), this spec covers everything a client does before that —
+-- begin / buffer / commit, access-mode resolution, and the read basis a transaction's
+-- reads observe.
+--
+-- Scope: one client connection's transaction lifecycle.
+-- Entity/field names match the Kotlin in core/src/main/kotlin/xtdb/api/Xtdb.kt
+-- (Connection, Transaction, AccessMode.ReadOnly/ReadWrite, DmlBuffer) and the SQL
+-- classifier in core/src/main/kotlin/xtdb/query/SqlParser.kt → ParsedStatement.
+--
+-- == Frontend parity (the point of this spec) ==
+--
+-- Both protocol frontends — pgwire and ADBC / Flight SQL — reach this ENTIRE model
+-- through one shared Connection. There are two ways a client drives a transaction:
+--
+--   1. tx-control-as-SQL: BEGIN [READ ONLY | READ WRITE] [WITH (...)], COMMIT, ROLLBACK
+--      sent as SQL, classified by the SqlParser (Begin / Commit / Rollback) and handled
+--      by the connection. This is the FULL surface — access mode, read basis and
+--      commit-opts are all expressible here. An ADBC / Flight SQL client expresses the
+--      whole model this way.
+--   2. programmatic basic-control: setAutoCommit / commit / rollback on the ADBC
+--      AdbcConnection surface. Retained for driver ergonomics; a strict subset of (1).
+--
+-- This is the TARGET contract for an in-progress arc. The work in progress brings ADBC
+-- up to this contract (tx-control-as-SQL + retained programmatic control); once ADBC
+-- reaches it, pgwire is migrated onto the same Connection model wholesale. Code will
+-- catch up increment by increment — this describes the intended complete model, not
+-- only what is implemented today.
+--
+-- == Boundaries ==
+--
+-- Below: db.allium's submitTx / executeTx. A ReadWrite commit drains the buffer and
+--        crosses this boundary (submit when async, execute-and-await when sync).
+-- Above: the Frontend (pgwire / ADBC client) that decodes the wire protocol and feeds
+--        SQL strings and programmatic calls into the Connection.
+
+---- Given
+
+given {
+    connection: Connection
+}
+
+---- External Entities
+
+external entity Frontend {
+    -- The protocol frontend driving the connection: pgwire, or an ADBC / Flight SQL
+    -- client. It decodes the wire protocol and feeds SQL strings (and, for ADBC, the
+    -- programmatic setAutoCommit/commit/rollback calls) into the Connection. The
+    -- connection model is frontend-agnostic; this is the party on the far side.
+}
+
+external entity Database {
+    -- The db.allium submit/execute boundary. submitTx is fire-and-forget; executeTx
+    -- submits then awaits the result. A ReadWrite commit drains the buffer across this
+    -- boundary. See: dev/doc/db.allium, database/Database.kt
+}
+
+external entity SqlParser {
+    -- The SQL classifier (xtdb.query.SqlParser → ParsedStatement). Recognises
+    -- tx-control statements (Begin / Commit / Rollback) and statement kinds
+    -- (Query vs Dml) without planning. The shared path by which a client expresses
+    -- the full transaction model as SQL. See: core/src/main/kotlin/xtdb/query/SqlParser.kt
+}
+
+external entity SqlPlanner {
+    -- The connection's expression evaluator (xtdb.query.SqlPlanner). Sibling of the
+    -- SqlParser: where the parser CLASSIFIES a statement, the planner EVALUATES a
+    -- standalone transaction-option expression to its runtime value — it plans the
+    -- expression and substitutes positional params, turning e.g. SYSTEM_TIME's
+    -- `TIMESTAMP '…'` into a concrete instant. Injected (an SPI), shared with pgwire.
+    -- See: core/src/main/kotlin/xtdb/query/SqlPlanner.kt
+}
+
+external entity User {
+    -- The session identity, established once at authentication. Stamped onto every
+    -- transaction this connection submits. Not a per-transaction option.
+}
+
+---- Value Types
+
+-- Host-platform types carried opaquely at this level. (Instants map to the Allium
+-- primitive Timestamp; ZoneId and Bytes have no primitive equivalent, so they are
+-- structureless value types — opaque by-value carriers.)
+value ZoneId {
+    -- java.time.ZoneId — a connection / transaction timezone.
+}
+
+value Bytes {
+    -- Opaque serialized bytes (e.g. per-transaction user metadata).
+}
+
+value TxBasisToken {
+    -- An opaque await-token: the read basis carried between connection and Database so
+    -- a connection's reads observe (at least) its own prior writes. Each write advances
+    -- it; each read threads it through. See: database/encodeTxBasisToken.
+}
+
+value ReadBasis {
+    -- The pinned point-in-time a transaction's reads observe, fixed AT BEGIN for every
+    -- transaction (begin-time snapshot isolation). The begin-time pin sets snapshot_token
+    -- to the connection's await_token and clock_time to the current-time at begin; a
+    -- BEGIN READ ONLY WITH (...) clause overrides individual fields. The WITH options are
+    -- grammar-scoped to READ ONLY (readOnlyTxOption in the SQL grammar).
+    --   snapshot_token — an opaque basis token (as TxBasisToken).
+    --   snapshot_time  — observe state as of a wall-clock instant.
+    --   clock_time     — pin the transaction's notion of "now".
+    snapshot_token: TxBasisToken?
+    snapshot_time: Timestamp?
+    clock_time: Timestamp?
+}
+
+value CommitOpts {
+    -- Write-side options, grammar-scoped to READ WRITE (readWriteTxOption in the SQL
+    -- grammar). Their very presence implies the transaction is ReadWrite.
+    --   system_time   — the system-time to record the transaction at.
+    --   user_metadata — opaque per-transaction metadata.
+    --   async         — true: commit submits without awaiting; false: execute-and-await.
+    --   tz_override    — overrides the connection defaultTz for this transaction.
+    system_time: Timestamp?
+    user_metadata: Bytes?
+    async: Boolean
+    tz_override: ZoneId?
+}
+
+value TxOp {
+    -- A single buffered operation (a SQL DML statement plus its column-major args, or a
+    -- doc put). Opaque at this level. See: tx/TxOp.kt
+}
+
+---- Enumerations
+
+enum StatementKind {
+    -- How the SqlParser classifies an executable statement for access-mode resolution.
+    -- A query resolves an unresolved tx to ReadOnly; a DML statement resolves it to
+    -- ReadWrite. (DDL that submits as tx-ops — CREATE TABLE, GRANT — classifies as dml.)
+    query | dml
+}
+
+enum BeginAccessMode {
+    -- The access mode carried explicitly on a BEGIN. `read_only` / `read_write` fix the
+    -- mode at BEGIN; `none` leaves it Unresolved (resolved on the first statement). This
+    -- is distinct from inferring the mode from a non-null read-basis or commit-opts: it
+    -- lets `BEGIN READ ONLY` with no WITH clause still open a ReadOnly tx.
+    read_only | read_write | none
+}
+
+---- Entities and Variants
+
+entity Connection {
+    -- A session-scoped handle onto the node, shared by both protocol frontends.
+    -- See: core/src/main/kotlin/xtdb/api/Xtdb.kt (Xtdb.Connection)
+    user: User                       -- session identity, set once at authentication
+    auto_commit: Boolean
+    default_tz: ZoneId
+    await_token: TxBasisToken?       -- advanced by every write, threaded through every read
+
+    -- At most one open transaction. Singular relationship: the value is the open
+    -- Transaction, or null when none is open.
+    tx: Transaction with connection = this
+
+    invariant AtMostOneOpenTransaction {
+        -- Enforced structurally by the singular relationship: a connection has at most
+        -- one open Transaction at a time. BEGIN while tx != null is an error
+        -- (see BeginWhileOpenRejected).
+        true
+    }
+}
+
+entity Transaction {
+    -- One open transaction on a connection. Its access mode may be fixed at BEGIN or
+    -- left to resolve on the first statement. `failed` records an abort: once set, the
+    -- transaction rejects all further statements until rolled back.
+    -- See: Xtdb.Connection.Transaction
+    connection: Connection
+    mode: Unresolved | ReadOnly | ReadWrite
+    failed: Boolean
+}
+
+variant Unresolved : Transaction {
+    -- Opened by BEGIN with no explicit access mode. Resolves on the first statement: a
+    -- query → ReadOnly, DML → ReadWrite (see FirstStatementResolvesReadOnly /
+    -- FirstStatementResolvesReadWrite).
+    --
+    -- Carries the read basis pinned AT BEGIN: a transaction's notion of visible data and
+    -- "now" is fixed at BEGIN, before the access mode is known. If the tx resolves to
+    -- ReadOnly the resolution inherits this begin-pinned basis unchanged; if it resolves
+    -- to ReadWrite the basis is discarded (writes don't read).
+    read_basis: ReadBasis
+}
+
+variant ReadOnly : Transaction {
+    -- A read-only transaction. Carries the read basis its reads observe. XTDB read-only
+    -- transactions are READ-only in the strict sense: DML is rejected (see DmlInReadOnlyRejected).
+    read_basis: ReadBasis
+}
+
+variant ReadWrite : Transaction {
+    -- A write-only transaction. Buffers DML; queries are rejected (see QueryInReadWriteRejected).
+    -- Carries the commit-opts that govern how the buffer is submitted at COMMIT.
+    buffer: DmlBuffer with transaction = this
+    commit_opts: CommitOpts
+}
+
+entity DmlBuffer {
+    -- Accumulates buffered ops for a ReadWrite transaction. Consecutive same-SQL ops
+    -- coalesce: their args are appended column-major into the last op, so a prepared
+    -- INSERT executed in a loop becomes one multi-row op. Drained at COMMIT.
+    -- See: Xtdb.Connection.DmlBuffer
+    transaction: Transaction
+    ops: List<TxOp>
+}
+
+---- Rules: Beginning a Transaction
+
+-- An explicit SQL BEGIN opens a transaction regardless of auto_commit; the flag is left
+-- untouched and the explicit transaction coexists with it.
+--
+-- Every BEGIN pins a read basis NOW, at begin-time — the connection's current await_token
+-- as the snapshot token and the current-time as the clock_time. This gives begin-time
+-- snapshot isolation: a transaction's notion of visible data and "now" is fixed at BEGIN,
+-- before the access mode is known. The variant opened depends on the access mode carried
+-- on the BEGIN event (READ_ONLY | READ_WRITE | none — see BeginAccessMode):
+--   READ ONLY [WITH (read-basis)]   → ReadOnly, basis = begin-time pin (WITH overrides)
+--   READ WRITE [WITH (commit-opts)] → ReadWrite, empty buffer (no basis — writes don't read)
+--   (no mode)                       → Unresolved carrying the begin-time pin, resolved later
+--
+-- The mode comes from the explicit access_mode, NOT from inferring ReadOnly from a non-null
+-- read-basis: `BEGIN READ ONLY` with no WITH clause still opens a ReadOnly tx, pinned to the
+-- begin-time basis.
+
+rule BeginReadOnly {
+    -- BEGIN READ ONLY [WITH (snapshot-token | snapshot-time | clock-time)]. The basis is
+    -- the begin-time pin (connection await_token + current-time); any field supplied in
+    -- the WITH clause overrides the corresponding pinned default.
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    requires: connection.tx = null
+    requires: access_mode = read_only
+
+    ensures:
+        ReadOnly.created(
+            connection: connection,
+            failed: false,
+            read_basis: ReadBasis(
+                snapshot_token: read_basis?.snapshot_token ?? connection.await_token,
+                snapshot_time: read_basis?.snapshot_time,
+                clock_time: read_basis?.clock_time ?? now
+            )
+        )
+}
+
+rule BeginReadWrite {
+    -- BEGIN READ WRITE [WITH (system-time | metadata | async | tz)]. A ReadWrite tx carries
+    -- no read basis — writes don't read. commit_opts may be null (BEGIN READ WRITE with no
+    -- WITH clause); default commit-opts then apply at COMMIT.
+    --
+    -- The commit-opts values (system_time, user_metadata, async) are obtained by evaluating
+    -- their WITH-clause expressions through the SqlPlanner — it plans each option expression
+    -- (e.g. SYSTEM_TIME's `TIMESTAMP '…'`) and substitutes positional params to a runtime
+    -- value. The READ ONLY read-basis options are evaluated likewise, once that increment lands.
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    requires: connection.tx = null
+    requires: access_mode = read_write
+
+    ensures:
+        let buffer = DmlBuffer.created(ops: {})
+        ReadWrite.created(
+            connection: connection,
+            failed: false,
+            buffer: buffer,
+            commit_opts: commit_opts ?? CommitOpts(
+                system_time: null,
+                user_metadata: null,
+                async: false,
+                tz_override: null
+            )
+        )
+}
+
+rule BeginUnresolved {
+    -- BEGIN with no explicit access mode. The read basis is pinned NOW (begin-time) even
+    -- though the mode is not yet known; if the tx resolves to ReadOnly this basis is
+    -- inherited unchanged. Access mode resolves on the first statement.
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    requires: connection.tx = null
+    requires: access_mode = none
+
+    ensures:
+        Unresolved.created(
+            connection: connection,
+            failed: false,
+            read_basis: ReadBasis(
+                snapshot_token: connection.await_token,
+                snapshot_time: null,
+                clock_time: now
+            )
+        )
+}
+
+rule BeginWhileOpenRejected {
+    -- At most one open transaction per connection: BEGIN while one is open is an error.
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    requires: connection.tx != null
+
+    ensures:
+        BeginRejected(error_code: `xtdb/tx-already-open`)
+}
+
+---- Rules: Access-Mode Resolution
+
+-- When BEGIN did not fix the access mode, the first statement resolves it: a query
+-- resolves the transaction to ReadOnly, a DML statement to ReadWrite. Only an
+-- Unresolved transaction resolves; a fixed ReadOnly / ReadWrite stays as it is and
+-- enforces its direction (see the write-only rules below).
+
+rule FirstStatementResolvesReadOnly {
+    -- First statement in an Unresolved tx is a query → resolve to ReadOnly. The basis is
+    -- INHERITED from the Unresolved tx's begin-time pin — it is NOT re-pinned to the
+    -- connection's await_token at resolution time. Reads observe state as of BEGIN.
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: connection.tx != null
+    requires: connection.tx.mode = Unresolved
+    requires: kind = query
+
+    ensures:
+        connection.tx.mode = ReadOnly
+        connection.tx.read_basis = connection.tx.read_basis
+}
+
+rule FirstStatementResolvesReadWrite {
+    -- First statement in an Unresolved tx is DML → resolve to ReadWrite with an empty
+    -- buffer and default commit-opts (synchronous, no system-time override). The DML op
+    -- itself is then buffered by BufferDml.
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: connection.tx != null
+    requires: connection.tx.mode = Unresolved
+    requires: kind = dml
+
+    ensures:
+        let buffer = DmlBuffer.created(ops: {})
+        connection.tx.mode = ReadWrite
+        connection.tx.buffer = buffer
+        connection.tx.commit_opts = CommitOpts(
+            system_time: null,
+            user_metadata: null,
+            async: false,
+            tz_override: null
+        )
+}
+
+---- Rules: Statement Execution
+
+-- A DML statement auto-executes as its own single-op transaction IFF no explicit
+-- transaction is open. Otherwise it buffers into the open transaction — even when
+-- auto_commit is on. (An explicit BEGIN coexists with auto_commit; the open tx wins.)
+--
+-- The auto_commit guards across these rules partition the no-explicit-BEGIN cases cleanly:
+--   {auto_commit + no tx}  → AutoCommitDml / AutoCommitQuery (transient per-statement tx)
+--   {not auto_commit + no tx} → ManualLazyOpenDml / ManualLazyOpenQuery (lazy-open, below)
+--   {tx open}              → BufferDml / QueryInReadOnly / the rejection rules
+
+rule AutoCommitDml {
+    -- No explicit transaction open: the DML statement is its own transaction. It submits
+    -- through the Database boundary as a single-op execute-and-await. auto_commit must be
+    -- on (an explicit BEGIN would have opened a tx, taking the BufferDml path instead).
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = dml
+    requires: connection.tx = null
+    requires: connection.auto_commit
+
+    ensures:
+        Database.executeTx(
+            ops: { statement },
+            opts: { user: connection.user, default_tz: connection.default_tz }
+        )
+        AwaitTokenAdvanced(connection: connection)
+
+    @guidance
+        -- A single-statement auto-commit DML carries no buffering; it is the degenerate
+        -- case of "open, buffer one op, commit synchronously". executeTx advances the
+        -- connection's await_token so subsequent reads on this connection see the write.
+}
+
+rule ManualLazyOpenDml {
+    -- Manual mode (auto_commit off), no open transaction, statement is DML. Per pgjdbc's
+    -- lazy BEGIN — setAutoCommit(false) does not BEGIN immediately; the next statement does
+    -- — this opens an Unresolved tx, pinning the begin-time basis NOW (connection
+    -- await_token + current-time), then resolves it by the normal rules: DML → ReadWrite
+    -- (basis discarded — writes don't read), with the DML buffered. Open + resolve are one
+    -- step here because the resolution rules trigger on a tx that is already open; a freshly
+    -- lazily-opened tx must resolve within the same statement.
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = dml
+    requires: connection.tx = null
+    requires: not connection.auto_commit
+
+    ensures:
+        let buffer = DmlBuffer.created(ops: { statement })
+        ReadWrite.created(
+            connection: connection,
+            failed: false,
+            buffer: buffer,
+            commit_opts: CommitOpts(
+                system_time: null,
+                user_metadata: null,
+                async: false,
+                tz_override: null
+            )
+        )
+}
+
+rule ManualLazyOpenQuery {
+    -- Manual mode (auto_commit off), no open transaction, statement is a query. Per pgjdbc's
+    -- lazy BEGIN, this opens an Unresolved tx pinning the begin-time basis NOW (connection
+    -- await_token + current-time), then resolves it by the normal rules: query → ReadOnly,
+    -- inheriting that begin-time pin. Because the ReadOnly tx persists, subsequent reads in
+    -- the manual transaction share this one snapshot — this is the manual-mode transaction's
+    -- cross-statement snapshot isolation. Open + resolve are one step (see ManualLazyOpenDml).
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = query
+    requires: connection.tx = null
+    requires: not connection.auto_commit
+
+    ensures:
+        let opened = ReadOnly.created(
+            connection: connection,
+            failed: false,
+            read_basis: ReadBasis(
+                snapshot_token: connection.await_token,
+                snapshot_time: null,
+                clock_time: now
+            )
+        )
+        Database.openSnapshot(basis: opened.read_basis)
+}
+
+rule BufferDml {
+    -- An explicit transaction is open: buffer the DML into it, even when auto_commit is
+    -- on. Rejected if the open tx is ReadOnly (see DmlInReadOnlyRejected) or failed
+    -- (see FailedTransactionRejectsStatements).
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = dml
+    requires: connection.tx != null
+    requires: connection.tx.mode = ReadWrite
+    requires: not connection.tx.failed
+
+    ensures:
+        connection.tx.buffer.ops.add(statement)
+
+    @guidance
+        -- Consecutive same-SQL ops coalesce: rather than appending a distinct op, the
+        -- args are appended column-major into the trailing op when its SQL text matches.
+        -- This is a buffer-internal representation detail; observably the op is buffered.
+}
+
+rule QueryInReadWriteRejected {
+    -- ReadWrite is write-only: a query in a ReadWrite transaction is rejected. The
+    -- `not failed` guard yields failed-first precedence: on a failed tx,
+    -- FailedTransactionRejectsStatements fires instead (unambiguous).
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = query
+    requires: connection.tx != null
+    requires: connection.tx.mode = ReadWrite
+    requires: not connection.tx.failed
+
+    ensures:
+        StatementRejected(error_code: `xtdb/queries-in-read-write-tx`)
+}
+
+rule DmlInReadOnlyRejected {
+    -- ReadOnly is read-only: DML in a ReadOnly transaction is rejected. The `not failed`
+    -- guard yields failed-first precedence: on a failed tx,
+    -- FailedTransactionRejectsStatements fires instead (unambiguous).
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = dml
+    requires: connection.tx != null
+    requires: connection.tx.mode = ReadOnly
+    requires: not connection.tx.failed
+
+    ensures:
+        StatementRejected(error_code: `xtdb/read-only-tx`)
+}
+
+rule QueryInReadOnly {
+    -- A query in a ReadOnly transaction observes the pinned read basis. The basis is
+    -- threaded to the Database so reads see exactly that point-in-time.
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = query
+    requires: connection.tx != null
+    requires: connection.tx.mode = ReadOnly
+    requires: not connection.tx.failed
+
+    ensures:
+        Database.openSnapshot(basis: connection.tx.read_basis)
+}
+
+rule AutoCommitQuery {
+    -- Autocommit, no open transaction: the query transiently promotes to a read-only
+    -- transaction. It resolves its basis to the connection's CURRENT basis (await_token +
+    -- current-time) at this moment, reads against it, then discards — each autocommit read
+    -- is fresh, with no cross-statement snapshot. Behaviourally identical to reading at the
+    -- current await_token; framed as a transient per-statement ReadOnly tx so that every
+    -- read in the model runs inside a read-only transaction.
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: kind = query
+    requires: connection.tx = null
+    requires: connection.auto_commit
+
+    ensures:
+        Database.openSnapshot(
+            basis: ReadBasis(
+                snapshot_token: connection.await_token,
+                snapshot_time: null,
+                clock_time: now
+            )
+        )
+
+    @guidance
+        -- The transient read-only tx is not materialised as a Transaction entity: it opens,
+        -- resolves its basis, reads and discards within the single statement. The contrast
+        -- with the manual-mode lazy-open path (ManualLazyOpenQuery) is the lifetime — there
+        -- the ReadOnly tx persists and its basis is shared across subsequent reads.
+}
+
+rule FailedTransactionRejectsStatements {
+    -- A transaction that has failed (aborted) rejects all further statements until it is
+    -- rolled back. Applies to both queries and DML, on either resolved mode.
+    when: ExecuteStatement(frontend, connection, kind, statement)
+    requires: connection.tx != null
+    requires: connection.tx.failed
+
+    ensures:
+        StatementRejected(error_code: `xtdb/tx-failed`)
+}
+
+---- Rules: Commit and Rollback
+
+-- SQL COMMIT / ROLLBACK act on the explicit transaction regardless of auto_commit.
+-- Programmatic commit() / rollback() are valid only when auto_commit is off.
+
+rule CommitReadWrite {
+    -- Commit of a ReadWrite transaction drains the buffer and crosses the Database
+    -- boundary EVEN IF the buffer is empty: async commit submits (fire-and-forget),
+    -- sync commit executes-and-awaits. tz_override (if set) overrides default_tz.
+    when: CommitTransaction(frontend, connection)
+    requires: connection.tx != null
+    requires: connection.tx.mode = ReadWrite
+    requires: not connection.tx.failed
+
+    ensures:
+        let ops = connection.tx.buffer.ops
+        let opts = {
+            user: connection.user,
+            default_tz: connection.tx.commit_opts.tz_override ?? connection.default_tz,
+            system_time: connection.tx.commit_opts.system_time,
+            user_metadata: connection.tx.commit_opts.user_metadata
+        }
+
+        if connection.tx.commit_opts.async:
+            Database.submitTx(ops: ops, opts: opts)
+        else:
+            Database.executeTx(ops: ops, opts: opts)
+
+        AwaitTokenAdvanced(connection: connection)
+        not exists connection.tx
+
+    @guidance
+        -- "even if empty" is deliberate: an explicit COMMIT of a ReadWrite tx that
+        -- buffered nothing still submits an empty transaction. This differs from the
+        -- ReadOnly / Unresolved no-op below.
+}
+
+rule CommitNoOp {
+    -- Commit of a ReadOnly or still-Unresolved transaction submits nothing — there is no
+    -- buffer to drain. The transaction simply closes.
+    when: CommitTransaction(frontend, connection)
+    requires: connection.tx != null
+    requires: connection.tx.mode = ReadOnly or connection.tx.mode = Unresolved
+    requires: not connection.tx.failed
+
+    ensures:
+        not exists connection.tx
+}
+
+rule Rollback {
+    -- Rollback discards the open transaction (and its buffer, if any), submitting
+    -- nothing. Valid even on a failed transaction — this is how a failed tx is cleared.
+    when: RollbackTransaction(frontend, connection)
+    requires: connection.tx != null
+
+    ensures:
+        not exists connection.tx
+}
+
+rule ProgrammaticCommitInAutoCommitRejected {
+    -- Programmatic commit() is valid only when auto_commit is off.
+    when: ProgrammaticCommit(frontend, connection)
+    requires: connection.auto_commit
+
+    ensures:
+        CommitRejected(error_code: `xtdb.adbc/commit-in-autocommit`)
+}
+
+rule ProgrammaticRollbackInAutoCommitRejected {
+    -- Programmatic rollback() is valid only when auto_commit is off.
+    when: ProgrammaticRollback(frontend, connection)
+    requires: connection.auto_commit
+
+    ensures:
+        RollbackRejected(error_code: `xtdb.adbc/rollback-in-autocommit`)
+}
+
+rule DisableAutoCommitCommitsOpen {
+    -- setAutoCommit(false) when already off is a no-op; turning it ON commits any open
+    -- transaction first (so buffered work is not silently stranded), then sets the flag.
+    when: SetAutoCommit(frontend, connection, enabled)
+    requires: enabled
+    requires: not connection.auto_commit
+
+    ensures:
+        if connection.tx != null:
+            CommitTransaction(frontend: frontend, connection: connection)
+        connection.auto_commit = true
+}
+
+---- Rules: Connection Close
+
+rule CloseConnection {
+    -- Closing the connection discards any open transaction WITHOUT submitting. Buffered
+    -- but uncommitted work is lost — closing is not an implicit commit.
+    when: CloseConnection(frontend, connection)
+
+    ensures:
+        if connection.tx != null:
+            not exists connection.tx
+}
+
+---- Invariants
+
+invariant ReadWriteCarriesCommitOpts {
+    -- Commit-opts exist only on a ReadWrite transaction: their presence implies ReadWrite
+    -- (grammar-enforced at BEGIN). The variant structure makes this hold by construction;
+    -- stated here as the cross-cutting property.
+    true
+}
+
+invariant ReadBasisPinnedAtBegin {
+    -- The read basis is pinned at BEGIN and carried by both Unresolved and ReadOnly
+    -- transactions (a ReadWrite tx has none — writes don't read). An Unresolved tx that
+    -- resolves to ReadOnly inherits its begin-time basis unchanged; one that resolves to
+    -- ReadWrite discards it. Structural — stated here as the cross-cutting property.
+    true
+}
+
+---- Actor Declarations
+
+actor FrontendActor {
+    -- Either protocol frontend (pgwire or ADBC / Flight SQL). Any Frontend may drive a
+    -- connection through the surfaces below.
+    identified_by: Frontend where true
+}
+
+---- Surfaces
+
+surface TxControlAsSql {
+    -- The shared path: tx-control expressed as SQL, classified by the SqlParser. This is
+    -- the full surface — an ADBC / Flight SQL client reaches the entire model here.
+    facing frontend: FrontendActor
+
+    context conn: Connection
+
+    provides:
+        BeginTransaction(frontend, conn, access_mode, read_basis, commit_opts)
+            when conn.tx = null
+        ExecuteStatement(frontend, conn, kind, statement)
+        CommitTransaction(frontend, conn)
+            when conn.tx != null
+        RollbackTransaction(frontend, conn)
+            when conn.tx != null
+
+    @guarantee SingleOpenTransaction
+        -- At most one transaction is open on a connection at any time.
+
+    @guarantee WriteOnlyReadWrite
+        -- A ReadWrite transaction rejects queries; a ReadOnly transaction rejects DML.
+
+    @guarantee ConnectionScopedIdentity
+        -- Every transaction this connection submits is stamped with the connection's
+        -- user; it is not a per-transaction option.
+}
+
+surface AdbcBasicControl {
+    -- Retained programmatic control on the ADBC AdbcConnection surface: a strict subset
+    -- of TxControlAsSql, kept for driver ergonomics.
+    facing frontend: FrontendActor
+
+    context conn: Connection
+
+    provides:
+        SetAutoCommit(frontend, conn, enabled)
+        ProgrammaticCommit(frontend, conn)
+            when not conn.auto_commit
+        ProgrammaticRollback(frontend, conn)
+            when not conn.auto_commit
+
+    @guarantee ProgrammaticControlNeedsManualMode
+        -- Programmatic commit / rollback are valid only when auto_commit is off.
+}
+
+surface ConnectionLifecycle {
+    facing frontend: FrontendActor
+
+    context conn: Connection
+
+    provides:
+        CloseConnection(frontend, conn)
+
+    @guarantee CloseDiscardsOpenTx
+        -- Closing the connection discards any open transaction without submitting.
+        -- Closing is not an implicit commit.
+}
+
+---- Open Questions
+
+open question "AutoCommitDml stamps opts with user and default_tz only (no system_time). Is the read basis (await_token) the right post-write visibility contract for the immediately-following auto-commit query, or should auto-commit DML and the following query share a tighter basis?"

--- a/dev/doc/tx.allium
+++ b/dev/doc/tx.allium
@@ -124,15 +124,15 @@ value ReadBasis {
 
 value CommitOpts {
     -- Write-side options, grammar-scoped to READ WRITE (readWriteTxOption in the SQL
-    -- grammar). Their very presence implies the transaction is ReadWrite.
+    -- grammar). Their very presence implies the transaction is ReadWrite. The transaction's
+    -- effective timezone is NOT a commit-opt: it is set at BEGIN as the tx's tx_default_tz
+    -- (see Transaction), not deferred to COMMIT.
     --   system_time   — the system-time to record the transaction at.
     --   user_metadata — opaque per-transaction metadata.
     --   async         — true: commit submits without awaiting; false: execute-and-await.
-    --   tz_override    — overrides the connection defaultTz for this transaction.
     system_time: Timestamp?
     user_metadata: Bytes?
     async: Boolean
-    tz_override: ZoneId?
 }
 
 value TxOp {
@@ -195,7 +195,8 @@ entity Transaction {
     connection: Connection
     mode: Unresolved | ReadOnly | ReadWrite
     failed: Boolean
-    entered_tz: ZoneId               -- the connection's default_tz as at BEGIN; ROLLBACK restores it
+    tx_default_tz: ZoneId            -- the tz this tx's DML and reads anchor in (WITH (TIMEZONE) override, else the connection default at BEGIN)
+    session_default_tz: ZoneId       -- the connection default_tz to write back to the connection on COMMIT
 }
 
 variant Unresolved : Transaction {
@@ -256,7 +257,11 @@ rule BeginReadOnly {
     -- begin-time pin — the latest-completed snapshot (Database.snapshotToken, captured after
     -- awaiting the connection's await_token) plus the current-time; any field supplied in the
     -- WITH clause overrides the corresponding pinned default.
-    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    -- tx_default_tz is the WITH (TIMEZONE) override if present, else the connection's
+    -- default_tz; session_default_tz is the connection's default_tz. WITH (TIMEZONE) is
+    -- available on any access mode (READ ONLY as well as READ WRITE), so it sets the tx's
+    -- effective tz at BEGIN — it is not a ReadWrite commit-opt.
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts, tz_override)
     requires: connection.tx = null
     requires: access_mode = read_only
 
@@ -264,7 +269,8 @@ rule BeginReadOnly {
         ReadOnly.created(
             connection: connection,
             failed: false,
-            entered_tz: connection.default_tz,
+            tx_default_tz: tz_override ?? connection.default_tz,
+            session_default_tz: connection.default_tz,
             read_basis: ReadBasis(
                 snapshot_token: read_basis?.snapshot_token ?? Database.snapshotToken,
                 snapshot_time: read_basis?.snapshot_time,
@@ -281,9 +287,12 @@ rule BeginReadWrite {
     -- The commit-opts values (system_time, user_metadata, async) are obtained by evaluating
     -- their WITH-clause expressions through the SqlPlanner — it plans each option expression
     -- (e.g. SYSTEM_TIME's `TIMESTAMP '…'`) and substitutes positional params to a runtime
-    -- value. The READ ONLY read-basis options (SNAPSHOT_TOKEN / SNAPSHOT_TIME / CLOCK_TIME) are
-    -- evaluated likewise.
-    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    -- value. The READ ONLY read-basis options (SNAPSHOT_TOKEN / SNAPSHOT_TIME / CLOCK_TIME) and
+    -- the WITH (TIMEZONE) override are evaluated likewise.
+    --
+    -- tx_default_tz is the WITH (TIMEZONE) override if present, else the connection's
+    -- default_tz; session_default_tz is the connection's default_tz.
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts, tz_override)
     requires: connection.tx = null
     requires: access_mode = read_write
 
@@ -292,13 +301,13 @@ rule BeginReadWrite {
         ReadWrite.created(
             connection: connection,
             failed: false,
-            entered_tz: connection.default_tz,
+            tx_default_tz: tz_override ?? connection.default_tz,
+            session_default_tz: connection.default_tz,
             buffer: buffer,
             commit_opts: commit_opts ?? CommitOpts(
                 system_time: null,
                 user_metadata: null,
-                async: false,
-                tz_override: null
+                async: false
             )
         )
 }
@@ -309,7 +318,10 @@ rule BeginUnresolved {
     -- opens ReadOnly / ReadWrite directly; with no default set it stays Unresolved, resolved
     -- on the first statement (the common case). Either way the read basis is pinned NOW
     -- (begin-time): an Unresolved or ReadOnly tx inherits it; a ReadWrite tx discards it.
-    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    -- tx_default_tz is the WITH (TIMEZONE) override if present, else the connection's
+    -- default_tz; session_default_tz is the connection's default_tz. A bare
+    -- BEGIN WITH (TIMEZONE = ...) still carries the override into tx_default_tz.
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts, tz_override)
     requires: connection.tx = null
     requires: access_mode = none
 
@@ -319,11 +331,13 @@ rule BeginUnresolved {
             snapshot_time: null,
             clock_time: now
         )
+        let tx_tz = tz_override ?? connection.default_tz
         if connection.default_access_mode = read_only:
             ReadOnly.created(
                 connection: connection,
                 failed: false,
-                entered_tz: connection.default_tz,
+                tx_default_tz: tx_tz,
+                session_default_tz: connection.default_tz,
                 read_basis: begin_basis
             )
         else if connection.default_access_mode = read_write:
@@ -331,27 +345,28 @@ rule BeginUnresolved {
             ReadWrite.created(
                 connection: connection,
                 failed: false,
-                entered_tz: connection.default_tz,
+                tx_default_tz: tx_tz,
+                session_default_tz: connection.default_tz,
                 buffer: buffer,
                 commit_opts: CommitOpts(
                     system_time: null,
                     user_metadata: null,
-                    async: false,
-                    tz_override: null
+                    async: false
                 )
             )
         else:
             Unresolved.created(
                 connection: connection,
                 failed: false,
-                entered_tz: connection.default_tz,
+                tx_default_tz: tx_tz,
+                session_default_tz: connection.default_tz,
                 read_basis: begin_basis
             )
 }
 
 rule BeginWhileOpenRejected {
     -- At most one open transaction per connection: BEGIN while one is open is an error.
-    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts)
+    when: BeginTransaction(frontend, connection, access_mode, read_basis, commit_opts, tz_override)
     requires: connection.tx != null
 
     ensures:
@@ -395,9 +410,51 @@ rule FirstStatementResolvesReadWrite {
         connection.tx.commit_opts = CommitOpts(
             system_time: null,
             user_metadata: null,
-            async: false,
-            tz_override: null
+            async: false
         )
+}
+
+---- Rules: Timezone
+
+-- SET TIME ZONE is a session operator. This spec touches it only for its transaction
+-- scoping — the broader SET / SHOW session surface is out of frame (as with SET SESSION
+-- CHARACTERISTICS, referenced only as a source of default_access_mode). WITH (TIMEZONE)
+-- stays tx-scoped (it sets tx_default_tz at BEGIN, never session_default_tz); a mid-tx
+-- SET TIME ZONE writes both, so it persists on COMMIT and reverts on ROLLBACK.
+
+rule SetTimeZoneInTx {
+    -- Mid-transaction SET TIME ZONE writes BOTH the tx's tx_default_tz (so this tx's DML and
+    -- reads re-anchor) AND its session_default_tz (so the change is written back to the
+    -- connection on COMMIT and persists past the tx). The connection's own default_tz is left
+    -- untouched while the tx is open — that is what makes the ROLLBACK revert implicit.
+    when: SetTimeZone(frontend, connection, zone)
+    requires: connection.tx != null
+    requires: not (connection.tx.mode = ReadWrite and connection.tx.buffer.ops.count > 0)
+
+    ensures:
+        connection.tx.tx_default_tz = zone
+        connection.tx.session_default_tz = zone
+}
+
+rule SetTimeZoneInWriteTxRejected {
+    -- SET TIME ZONE is rejected once a ReadWrite tx has buffered ops: those ops captured
+    -- temporal literals under the old zone, so changing it mid-buffer would be inconsistent.
+    when: SetTimeZone(frontend, connection, zone)
+    requires: connection.tx != null
+    requires: connection.tx.mode = ReadWrite
+    requires: connection.tx.buffer.ops.count > 0
+
+    ensures:
+        StatementRejected(error_code: `xtdb/set-tz-in-write-tx`)
+}
+
+rule SetTimeZoneNoTx {
+    -- With no open transaction, SET TIME ZONE updates the connection's default_tz directly.
+    when: SetTimeZone(frontend, connection, zone)
+    requires: connection.tx = null
+
+    ensures:
+        connection.default_tz = zone
 }
 
 ---- Rules: Statement Execution
@@ -451,13 +508,13 @@ rule ManualLazyOpenDml {
         ReadWrite.created(
             connection: connection,
             failed: false,
-            entered_tz: connection.default_tz,
+            tx_default_tz: connection.default_tz,
+            session_default_tz: connection.default_tz,
             buffer: buffer,
             commit_opts: CommitOpts(
                 system_time: null,
                 user_metadata: null,
-                async: false,
-                tz_override: null
+                async: false
             )
         )
 }
@@ -478,7 +535,8 @@ rule ManualLazyOpenQuery {
         let opened = ReadOnly.created(
             connection: connection,
             failed: false,
-            entered_tz: connection.default_tz,
+            tx_default_tz: connection.default_tz,
+            session_default_tz: connection.default_tz,
             read_basis: ReadBasis(
                 snapshot_token: connection.await_token,
                 snapshot_time: null,
@@ -595,7 +653,10 @@ rule FailedTransactionRejectsStatements {
 rule CommitReadWrite {
     -- Commit of a ReadWrite transaction drains the buffer and crosses the Database
     -- boundary EVEN IF the buffer is empty: async commit submits (fire-and-forget),
-    -- sync commit executes-and-awaits. tz_override (if set) overrides default_tz.
+    -- sync commit executes-and-awaits. The submit anchors in the tx's tx_default_tz. COMMIT
+    -- also writes the tx's session_default_tz back to the connection, so a mid-tx SET TIME
+    -- ZONE persists past the tx while a WITH (TIMEZONE) override (which never touched
+    -- session_default_tz) does not.
     when: CommitTransaction(frontend, connection)
     requires: connection.tx != null
     requires: connection.tx.mode = ReadWrite
@@ -605,10 +666,12 @@ rule CommitReadWrite {
         let ops = connection.tx.buffer.ops
         let opts = {
             user: connection.user,
-            default_tz: connection.tx.commit_opts.tz_override ?? connection.default_tz,
+            default_tz: connection.tx.tx_default_tz,
             system_time: connection.tx.commit_opts.system_time,
             user_metadata: connection.tx.commit_opts.user_metadata
         }
+
+        connection.default_tz = connection.tx.session_default_tz
 
         if connection.tx.commit_opts.async:
             Database.submitTx(ops: ops, opts: opts)
@@ -626,27 +689,32 @@ rule CommitReadWrite {
 
 rule CommitNoOp {
     -- Commit of a ReadOnly or still-Unresolved transaction submits nothing — there is no
-    -- buffer to drain. The transaction simply closes.
+    -- buffer to drain. It still writes the tx's session_default_tz back to the connection
+    -- (COMMIT writes the session tz back regardless of mode, before the ReadWrite / no-op
+    -- split), so a mid-tx SET TIME ZONE persists on a read-only commit too. The transaction
+    -- then closes.
     when: CommitTransaction(frontend, connection)
     requires: connection.tx != null
     requires: connection.tx.mode = ReadOnly or connection.tx.mode = Unresolved
     requires: not connection.tx.failed
 
     ensures:
+        connection.default_tz = connection.tx.session_default_tz
         not exists connection.tx
 }
 
 rule Rollback {
     -- Rollback discards the open transaction (and its buffer, if any), submitting
     -- nothing. Valid even on a failed transaction — this is how a failed tx is cleared.
-    -- Restores the connection's default_tz to the value captured at BEGIN, discarding any
-    -- mid-transaction SET TIME ZONE (Postgres semantics — a plain SET in an aborted tx is
-    -- rolled back; COMMIT keeps the new zone).
+    -- The connection's default_tz reverts implicitly: it was never mutated while the tx was
+    -- open (a mid-tx SET TIME ZONE writes the tx's tx_default_tz / session_default_tz, not
+    -- the connection), so dropping the tx discards any mid-transaction SET TIME ZONE.
+    -- Postgres semantics — a plain SET in an aborted tx is rolled back; only COMMIT keeps
+    -- the new zone (see CommitReadWrite / CommitNoOp).
     when: RollbackTransaction(frontend, connection)
     requires: connection.tx != null
 
     ensures:
-        connection.default_tz = connection.tx.entered_tz
         not exists connection.tx
 }
 
@@ -728,9 +796,10 @@ surface TxControlAsSql {
     context conn: Connection
 
     provides:
-        BeginTransaction(frontend, conn, access_mode, read_basis, commit_opts)
+        BeginTransaction(frontend, conn, access_mode, read_basis, commit_opts, tz_override)
             when conn.tx = null
         ExecuteStatement(frontend, conn, kind, statement)
+        SetTimeZone(frontend, conn, zone)
         CommitTransaction(frontend, conn)
             when conn.tx != null
         RollbackTransaction(frontend, conn)

--- a/src/test/kotlin/xtdb/ConnectionTest.kt
+++ b/src/test/kotlin/xtdb/ConnectionTest.kt
@@ -14,6 +14,7 @@ import xtdb.database.Database
 import xtdb.database.DatabaseName
 import xtdb.database.decodeTxBasisToken
 import xtdb.database.encodeTxBasisToken
+import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 
@@ -40,7 +41,7 @@ class ConnectionTest {
         every { dbCat.databaseOrNull(any()) } returns db
         every { dbCat.primary } returns db
 
-        return Xtdb.Connection(mockk(relaxed = true), dbCat, mockk(relaxed = true), mockk(relaxed = true), ZoneOffset.UTC, null, null, null, null, dbName)
+        return Xtdb.Connection(mockk(relaxed = true), dbCat, mockk(relaxed = true), mockk(relaxed = true), Clock.systemUTC(), ZoneOffset.UTC, null, null, null, null, dbName)
     }
 
     private fun tokenOf(awaitToken: String?) = awaitToken?.decodeTxBasisToken()

--- a/src/test/kotlin/xtdb/ConnectionTest.kt
+++ b/src/test/kotlin/xtdb/ConnectionTest.kt
@@ -40,7 +40,7 @@ class ConnectionTest {
         every { dbCat.databaseOrNull(any()) } returns db
         every { dbCat.primary } returns db
 
-        return Xtdb.Connection(mockk(relaxed = true), dbCat, mockk(relaxed = true), ZoneOffset.UTC, null, null, null, null, dbName)
+        return Xtdb.Connection(mockk(relaxed = true), dbCat, mockk(relaxed = true), mockk(relaxed = true), ZoneOffset.UTC, null, null, null, null, dbName)
     }
 
     private fun tokenOf(awaitToken: String?) = awaitToken?.decodeTxBasisToken()

--- a/src/test/kotlin/xtdb/ConnectionTest.kt
+++ b/src/test/kotlin/xtdb/ConnectionTest.kt
@@ -41,7 +41,7 @@ class ConnectionTest {
         every { dbCat.databaseOrNull(any()) } returns db
         every { dbCat.primary } returns db
 
-        return Xtdb.Connection(mockk(relaxed = true), dbCat, mockk(relaxed = true), mockk(relaxed = true), Clock.systemUTC(), ZoneOffset.UTC, null, null, null, null, dbName)
+        return Xtdb.Connection(mockk(relaxed = true), dbCat, mockk(relaxed = true), mockk(relaxed = true), Clock.systemUTC(), null, ZoneOffset.UTC, null, null, null, null, dbName)
     }
 
     private fun tokenOf(awaitToken: String?) = awaitToken?.decodeTxBasisToken()

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -16,6 +16,8 @@ import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation
 import xtdb.arrow.VectorType.Companion.I64
 import xtdb.arrow.VectorType.Companion.ofType
+import xtdb.database.encodeTimeBasisToken
+import java.time.Instant
 
 class InProcessAdbcTest {
 
@@ -255,6 +257,83 @@ class InProcessAdbcTest {
             assertEquals(listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"))
 
             assertThrows(Incorrect::class.java) { conn.update("INSERT INTO foo RECORDS {_id: 1}") }
+        }
+    }
+
+    @Test
+    fun `a read-only transaction is isolated from a concurrent write`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ ONLY")
+            assertEquals(listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"))
+
+            insertData("INSERT INTO foo RECORDS {_id: 1}")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "the concurrent write is invisible within the begin-pinned snapshot"
+            )
+
+            conn.update("COMMIT")
+            assertEquals(
+                listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "visible once the snapshot is released"
+            )
+        }
+    }
+
+    @Test
+    fun `manual-mode reads share a snapshot without an explicit BEGIN`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.setAutoCommit(false)
+            assertEquals(listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"))
+
+            insertData("INSERT INTO foo RECORDS {_id: 1}")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "the first read lazily pinned the snapshot; the concurrent write stays invisible"
+            )
+
+            conn.rollback()
+        }
+    }
+
+    @Test
+    fun `current-time is pinned across a read-only transaction`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ ONLY")
+            val first = conn.select("SELECT CURRENT_TIMESTAMP ts")
+            val second = conn.select("SELECT CURRENT_TIMESTAMP ts")
+            assertEquals(first, second, "current_timestamp is fixed at BEGIN, identical across reads in the tx")
+            conn.update("COMMIT")
+        }
+    }
+
+    @Test
+    fun `READ ONLY WITH CLOCK_TIME pins the transaction wall-clock`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ ONLY WITH (CLOCK_TIME = TIMESTAMP '2021-07-01T00:00:00Z')")
+            assertEquals(
+                listOf(mapOf("in_2021" to true)),
+                conn.select(
+                    "SELECT (CURRENT_TIMESTAMP >= TIMESTAMP '2021-01-01T00:00:00Z'" +
+                        " AND CURRENT_TIMESTAMP < TIMESTAMP '2022-01-01T00:00:00Z') in_2021"
+                )
+            )
+            conn.update("COMMIT")
+        }
+    }
+
+    @Test
+    fun `READ ONLY WITH AWAIT_TOKEN is rejected`() {
+        xtdb.connect().use { conn ->
+            assertThrows(Incorrect::class.java) {
+                conn.update("BEGIN READ ONLY WITH (AWAIT_TOKEN = 'whatever')")
+            }
         }
     }
 
@@ -521,9 +600,21 @@ class InProcessAdbcTest {
     }
 
     @Test
-    fun `BEGIN READ ONLY WITH SNAPSHOT_TOKEN is rejected`() {
+    fun `READ ONLY WITH SNAPSHOT_TOKEN bounds reads to the given snapshot`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        // a past snapshot bound — earlier than the row's commit, so the explicit token must decode, apply, and
+        // bound the read below it: the row is excluded. (Avoid the epoch: it collides with the encoding's
+        // "no completed tx" sentinel and decodes to null; a future token would be rejected as unindexed.)
+        val token = mapOf("xtdb" to listOf<Instant?>(Instant.parse("2020-01-01T00:00:00Z"))).encodeTimeBasisToken()
+
         xtdb.connect().use { conn ->
-            assertThrows(Incorrect::class.java) { conn.update("BEGIN READ ONLY WITH (SNAPSHOT_TOKEN = 'tok')") }
+            conn.update("BEGIN READ ONLY WITH (SNAPSHOT_TOKEN = '$token')")
+            assertEquals(
+                emptyList<Map<*, *>>(), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "as of the epoch the row's commit is in the future, so nothing is visible"
+            )
+            conn.update("COMMIT")
         }
     }
 

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -18,6 +18,7 @@ import xtdb.arrow.VectorType.Companion.I64
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.database.encodeTimeBasisToken
 import java.time.Instant
+import java.util.UUID
 
 class InProcessAdbcTest {
 
@@ -703,6 +704,55 @@ class InProcessAdbcTest {
             val after = conn.select("SELECT count(*) AS c FROM xt.txs").single()["c"] as Long
 
             assertEquals(before + 1, after, "an explicit write tx commits even when empty")
+        }
+    }
+
+    @Test
+    fun `a literal UUID _id round-trips through static expansion`() {
+        val id = "7f8e9d6c-5b4a-4c2d-9e0f-a9b8c7d6e5f4"
+        insertData("INSERT INTO foo RECORDS {_id: UUID '$id', n: 1}")
+
+        xtdb.connect().use { conn ->
+            assertEquals(
+                listOf(mapOf("_id" to UUID.fromString(id), "n" to 1L)),
+                conn.select("SELECT _id, n FROM foo"),
+                "a literal UUID id is coerced via PutDocs, not rejected as raw-SQL 'Invalid ID type: [B'"
+            )
+        }
+    }
+
+    @Test
+    fun `a literal UUID _id in PATCH RECORDS round-trips`() {
+        val id = "7f8e9d6c-5b4a-4c2d-9e0f-a9b8c7d6e5f4"
+        insertData("INSERT INTO foo RECORDS {_id: UUID '$id', n: 1}")
+        insertData("PATCH INTO foo RECORDS {_id: UUID '$id', n: 2}")
+
+        xtdb.connect().use { conn ->
+            assertEquals(
+                listOf(mapOf("_id" to UUID.fromString(id), "n" to 2L)),
+                conn.select("SELECT _id, n FROM foo")
+            )
+        }
+    }
+
+    @Test
+    fun `INSERT RECORDS without _id surfaces the static missing-id error`() {
+        xtdb.connect().use { conn ->
+            val ex = assertThrows(Incorrect::class.java) { conn.update("INSERT INTO foo RECORDS {n: 1}") }
+            assertTrue(ex.message?.contains("_id") == true, "expected a missing-_id message, got: ${ex.message}")
+        }
+    }
+
+    @Test
+    fun `a non-expandable DELETE falls back to the raw Sql op`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}, {_id: 2}")
+
+        xtdb.connect().use { conn ->
+            conn.update("DELETE FROM foo WHERE _id = 1")
+            assertEquals(
+                listOf(mapOf("_id" to 2L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "DELETE isn't statically expandable — it submits the raw Sql op, expanded at index time"
+            )
         }
     }
 }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -338,6 +338,82 @@ class InProcessAdbcTest {
     }
 
     @Test
+    fun `SET and SHOW AWAIT_TOKEN round-trip`() {
+        xtdb.connect().use { conn ->
+            conn.update("SET AWAIT_TOKEN = 'abc'")
+            assertEquals(listOf(mapOf("await_token" to "abc")), conn.select("SHOW AWAIT_TOKEN"))
+        }
+    }
+
+    @Test
+    fun `SET and SHOW a session parameter round-trip`() {
+        xtdb.connect().use { conn ->
+            conn.update("SET datestyle = 'ISO'")
+            assertEquals(listOf(mapOf("datestyle" to "ISO")), conn.select("SHOW datestyle"))
+        }
+    }
+
+    @Test
+    fun `SET SESSION CHARACTERISTICS READ ONLY makes a bare BEGIN read-only`() {
+        xtdb.connect().use { conn ->
+            conn.update("SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY")
+            conn.update("BEGIN")
+            assertThrows(Incorrect::class.java) { conn.update("INSERT INTO foo RECORDS {_id: 1}") }
+            conn.update("ROLLBACK")
+        }
+    }
+
+    @Test
+    fun `SET TIME ZONE is reflected by SHOW timezone`() {
+        xtdb.connect().use { conn ->
+            conn.update("SET TIME ZONE 'America/New_York'")
+            assertEquals(listOf(mapOf("timezone" to "America/New_York")), conn.select("SHOW timezone"))
+        }
+    }
+
+    @Test
+    fun `a mid-transaction SET TIME ZONE is discarded on ROLLBACK and kept on COMMIT`() {
+        xtdb.connect().use { conn ->
+            conn.update("SET TIME ZONE 'UTC'")
+
+            conn.update("BEGIN")
+            conn.update("SET TIME ZONE 'America/New_York'")
+            assertEquals(listOf(mapOf("timezone" to "America/New_York")), conn.select("SHOW timezone"))
+            conn.update("ROLLBACK")
+            assertEquals(
+                listOf(mapOf("timezone" to "UTC")), conn.select("SHOW timezone"),
+                "ROLLBACK reverts the mid-transaction SET TIME ZONE"
+            )
+
+            conn.update("BEGIN")
+            conn.update("SET TIME ZONE 'America/New_York'")
+            conn.update("COMMIT")
+            assertEquals(
+                listOf(mapOf("timezone" to "America/New_York")), conn.select("SHOW timezone"),
+                "COMMIT keeps it"
+            )
+        }
+    }
+
+    @Test
+    fun `SET TIME ZONE is rejected in a write transaction with buffered writes`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            assertThrows(Incorrect::class.java) { conn.update("SET TIME ZONE 'UTC'") }
+            conn.update("ROLLBACK")
+        }
+    }
+
+    @Test
+    fun `SET TRANSACTION and SET ROLE are accepted no-ops`() {
+        xtdb.connect().use { conn ->
+            conn.update("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+            conn.update("SET ROLE some_role")
+        }
+    }
+
+    @Test
     fun `rollback discards buffered writes`() {
         insertData("INSERT INTO foo RECORDS {_id: 0}")
 

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -221,16 +221,40 @@ class InProcessAdbcTest {
             conn.setAutoCommit(false)
             conn.update("INSERT INTO foo RECORDS {_id: 1}")
 
-            assertEquals(
-                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
-                "the buffered write is not yet committed"
-            )
+            xtdb.connect().use { other ->
+                assertEquals(
+                    listOf(mapOf("_id" to 0L)), other.select("SELECT _id FROM foo ORDER BY _id"),
+                    "the buffered write is not visible to another connection before commit"
+                )
+            }
 
             conn.commit()
             assertEquals(
                 listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
                 "visible once committed"
             )
+        }
+    }
+
+    @Test
+    fun `a query in a read-write transaction is rejected`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+
+            assertThrows(Incorrect::class.java) { conn.select("SELECT _id FROM foo") }
+        }
+    }
+
+    @Test
+    fun `a query resolves a bare BEGIN to read-only, then DML is rejected`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            assertEquals(listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"))
+
+            assertThrows(Incorrect::class.java) { conn.update("INSERT INTO foo RECORDS {_id: 1}") }
         }
     }
 
@@ -342,10 +366,12 @@ class InProcessAdbcTest {
             conn.update("BEGIN")
             conn.update("INSERT INTO foo RECORDS {_id: 1}")
 
-            assertEquals(
-                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
-                "buffered until COMMIT"
-            )
+            xtdb.connect().use { other ->
+                assertEquals(
+                    listOf(mapOf("_id" to 0L)), other.select("SELECT _id FROM foo ORDER BY _id"),
+                    "buffered until COMMIT — not visible to another connection"
+                )
+            }
 
             conn.update("COMMIT")
             assertEquals(

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -333,4 +333,183 @@ class InProcessAdbcTest {
             )
         }
     }
+
+    @Test
+    fun `SQL BEGIN COMMIT buffers then lands the writes`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "buffered until COMMIT"
+            )
+
+            conn.update("COMMIT")
+            assertEquals(
+                listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "visible once committed"
+            )
+        }
+    }
+
+    @Test
+    fun `SQL ROLLBACK discards the buffered writes`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.update("ROLLBACK")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "the buffered write is discarded"
+            )
+        }
+    }
+
+    @Test
+    fun `SQL BEGIN while a transaction is open is rejected`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            assertThrows(Incorrect::class.java) { conn.update("BEGIN") }
+        }
+    }
+
+    @Test
+    fun `executeUpdate rejects multi-statement input`() {
+        xtdb.connect().use { conn ->
+            assertThrows(Incorrect::class.java) { conn.update("BEGIN; COMMIT") }
+        }
+    }
+
+    @Test
+    fun `closing the connection discards an open transaction`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            // no COMMIT/ROLLBACK — the connection closes (via use) with the write still buffered
+        }
+
+        xtdb.connect().use { conn ->
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "an uncommitted tx is dropped on close, not submitted (and its buffer freed — node close would fail on a leak)"
+            )
+        }
+    }
+
+    @Test
+    fun `BEGIN then COMMIT with no writes is a no-op`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+            conn.update("COMMIT")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "an unresolved tx commits as a no-op — nothing submitted"
+            )
+        }
+    }
+
+    @Test
+    fun `BEGIN READ WRITE buffers and commits`() {
+        insertData("INSERT INTO foo RECORDS {_id: 0}")
+
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ WRITE")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.update("COMMIT")
+
+            assertEquals(
+                listOf(mapOf("_id" to 0L), mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id")
+            )
+        }
+    }
+
+    @Test
+    fun `BEGIN READ ONLY rejects a write`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ ONLY")
+            assertThrows(Incorrect::class.java) { conn.update("INSERT INTO foo RECORDS {_id: 1}") }
+        }
+    }
+
+    @Test
+    fun `BEGIN READ WRITE WITH SYSTEM_TIME applies the requested system-time`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ WRITE WITH (SYSTEM_TIME TIMESTAMP '2021-08-03T00:00:00')")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.update("COMMIT")
+
+            // connection defaultTz is UTC, so a zoneless TIMESTAMP literal anchors there
+            assertEquals(
+                listOf(mapOf("_system_from" to "2021-08-03T00:00Z[UTC]")),
+                conn.select("SELECT _system_from FROM foo").map { row -> mapOf("_system_from" to row["_system_from"].toString()) },
+                "the row's system-from is the requested system-time"
+            )
+        }
+    }
+
+    @Test
+    fun `BEGIN READ WRITE WITH METADATA round-trips`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ WRITE WITH (METADATA = {source: 'mobile-app'})")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.update("COMMIT")
+
+            // the metadata is carried into the commit options; assert the tx committed and the row landed
+            assertEquals(
+                listOf(mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "a READ WRITE tx carrying user-metadata commits its writes"
+            )
+        }
+    }
+
+    @Test
+    fun `BEGIN READ WRITE WITH ASYNC commits and the row lands`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN READ WRITE WITH (ASYNC = TRUE)")
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+            conn.update("COMMIT")
+
+            assertEquals(
+                listOf(mapOf("_id" to 1L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
+                "an async commit still lands the row (the read awaits this connection's own write)"
+            )
+        }
+    }
+
+    @Test
+    fun `BEGIN READ WRITE WITH TIMEZONE is rejected`() {
+        xtdb.connect().use { conn ->
+            assertThrows(Incorrect::class.java) { conn.update("BEGIN READ WRITE WITH (TIMEZONE = 'America/New_York')") }
+        }
+    }
+
+    @Test
+    fun `BEGIN READ ONLY WITH SNAPSHOT_TOKEN is rejected`() {
+        xtdb.connect().use { conn ->
+            assertThrows(Incorrect::class.java) { conn.update("BEGIN READ ONLY WITH (SNAPSHOT_TOKEN = 'tok')") }
+        }
+    }
+
+    @Test
+    fun `empty READ WRITE commit still records a transaction`() {
+        xtdb.connect().use { conn ->
+            val before = conn.select("SELECT count(*) AS c FROM xt.txs").single()["c"] as Long
+            conn.update("BEGIN READ WRITE")
+            conn.update("COMMIT")
+            val after = conn.select("SELECT count(*) AS c FROM xt.txs").single()["c"] as Long
+
+            assertEquals(before + 1, after, "an explicit write tx commits even when empty")
+        }
+    }
 }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -700,9 +700,29 @@ class InProcessAdbcTest {
     }
 
     @Test
-    fun `BEGIN READ WRITE WITH TIMEZONE is rejected`() {
+    fun `BEGIN WITH TIMEZONE sets the tz for the transaction and reverts after`() {
         xtdb.connect().use { conn ->
-            assertThrows(Incorrect::class.java) { conn.update("BEGIN READ WRITE WITH (TIMEZONE = 'America/New_York')") }
+            conn.update("SET TIME ZONE 'Asia/Tokyo'")
+
+            conn.update("BEGIN READ WRITE WITH (TIMEZONE = 'America/New_York')")
+            conn.update("INSERT INTO foo RECORDS {_id: 1, ts: (TIMESTAMP '2020-01-01'::timestamptz)}")
+            conn.update("COMMIT")
+
+            assertEquals(
+                listOf(mapOf("_id" to 1L, "ts" to "2020-01-01T00:00-05:00[America/New_York]")),
+                conn.select("SELECT _id, ts FROM foo").map { mapOf("_id" to it["_id"], "ts" to it["ts"].toString()) },
+                "the DML anchors its zoneless timestamptz in the tx zone, not the session's Asia/Tokyo"
+            )
+            assertEquals(listOf(mapOf("timezone" to "Asia/Tokyo")), conn.select("SHOW timezone"), "reverts after COMMIT")
+
+            conn.update("BEGIN READ ONLY WITH (TIMEZONE = 'America/New_York')")
+            assertEquals(listOf(mapOf("timezone" to "America/New_York")), conn.select("SHOW timezone"))
+            assertEquals(
+                listOf(mapOf("ts" to "2020-01-01T00:00-05:00[America/New_York]")),
+                conn.select("SELECT TIMESTAMP '2020-01-01'::timestamptz ts").map { mapOf("ts" to it["ts"].toString()) }
+            )
+            conn.update("COMMIT")
+            assertEquals(listOf(mapOf("timezone" to "Asia/Tokyo")), conn.select("SHOW timezone"), "reverts after COMMIT")
         }
     }
 

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -6,6 +6,8 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import xtdb.error.Incorrect
@@ -351,6 +353,34 @@ class InProcessAdbcTest {
         xtdb.connect().use { conn ->
             conn.update("SET datestyle = 'ISO'")
             assertEquals(listOf(mapOf("datestyle" to "ISO")), conn.select("SHOW datestyle"))
+        }
+    }
+
+    @Test
+    fun `SHOW latest_submitted_tx reports this connection's own writes`() {
+        xtdb.connect().use { conn ->
+            assertEquals(
+                emptyList<Map<*, *>>(), conn.select("SHOW latest_submitted_tx"),
+                "no rows until this connection has submitted a tx"
+            )
+
+            conn.update("INSERT INTO foo RECORDS {_id: 1}")
+
+            val committed = conn.select("SHOW latest_submitted_tx").single()
+            assertEquals(0L, committed["tx_id"])
+            assertEquals(true, committed["committed"])
+            assertNull(committed["error"])
+            assertNotNull(committed["system_time"])
+            assertNotNull(committed["await_token"])
+
+            // a tx that aborts at index time is still recorded — committed=false with the error populated.
+            // This exercises writing a Throwable into the transit-typed error column.
+            runCatching { conn.update("ASSERT FALSE") }
+
+            val aborted = conn.select("SHOW latest_submitted_tx").single()
+            assertEquals(1L, aborted["tx_id"])
+            assertEquals(false, aborted["committed"])
+            assertNotNull(aborted["error"], "the aborted tx's error surfaces through the transit column")
         }
     }
 


### PR DESCRIPTION
Part of #5132.

## Summary

Brings `Xtdb.Connection` — the connection handle shared by pgwire and ADBC/Flight SQL — to parity on the SQL transaction and session model, exercised through ADBC. Transaction control, access modes, commit options, read-only snapshot isolation, the `SET`/`SHOW` session surface (including `SHOW LATEST_SUBMITTED_TX` and `BEGIN … WITH (TIMEZONE)`), query tracing, and eager expansion of DML to static ops now all live on the connection rather than in pgwire. Reads open through a single gated `openQuery`, so a frontend that drives its own cursor no longer reconstructs the basis/tz/tracer nor re-implements the access-mode gate.

## Context / motivation

The transaction and session logic lived in pgwire (Clojure), so ADBC and Flight SQL clients couldn't open transactions, pin a read snapshot, or issue `SET`/`SHOW` — they could only auto-commit single statements, and even those skipped pgwire's commit-time DML expansion (so a literal UUID `_id` failed where pgwire accepted it).

The broader goal (#5132) is to consolidate *all* transaction state onto the connection, so pgwire becomes pg-protocol-only and both frontends share one implementation. This PR does the ADBC-parity-first half: build the connection's model out to parity with ADBC driving it — which forces it complete and correct — so the eventual pgwire migration is a thin delegation rather than a translation layer. It also unblocks transaction support for ADBC/Flight SQL in its own right.

## Usage

ADBC / Flight SQL clients can now drive the full transaction and session surface as SQL (via `executeUpdate` / `executeQuery`), alongside the programmatic `setAutoCommit` / `commit` / `rollback`:

\`\`\`sql
BEGIN READ WRITE WITH (SYSTEM_TIME = TIMESTAMP '2024-01-01Z', ASYNC = true);
INSERT INTO foo RECORDS {_id: 1};
COMMIT;

-- cross-statement snapshot isolation
BEGIN READ ONLY WITH (SNAPSHOT_TOKEN = '…');   -- or SNAPSHOT_TIME / CLOCK_TIME; a bare BEGIN READ ONLY auto-pins
SELECT ...;   -- every read in the transaction sees one consistent snapshot
COMMIT;

BEGIN READ WRITE WITH (TIMEZONE = 'America/New_York');   -- tz for this transaction only
SET TIME ZONE 'America/New_York';   -- session tz; transactional (reverted on ROLLBACK)
SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;
SHOW AWAIT_TOKEN;
SHOW LATEST_SUBMITTED_TX;   -- this connection's own last write
\`\`\`

## Changes (reading order)

1. \`docs(tx)\` — the connection transaction-model spec (\`tx.allium\`).
2. \`feat(adbc)\` — drive \`BEGIN\` / \`COMMIT\` / \`ROLLBACK\` (with access mode and commit options) as SQL on the connection.
3. \`feat(adbc)\` — reject queries in a write transaction; resolve a bare \`BEGIN\` to read-only on its first query.
4. \`refactor(database)\` — a Kotlin time-basis token and \`Catalog.snapshotToken()\` (groundwork for begin-time snapshots).
5. \`feat(adbc)\` — pin a read basis for \`READ ONLY\` transactions (snapshot isolation).
6. \`feat(adbc)\` — answer the session \`SET\` / \`SHOW\` surface on the connection.
7. \`feat(adbc)\` — eager-expand connection DML to core tx-ops (\`INSERT\`/\`PATCH RECORDS\` → \`PutDocs\`/\`PatchDocs\`) through a \`SqlPlanner.toStaticOps\` adapter over the (now \`RelationReader\`-based) \`sql->static-ops\`, matching pgwire's commit-time expansion.
8. \`feat(adbc)\` — answer \`SHOW LATEST_SUBMITTED_TX\` from the connection's own last-write record (tx-id / system-time / committed / error / await-token).
9. \`feat(adbc)\` — set the transaction time zone via \`BEGIN … WITH (TIMEZONE = …)\`; tx-scoped, so the session tz is restored after the transaction, while a mid-transaction \`SET TIME ZONE\` persists on \`COMMIT\`.
10. \`feat(adbc)\` — expose the connection's default access mode (frontend introspection).
11. \`feat(adbc)\` — the connection owns query tracing: the node resolves the (config-gated) query-tracer once and hands it to every connection, so tracing follows the node's config uniformly across frontends. Previously only pgwire threaded it, so ADBC/Flight never traced.
12. \`refactor(adbc)\` — fold the read access-mode gate into \`openQuery\`; \`resolveForQuery\` and \`queryOpts\` go private, reached only through it.
13. \`feat(adbc)\` — expose \`openUncheckedQuery\`, the one sanctioned ungated read (a frontend's driver-compatibility probe, e.g. pgjdbc's type-metadata query issued mid-write-tx).

## Implementation notes

Transaction control is expressed as SQL and classified by the shared \`SqlParser\` / \`ParsedStatement\` (the same path pgwire will delegate through). A \`ReadWrite\` transaction is write-only (queries rejected) and a \`ReadOnly\` one is read-only (DML rejected), matching XTDB's existing pgwire semantics; a bare \`BEGIN\` resolves on its first statement.

A read-only transaction pins a begin-time basis — a snapshot token plus the current-time — so every read in it observes one consistent snapshot (hence the Kotlin time-basis token and a \`Clock\` on the connection); \`READ ONLY WITH (...)\` overrides the auto-pin.

**Session surface.** \`SHOW AWAIT_TOKEN\` / \`SHOW LATEST_SUBMITTED_TX\` / \`SHOW <param>\` are answered from connection state via a small in-memory result cursor, ahead of the access-mode gate (SHOW is valid in any transaction). \`SET TIME ZONE\` is transactional — reverted on \`ROLLBACK\`, kept on \`COMMIT\`, rejected once a write transaction has buffered ops; \`BEGIN … WITH (TIMEZONE)\` overrides the zone for that transaction only. The model is captured in \`tx.allium\`.

**DML expansion.** DML is eager-expanded to core tx-ops before submit — the way pgwire expands at commit — rather than submitted as a raw \`Sql\` op for index-time expansion: \`INSERT\` / \`PATCH RECORDS\` become \`PutDocs\` / \`PatchDocs\`, which coerces literal ids (a UUID \`_id\` round-trips, where the raw path failed at index time as \`Invalid ID type: [B\`) and surfaces planner-style errors; a non-expandable statement (\`DELETE\` / \`UPDATE\`) keeps its raw \`Sql\` op. \`expandStaticOps\` applies \`SqlPlanner.toStaticOps\` at both submit sites — the commit-buffer drain and the autocommit single op — closing each buffered op exactly once.

**Query open + tracing.** Reads open through \`openQuery(pq, args)\`: it resolves the tx access mode and basis, then opens at the connection's basis, tz and tracer. Every read routes through it (\`executeQuery\`, \`getObjects\`), so \`resolveForQuery\` and \`queryOpts\` are private — a caller reconstructs neither the \`QueryOpts\` nor the gate. \`openUncheckedQuery\` is the lone bypass, for driver-compat probes that must run in any transaction. Query tracing moved off pgwire: the node resolves the gated tracer and the connection threads it into every read's \`QueryOpts\`, so ADBC/Flight now trace when query-tracing is enabled. This is the read surface the pgwire flip will drive.

## Out of scope (follow-ups)

- **Connection \`user\` / authn** — its own increment. ADBC's parameter-less \`connect()\` can't supply a user, so pgwire will populate it at the handshake (threaded into \`TxOpts.user\` and authz).
- **pgwire wholesale flip** — route pgwire's statement dispatch and reads/writes through the connection (\`openQuery\` / \`openUncheckedQuery\` / \`executeDml\` / \`begin*\` / \`commitTx\`), reducing it to a protocol shim. pgwire's \`verify-permissibility\` keeps only the read-only-*server* rule (a pgwire deployment property, not connection state) and the pgjdbc carve-out (routed through \`openUncheckedQuery\`). The node's Clojure \`snapshot-token\` de-dupes onto \`Catalog.snapshotToken()\` then.

## Test plan

\`InProcessAdbcTest\` (transaction control, access-mode, snapshot isolation, session surface, static-ops expansion, tz), \`FlightSqlAdbcTest\`, \`ConnectionTest\`, \`AdbcTest\`; the \`pgwire\` and \`sql\` suites as a no-regression oracle (the \`pg2_test/test-transit-id-formats\` id-format gate included); full \`./gradlew test\`, no reflection/boxed-math warnings. \`allium check\` clean.