### PR TITLE
refactor(indexer): extract the leader replica-writer coroutine (#5507)

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -18,10 +18,29 @@
 --     which variant is in play.
 --   - Multiple concurrent readers: snapshots can be held and read concurrently
 --   - Writes don't block reads: a shared, reference-counted snapshot is published
---     after each commit; existing snapshots remain valid until their last holder
---     releases them
+--     after each DURABLE confirmation; existing snapshots remain valid until their
+--     last holder releases them
 --
--- Critical invariant: External queries MUST NOT see in-flight transaction data
+-- Pipelining (leader only):
+--   On a leader, transaction RESOLUTION runs ahead of the replica-log write. A
+--   resolved, committed tx is applied to a STAGING index immediately (so later
+--   txs in the same stream resolve against it — read-your-writes), advancing the
+--   staging area's own APPLIED head (StagingIndex.latest_completed_tx). It is
+--   NOT yet visible to external queries. Only once its batch is confirmed durably
+--   written to the replica log is it PROMOTED into the durable live tables,
+--   advancing the DURABLE basis (LiveIndex.latest_completed_tx), refreshing the
+--   shared external snapshot, and notifying watchers. Followers and the
+--   transition processor have no staging index: the messages they import are
+--   already durable, so they advance LiveIndex.latest_completed_tx directly.
+--
+--   Two heads, two homes — callers choose: the durable basis is
+--   LiveIndex.latest_completed_tx (query basis); the applied/resolution head is
+--   StagingIndex.latest_completed_tx (next tx_id, smoothing).
+--
+-- Critical invariant: External queries see only durably-replicated transactions
+--   (LiveIndex.latest_completed_tx). A query returned to a user must never
+--   include a tx that could vanish if the leader crashed before its replica-log
+--   write landed. Resolution sees durable ⊕ staging.
 
 ------------------------------------------------------------
 -- External Entities
@@ -90,18 +109,84 @@ value Erase { }    -- null marker in the "erase" leg
 ------------------------------------------------------------
 
 entity LiveIndex {
+    -- DURABLE basis / QUERY BASIS: the highest tx in the durable live tables.
+    -- shared_snap is built with basis_tx = latest_completed_tx; external queries
+    -- open at it. On a leader it is advanced by promotion from staging (it lags
+    -- the APPLIED head by the in-flight/staged txs); on a follower/transition by
+    -- importTx (every imported message is already durable, so there is no lag).
+    --
+    -- The APPLIED head (the resolution head — next external-source tx_id is
+    -- head.tx_id + 1, and system-time smoothing reads it) is NOT here: on a
+    -- leader the staging area maintains its own latest_completed_tx (see
+    -- StagingIndex). Callers choose which to read — resolution reads the staging
+    -- head, external queries read this durable one.
     latest_completed_tx: TransactionKey?
+
     rows_per_block: Integer
 
+    -- Durable live tables: hold only promoted (durably-replicated) rows.
     tables: LiveTable with index = this
 
-    -- Current shared external snapshot. Refreshed on every commit and on
-    -- NextBlock (see RefreshSharedSnapshot). External readers retain this
-    -- snapshot when calling OpenSnapshot(index); see OpenExternalSnapshot.
+    -- Staging index: committed-but-not-yet-durable txs. Leader-owned and
+    -- leader-term-scoped (dropped wholesale on demotion; see DropStaging).
+    -- Absent on followers and the transition processor, which only import
+    -- already-durable messages. See StagingIndex.
+    staging: StagingIndex?
+
+    -- Current shared external snapshot. Refreshed on each durable confirmation
+    -- (promotion) and on NextBlock (see RefreshSharedSnapshot). External readers
+    -- retain this snapshot when calling OpenSnapshot(index); see
+    -- OpenExternalSnapshot. Its basis is latest_completed_tx (durable).
     shared_snap: Snapshot
 
     row_count: tables.sum(t => t.row_count)
     is_full: row_count >= rows_per_block
+}
+
+entity StagingIndex {
+    -- Holds committed-but-not-yet-durable transactions, double-buffered into
+    -- exactly two slots. At most one batch is ever in flight to the replica log
+    -- (the producer is single / not concurrent-safe), so two slots is optimal:
+    --   - accumulating: open, taking newly-resolved committed txs
+    --   - committing:   sealed, its batch currently being written to the
+    --                   replica log; promoted on durable confirmation
+    -- Each slot mirrors the live tables (per-table relation + trie) so it
+    -- composes with the snapshot/segment layering as an extra segment layer.
+    index: LiveIndex
+
+    -- APPLIED head: the highest tx resolved and applied to staging. Drives
+    -- RESOLUTION — next external-source tx_id is latest_completed_tx.tx_id + 1,
+    -- and system-time smoothing reads it. Seeded from index.latest_completed_tx
+    -- (the durable head) when the staging area is created, then advanced by
+    -- CommitTransaction / AbortTransaction. Always >= index.latest_completed_tx.
+    latest_completed_tx: TransactionKey?
+
+    accumulating: StagingSlot
+    committing: StagingSlot?   -- absent when no batch is in flight
+
+    -- Derived: staging is drained when nothing is accumulated and nothing is
+    -- in flight. FinishBlock requires this so a durable block never contains
+    -- non-durable rows.
+    is_drained: accumulating.is_empty and committing = null
+}
+
+entity StagingSlot {
+    -- One double-buffer slot. Mirrors the live tables structurally.
+    staging: StagingIndex
+    tables: StagingTable with slot = this
+
+    row_count: tables.sum(t => t.row_count)
+    is_empty: row_count = 0
+}
+
+entity StagingTable {
+    -- Per-table relation + trie within a staging slot. The staged counterpart
+    -- of LiveTable; promoted into the matching LiveTable on durable confirmation.
+    slot: StagingSlot
+    table_ref: TableRef
+    rows: Set<Row>
+
+    row_count: rows.count
 }
 
 entity LiveTable {
@@ -182,14 +267,22 @@ entity TableSnapshot {
     snapshot: Snapshot
     table_ref: TableRef
 
-    -- Live segment: slice of the LiveTable's liveRelation paired with its
-    -- MemoryHashTrie. Absent when the table has no live data at snapshot time.
+    -- Live segment: slice of the LiveTable's (DURABLE) liveRelation paired with
+    -- its MemoryHashTrie. Absent when the table has no durable data at snapshot
+    -- time. This is the only layer on external snapshots.
     live_segment: MemorySegment?
+
+    -- Staging segments: slices of this table's StagingTable relations from each
+    -- occupied staging slot (committing below accumulating), layered on top of
+    -- live_segment. Empty on external snapshots (which see durable data only);
+    -- populated only on transaction snapshots so a resolving tx reads staged
+    -- prior txs. See StagingSegments.for.
+    staging_segments: Set<MemorySegment>
 
     -- Tx segment: slice of the enclosing OpenTx.Table's txRelation paired with
     -- its MemoryHashTrie. Present only on transaction snapshots where the tx
-    -- has written rows for this table. Layered on top of live_segment so that
-    -- a query inside the tx sees committed rows + its own uncommitted rows.
+    -- has written rows for this table. Layered on top of staging_segments so a
+    -- query inside the tx sees durable + staged rows + its own uncommitted rows.
     tx_segment: MemorySegment?
 }
 
@@ -283,63 +376,133 @@ rule LogErase {
 ------------------------------------------------------------
 
 rule CommitTransaction {
+    -- A committed tx is imported into the STAGING accumulating slot and advances
+    -- the staging area's APPLIED head (StagingIndex.latest_completed_tx). It does
+    -- NOT advance the DURABLE basis (LiveIndex.latest_completed_tx) and does NOT
+    -- refresh the external shared snapshot — those happen only on durable
+    -- confirmation (see PromoteStaging). Later txs in the same stream resolve
+    -- against staging (read-your-writes), but external queries cannot yet see it.
     when: CommitTransaction(tx)
 
     requires: tx.status = active
+    -- Staging only exists on a leader; resolution runs there.
+    requires: tx.index.staging != null
 
     ensures: tx.status = committed
-    ensures: tx.index.latest_completed_tx = tx.tx_key
+    ensures: tx.index.staging.latest_completed_tx = tx.tx_key
 
     -- For each touched table with tx data: import the tx rows into the
-    -- (possibly new) live table. There is a single path regardless of
-    -- whether the live table previously existed: `tables.getOrPut` creates
-    -- one on demand, and tables with no tx rows are skipped entirely.
+    -- (possibly new) staging table in the accumulating slot. Single path:
+    -- the staging slot creates a StagingTable on demand, and tables with no tx
+    -- rows are skipped entirely.
     ensures: for table_tx in tx.table_txs where table_tx.rows.count > 0:
-        let live_table =
-            if table_tx.live_table != null:
-                table_tx.live_table
+        let slot = tx.index.staging.accumulating
+        let staging_table =
+            let existing = slot.tables.find(st => st.table_ref = table_tx.table_ref)
+            if existing != null:
+                existing
             else:
-                LiveTable.created(
-                    index: tx.index,
+                StagingTable.created(
+                    slot: slot,
                     table_ref: table_tx.table_ref,
                     rows: {}
                 )
-        live_table.rows.addAll(table_tx.rows)
+        staging_table.rows.addAll(table_tx.rows)
+}
 
-    -- After committing, the shared external snapshot is refreshed to a new
-    -- Snapshot with basis_tx = tx.tx_key. Previously-published shared
-    -- snapshots remain valid for any readers still holding them until those
-    -- readers release their retention.
-    ensures: RefreshSharedSnapshot(tx.index)
+rule SealStagingBatch {
+    -- The replica-writer takes the current batch in flight: the accumulating
+    -- slot is sealed and becomes the committing slot, and a fresh empty slot
+    -- takes over accumulation. Double-buffering means there are only ever two
+    -- slots; this is invoked only when no batch is already in flight (the
+    -- replica-log producer is single, so at most one batch at a time).
+    when: SealStagingBatch(index)
+
+    requires: index.staging != null
+    requires: index.staging.committing = null
+    requires: not index.staging.accumulating.is_empty
+
+    ensures:
+        index.staging.committing = index.staging.accumulating
+        index.staging.accumulating = StagingSlot.created(
+            staging: index.staging,
+            tables: {}
+        )
+}
+
+rule PromoteStaging {
+    -- Durable confirmation: the committing slot's batch has been confirmed
+    -- durably written to the replica log. Promote its rows into the durable
+    -- live tables, advance the DURABLE basis, refresh the external shared
+    -- snapshot (now reflecting the newly-durable txs), and notify watchers.
+    -- This is the point at which committed txs become queryable.
+    -- durable_tx is the highest tx key in the promoted batch.
+    when: PromoteStaging(index, durable_tx)
+
+    requires: index.staging != null
+    requires: index.staging.committing != null
+
+    ensures:
+        -- Move each staged table's rows into the (possibly new) durable live table.
+        for staging_table in index.staging.committing.tables where staging_table.rows.count > 0:
+            let live_table =
+                let existing = index.tables.find(t => t.table_ref = staging_table.table_ref)
+                if existing != null:
+                    existing
+                else:
+                    LiveTable.created(
+                        index: index,
+                        table_ref: staging_table.table_ref,
+                        rows: {}
+                    )
+            live_table.rows.addAll(staging_table.rows)
+
+        -- The committing slot is now empty; drop it (no batch in flight).
+        index.staging.committing = null
+
+        -- Advance the durable basis (the durable live index's own
+        -- latest_completed_tx) and refresh the external snapshot to reflect the
+        -- newly-durable txs.
+        index.latest_completed_tx = durable_tx
+        RefreshSharedSnapshot(index)
+        -- Watcher notification (post-durable, not at resolution time) is driven
+        -- by the replica-writer in db.allium, which orchestrates promotion.
 }
 
 rule AbortTransaction {
     when: AbortTransaction(tx)
 
     requires: tx.status = active
+    -- Staging only exists on a leader; resolution runs there.
+    requires: tx.index.staging != null
 
     ensures: tx.status = aborted
-    -- latest_completed_tx tracks "processed up to", not "successfully committed up to"
-    -- even aborted transactions advance this marker
-    ensures: tx.index.latest_completed_tx = tx.tx_key
-    -- tx rows are discarded (not moved to live tables)
-    -- new tables are not created
+    -- The applied head tracks "resolved up to", not "successfully committed up
+    -- to" — even aborted transactions consume a tx_id and advance the staging
+    -- area's marker, so the next tx_id is correct.
+    ensures: tx.index.staging.latest_completed_tx = tx.tx_key
+    -- tx rows are discarded (not staged); new tables are not created
 }
 
 ------------------------------------------------------------
 -- Rules: Snapshot visibility
 --
--- CRITICAL: External queries must not see in-flight transaction data
+-- CRITICAL: External queries see only DURABLY-REPLICATED transactions
+-- (LiveIndex.latest_completed_tx) — durable live segments only, no staging.
+-- Resolution (queries inside an in-flight tx) sees durable ⊕ staging ⊕ the
+-- tx's own writes.
 ------------------------------------------------------------
 
 rule OpenExternalSnapshot {
     -- Called by queries outside any transaction.
     --
-    -- The index publishes a single shared Snapshot that is refreshed on each
-    -- commit (see CommitTransaction / RefreshSharedSnapshot). Each external
-    -- opener retains the current shared snapshot rather than building a
-    -- fresh one, and releases it on close. The underlying segments are
-    -- freed when the last holder releases.
+    -- The index publishes a single shared Snapshot whose basis is
+    -- latest_completed_tx (durable) and whose layers are the DURABLE live segments only
+    -- — no staging. It is refreshed on each durable confirmation (see
+    -- PromoteStaging / RefreshSharedSnapshot). Each external opener retains
+    -- the current shared snapshot rather than building a fresh one, and
+    -- releases it on close. The underlying segments are freed when the last
+    -- holder releases.
     when: OpenSnapshot(index)
 
     ensures:
@@ -349,45 +512,48 @@ rule OpenExternalSnapshot {
 }
 
 rule OpenTransactionSnapshot {
-    -- Called by queries within a transaction (e.g. UPDATE...WHERE).
-    -- Only active transactions can open snapshots; committed/aborted txs
-    -- are closed. Transaction snapshots are built per-OpenTx and are NOT
-    -- shared: each call produces a fresh Snapshot whose table snapshots
-    -- layer the tx segment on top of the live table segment.
+    -- Called by queries within an in-flight resolving transaction
+    -- (e.g. UPDATE...WHERE). Only active transactions can open snapshots;
+    -- committed/aborted txs are closed. Transaction snapshots are built
+    -- per-OpenTx and are NOT shared.
+    --
+    -- A resolving tx must read all prior txs whether DURABLE or merely STAGED,
+    -- plus its own uncommitted writes. So each TableSnapshot layers, bottom to
+    -- top: the durable live segment ⊕ the staging segments (accumulating, and
+    -- the committing slot if a batch is in flight) ⊕ the tx's own segment.
     when: OpenSnapshot(tx)
 
     requires: tx.status = active
+    -- Resolution only runs on a leader, where staging exists.
+    requires: tx.index.staging != null
 
     ensures:
         let snap = Snapshot.created(basis_tx: tx.tx_key, ref_count: 1)
+        let staging = tx.index.staging
 
-        -- One TableSnapshot per table touched by the tx: live segment from
-        -- the existing LiveTable (if any) plus the tx segment from this
-        -- OpenTx's Table.
+        -- One TableSnapshot per table touched by the tx: durable live segment
+        -- from the existing LiveTable (if any), the staging segments for the
+        -- table from each occupied slot, and the tx segment from this OpenTx.
         for table_tx in tx.table_txs:
+            let live_seg = if table_tx.live_table != null: MemorySegment.for(table_tx.live_table) else: null
+            let tx_seg = if table_tx.rows.count > 0: MemorySegment.for(table_tx) else: null
             TableSnapshot.created(
                 snapshot: snap,
                 table_ref: table_tx.table_ref,
-                live_segment:
-                    if table_tx.live_table != null:
-                        MemorySegment.for(table_tx.live_table)
-                    else:
-                        null,
-                tx_segment:
-                    if table_tx.rows.count > 0:
-                        MemorySegment.for(table_tx)
-                    else:
-                        null
+                live_segment: live_seg,
+                staging_segments: StagingSegments.for(staging, table_tx.table_ref),
+                tx_segment: tx_seg
             )
 
-        -- Plus the remaining live tables the tx hasn't touched: live
-        -- segment only, no tx segment.
+        -- Plus the remaining live tables the tx hasn't touched: durable live
+        -- segment plus any staging segments for the table, no tx segment.
         for table in tx.index.tables
                 where not tx.table_txs.any(tt => tt.table_ref = table.table_ref):
             TableSnapshot.created(
                 snapshot: snap,
                 table_ref: table.table_ref,
                 live_segment: MemorySegment.for(table),
+                staging_segments: StagingSegments.for(staging, table.table_ref),
                 tx_segment: null
             )
 
@@ -395,16 +561,18 @@ rule OpenTransactionSnapshot {
 }
 
 rule RefreshSharedSnapshot {
-    -- Triggered at the end of each commit (and on NextBlock, which drops
-    -- all live tables). The index atomically swaps its shared snapshot for
-    -- a freshly-built one reflecting the new committed state, and releases
-    -- its own retention on the previous shared snapshot. Readers already
-    -- holding the previous shared snapshot retain it independently.
+    -- Triggered on each durable confirmation (promotion) and on NextBlock (which
+    -- drops all live tables). The index atomically swaps its shared snapshot for
+    -- a freshly-built one reflecting the newly-durable state, and releases its
+    -- own retention on the previous shared snapshot. Readers already holding the
+    -- previous shared snapshot retain it independently.
     when: RefreshSharedSnapshot(index)
 
     ensures:
         let old_snap = index.shared_snap
         let new_snap = Snapshot.created(
+            -- DURABLE basis: the external snapshot sees only durably-replicated
+            -- txs, never the staged-but-not-yet-durable head.
             basis_tx: index.latest_completed_tx,
             ref_count: 1   -- the index's own retention on the shared snap
         )
@@ -413,6 +581,8 @@ rule RefreshSharedSnapshot {
                 snapshot: new_snap,
                 table_ref: table.table_ref,
                 live_segment: MemorySegment.for(table),
+                -- External snapshot: durable data only, no staging layers.
+                staging_segments: {},
                 tx_segment: null
             )
         index.shared_snap = new_snap
@@ -428,9 +598,30 @@ rule RefreshSharedSnapshot {
 rule FinishBlock {
     when: FinishBlock(index, block_idx)
 
-    -- Writes current live table contents to block storage
-    -- Rows remain in memory until NextBlock
+    -- Staging MUST be drained before the block is written: all in-flight
+    -- commits promoted, nothing accumulated or committing. Otherwise a durable
+    -- L0 block could contain non-durable rows. ("BlockBoundary closes the
+    -- batch": the replica-writer flushes and promotes the pending batch before
+    -- the boundary, leaving staging drained.) On followers/transition there is
+    -- no staging, so this is trivially satisfied.
+    requires: index.staging = null or index.staging.is_drained
+
+    -- Writes current (durable) live table contents to block storage.
+    -- Rows remain in memory until NextBlock.
     ensures: BlockWritten(index, block_idx)
+}
+
+rule DropStaging {
+    -- Leader → follower demotion: the staging index is discarded wholesale.
+    -- The uncommitted txs it held will be re-read from the source log and
+    -- re-resolved by the next leader. The DURABLE live index is untouched —
+    -- only staged, not-yet-durable rows are lost, and those were never visible
+    -- to external queries.
+    when: DropStaging(index)
+
+    requires: index.staging != null
+
+    ensures: index.staging = null
 }
 
 rule NextBlock {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -147,6 +147,41 @@ class LeaderLogProcessor(
     private val gcCh =
         Channel<GcTask>(onUndeliveredElement = { it.onComplete.cancel() })
 
+    // proc 1 resolves a record into a ReplicaTask and hands it to proc 2 (the replica-writer, sole
+    // owner of `replicaProducer`), then awaits the ack. RENDEZVOUS for now → fully serial, so runtime
+    // behaviour matches the single-loop persister; the seam is here for later batching/pipelining.
+    private sealed interface ReplicaTask {
+        val onApplied: CompletableDeferred<Unit>
+
+        data class ResolvedTx(val resolvedTx: ReplicaMessage.ResolvedTx, val srcMsgId: MessageId?) : ReplicaTask {
+            override val onApplied = CompletableDeferred<Unit>()
+        }
+
+        data class DbOpTx(val resolvedTx: ReplicaMessage.ResolvedTx) : ReplicaTask {
+            override val onApplied = CompletableDeferred<Unit>()
+        }
+
+        data class Forward(val message: ReplicaMessage, val srcMsgId: MessageId) : ReplicaTask {
+            override val onApplied = CompletableDeferred<Unit>()
+        }
+
+        data class FlushBlockFinish(
+            val latestProcessedMsgId: MessageId, val externalSourceToken: ExternalSourceToken?
+        ) : ReplicaTask {
+            override val onApplied = CompletableDeferred<Unit>()
+        }
+
+        data class TriesDeleted(val tableName: TableRef, val trieKeys: Set<TrieKey>) : ReplicaTask {
+            override val onApplied = CompletableDeferred<Unit>()
+        }
+
+        data class NotifyMsg(val msgId: MessageId) : ReplicaTask {
+            override val onApplied = CompletableDeferred<Unit>()
+        }
+    }
+
+    private val replicaCh = Channel<ReplicaTask>(onUndeliveredElement = { it.onApplied.cancel() })
+
     private suspend fun handleSourceLogBatch(records: List<Log.Record<SourceMessage>>) {
         for (record in records) {
             LOG.trace { "[$dbName] leader: message ${record.msgId} (${record.message::class.simpleName})" }
@@ -159,17 +194,16 @@ class LeaderLogProcessor(
 
         when (val msg = record.message) {
             is SourceMessage.Tx, is SourceMessage.LegacyTx ->
-                handleResolvedTx(resolveTx(msgId, record, msg), msgId)
+                dispatch(ReplicaTask.ResolvedTx(resolveTx(msgId, record, msg), msgId))
 
             is SourceMessage.FlushBlock -> {
                 val expectedBlockIdx = msg.expectedBlockIdx
                 if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L)) {
-                    finishBlock(msgId, watchers.externalSourceToken)
+                    dispatch(ReplicaTask.FlushBlockFinish(msgId, watchers.externalSourceToken))
                 } else {
                     // see #5680
-                    appendToReplica(ReplicaMessage.NoOp(srcMsgId = msgId))
+                    dispatch(ReplicaTask.Forward(ReplicaMessage.NoOp(srcMsgId = msgId), msgId))
                 }
-                watchers.notifyMsg(msgId)
             }
 
             is SourceMessage.AttachDatabase -> {
@@ -187,11 +221,7 @@ class LeaderLogProcessor(
                 val resolvedTx = openTx(txKey, null).use { it.commitTx(error).copy(srcMsgId = msgId) }
                     .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
 
-                appendToReplica(resolvedTx)
-                liveIndex.importTx(resolvedTx)
-
-                val result = if (error == null) Committed(txKey) else Aborted(txKey, error)
-                watchers.notifyTx(result, msgId, null)
+                dispatch(ReplicaTask.DbOpTx(resolvedTx))
             }
 
             is SourceMessage.DetachDatabase -> {
@@ -209,11 +239,7 @@ class LeaderLogProcessor(
                 val resolvedTx = openTx(txKey, null).use { it.commitTx(error).copy(srcMsgId = msgId) }
                     .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
 
-                appendToReplica(resolvedTx)
-                liveIndex.importTx(resolvedTx)
-
-                val result = if (error == null) Committed(txKey) else Aborted(txKey, error)
-                watchers.notifyTx(result, msgId, null)
+                dispatch(ReplicaTask.DbOpTx(resolvedTx))
             }
 
             is SourceMessage.TriesAdded -> {
@@ -223,19 +249,30 @@ class LeaderLogProcessor(
                     }
                 }
 
-                appendToReplica(TriesAdded(msg.storageVersion, msg.storageEpoch, msg.tries, sourceMsgId = msgId))
-
-                watchers.notifyMsg(msgId)
+                dispatch(
+                    ReplicaTask.Forward(
+                        TriesAdded(msg.storageVersion, msg.storageEpoch, msg.tries, sourceMsgId = msgId), msgId
+                    )
+                )
             }
 
             // TODO this one's going after 2.2
-            is SourceMessage.BlockUploaded -> {
-                watchers.notifyMsg(msgId)
-            }
+            is SourceMessage.BlockUploaded ->
+                dispatch(ReplicaTask.NotifyMsg(msgId))
         }
     }
 
-    private suspend fun handleResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx, srcMsgId: MessageId?) {
+    // Dispatch a resolved task to proc 2 and await its ack — keeps proc 1 and proc 2 in lock-step
+    // (fully serial) for now. If proc 2 fails applying this task it completes `onApplied` exceptionally,
+    // so the `await` rethrows the cause into proc 1's per-task catch (and any later `send` onto the
+    // now-closed channel throws it too).
+    private suspend fun dispatch(task: ReplicaTask) {
+        replicaCh.send(task)
+        task.onApplied.await()
+    }
+
+    // proc 2: append + import + notify for a source-log/ext-source tx.
+    private suspend fun applyResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx, srcMsgId: MessageId?) {
         val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
         val txResult = if (resolvedTx.committed) Committed(txKey) else Aborted(txKey, resolvedTx.error)
 
@@ -254,6 +291,17 @@ class LeaderLogProcessor(
 
         if (liveIndex.isFull())
             finishBlock(effectiveSrcMsgId, resolvedTx.externalSourceToken)
+    }
+
+    // proc 2: append + import + notify for an attach/detach. No isFull/finishBlock — preserving the
+    // attach/detach asymmetry against `applyResolvedTx`.
+    private suspend fun applyDbOpTx(resolvedTx: ReplicaMessage.ResolvedTx) {
+        appendToReplica(resolvedTx)
+        liveIndex.importTx(resolvedTx)
+
+        val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
+        val result = if (resolvedTx.committed) Committed(txKey) else Aborted(txKey, resolvedTx.error)
+        watchers.notifyTx(result, resolvedTx.txId, null)
     }
 
     private suspend fun handleIndexTx(task: ExtSourceTask.IndexTx) {
@@ -280,16 +328,11 @@ class LeaderLogProcessor(
                 }
             }
 
-            handleResolvedTx(resolvedTx, srcMsgId = null)
+            dispatch(ReplicaTask.ResolvedTx(resolvedTx, srcMsgId = null))
             task.result.complete(writerResult)
         } finally {
             openTx.close()
         }
-    }
-
-    private suspend fun handleTriesDeleted(task: GcTask.TriesDeleted) {
-        appendToReplica(ReplicaMessage.TriesDeleted(task.tableName.schemaAndTable, task.trieKeys))
-        trieCatalog.deleteTries(task.tableName, task.trieKeys)
     }
 
     // Hand the task to the persister and return its completion handle. The caller decides whether to
@@ -357,7 +400,7 @@ class LeaderLogProcessor(
                             when (task) {
                                 is SourceLogTask.Batch -> handleSourceLogBatch(task.records)
                                 is ExtSourceTask.IndexTx -> handleIndexTx(task)
-                                is GcTask.TriesDeleted -> handleTriesDeleted(task)
+                                is GcTask.TriesDeleted -> dispatch(ReplicaTask.TriesDeleted(task.tableName, task.trieKeys))
                             }
                             task.onComplete.complete(Unit)
                         } catch (e: CancellationException) {
@@ -383,6 +426,61 @@ class LeaderLogProcessor(
                     sourceLogCh.close(cause)
                     extSourceCh.close(cause)
                     gcCh.close(cause)
+                }
+            }
+
+            // proc 2: the replica-writer. Sole owner of `replicaProducer` — proc 1 resolves and hands off
+            // here, then awaits the ack. On failure, close `replicaCh` with the cause so proc 1's next
+            // `send` throws it (mirroring how the persister loop closes the source channels).
+            launch {
+                var cause: Throwable? = null
+                try {
+                    for (task in replicaCh) {
+                        try {
+                            when (task) {
+                                is ReplicaTask.ResolvedTx -> applyResolvedTx(task.resolvedTx, task.srcMsgId)
+                                is ReplicaTask.DbOpTx -> applyDbOpTx(task.resolvedTx)
+                                is ReplicaTask.Forward -> {
+                                    appendToReplica(task.message)
+                                    watchers.notifyMsg(task.srcMsgId)
+                                }
+
+                                is ReplicaTask.FlushBlockFinish -> {
+                                    finishBlock(task.latestProcessedMsgId, task.externalSourceToken)
+                                    watchers.notifyMsg(task.latestProcessedMsgId)
+                                }
+
+                                is ReplicaTask.TriesDeleted -> {
+                                    appendToReplica(ReplicaMessage.TriesDeleted(task.tableName.schemaAndTable, task.trieKeys))
+                                    trieCatalog.deleteTries(task.tableName, task.trieKeys)
+                                }
+
+                                is ReplicaTask.NotifyMsg -> watchers.notifyMsg(task.msgId)
+                            }
+                            task.onApplied.complete(Unit)
+                        } catch (e: CancellationException) {
+                            task.onApplied.cancel(e)
+                            throw e
+                        } catch (e: InterruptedException) {
+                            task.onApplied.completeExceptionally(e)
+                            throw e
+                        } catch (e: Interrupted) {
+                            task.onApplied.completeExceptionally(e)
+                            throw e
+                        } catch (e: Throwable) {
+                            // Don't notifyError here: proc 1 awaits onApplied, so completing it
+                            // exceptionally surfaces the failure in the persister loop's own catch,
+                            // which is the single notifyError + source-channel teardown point.
+                            task.onApplied.completeExceptionally(e)
+                            throw e
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    // term cancellation: close the channel without an error cause
+                } catch (t: Throwable) {
+                    cause = t
+                } finally {
+                    replicaCh.close(cause)
                 }
             }
 

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -15,6 +15,24 @@
 -- Leader/follower transitions driven by Kafka consumer group rebalancing (or local log startup).
 -- A single LiveIndex sits outside the processor as shared state.
 -- Leader mode feeds it from source processing; follower mode feeds it from replica processing.
+--
+-- Leader pipelining (see live-index.allium): on a leader, resolution runs ahead
+-- of the replica-log write, modelled as two cooperating processes:
+--   Resolver (proc 1)       — serialises source-log / external-source messages,
+--                             resolves each, writes it to the staging accumulating
+--                             slot (advancing the staging area's own
+--                             latest_completed_tx, the applied head), and hands it
+--                             downstream. No watcher notify here.
+--   Replica-writer (proc 2) — sole owner of the replica-log producer. Seals the
+--                             staged batch, writes it to the replica log; on durable
+--                             confirmation, promotes staging → durable live tables,
+--                             advances the durable LiveIndex.latest_completed_tx,
+--                             refreshes the shared snapshot, and notifies watchers.
+-- A query MUST NEVER see a tx that isn't yet durably on the replica log: external
+-- snapshots open at the durable LiveIndex.latest_completed_tx. The applied head is
+-- the staging area's own latest_completed_tx — callers choose which to read.
+-- Followers/transition have no staging — they import already-durable replica
+-- messages straight into the durable live index.
 -- A single Watchers instance tracks both txId and sourceMsgId for client correlation,
 -- plus the latest ExternalSourceToken for external-source databases.
 -- Follower→leader transition sync uses a separate MutableStateFlow on the FollowerProcessor,
@@ -35,6 +53,7 @@ use "./compaction.allium" as compaction
 given {
     database: Database
     log_processor: LogProcessor
+    replica_writer: ReplicaWriter      -- leader-only (proc 2); absent in follower/transition modes
     live_index: LiveIndex              -- shared across leader/follower modes
     watchers: Watchers                 -- single instance: correlates source msg_ids and tx_ids with client futures
     block_catalog: BlockCatalog
@@ -75,8 +94,19 @@ external entity ExternalSource {
 ---- Entities
 
 entity LiveIndex {
-    -- See: indexer/LiveIndex.kt
+    -- See: indexer/LiveIndex.kt, live-index.allium
     -- Single instance shared across leader and follower modes.
+    --
+    -- latest_completed_tx — DURABLE basis / QUERY BASIS: highest tx in the
+    --   durable live tables. External snapshots open at this. On a leader it is
+    --   advanced by promotion from staging; on a follower/transition by importTx.
+    -- The APPLIED/resolution head (next external-source tx_id, system-time
+    --   smoothing) is NOT a field here: on a leader it lives in the staging area
+    --   (the staging area's own latest_completed_tx, see live-index.allium
+    --   StagingIndex), which db.allium does not import and therefore cannot read
+    --   directly. Resolution that needs the next tx key delegates id-assignment to
+    --   the staging layer via beginStagedTx (below); external queries read the
+    --   durable latest_completed_tx.
     latest_completed_tx: TransactionKey?
     is_full: Boolean
 
@@ -161,6 +191,41 @@ variant Transition : LogProcessor {
     -- On BlockBoundary: directly calls blockUploader.uploadBlock() (unlike the
     -- follower, which enters pending mode and waits for BlockUploaded).
     -- See: indexer/TransitionLogProcessor.kt
+}
+
+entity ReplicaWriter {
+    -- The leader's replica-writer (proc 2): sole owner of the replica-log
+    -- transactional producer and the staging area's write lifecycle. Exists only
+    -- on a leader (client-driven Leader or ExternalSourceLeader); followers and
+    -- the transition processor have no staging and no writer.
+    -- See: indexer/LeaderLogProcessor.kt (replica-write half), live-index.allium.
+    --
+    -- A STATE STORE, not a state machine. It owns the staging area (whose
+    -- structure lives under LiveIndex in live-index.allium so the resolution
+    -- snapshots can see it) and the replica producer; it has no idle/committing
+    -- FSM. The "one batch in flight at a time" property comes from the
+    -- single-threaded proviso below, not from a modelled state.
+    --
+    -- SINGLE-THREADED (like the live-index single-writer thread): the writer
+    -- handles one event to completion before the next. So a batch is sealed,
+    -- durably written, awaited, and promoted within a single event-handling —
+    -- there is never a second batch in flight, and any txs the resolver stages
+    -- meanwhile simply coalesce into the next batch. This is the proviso that
+    -- replaces the FSM gate.
+    --
+    -- Both the client-driven leader and the external-source leader share this one
+    -- writer: the resolved txs in a batch carry their own external_source_token
+    -- (null for the client-driven leader, the LSN for an external source), so the
+    -- writer threads whatever the batch carries.
+    --
+    -- The in-flight batch and the staging slots are reached only via opaque
+    -- live_index calls — db.allium does not `use` live-index.allium, so it cannot
+    -- name StagingSlot directly.
+
+    -- Highest replica-log message id this writer has durably written.
+    -- Monotonicity (advances, never decreases) is a runtime/temporal property,
+    -- not a single-point-in-time invariant — documented here, not asserted.
+    latest_replica_msg_id: MessageId
 }
 
 entity BlockCatalog {
@@ -561,6 +626,13 @@ rule TransitionToLeader {
         log_processor.mode = Leader
         log_processor.start(source_resume, after_replica_msg_id: replay_target)
 
+        -- Stand up the replica-writer (proc 2) for this leader term, owning the
+        -- transactional producer opened above. It is torn down on revocation
+        -- (TransitionToFollower drops staging).
+        ReplicaWriter.created(
+            latest_replica_msg_id: replay_target
+        )
+
     @guidance
         -- ReplayEquivalence: the live index state after transition is identical
         -- regardless of how much work the follower had already done.
@@ -576,6 +648,12 @@ rule TransitionToFollower {
         -- Capture the leader's positions and pending block before switching.
         let leader = log_processor as Leader
         leader.close()
+
+        -- Drop the leader-term-scoped staging index wholesale: any staged-but-
+        -- not-yet-durable txs are discarded (they were never visible to external
+        -- queries) and will be re-read from the source log and re-resolved by the
+        -- next leader. The durable live index is untouched (live-index DropStaging).
+        live_index.dropStaging()
 
         -- The leader's pending_block is passed to the new follower.
         -- If the leader was mid-block-flush when revoked (between BlockBoundary
@@ -624,13 +702,17 @@ rule ClientSubmitsTransactionToExternalSourceDb {
         )
 }
 
----- Rules: Leader Mode (source processing)
+---- Rules: Leader Mode — Resolver (proc 1, source processing)
 
--- The leader subscribes to the source log.
--- It resolves each message and writes the result to the replica log.
--- Feeds the shared live_index directly.
--- At the start of each processRecords batch, the leader checks the block
--- flush timeout via BlockFlusher.
+-- The leader subscribes to the source log. The RESOLVER resolves each message
+-- and writes the result to the STAGING accumulating slot (live_index.applyToStaging),
+-- advancing the staging area's own latest_completed_tx (the applied head). It does
+-- NOT write to the replica log and does NOT notify watchers — those are the replica-writer's job
+-- (proc 2). It then wakes the writer with StagedTxReady (a bare signal — the writer
+-- seals whatever staging holds, not a specific tx). Resolution runs AHEAD of the
+-- durable write: later txs resolve against staging.
+-- At the start of each processRecords batch, the leader checks the block flush
+-- timeout via BlockFlusher.
 
 rule LeaderProcessesTx {
     when: msg: TxMessage consumed from database.source_log
@@ -639,19 +721,15 @@ rule LeaderProcessesTx {
     requires: msg.msg_id > log_processor.latest_source_msg_id
 
     ensures:
+        -- Resolve and apply to staging (advances latest_completed_tx).
         let resolved = IndexTransaction(msg)
-        ResolvedTxMessage.created(
-            tx_id: msg.msg_id,
-            committed: resolved.committed,
-            db_op: resolved.db_op,
-            external_source_token: null
-        ) appended to database.replica_log
-
-        watchers.notifyTx(resolved.result, msg.msg_id, null)
+        live_index.applyToStaging(resolved)
         log_processor.latest_source_msg_id = msg.msg_id
 
-        if live_index.is_full:
-            LeaderFinishesBlock(msg.msg_id)
+        -- Hand downstream to the replica-writer (proc 2). No replica-log write
+        -- and no watcher notify here.
+        -- Wake the replica-writer; it seals whatever staging now holds.
+        StagedTxReady(database)
 }
 
 rule LeaderProcessesAttachDb {
@@ -662,15 +740,11 @@ rule LeaderProcessesAttachDb {
 
     ensures:
         let resolved = ResolveAttach(msg)
-        ResolvedTxMessage.created(
-            tx_id: msg.msg_id,
-            committed: resolved.committed,
-            db_op: resolved.db_op,
-            external_source_token: null
-        ) appended to database.replica_log
-
-        watchers.notifyTx(resolved.result, msg.msg_id, null)
+        live_index.applyToStaging(resolved)
         log_processor.latest_source_msg_id = msg.msg_id
+
+        -- Wake the replica-writer; it seals whatever staging now holds.
+        StagedTxReady(database)
 }
 
 rule LeaderProcessesDetachDb {
@@ -681,18 +755,92 @@ rule LeaderProcessesDetachDb {
 
     ensures:
         let resolved = ResolveDetach(msg)
-        ResolvedTxMessage.created(
-            tx_id: msg.msg_id,
-            committed: resolved.committed,
-            db_op: resolved.db_op,
-            external_source_token: null
-        ) appended to database.replica_log
-
-        watchers.notifyTx(resolved.result, msg.msg_id, null)
+        live_index.applyToStaging(resolved)
         log_processor.latest_source_msg_id = msg.msg_id
+
+        -- Wake the replica-writer; it seals whatever staging now holds.
+        StagedTxReady(database)
+}
+
+---- Rules: Leader Mode — Replica-writer (proc 2, durable write + promotion)
+
+-- The REPLICA-WRITER (entity ReplicaWriter, proc 2) is the sole owner of the
+-- replica-log transactional producer and the staging area's write lifecycle. It
+-- is SINGLE-THREADED, not a state machine: each event is handled to completion
+-- before the next, so a batch is sealed, durably written, awaited, and promoted
+-- within one handling — there is never a second batch in flight, and txs the
+-- resolver stages meanwhile coalesce into the next batch.
+--
+-- Both the client-driven leader and the external-source leader use this one
+-- writer. The resolved txs in a batch carry their own external_source_token (null
+-- for the client-driven leader, the LSN for an external source); the writer
+-- threads whatever the batch carries — there is no separate external-source
+-- variant of the writer.
+--
+-- Handoff: the resolver emits StagedTxReady as it stages txs; the writer coalesces
+-- whatever has accumulated into one batch when it next handles the signal (the
+-- coalescing policy — batch size / linger — is a pipelining concern below this
+-- contract-level model). The spec asserts only the ordering and durability
+-- invariants, not the batching mechanics.
+
+rule WriteStagedBatch {
+    -- The writer's event handler. Single-threaded, so this runs start-to-finish
+    -- per batch: seal the staged batch, write its resolved txs durably to the
+    -- replica log, await durable confirmation INLINE (the transactional commit
+    -- ack — not a separate event), promote staging → durable, notify watchers
+    -- POST-DURABLE, and finish the block if the durable live index is now full.
+    --
+    -- The triggering StagedTxReady's per-tx payload is NOT read: the writer seals
+    -- whatever the staging accumulating slot holds (possibly several txs coalesced
+    -- since the last write). resolved_batch is the ordered list of resolved txs in
+    -- the sealed slot, each carrying its own external_source_token (null for the
+    -- client-driven leader). durable_tx is the highest tx key in the batch;
+    -- durable_token is the token as of its last tx.
+    when: StagedTxReady(database)
+
+    requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
+
+    ensures:
+        -- Seal the accumulating slot into the committing slot (double-buffer) and
+        -- take the batch.
+        let resolved_batch = live_index.sealStagingBatch()
+        let durable_tx = resolved_batch.last.tx_key
+        let durable_token = resolved_batch.last.external_source_token
+
+        -- Write each resolved tx to the replica log via the transactional producer
+        -- and await durable confirmation inline. WriteResolvedToReplica builds the
+        -- per-tx ResolvedTxMessage (incl. the abort-error projection and the tx's
+        -- own external_source_token).
+        for resolved in resolved_batch:
+            WriteResolvedToReplica(database, resolved)
+
+        -- Durable: promote staging → durable, advancing the durable basis and
+        -- refreshing the external snapshot (live-index PromoteStaging).
+        live_index.promoteStaging(durable_tx)
+
+        -- Notify watchers POST-DURABLE, threading each tx's own external_source_token
+        -- so restarts can resume the external source.
+        for resolved in resolved_batch:
+            watchers.notifyTx(resolved.result, resolved.tx_key.tx_id, resolved.external_source_token)
+
+        replica_writer.latest_replica_msg_id = durable_tx.tx_id
+
+        -- BlockBoundary closes the batch: finish the block once durable and full,
+        -- by which point staging is drained (see live-index FinishBlock). An
+        -- external-source batch carries a non-null token and finishes via
+        -- ExternalSourceFinishesBlock so it is persisted in the Block; the
+        -- client-driven leader carries null and finishes via LeaderFinishesBlock.
+        if live_index.is_full:
+            if durable_token != null:
+                ExternalSourceFinishesBlock(durable_tx.tx_id, durable_token)
+            else:
+                LeaderFinishesBlock(durable_tx.tx_id)
 }
 
 rule LeaderProcessesFlushBlock {
+    -- Source-log coordination message, handled on the resolver thread. Block
+    -- finishing itself is a replica-writer (proc 2) operation: it drains staging
+    -- first (see live-index FinishBlock).
     when: msg: FlushBlockMessage consumed from database.source_log
     requires: log_processor.mode = Leader
 
@@ -712,7 +860,8 @@ rule LeaderProcessesFlushBlock {
 
 rule LeaderProcessesTriesAdded {
     -- L1+ from compactor. The leader needs these in its trie catalog
-    -- for correct partition info at block time, and forwards them to the replica log.
+    -- for correct partition info at block time, and forwards them to the replica
+    -- log (a replica-writer / proc-2 op, since it owns the producer).
     when: msg: TriesAddedMessage consumed from database.source_log
     requires: log_processor.mode = Leader
 
@@ -752,15 +901,19 @@ rule LeaderProcessesBlockUploaded {
 
 ---- Rules: Leader Block Finishing
 
--- The leader finishes blocks via BlockUploader.
+-- The leader finishes blocks via BlockUploader, on the replica-writer (proc 2)
+-- side: by the time we get here the in-flight batch has been promoted and
+-- staging is drained, so the durable block never contains non-durable rows
+-- (see live-index FinishBlock, which requires staging drained).
 -- The leader sets pending_block between writing BlockBoundary and BlockUploaded.
 -- If the leader is revoked during this window, the pending block gets passed
 -- to the follower (see TransitionToFollower).
 --
 -- Double-finish is not possible: LeaderFinishesBlock is fired by either
--- LeaderProcessesTx (when live_index.is_full) or LeaderProcessesFlushBlock.
+-- WriteStagedBatch (when live_index.is_full, post-promotion) or
+-- LeaderProcessesFlushBlock.
 -- These are processed sequentially on the source log subscription thread.
--- If LeaderProcessesTx triggers a flush, it finishes the block and calls
+-- If a batch flush triggers a block finish, it calls
 -- nextBlock() — the live index is no longer full. If a FlushBlock message
 -- arrives later for the same block_index, its CAS (expected_block_idx ==
 -- block_catalog.current_block_index) fails because the block catalog has
@@ -859,34 +1012,33 @@ rule ExternalSourceIndexesTx {
     -- identical for both; they differ only in whether the caller awaits the
     -- result, which is caller-side and below this spec's abstraction level.
     --
-    -- Unlike the client-driven leader, tx_id here is assigned by the
-    -- processor as live_index.latest_completed_tx.tx_id + 1, NOT taken
-    -- from a source-log position. system_time is "smoothed" so it is
-    -- strictly greater than the previous tx's system_time.
+    -- Unlike the client-driven leader, tx_id here is assigned off the STAGING
+    -- head (the staging area's own latest_completed_tx), NOT a source-log
+    -- position and NOT the durable basis. db.allium does not import the staging
+    -- area, so it cannot read that head; id-assignment is delegated to the
+    -- staging layer via live_index.beginStagedTx, which assigns the next tx_id
+    -- (staging-head tx_id + 1), smooths system_time strictly greater than the
+    -- previous tx's, applies the resolved data to staging, and returns the
+    -- assigned TransactionKey. (See live-index.allium BeginStagedTx / deferred
+    -- below.)
     --
     -- The resulting ResolvedTx carries the external_source_token all the way
     -- through watchers, so block boundaries and restarts can resume from it.
+    --
+    -- This is the RESOLVER (proc 1): resolve and apply to staging, then hand
+    -- downstream. The durable replica-log write, promotion and watcher notify are
+    -- done by the replica-writer (proc 2): WriteStagedBatch.
     when: ExternalSourceIndexTx(external_source_token, system_time, writer)
     requires: log_processor.mode = ExternalSourceLeader
 
     ensures:
-        let tx_id = (live_index.latest_completed_tx?.tx_id ?? -1) + 1
-        let resolved_system_time = smooth_system_time(system_time, live_index.latest_completed_tx?.system_time)
-        let result = writer(OpenTx(tx_id, resolved_system_time))
+        -- Delegate id-assignment and the staging apply to the staging layer.
+        -- beginStagedTx assigns tx_id off the staging head, smooths system_time,
+        -- applies the writer's resolved data to staging, and returns the key.
+        let tx_key = live_index.beginStagedTx(system_time, external_source_token, writer)
 
-        ResolvedTxMessage.created(
-            tx_id: tx_id,
-            system_time: resolved_system_time,
-            committed: result is Committed,
-            error: (result as Aborted)?.error,
-            db_op: null,
-            external_source_token: external_source_token
-        ) appended to database.replica_log
-
-        watchers.notifyTx(result, log_processor.latest_source_msg_id, external_source_token)
-
-        if live_index.is_full:
-            ExternalSourceFinishesBlock(log_processor.latest_source_msg_id, external_source_token)
+        -- Wake the replica-writer; it seals whatever staging now holds.
+        StagedTxReady(database)
 }
 
 rule ExternalSourceProcessesFlushBlock {
@@ -946,7 +1098,9 @@ rule ExternalSourceFinishesBlock {
     -- Mirror of LeaderFinishesBlock for the external-source leader. The
     -- BlockBoundary and the persisted Block both carry the
     -- external_source_token so that a restart can resume the external source
-    -- from the last durably persisted position.
+    -- from the last durably persisted position. Driven by the replica-writer
+    -- (proc 2) after the in-flight batch is promoted, so staging is drained
+    -- before the block is written.
     when: ExternalSourceFinishesBlock(latest_processed_msg_id, external_source_token)
 
     let block_index = (block_catalog.current_block_index ?? -1) + 1
@@ -1179,6 +1333,9 @@ rule CompactionJobConfirmed {
 ---- Rules: Query Serving
 
 rule ClientOpensSnapshot {
+    -- External queries open at the DURABLE basis: latest_completed_tx, never the
+    -- staged-but-not-yet-durable applied head. A query must never see a tx that
+    -- could vanish if the leader crashed before its replica-log write landed.
     when: ClientOpensSnapshot(client, database)
 
     ensures:
@@ -1231,7 +1388,9 @@ surface QueryAccess {
 
     @guarantee SnapshotIsolation
         -- A snapshot sees a consistent point-in-time view.
-        -- It includes all transactions up to latest_completed_tx.
+        -- It includes all transactions up to latest_completed_tx — durably-
+        -- replicated transactions only. Staged-but-not-yet-durable txs (resolved
+        -- on the leader but not yet confirmed on the replica log) are NOT visible.
 }
 
 ---- Deferred Specifications
@@ -1239,3 +1398,14 @@ surface QueryAccess {
 deferred IndexTransaction           -- transaction resolution (put/delete/erase logic)
 deferred ResolveAttach              -- attach database resolution
 deferred ResolveDetach              -- detach database resolution
+deferred WriteResolvedToReplica     -- builds the per-tx ResolvedTxMessage (incl. abort-error
+                                    -- projection and external_source_token) and appends it to
+                                    -- the replica log via the transactional producer
+deferred BeginStagedTx              -- live_index.beginStagedTx(system_time, token, writer): the
+                                    -- staging layer assigns the next external-source tx_id off the
+                                    -- staging head (head tx_id + 1), smooths system_time strictly
+                                    -- greater than the previous tx's, applies the writer's resolved
+                                    -- data to staging, and returns the assigned TransactionKey.
+                                    -- db.allium delegates here rather than reading the staging head
+                                    -- (which it cannot — it does not use live-index.allium).
+                                    -- See: live-index.allium BeginStagedTx


### PR DESCRIPTION
Part of #5507.

First, deliberately behaviour-preserving increment toward batching and pipelining the leader's replica-log writes. It splits the leader persister into a resolver (proc 1) and a replica-writer (proc 2), and commits the Allium spec for the full target model ahead of the code. No staging, batching or pipelining yet — proc 1 awaits a per-task ack, so runtime behaviour is identical to today.

## Context

The leader runs a single persister coroutine that, per task, resolves a source-log or external-source message and then writes it to the replica log and applies it — imports into the live index, notifies watchers, finishes blocks. That couples transaction resolution (the heavy DML work) to the replica-log commit's latency on one thread, which is what blocks pipelining the commit.

## What's here

Two coroutines under the same term `supervisorScope`:

- **proc 1 (resolver)** — the existing `selectUnbiased` loop over the source-log / external-source / GC channels. It resolves each message into a sealed `ReplicaTask` and hands it to proc 2.
- **proc 2 (replica-writer)** — sole owner of `replicaProducer`. Per task it appends to the replica log and does all the post-append work: import into the live index, notify watchers, `finishBlock`, the trie-GC catalog delete.

proc 1 awaits a unit ack per task over a RENDEZVOUS channel, so the two coroutines stay fully serial. This commit is the seam, not the pipeline.

## Decision rationale

- proc 2 owning the producer is the precondition for batching `withTx` safely in a later increment — `withTx` isn't concurrent-safe.
- Post-append work moves *downstream* of the append rather than handing the assigned replica msg-id back to the resolver. So when the await is later dropped — letting the resolver run ahead of the durable write — nothing about where import / notify / `finishBlock` live has to change.
- The handoff is a sealed `ReplicaTask`, not a closure: the replica-write work is fixed data, and a sealed type lets proc 2 dispatch each kind explicitly (illegal states unrepresentable).
- Errors propagate through the ack — proc 2 completes it exceptionally and closes the channel with the cause, so the resolver's `await` rethrows into its existing per-task catch. That keeps a single `notifyError` + teardown point rather than two.
- The #5741 teardown lock-step holds: the resolver awaits the writer, so both coroutines are quiescent whenever the poll loop re-enters `poll()` (where Kafka runs the rebalance-callback `runBlocking`).

## Allium spec (ahead of code)

This PR also commits the Allium spec for the *full* target model — a leader-owned staging index, a two-homes watermark split (durable / query basis vs. applied head), strict visibility (external queries see durable txs only), and the single-threaded replica-writer. It's the fixed contract the later increments build toward and review against.

Because it models the end state, `weed` reports divergence until those increments land — that's expected. The local `allium` CLI is 3.0.5 and cannot parse the 3.3.0 specs (`main` itself reports ~84-86 errors on them), so the spec was validated as "no new error categories vs. baseline" plus hand-tracing, not a clean check.

## Out of scope (later increments)

Staging index, the two-homes watermark split, dropping the await (the actual pipelining), the double-buffer, and batching. Dropping the await re-opens the #5741 rebalance-callback reconciliation — the headline checkpoint for the pipelining increment.

## Note on commits

The base `test:` commit fixes a pre-existing flake in the `DatabaseCatalogTest` (#5613) design that this branch's CI surfaced — the reattach assertion raced the detach's background teardown. It's landing on `main` independently, so it dedupes here once that merges.

## Test plan

- `./gradlew test` green across the indexer / log / node suites (143/143), behaviour-preserving — existing tests pass unchanged.
- `DatabaseCatalogTest` passes 13/13 under `--rerun-tasks`, confirming the flake fix is deterministic.

Generated with [Claude Code](https://claude.com/claude-code)