### PR TITLE
refactor(postgres-source)!: move database from the !Postgres remote onto the source

### DIFF
--- a/modules/postgres-source/src/main/clojure/xtdb/postgres.clj
+++ b/modules/postgres-source/src/main/clojure/xtdb/postgres.clj
@@ -6,5 +6,5 @@
   (:import [xtdb.postgres PostgresRemote$Factory]))
 
 (defmethod remote/->remote-factory ::remote
-  [_ {:keys [host port database username password] :or {port 5432}}]
-  (PostgresRemote$Factory. host port database username password))
+  [_ {:keys [host port username password] :or {port 5432}}]
+  (PostgresRemote$Factory. host port username password))

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresRemote.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresRemote.kt
@@ -9,7 +9,6 @@ import xtdb.api.Remote
 class PostgresRemote(
     val hostname: String,
     val port: Int,
-    val database: String,
     val username: String,
     val password: String,
 ) : Remote {
@@ -21,11 +20,10 @@ class PostgresRemote(
     data class Factory(
         val hostname: String,
         val port: Int = 5432,
-        val database: String,
         val username: String,
         val password: String,
     ) : Remote.Factory<PostgresRemote> {
-        override fun open() = PostgresRemote(hostname, port, database, username, password)
+        override fun open() = PostgresRemote(hostname, port, username, password)
     }
 
     class Registration : Remote.Registration {

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -116,6 +116,7 @@ class PostgresSource(
     @SerialName("!Postgres")
     data class Factory(
         val remote: RemoteAlias,
+        val database: String,
         val slotName: String,
         val publicationName: String,
         val indexer: PgIndexer.Factory = DirectMirror.Factory(),
@@ -143,7 +144,7 @@ class PostgresSource(
                 )
 
             val driver = PgWireDriver(
-                dbName, pg.hostname, pg.port, pg.database, pg.username, pg.password,
+                dbName, pg.hostname, pg.port, database, pg.username, pg.password,
                 slotName, publicationName,
             )
 
@@ -158,6 +159,7 @@ class PostgresSource(
             override fun toProto(factory: Factory): ProtoAny =
                 ProtoAny.pack(postgresSourceConfig {
                     remote = factory.remote
+                    database = factory.database
                     slotName = factory.slotName
                     publicationName = factory.publicationName
                     indexer = PgIndexer.Factory.toProto(factory.indexer)
@@ -167,6 +169,7 @@ class PostgresSource(
                 val config = msg.unpack(PostgresSourceConfig::class.java)
                 return Factory(
                     remote = config.remote,
+                    database = config.database,
                     slotName = config.slotName,
                     publicationName = config.publicationName,
                     // absent on configs persisted before pluggable indexers landed

--- a/modules/postgres-source/src/main/proto/postgres_source.proto
+++ b/modules/postgres-source/src/main/proto/postgres_source.proto
@@ -10,6 +10,7 @@ message PostgresSourceConfig {
     string remote = 1;
     string slot_name = 2;
     string publication_name = 3;
+    string database = 5;
 
     // Carried as Any so the proto stays decoupled from specific indexer config shapes —
     // mirrors KafkaConnectSourceConfig.indexer and DatabaseConfig.external_source.

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
@@ -17,6 +17,7 @@ class PostgresSourceFactoryTest {
     fun `proto round-trips factory`() {
         val original = PostgresSource.Factory(
             remote = "pg",
+            database = "app",
             slotName = "my_slot",
             publicationName = "my_pub",
         )
@@ -24,13 +25,14 @@ class PostgresSourceFactoryTest {
         val restored = protoRoundTrip(original)
 
         assertEquals("pg", restored.remote)
+        assertEquals("app", restored.database)
         assertEquals("my_slot", restored.slotName)
         assertEquals("my_pub", restored.publicationName)
     }
 
     @Test
     fun `indexer defaults to DirectMirror`() {
-        val factory = PostgresSource.Factory(remote = "pg", slotName = "s", publicationName = "p")
+        val factory = PostgresSource.Factory(remote = "pg", database = "app", slotName = "s", publicationName = "p")
         assertTrue(factory.indexer is DirectMirror.Factory)
 
         assertTrue(protoRoundTrip(factory).indexer is DirectMirror.Factory, "survives proto round-trip")
@@ -54,6 +56,7 @@ class PostgresSourceFactoryTest {
         val yaml = """
             externalSource: !Postgres
               remote: pg
+              database: app
               slotName: my_slot
               publicationName: my_pub
         """.trimIndent()
@@ -62,6 +65,7 @@ class PostgresSourceFactoryTest {
         val factory = config.externalSource as PostgresSource.Factory
 
         assertEquals("pg", factory.remote)
+        assertEquals("app", factory.database)
         assertEquals("my_slot", factory.slotName)
         assertEquals("my_pub", factory.publicationName)
     }
@@ -73,7 +77,6 @@ class PostgresSourceFactoryTest {
               pg: !Postgres
                 hostname: pg.prod.internal
                 port: 5433
-                database: app
                 username: xtdb
                 password: secret
         """.trimIndent()
@@ -83,7 +86,6 @@ class PostgresSourceFactoryTest {
 
         assertEquals("pg.prod.internal", remote.hostname)
         assertEquals(5433, remote.port)
-        assertEquals("app", remote.database)
         assertEquals("xtdb", remote.username)
         assertEquals("secret", remote.password)
     }
@@ -94,7 +96,6 @@ class PostgresSourceFactoryTest {
             remotes:
               pg: !Postgres
                 hostname: localhost
-                database: test
                 username: u
                 password: p
         """.trimIndent()
@@ -112,7 +113,6 @@ class PostgresSourceFactoryTest {
             remotes:
               pg: !Postgres
                 hostname: localhost
-                database: db
                 username: u
                 password: p
         """.trimIndent()
@@ -120,6 +120,7 @@ class PostgresSourceFactoryTest {
         val dbYaml = """
             externalSource: !Postgres
               remote: pg
+              database: db
               slotName: s
               publicationName: p
         """.trimIndent()

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIndexerTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIndexerTest.kt
@@ -38,6 +38,7 @@ class PostgresSourceIndexerTest : PostgresSourceTestBase() {
                           path: $cdcLog
                         externalSource: !Postgres
                           remote: pg
+                          database: testdb
                           slotName: $slot
                           publicationName: $pub
                           indexer: !TestReroute

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -96,7 +96,6 @@ class PostgresSourceIntegrationTest {
         remote("pg", PostgresRemote.Factory(
             hostname = pgContainer.host,
             port = pgContainer.getMappedPort(5432),
-            database = pgContainer.databaseName,
             username = pgContainer.username,
             password = pgPassword,
         ))
@@ -119,6 +118,7 @@ class PostgresSourceIntegrationTest {
                           topic: test-replica-${UUID.randomUUID()}
                         externalSource: !Postgres
                           remote: pg
+                          database: testdb
                           slotName: $slotName
                           publicationName: $publicationName
                     $$""".trimIndent()
@@ -148,6 +148,7 @@ class PostgresSourceIntegrationTest {
                           topic: test-replica-${UUID.randomUUID()}
                         externalSource: !Postgres
                           remote: pg
+                          database: testdb
                           slotName: $slotName
                           publicationName: $publicationName
                     $$""".trimIndent()

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceTestBase.kt
@@ -62,7 +62,7 @@ abstract class PostgresSourceTestBase {
         storage(Storage.local(storageDir))
         remote("pg", PostgresRemote.Factory(
             hostname = pg.host, port = pg.firstMappedPort,
-            database = "testdb", username = username, password = password,
+            username = username, password = password,
         ))
     }
 
@@ -78,6 +78,7 @@ abstract class PostgresSourceTestBase {
                           path: $cdcLog
                         externalSource: !Postgres
                           remote: pg
+                          database: testdb
                           slotName: $slot
                           publicationName: $pub
                     $$""".trimIndent()


### PR DESCRIPTION
## Summary

Moves the `database` field off the `!Postgres` remote and onto the `!Postgres` external source, so a single remote can back several sources.

## Motivation

`database` lived on the `!Postgres` remote, which pinned a remote to one upstream database. Two Postgres sources streaming different databases off the same server couldn't share a remote — you had to declare a near-duplicate remote per database, identical but for the `database` line. Hostname, port and credentials are genuinely reusable across sources; the database to replicate is the one part that varies per source, so it moves to where that variation lives.

## Config change

The connection details stay on the remote; the database moves to each source:

```yaml
remotes:
  pg: !Postgres
    hostname: pg.prod.internal
    username: xtdb
    password: secret

# database config
externalSource: !Postgres
  remote: pg
  database: app          # ← was on the remote
  slotName: my_slot
  publicationName: my_pub
```

To adopt: drop `database:` from each `!Postgres` remote under `remotes:`, and add it to each `externalSource: !Postgres` block.

## Breaking change

The `!Postgres` YAML shape is user-facing, hence the `!`.

On the wire, `PostgresSourceConfig` gains `database` as field 5 (1–4 untouched). A config persisted *before* this change has no field 5, so it decodes with `database = ""` and fails at connect time (`jdbc:postgresql://host:port/`). Unlike `indexer` — which back-fills to `!DirectMirror` when absent — `database` has no sensible default, so a loud failure is preferable to silently connecting to the wrong place.

## The counter-argument (why this is an ask)

There's a real case *against* this move: `database` is part of forming the JDBC connection — host, port, credentials **and** database together are what open a session, and without it we can't connect to Postgres at all. By that reading it belongs alongside the other connection parameters on the remote, and the source should only name *what* to stream (slot, publication), not *where*.

The view this PR takes is that the database is the unit a source replicates, not a property of the endpoint: the same server, reachable by one set of credentials, can host many databases, and we want one remote to serve all of them. The connection is still fully specified — it's just assembled from the remote (the reusable endpoint) plus the source (the per-source database) at `open` time, rather than being baked whole into the remote.

That's the judgement I'd like a second opinion on before merging.

## Test plan

- `:modules:xtdb-postgres-source:test` — passes (proto + YAML round-trips assert the field lands on the source).
- `:modules:xtdb-postgres-source:integration-test` — the replication path passes, confirming the database value reaches the real Postgres connection from its new home.
- One reroute test (`PostgresSourceIndexerTest`) is failing/hanging on a known `main` bug unrelated to this change, being fixed separately.
