### PR TITLE
refactor(sql): extract SQL expression evaluation into a SqlPlanner SPI

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -50,7 +50,7 @@
            xtdb.JsonSerde
            xtdb.JsonLdSerde
            xtdb.NodeBase
-           (xtdb.query PreparedQuery QueryOpts SqlParser
+           (xtdb.query PreparedQuery QueryOpts SqlParser SqlPlanner
                        ParsedStatement ParsedStatement$Visitor ParsedStatement$TxOptions
                        ParsedStatement$Query ParsedStatement$Dml ParsedStatement$ShowVariable
                        ParsedStatement$CopyIn ParsedStatement$Execute)
@@ -73,7 +73,9 @@
 
                    server-state
 
-                   ^Authenticator authn]
+                   ^Authenticator authn
+
+                   ^SqlPlanner sql-planner]
   DataSource
   (createConnectionBuilder [_]
     ;; connect back to the interface we actually bound, not a hardcoded
@@ -523,16 +525,6 @@
 
 ;;; server impl
 
-(defn- apply-args [expr args]
-  (if (symbol? expr)
-    (let [args-map (zipmap (map (fn [idx]
-                                  (symbol (str "?_" idx)))
-                                (range))
-                           args)]
-      (or (args-map expr)
-          (throw (pgio/err-protocol-violation (str "missing arg: " expr)))))
-    expr))
-
 (defn- coerce->tz [tz]
   (cond
     (instance? ZoneId tz) tz
@@ -543,37 +535,40 @@
 
     :else (throw (pgio/err-protocol-violation (format "invalid timezone '%s'" (str tz))))))
 
-(defn cmd-begin [{:keys [node conn-state]} tx-opts {:keys [args]}]
-  (swap! conn-state
-         (fn [{:keys [session ^Xtdb$Connection node-conn] :as st}]
-           (let [await-token (if-let [[_ tok] (find tx-opts :await-token)]
-                               (apply-args tok args)
-                               (.getAwaitToken node-conn))
-                 {:keys [^Clock clock]} session]
+(defn cmd-begin [{:keys [node conn-state server]} tx-opts {:keys [args]}]
+  (let [^SqlPlanner planner (:sql-planner server)
+        eval-lit (fn [expr] (.evalLiteral planner expr args))]
+    (swap! conn-state
+           (fn [{:keys [session ^Xtdb$Connection node-conn] :as st}]
+             (let [await-token (if-let [[_ tok] (find tx-opts :await-token)]
+                                 (eval-lit tok)
+                                 (.getAwaitToken node-conn))
+                   {:keys [^Clock clock]} session]
 
-             (when-not (= :read-write (:access-mode tx-opts))
-               (xt-log/await-node node await-token #xt/duration "PT30S"))
+               (when-not (= :read-write (:access-mode tx-opts))
+                 (xt-log/await-node node await-token #xt/duration "PT30S"))
 
-             (-> st
-                 (update :transaction
-                         (fn [{:keys [access-mode]}]
-                           (if access-mode
-                             (throw (pgio/err-protocol-violation "transaction already started"))
+               (-> st
+                   (update :transaction
+                           (fn [{:keys [access-mode]}]
+                             (if access-mode
+                               (throw (pgio/err-protocol-violation "transaction already started"))
 
-                             (-> {:current-time (.instant clock)
-                                  :snapshot-token (xtp/snapshot-token node)
-                                  :default-tz (.getDefaultTz node-conn)
-                                  :implicit? false}
-                                 (into (:characteristics session))
-                                 (into (-> tx-opts
-                                           (update :default-tz #(some-> % (apply-args args) (coerce->tz)))
-                                           (update :system-time #(some-> % (apply-args args) (time/->instant {:default-tz (.getDefaultTz node-conn)})))
-                                           (update :current-time #(some-> % (apply-args args) (time/->instant {:default-tz (.getDefaultTz node-conn)})))
-                                           (update :snapshot-token #(some-> % (apply-args args)))
-                                           (update :snapshot-time #(some-> % (apply-args args)))
-                                           (update :user-metadata #(some-> % (apply-args args)))
-                                           (->> (into {} (filter (comp some? val))))))
-                                 (assoc :await-token await-token))))))))))
+                               (-> {:current-time (.instant clock)
+                                    :snapshot-token (xtp/snapshot-token node)
+                                    :default-tz (.getDefaultTz node-conn)
+                                    :implicit? false}
+                                   (into (:characteristics session))
+                                   (into (-> tx-opts
+                                             (update :default-tz #(some-> % eval-lit (coerce->tz)))
+                                             (update :system-time #(some-> % eval-lit (time/->instant {:default-tz (.getDefaultTz node-conn)})))
+                                             (update :current-time #(some-> % eval-lit (time/->instant {:default-tz (.getDefaultTz node-conn)})))
+                                             (update :snapshot-token #(some-> % eval-lit))
+                                             (update :snapshot-time #(some-> % eval-lit))
+                                             (update :user-metadata #(some-> % eval-lit))
+                                             (update :async? #(some-> % eval-lit boolean))
+                                             (->> (into {} (filter (comp some? val))))))
+                                   (assoc :await-token await-token)))))))))))
 
 (defn close-transaction [{:keys [conn-state] :as conn}]
   (swap! conn-state dissoc :transaction)
@@ -1128,12 +1123,12 @@
   ;; doesn't mean anything to us because we're always serializable
   (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET TRANSACTION"}))
 
-(defn cmd-set-time-zone [conn zone-expr args]
-  (set-time-zone conn (-> zone-expr (sql/plan-expr (sql/->env)) (apply-args args)))
+(defn cmd-set-time-zone [{:keys [server] :as conn} zone-expr args]
+  (set-time-zone conn (.evalLiteral ^SqlPlanner (:sql-planner server) zone-expr args))
   (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET TIME ZONE"}))
 
-(defn cmd-set-await-token [{:keys [conn-state] :as conn} token-expr args]
-  (.setAwaitToken ^Xtdb$Connection (:node-conn @conn-state) (-> token-expr (sql/plan-expr (sql/->env)) (apply-args args)))
+(defn cmd-set-await-token [{:keys [conn-state server] :as conn} token-expr args]
+  (.setAwaitToken ^Xtdb$Connection (:node-conn @conn-state) (.evalLiteral ^SqlPlanner (:sql-planner server) token-expr args))
   (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "SET AWAIT_TOKEN"}))
 
 (defn cmd-set-session-characteristics [{:keys [conn-state] :as conn} session-characteristics]
@@ -1333,21 +1328,19 @@
         (throw error)))))
 
 (defn- ->tx-opts-map [^ParsedStatement$TxOptions tx-opts]
-  ;; resolve a parsed Begin's options into the map cmd-begin consumes (planned exprs; cmd-begin apply-args + coerces)
-  (let [env (sql/->env)
-        pe (fn [expr] (some-> expr (sql/plan-expr env)))]
-    (cond-> {}
-      (.getAccessMode tx-opts) (assoc :access-mode (case (str (.getAccessMode tx-opts))
-                                                     "READ_ONLY" :read-only
-                                                     "READ_WRITE" :read-write))
-      (.getSystemTime tx-opts) (assoc :system-time (pe (.getSystemTime tx-opts)))
-      (.getSnapshotToken tx-opts) (assoc :snapshot-token (pe (.getSnapshotToken tx-opts)))
-      (.getSnapshotTime tx-opts) (assoc :snapshot-time (pe (.getSnapshotTime tx-opts)))
-      (.getClockTime tx-opts) (assoc :current-time (pe (.getClockTime tx-opts)))
-      (.getAwaitToken tx-opts) (assoc :await-token (pe (.getAwaitToken tx-opts)))
-      (.getDefaultTz tx-opts) (assoc :default-tz (pe (.getDefaultTz tx-opts)))
-      (.getUserMetadata tx-opts) (assoc :user-metadata (pe (.getUserMetadata tx-opts)))
-      (.getAsync tx-opts) (assoc :async? (boolean (sql/plan-expr (.getAsync tx-opts) env))))))
+  ;; pass the raw expr contexts through; cmd-begin evaluates them via the SqlPlanner and coerces
+  (cond-> {}
+    (.getAccessMode tx-opts) (assoc :access-mode (case (str (.getAccessMode tx-opts))
+                                                   "READ_ONLY" :read-only
+                                                   "READ_WRITE" :read-write))
+    (.getSystemTime tx-opts) (assoc :system-time (.getSystemTime tx-opts))
+    (.getSnapshotToken tx-opts) (assoc :snapshot-token (.getSnapshotToken tx-opts))
+    (.getSnapshotTime tx-opts) (assoc :snapshot-time (.getSnapshotTime tx-opts))
+    (.getClockTime tx-opts) (assoc :current-time (.getClockTime tx-opts))
+    (.getAwaitToken tx-opts) (assoc :await-token (.getAwaitToken tx-opts))
+    (.getDefaultTz tx-opts) (assoc :default-tz (.getDefaultTz tx-opts))
+    (.getUserMetadata tx-opts) (assoc :user-metadata (.getUserMetadata tx-opts))
+    (.getAsync tx-opts) (assoc :async? (.getAsync tx-opts))))
 
 (defn execute-portal [{:keys [conn-state query-timer] :as conn} {:keys [^ParsedStatement parsed canned-response] :as portal}]
   (verify-permissibility conn portal)
@@ -1395,7 +1388,8 @@
                (visitSetTimeZone [_ stmt] (cmd-set-time-zone conn (.getZone stmt) (:args portal)))
                (visitSetAwaitToken [_ stmt] (cmd-set-await-token conn (.getToken stmt) (:args portal)))
                (visitSetSessionParameter [_ stmt]
-                 (cmd-set-session-parameter conn (.getName stmt) (sql/plan-expr (.getValue stmt) (sql/->env))))
+                 (cmd-set-session-parameter conn (.getName stmt)
+                                            (.evalLiteral ^SqlPlanner (-> conn :server :sql-planner) (.getValue stmt) nil)))
                (visitSetRole [_ _] nil)
 
                (visitCopyIn [_ stmt]
@@ -1818,6 +1812,7 @@
            server (map->Server {:allocator allocator
                                 :node node
                                 :authn (authn/<-node node)
+                                :sql-planner (sql/->sql-planner)
                                 :host host
                                 :port port
                                 :read-only? read-only?

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -25,6 +25,7 @@
            (org.antlr.v4.runtime ParserRuleContext)
            (org.apache.arrow.vector.types.pojo Field)
            (org.apache.commons.codec.binary Hex)
+           xtdb.query.SqlPlanner
            (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
            xtdb.table.TableRef
            xtdb.util.StringUtil))
@@ -3408,6 +3409,19 @@
 (defn plan-expr
   ([sql] (plan-expr sql {}))
   ([sql opts] (-plan-expr sql opts)))
+
+(defn- apply-args [expr args]
+  (if (symbol? expr)
+    (let [args-map (zipmap (map (fn [idx] (symbol (str "?_" idx))) (range)) args)]
+      (or (args-map expr)
+          (throw (err/incorrect :xtdb/missing-arg (str "missing arg: " expr) {}))))
+    expr))
+
+(defn ->sql-planner ^SqlPlanner []
+  (reify SqlPlanner
+    (evalLiteral [_ expr args]
+      (-> (plan-expr expr (->env))
+          (apply-args args)))))
 
 (defprotocol PlanQuery
   (-plan-query [query opts]))

--- a/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
+++ b/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
@@ -1,0 +1,13 @@
+package xtdb.query
+
+import org.antlr.v4.runtime.ParserRuleContext
+
+interface SqlPlanner {
+    /**
+     * Evaluate a standalone SQL expression (a transaction-option or SET value) to its runtime value,
+     * substituting positional params (?_0, ?_1, …) from [args].
+     *
+     * [expr] is the parsed expression context — a `Sql.ExprContext` or `Sql.LiteralContext`.
+     */
+    fun evalLiteral(expr: ParserRuleContext, args: List<*>?): Any?
+}


### PR DESCRIPTION
Part of #5132.

## Summary

Extracts pgwire's inline SQL-expression evaluation into a `SqlPlanner` SPI and migrates pgwire onto it. Behaviour-preserving — a pure refactor.

## Context

pgwire evaluates standalone SQL expressions — a `BEGIN`'s transaction options (`SYSTEM_TIME`, `ASYNC`, …), `SET TIME ZONE` / `SET AWAIT_TOKEN`, `SET <session-param>` — inline, via `sql/plan-expr` plus a private `apply-args`. The next step in the ADBC / Flight SQL transaction work needs that *same* evaluation on the `Xtdb.Connection` (to honour a `BEGIN`'s options), but the connection is Kotlin and shouldn't reach into the Clojure planner via `requiring-resolve`. So we give it an injectable SPI, and prove the SPI by putting pgwire on it first — landing it independently of the parity work.

## What this PR does

A `SqlPlanner` interface (`xtdb.query`, beside `IQuerySource`) with one method — `evalLiteral(expr, args)` — that plans the expression and substitutes positional params. The Clojure implementation (`xtdb.sql/->sql-planner`) is the existing `plan-expr` + `apply-args`, moved behind the interface. pgwire is migrated to call it at every expression-eval site, and its local `apply-args` removed; the per-server `SqlPlanner` instance is threaded through the connection.

`evalLiteral` takes a `ParserRuleContext` rather than `Sql.ExprContext` because two sites (`ASYNC`, the `SET` session value) pass a `Sql.LiteralContext` — a sibling of `ExprContext` that `plan-expr` already dispatches on.

## Test plan

The pgwire + sql suites are the behaviour oracle — every migrated site (BEGIN-with-options, `SET TIME ZONE` / `AWAIT_TOKEN`, `SET` session params) is exercised. 311/311 green, no reflection or boxed-math warnings. The diff relocates *where* expression-eval lives, not *what* it computes.

## Next

The `Xtdb.Connection` takes a `SqlPlanner` (injected at construction) to evaluate a `BEGIN`'s WITH-clause options — the ADBC transaction-parity work this unblocks.