### PR TITLE
refactor(connection): encapsulate last-submitted-tx and lock down the await token

### DIFF
--- a/api/src/main/clojure/xtdb/protocols.clj
+++ b/api/src/main/clojure/xtdb/protocols.clj
@@ -5,8 +5,6 @@
   (^java.util.stream.Stream open-sql-query [node ^String query opts])
   (^long submit-tx [node tx-ops tx-opts])
   (^xtdb.api.Xtdb$ExecutedTx execute-tx [node tx-ops tx-opts])
-  (^xtdb.api.Xtdb$ExecutedTx attach-db [node db-name db-config])
-  (^xtdb.api.Xtdb$ExecutedTx detach-db [node db-name])
   (^xtdb.api.Xtdb$Connection open-connection [node db-name]))
 
 (defprotocol PLocalNode

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -189,9 +189,3 @@
 
 (defn send-flush-block-msg! [^Database db]
   (.sendFlushBlockMessage db))
-
-(defn send-attach-db! ^long [^Database primary-db, db-name, db-config]
-  (.getMsgId (.sendAttachDbMessage primary-db db-name db-config)))
-
-(defn send-detach-db! ^long [^Database primary-db, db-name]
-  (.getMsgId (.sendDetachDbMessage primary-db db-name)))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -176,16 +176,6 @@
             (.increment query-error-counter))
           (throw e)))))
 
-  (attach-db [this db-name db-config]
-    (let [primary-db (.getPrimary db-cat)
-          msg-id (xt-log/send-attach-db! primary-db db-name db-config)]
-      (await-msg-result this primary-db msg-id)))
-
-  (detach-db [this db-name]
-    (let [primary-db (.getPrimary db-cat)
-          msg-id (xt-log/send-detach-db! primary-db db-name)]
-      (await-msg-result this primary-db msg-id)))
-
   (open-connection [_ db-name]
     (->node-connection db-cat allocator q-src default-tz tx-error-counter tx-await-timer tx-submit-timer tx-execute-timer db-name))
 

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -39,7 +39,7 @@
            [javax.net.ssl KeyManagerFactory SSLContext]
            (org.apache.arrow.memory BufferAllocator)
            org.apache.arrow.vector.types.pojo.Field
-           (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config Xtdb$Connection Xtdb$ExecutedTx Xtdb$SubmittedTx)
+           (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config Xtdb$Connection Xtdb$ExecutedTx)
            xtdb.api.module.XtdbModule
            (xtdb.arrow Relation Relation$ILoader VectorType)
            xtdb.arrow.RelationReader
@@ -596,19 +596,11 @@
                                                                                  [op])))
                                                                    (util/safe-mapv #(xt-log/open-tx-op % allocator {:default-tz default-tz})))]
                                         (if async?
-                                          (let [^Xtdb$SubmittedTx tx-id (with-auth-check conn
-                                                                          (.submitTx node-conn tx-ops tx-opts))
-                                                msg-id (.getTxId tx-id)]
-                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id}))
+                                          (with-auth-check conn
+                                            (.submitTx node-conn tx-ops tx-opts))
 
                                           (let [^Xtdb$ExecutedTx tx (with-auth-check conn
-                                                                      (.executeTx node-conn tx-ops tx-opts))
-                                                msg-id (.getTxId tx)]
-                                            (swap! conn-state assoc :latest-submitted-tx {:tx-id msg-id
-                                                                                          :system-time (.getSystemTime tx)
-                                                                                          :committed? (.getCommitted tx)
-                                                                                          :error (.getError tx)})
-
+                                                                      (.executeTx node-conn tx-ops tx-opts))]
                                             (when-let [error (.getError tx)]
                                               (throw error))))))))
         (catch Throwable t
@@ -1001,9 +993,10 @@
                                                                                                   :part (int part-idx)
                                                                                                   :msg_id msg-id})]
 
-                                                                   "latest_submitted_tx" (mapv (into {} (assoc (:latest-submitted-tx @conn-state)
-                                                                                                               :await-token await-token))
-                                                                                               [:tx-id :system-time :committed? :error :await-token])
+                                                                   "latest_submitted_tx" (let [lst (.getLastSubmittedTx node-conn)]
+                                                                                           [(some-> lst .getTxId) (some-> lst .getSystemTime)
+                                                                                            (some-> lst .getCommitted) (some-> lst .getError)
+                                                                                            await-token])
                                                                    [(get session-params variable)]))]
 
                        (-> stmt
@@ -1285,7 +1278,7 @@
       (metrics/inc-counter! query-error-counter)
       (throw e))))
 
-(defn- attach-db [{:keys [node conn-state] :as conn} db-name config-yaml sql]
+(defn- attach-db [{:keys [conn-state] :as conn} db-name config-yaml sql]
   (let [default-db (conn-db-name conn)]
     (when-not (= default-db "xtdb")
       (throw (err/incorrect ::attach-db-on-secondary "Can only attach databases when connected to the primary 'xtdb' database."
@@ -1302,14 +1295,11 @@
                                             (str "Invalid database config in `ATTACH DATABASE`: " (ex-message e))
                                             {:sql sql}))))]
     (with-auth-check conn
-      (let [{:keys [tx-id error] :as tx} (xtp/attach-db node db-name db-config)]
-        (.recordTx ^Xtdb$Connection (:node-conn @conn-state) "xtdb" tx-id)
-        (swap! conn-state assoc :latest-submitted-tx tx)
-
-        (when error
+      (let [tx (.attachDb ^Xtdb$Connection (:node-conn @conn-state) db-name db-config)]
+        (when-let [error (.getError tx)]
           (throw error))))))
 
-(defn- detach-db [{:keys [node conn-state] :as conn} db-name]
+(defn- detach-db [{:keys [conn-state] :as conn} db-name]
   (let [default-db (conn-db-name conn)]
     (when-not (= default-db "xtdb")
       (throw (err/incorrect ::detach-db-on-secondary "Can only detach databases when connected to the primary 'xtdb' database."
@@ -1320,11 +1310,8 @@
                           {:db-name db-name})))
 
   (with-auth-check conn
-    (let [{:keys [tx-id error] :as tx} (xtp/detach-db node db-name)]
-      (.recordTx ^Xtdb$Connection (:node-conn @conn-state) "xtdb" tx-id)
-      (swap! conn-state assoc :latest-submitted-tx tx)
-
-      (when error
+    (let [tx (.detachDb ^Xtdb$Connection (:node-conn @conn-state) db-name)]
+      (when-let [error (.getError tx)]
         (throw error)))))
 
 (defn- ->tx-opts-map [^ParsedStatement$TxOptions tx-opts]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -136,8 +136,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         private var _awaitToken: String? = null
 
-        // the accumulated await-token. read-only: it only moves through the write methods (submit / execute /
-        // attach / detach), so it can't be left stale by an out-of-band write.
+        // read-only to the outside: the token advances only through the write methods (submit / execute /
+        // attach / detach), so no other code can leave it stale.
         val awaitToken: String? get() = _awaitToken
 
         // the one sanctioned external writer: pgwire's `SET AWAIT_TOKEN`.
@@ -170,8 +170,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             _awaitToken = mergeTxBasisTokens(_awaitToken, mapOf(dbName to listOf(txId)).encodeTxBasisToken())
         }
 
-        // records a write against [dbName]: advances the token and captures the last-submitted-tx, so the two
-        // always move together. A fire-and-forget submitTx knows only the tx-id; an awaited write the rest.
+        // advances the token and captures the last-submitted-tx in one place, so the two can't drift apart.
         private fun SubmittedTx.record(dbName: DatabaseName): SubmittedTx = also {
             recordTx(dbName, txId)
             lastSubmittedTx = LastSubmittedTx(txId, null, null, null)
@@ -213,10 +212,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 txAwaitTimer.timed { awaitTx(txId) }
             }.record(dbName)
 
-        // attach/detach are primary-database operations: the message goes onto the primary's log and the
-        // resulting tx is awaited and recorded against the primary, independent of the connection's own db.
-        // Routing them through here keeps the await-token in step — there's no out-of-band write path that
-        // could leave it stale.
+        // attach/detach act on the primary database, not the connection's: the message goes onto the primary's
+        // log, and the resulting tx is awaited and recorded against the primary (it.name), not dbName.
         fun attachDb(dbName: DatabaseName, config: Database.Config): ExecutedTx =
             dbCat.primary.let { awaitTx(it.sendAttachDbMessage(dbName, config).msgId, it.name).record(it.name) }
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -134,7 +134,26 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         var dbName: DatabaseName,
     ) : AdbcConnection {
 
-        var awaitToken: String? = null
+        private var _awaitToken: String? = null
+
+        // the accumulated await-token. read-only: it only moves through the write methods (submit / execute /
+        // attach / detach), so it can't be left stale by an out-of-band write.
+        val awaitToken: String? get() = _awaitToken
+
+        // the one sanctioned external writer: pgwire's `SET AWAIT_TOKEN`.
+        fun setAwaitToken(token: String?) { _awaitToken = token }
+
+        // the connection's last write, for `SHOW latest_submitted_tx`. system-time/committed/error are null
+        // for a fire-and-forget submitTx (no await); populated for an awaited execute/attach/detach.
+        data class LastSubmittedTx(
+            val txId: MessageId,
+            val systemTime: Instant?,
+            val committed: Boolean?,
+            val error: Throwable?,
+        )
+
+        var lastSubmittedTx: LastSubmittedTx? = null
+            private set
 
         // how long to wait for this connection's writes to become visible before giving up, shared by every
         // read this connection prepares or snapshots
@@ -147,8 +166,20 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             dbCat.databaseOrNull(dbName)
                 ?: throw Incorrect("Unknown database: $dbName", "xtdb/unknown-db", mapOf("db-name" to dbName))
 
-        fun recordTx(dbName: DatabaseName, txId: MessageId) {
-            awaitToken = mergeTxBasisTokens(awaitToken, mapOf(dbName to listOf(txId)).encodeTxBasisToken())
+        private fun recordTx(dbName: DatabaseName, txId: MessageId) {
+            _awaitToken = mergeTxBasisTokens(_awaitToken, mapOf(dbName to listOf(txId)).encodeTxBasisToken())
+        }
+
+        // records a write against [dbName]: advances the token and captures the last-submitted-tx, so the two
+        // always move together. A fire-and-forget submitTx knows only the tx-id; an awaited write the rest.
+        private fun SubmittedTx.record(dbName: DatabaseName): SubmittedTx = also {
+            recordTx(dbName, txId)
+            lastSubmittedTx = LastSubmittedTx(txId, null, null, null)
+        }
+
+        private fun ExecutedTx.record(dbName: DatabaseName): ExecutedTx = also {
+            recordTx(dbName, txId)
+            lastSubmittedTx = LastSubmittedTx(txId, systemTime, committed, error)
         }
 
         private inline fun <T> Timer?.timed(body: () -> T): T {
@@ -174,13 +205,23 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             }
 
         fun submitTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): SubmittedTx =
-            txSubmitTimer.timed { doSubmit(ops, opts) }.also { recordTx(dbName, it.txId) }
+            txSubmitTimer.timed { doSubmit(ops, opts) }.record(dbName)
 
         fun executeTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): ExecutedTx =
             txExecuteTimer.timed {
                 val txId = doSubmit(ops, opts).txId
                 txAwaitTimer.timed { awaitTx(txId) }
-            }.also { recordTx(dbName, it.txId) }
+            }.record(dbName)
+
+        // attach/detach are primary-database operations: the message goes onto the primary's log and the
+        // resulting tx is awaited and recorded against the primary, independent of the connection's own db.
+        // Routing them through here keeps the await-token in step — there's no out-of-band write path that
+        // could leave it stale.
+        fun attachDb(dbName: DatabaseName, config: Database.Config): ExecutedTx =
+            dbCat.primary.let { awaitTx(it.sendAttachDbMessage(dbName, config).msgId, it.name).record(it.name) }
+
+        fun detachDb(dbName: DatabaseName): ExecutedTx =
+            dbCat.primary.let { awaitTx(it.sendDetachDbMessage(dbName).msgId, it.name).record(it.name) }
 
         private fun TransactionResult.toExecutedTx() =
             ExecutedTx(
@@ -189,14 +230,14 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 (this as? TransactionResult.Aborted)?.error
             )
 
-        private fun awaitTx(txId: MessageId): ExecutedTx {
-            db(dbName).awaitTxBlocking(txId, null)?.let { txRes ->
+        private fun awaitTx(txId: MessageId, awaitDb: DatabaseName = dbName): ExecutedTx {
+            db(awaitDb).awaitTxBlocking(txId, null)?.let { txRes ->
                 if (txRes.txKey.txId == txId) return txRes.toExecutedTx()
             }
 
             return Relation.openFromRows(allocator, listOf(mapOf("?_0" to txId)))
                 .closeOnCatch { args ->
-                    prepareSql("SELECT system_time, committed, error FROM xt.txs FOR ALL VALID_TIME WHERE _id = ?")
+                    prepareSql("SELECT system_time, committed, error FROM xt.txs FOR ALL VALID_TIME WHERE _id = ?", awaitDb)
                         .openQuery(args, QueryOpts(null, defaultTz))
                 }
                 .use { c ->
@@ -214,12 +255,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 }
         }
 
-        fun prepareSql(sql: String): PreparedQuery {
+        fun prepareSql(sql: String, defaultDb: DatabaseName = dbName): PreparedQuery {
             dbCat.awaitAll(awaitToken, awaitTimeout)
             return qSrc.prepareQuery(
                 sql,
                 dbCat,
-                PrepareOpts(defaultTz = defaultTz, defaultDb = dbName, queryText = sql)
+                PrepareOpts(defaultTz = defaultTz, defaultDb = defaultDb, queryText = sql)
             )
         }
 

--- a/src/test/kotlin/xtdb/ConnectionTest.kt
+++ b/src/test/kotlin/xtdb/ConnectionTest.kt
@@ -3,10 +3,12 @@ package xtdb
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
 import xtdb.api.Xtdb
+import xtdb.api.log.Log
 import xtdb.api.log.MessageId
 import xtdb.database.Database
 import xtdb.database.DatabaseName
@@ -19,10 +21,13 @@ class ConnectionTest {
 
     private var nextTxId: MessageId = 0
 
+    private lateinit var db: Database
+    private lateinit var dbCat: Database.Catalog
+
     // components mocked only to feed return values — submitTxBlocking yields the next tx id and
     // awaitTxBlocking returns it committed; the assertions observe the connection's real await-token.
     private fun connection(dbName: DatabaseName): Xtdb.Connection {
-        val db = mockk<Database>()
+        db = mockk()
         every { db.submitTxBlocking(any(), any()) } answers { Xtdb.SubmittedTx(nextTxId) }
         every { db.awaitTxBlocking(any(), any()) } answers {
             TransactionResult.Committed(mockk<TransactionKey> {
@@ -31,8 +36,9 @@ class ConnectionTest {
             })
         }
 
-        val dbCat = mockk<Database.Catalog>(relaxed = true)
+        dbCat = mockk(relaxed = true)
         every { dbCat.databaseOrNull(any()) } returns db
+        every { dbCat.primary } returns db
 
         return Xtdb.Connection(mockk(relaxed = true), dbCat, mockk(relaxed = true), ZoneOffset.UTC, null, null, null, null, dbName)
     }
@@ -81,12 +87,18 @@ class ConnectionTest {
     }
 
     @Test
-    fun `recordTx merges a foreign db without disturbing the connection db - the attach-detach case`() {
+    fun `attachDb merges the primary db without disturbing the connection db`() {
         nextTxId = 2
         val conn = connection("secondary")
-
         conn.submitTx(emptyList())
-        conn.recordTx("xtdb", 5)
+
+        nextTxId = 5
+        every { db.name } returns "xtdb"
+        every { db.sendAttachDbMessage(any(), any()) } returns mockk<Log.MessageMetadata> {
+            every { msgId } returns nextTxId
+        }
+
+        conn.attachDb("attached", Database.Config())
 
         assertEquals(mapOf("secondary" to listOf(2L), "xtdb" to listOf(5L)), tokenOf(conn.awaitToken))
     }
@@ -97,8 +109,36 @@ class ConnectionTest {
         val conn = connection("mydb")
 
         conn.submitTx(emptyList())
-        conn.awaitToken = mapOf("mydb" to listOf(42L)).encodeTxBasisToken()
+        conn.setAwaitToken(mapOf("mydb" to listOf(42L)).encodeTxBasisToken())
 
         assertEquals(mapOf("mydb" to listOf(42L)), tokenOf(conn.awaitToken))
+    }
+
+    @Test
+    fun `executeTx populates the full last-submitted-tx record`() {
+        nextTxId = 13
+        val conn = connection("mydb")
+
+        conn.executeTx(emptyList())
+
+        val last = conn.lastSubmittedTx!!
+        assertEquals(13L, last.txId)
+        assertEquals(Instant.EPOCH, last.systemTime)
+        assertEquals(true, last.committed)
+        assertNull(last.error)
+    }
+
+    @Test
+    fun `submitTx records only the tx-id in last-submitted-tx`() {
+        nextTxId = 17
+        val conn = connection("mydb")
+
+        conn.submitTx(emptyList())
+
+        val last = conn.lastSubmittedTx!!
+        assertEquals(17L, last.txId)
+        assertNull(last.systemTime)
+        assertNull(last.committed)
+        assertNull(last.error)
     }
 }


### PR DESCRIPTION
Closes #5704 (follow-up to #5695, umbrella #5132).

## Background

#5695 extracted per-connection read-your-writes into a connection handle so the invariant held "by construction"; #6f64fdd then collapsed that handle into the nested `Xtdb.Connection`.
Two seams undercut the "by construction" claim:

1. **`recordTx` was public and `awaitToken` a settable `var`.** pgwire's `ATTACH`/`DETACH DATABASE` wrote out-of-band via `xtp/attach-db`/`detach-db` on the node, then had to *remember* to call `.recordTx` by hand — the exact "a callsite can forget" failure the extraction was meant to kill.
2. **`latest-submitted-tx` was duplicated state**, tracked in pgwire's `conn-state` (set in four places, able to drift from the token).

## Change

`Xtdb.Connection` becomes the single owner of "the last write on this connection":

- `awaitToken` is now a read-only `val`; the one sanctioned external writer is `setAwaitToken` (pgwire's `SET AWAIT_TOKEN`). `recordTx` is private.
- The connection holds `lastSubmittedTx` (the richer record), advanced alongside the token by a shared `record` extension so the two always move together. `SHOW latest_submitted_tx` reads it off the handle; the four `swap!`s collapse into the write methods.
- `ATTACH`/`DETACH` route through new `attachDb`/`detachDb` methods that submit to the primary's log and await + record against the primary — no out-of-band write path survives. The now-dead node-level `xtp/attach-db`/`detach-db` and the `send-attach-db!`/`send-detach-db!` log helpers are removed.

Pure encapsulation — no change to await-token semantics or the `SET`/`SHOW AWAIT_TOKEN` SQL surface.

## Code review

Ran a code-review pass over the diff. The one substantive finding (raised independently by 3 finders): `attachDb`/`detachDb` were awaiting against the *connection's* `dbName` rather than the primary they sent to — functionally identical today (pgwire enforces primary-only) but the wrong altitude. Fixed: the await target is now threaded explicitly and derived from `dbCat.primary.name`, so the method is self-correct rather than relying on a caller invariant. Also unified `submitTx`'s token+last-tx update through the same `record` extension.

## Tests

All green, no reflection / boxed-math warnings:

- `xtdb.ConnectionTest` — 8/8 (incl. new `attachDb` and `lastSubmittedTx` coverage)
- `xtdb.pgwire-test` — 148/148 (incl. `test-show-await-token`, `test-show-latest-submitted-tx`, `in-tx-await-token`, `await-token+snapshot-token`)
- `xtdb.sql.multi-db-test` — 16/16 (the end-to-end `ATTACH`/`DETACH` SQL path)
- `xtdb.api.AdbcTest` — 11/11, `xtdb.FlightSqlAdbcTest` — 46/46

> Note: `secondary-node-handles-attach-db-in-shared-log` flaked once under a 229-test `--rerun-tasks` run (timing on a freshly-attached secondary's own-log catch-up, unrelated to this change — it awaits the identical primary attach tx); passes 2/2 in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)