### PR TITLE
feat(indexer): batch the leader's replica-log writes (#5507)

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -21,26 +21,40 @@
 --     after each DURABLE confirmation; existing snapshots remain valid until their
 --     last holder releases them
 --
--- Pipelining (leader only):
---   On a leader, transaction RESOLUTION runs ahead of the replica-log write. A
---   resolved, committed tx is applied to a STAGING index immediately (so later
---   txs in the same stream resolve against it — read-your-writes), advancing the
---   staging area's own APPLIED head (StagingIndex.latest_completed_tx). It is
---   NOT yet visible to external queries. Only once its batch is confirmed durably
---   written to the replica log is it PROMOTED into the durable live tables,
---   advancing the DURABLE basis (LiveIndex.latest_completed_tx), refreshing the
---   shared external snapshot, and notifying watchers. Followers and the
---   transition processor have no staging index: the messages they import are
---   already durable, so they advance LiveIndex.latest_completed_tx directly.
+-- Pipelining (leader only) — resolver-dominion model:
+--   On a leader, transaction RESOLUTION runs ahead of the replica-log write,
+--   modelled as two cooperating processes (see db.allium):
+--     - the RESOLVER owns the STAGING INDEX outright (it is the sole accessor, so
+--       staging needs no lock — single-threaded by construction);
+--     - the REPLICA is a pure writer of the replica-log producer.
+--   A resolved, committed tx is applied to the staging index's `accumulating` slot
+--   immediately (so later txs in the same stream resolve against it —
+--   read-your-writes), advancing the staging index's own APPLIED head
+--   (StagingIndex.latest_completed_tx). It is NOT yet visible to external queries.
+--   Only once its batch is confirmed durably written to the replica log (the
+--   replica posts a persist-result back to the resolver) does the RESOLVER PROMOTE
+--   the `committing` batch into the durable live tables — ONE TX AT A TIME, in
+--   send order — advancing the DURABLE basis (LiveIndex.latest_completed_tx),
+--   refreshing the shared external snapshot, and notifying watchers. Followers
+--   and the transition processor have
+--   no staging index: the messages they import are already durable, so they advance
+--   LiveIndex.latest_completed_tx directly.
 --
 --   Two heads, two homes — callers choose: the durable basis is
 --   LiveIndex.latest_completed_tx (query basis); the applied/resolution head is
 --   StagingIndex.latest_completed_tx (next tx_id, smoothing).
 --
+--   The staging index is NOT a field on LiveIndex. It is standing state the leader
+--   (LeaderLogProcessor) owns from construction and frees in its two-phase close
+--   (see CloseStagingIndex); LiveIndex stays the durable layer and stays
+--   staging-agnostic. Promotion appends into the durable LiveIndex under its
+--   existing write lock.
+--
 -- Critical invariant: External queries see only durably-replicated transactions
 --   (LiveIndex.latest_completed_tx). A query returned to a user must never
 --   include a tx that could vanish if the leader crashed before its replica-log
---   write landed. Resolution sees durable ⊕ staging.
+--   write landed. Resolution sees durable ⊕ committing ⊕ accumulating ⊕ the tx's
+--   own writes.
 
 ------------------------------------------------------------
 -- External Entities
@@ -117,8 +131,9 @@ entity LiveIndex {
     --
     -- The APPLIED head (the resolution head — next external-source tx_id is
     -- head.tx_id + 1, and system-time smoothing reads it) is NOT here: on a
-    -- leader the staging area maintains its own latest_completed_tx (see
-    -- StagingIndex). Callers choose which to read — resolution reads the staging
+    -- leader the resolver-owned staging index maintains its own latest_completed_tx
+    -- (see StagingIndex). LiveIndex is staging-agnostic — it knows only the durable
+    -- layer. Callers choose which head to read — resolution reads the staging
     -- head, external queries read this durable one.
     latest_completed_tx: TransactionKey?
 
@@ -126,12 +141,6 @@ entity LiveIndex {
 
     -- Durable live tables: hold only promoted (durably-replicated) rows.
     tables: LiveTable with index = this
-
-    -- Staging index: committed-but-not-yet-durable txs. Leader-owned and
-    -- leader-term-scoped (dropped wholesale on demotion; see DropStaging).
-    -- Absent on followers and the transition processor, which only import
-    -- already-durable messages. See StagingIndex.
-    staging: StagingIndex?
 
     -- Current shared external snapshot. Refreshed on each durable confirmation
     -- (promotion) and on NextBlock (see RefreshSharedSnapshot). External readers
@@ -144,45 +153,97 @@ entity LiveIndex {
 }
 
 entity StagingIndex {
-    -- Holds committed-but-not-yet-durable transactions, double-buffered into
-    -- exactly two slots. At most one batch is ever in flight to the replica log
-    -- (the producer is single / not concurrent-safe), so two slots is optimal:
+    -- Committed-but-not-yet-durable transactions. NOT a field on LiveIndex: this
+    -- is standing state the leader (LeaderLogProcessor) owns from construction and
+    -- the RESOLVER is the sole accessor of (single-threaded by construction, so it
+    -- needs no lock). Created once per leader term and freed by the leader's
+    -- two-phase close (see CloseStagingIndex); absent on followers and the
+    -- transition processor, which only import already-durable messages.
+    --
+    -- Double-buffered: an open accumulating slot, plus a sealed committing batch.
+    -- At most one batch is ever in flight to the replica log — the resolver enforces
+    -- this via in_flight, not channel capacity — so this is optimal:
     --   - accumulating: open, taking newly-resolved committed txs
-    --   - committing:   sealed, its batch currently being written to the
-    --                   replica log; promoted on durable confirmation
-    -- Each slot mirrors the live tables (per-table relation + trie) so it
-    -- composes with the snapshot/segment layering as an extra segment layer.
+    --   - committing:   the sealed batch currently being written to the replica log,
+    --                   held as an ORDERED SEQUENCE of staged txs (oldest→newest, i.e.
+    --                   send order) so the resolver can promote it ONE TX AT A TIME on
+    --                   the persist-result back-edge (see PromoteNext); empty when no
+    --                   batch is in flight.
+    -- The accumulating slot mirrors the live tables (per-table relation + trie) so it
+    -- composes with the snapshot/segment layering as an extra segment layer; it also
+    -- records its txs' send order (accumulated_txs) so a seal produces the ordered
+    -- committing batch.
+    --
+    -- The durable LiveIndex this staging index pipelines into. The link is one-way:
+    -- the staging index references the index, but the index does not reference the
+    -- staging index (it stays staging-agnostic).
     index: LiveIndex
 
     -- APPLIED head: the highest tx resolved and applied to staging. Drives
     -- RESOLUTION — next external-source tx_id is latest_completed_tx.tx_id + 1,
     -- and system-time smoothing reads it. Seeded from index.latest_completed_tx
-    -- (the durable head) when the staging area is created, then advanced by
+    -- (the durable head) when the staging index is created, then advanced by
     -- CommitTransaction / AbortTransaction. Always >= index.latest_completed_tx.
     latest_completed_tx: TransactionKey?
 
     accumulating: StagingSlot
-    committing: StagingSlot?   -- absent when no batch is in flight
+
+    -- The sealed batch in flight to the replica log: an ordered sequence of staged
+    -- txs, oldest→newest (send order). Empty when no batch is in flight. Promoted
+    -- one tx at a time from the front (see PromoteNext).
+    committing: List<StagedTx>
+
+    -- in_flight is true exactly while a batch is committing (between SealStagingBatch
+    -- and the last PromoteNext). The resolver checks it to enforce at-most-one-batch
+    -- in flight, rather than relying on channel capacity.
+    in_flight: committing.count > 0
 
     -- Derived: staging is drained when nothing is accumulated and nothing is
     -- in flight. FinishBlock requires this so a durable block never contains
     -- non-durable rows.
-    is_drained: accumulating.is_empty and committing = null
+    is_drained: accumulating.is_empty and committing.count = 0
 }
 
 entity StagingSlot {
-    -- One double-buffer slot. Mirrors the live tables structurally.
+    -- The open accumulating slot. Mirrors the live tables structurally (per-table
+    -- relation + trie, for the read-your-writes segment layering) and additionally
+    -- records the send order of the txs applied to it, so a seal produces the
+    -- ordered committing batch.
     staging: StagingIndex
     tables: StagingTable with slot = this
 
+    -- The txs applied to this slot, in send order (oldest→newest). SealStagingBatch
+    -- moves these into the committing sequence.
+    accumulated_txs: List<StagedTx>
+
     row_count: tables.sum(t => t.row_count)
-    is_empty: row_count = 0
+    is_empty: accumulated_txs.count = 0
 }
 
 entity StagingTable {
-    -- Per-table relation + trie within a staging slot. The staged counterpart
+    -- Per-table relation + trie within the accumulating slot. The staged counterpart
     -- of LiveTable; promoted into the matching LiveTable on durable confirmation.
     slot: StagingSlot
+    table_ref: TableRef
+    rows: Set<Row>
+
+    row_count: rows.count
+}
+
+entity StagedTx {
+    -- One resolved, committed tx held in the staging area, retaining its per-table
+    -- rows so PromoteNext can import it into the durable live tables on its own. Once
+    -- sealed into the committing sequence it is promoted (and dropped) one at a time,
+    -- in send order.
+    staging: StagingIndex
+    tx_key: TransactionKey
+    tables: StagedTxTable with staged_tx = this
+}
+
+entity StagedTxTable {
+    -- One tx's rows for one table, imported into the matching durable LiveTable
+    -- when the tx is promoted (see PromoteNext).
+    staged_tx: StagedTx
     table_ref: TableRef
     rows: Set<Row>
 
@@ -200,6 +261,13 @@ entity LiveTable {
 
 entity OpenTx {
     index: LiveIndex
+
+    -- The resolver-owned staging index this tx resolves against. A resolving tx
+    -- reads durable ⊕ committing ⊕ accumulating ⊕ its own writes, so it carries
+    -- the staging index (which the resolver, its sole accessor, hands it). Always
+    -- present: open transactions exist only on a leader, where staging exists.
+    staging: StagingIndex
+
     tx_key: TransactionKey
     status: active | committed | aborted
 
@@ -272,11 +340,14 @@ entity TableSnapshot {
     -- time. This is the only layer on external snapshots.
     live_segment: MemorySegment?
 
-    -- Staging segments: slices of this table's StagingTable relations from each
-    -- occupied staging slot (committing below accumulating), layered on top of
-    -- live_segment. Empty on external snapshots (which see durable data only);
-    -- populated only on transaction snapshots so a resolving tx reads staged
-    -- prior txs. See StagingSegments.for.
+    -- Staging segments: slices of this table's staged rows, layered on top of
+    -- live_segment (committing below accumulating). Two sources, oldest→newest:
+    -- first, from the committing batch, each StagedTx's matching StagedTxTable in
+    -- send order (a just-sealed batch's rows live ONLY here until promoted);
+    -- then, on top, the accumulating slot's StagingTable for this table. Empty on
+    -- external snapshots (which see durable data only); populated only on
+    -- transaction snapshots so a resolving tx reads staged prior txs. See
+    -- StagingSegments.for.
     staging_segments: Set<MemorySegment>
 
     -- Tx segment: slice of the enclosing OpenTx.Table's txRelation paired with
@@ -297,10 +368,15 @@ default ValidTimeRange erase_valid_time = { from: MIN_TIMESTAMP, to: MAX_TIMESTA
 ------------------------------------------------------------
 
 rule StartTransaction {
-    when: StartTransaction(index, tx_key)
+    -- Started by the resolver, which supplies its staging index so the tx can
+    -- resolve against durable ⊕ staging (read-your-writes).
+    when: StartTransaction(index, staging, tx_key)
+
+    requires: staging.index = index
 
     ensures: OpenTx.created(
         index: index,
+        staging: staging,
         tx_key: tx_key,
         status: active
     )
@@ -376,27 +452,28 @@ rule LogErase {
 ------------------------------------------------------------
 
 rule CommitTransaction {
-    -- A committed tx is imported into the STAGING accumulating slot and advances
-    -- the staging area's APPLIED head (StagingIndex.latest_completed_tx). It does
-    -- NOT advance the DURABLE basis (LiveIndex.latest_completed_tx) and does NOT
-    -- refresh the external shared snapshot — those happen only on durable
-    -- confirmation (see PromoteStaging). Later txs in the same stream resolve
-    -- against staging (read-your-writes), but external queries cannot yet see it.
+    -- The resolver imports a committed tx into the STAGING accumulating slot and
+    -- advances the staging index's APPLIED head (StagingIndex.latest_completed_tx).
+    -- It does NOT advance the DURABLE basis (LiveIndex.latest_completed_tx) and
+    -- does NOT refresh the external shared snapshot — those happen only when the
+    -- resolver promotes on the persist-result back-edge (see PromoteNext).
+    -- Later txs in the same stream resolve against staging (read-your-writes),
+    -- but external queries cannot yet see it.
     when: CommitTransaction(tx)
 
     requires: tx.status = active
-    -- Staging only exists on a leader; resolution runs there.
-    requires: tx.index.staging != null
+
+    let staging = tx.staging
 
     ensures: tx.status = committed
-    ensures: tx.index.staging.latest_completed_tx = tx.tx_key
+    ensures: staging.latest_completed_tx = tx.tx_key
 
     -- For each touched table with tx data: import the tx rows into the
     -- (possibly new) staging table in the accumulating slot. Single path:
     -- the staging slot creates a StagingTable on demand, and tables with no tx
     -- rows are skipped entirely.
     ensures: for table_tx in tx.table_txs where table_tx.rows.count > 0:
-        let slot = tx.index.staging.accumulating
+        let slot = staging.accumulating
         let staging_table =
             let existing = slot.tables.find(st => st.table_ref = table_tx.table_ref)
             if existing != null:
@@ -408,79 +485,109 @@ rule CommitTransaction {
                     rows: {}
                 )
         staging_table.rows.addAll(table_tx.rows)
+
+    -- Record the tx in send order, retaining its per-table rows, so SealStagingBatch
+    -- can produce an ordered committing batch that PromoteNext walks one tx at a time.
+    ensures:
+        let staged_tx = StagedTx.created(
+            staging: staging,
+            tx_key: tx.tx_key
+        )
+        for table_tx in tx.table_txs where table_tx.rows.count > 0:
+            StagedTxTable.created(
+                staged_tx: staged_tx,
+                table_ref: table_tx.table_ref,
+                rows: table_tx.rows
+            )
+        staging.accumulating.accumulated_txs.add(staged_tx)
 }
 
 rule SealStagingBatch {
-    -- The replica-writer takes the current batch in flight: the accumulating
-    -- slot is sealed and becomes the committing slot, and a fresh empty slot
-    -- takes over accumulation. Double-buffering means there are only ever two
-    -- slots; this is invoked only when no batch is already in flight (the
-    -- replica-log producer is single, so at most one batch at a time).
-    when: SealStagingBatch(index)
+    -- At a tx boundary the RESOLVER decides to send a batch: the accumulating slot's
+    -- txs are sealed into the committing sequence (in send order), a fresh empty slot
+    -- takes over accumulation, and the sealed batch's bytes are sent to the replica
+    -- (pure writer). Double-buffering means there is only ever the open slot plus the
+    -- one committing batch; the resolver only seals when no batch is already in flight
+    -- (committing empty) and work has accumulated, so at most one batch is in flight
+    -- at a time.
+    when: SealStagingBatch(staging)
 
-    requires: index.staging != null
-    requires: index.staging.committing = null
-    requires: not index.staging.accumulating.is_empty
+    requires: staging.committing.count = 0
+    requires: not staging.accumulating.is_empty
 
     ensures:
-        index.staging.committing = index.staging.accumulating
-        index.staging.accumulating = StagingSlot.created(
-            staging: index.staging,
-            tables: {}
+        -- Seal the accumulated txs into the committing sequence, preserving send
+        -- order so PromoteNext walks them oldest→newest.
+        staging.committing = staging.accumulating.accumulated_txs
+        staging.accumulating = StagingSlot.created(
+            staging: staging,
+            tables: {},
+            accumulated_txs: []
         )
 }
 
-rule PromoteStaging {
-    -- Durable confirmation: the committing slot's batch has been confirmed
-    -- durably written to the replica log. Promote its rows into the durable
-    -- live tables, advance the DURABLE basis, refresh the external shared
-    -- snapshot (now reflecting the newly-durable txs), and notify watchers.
-    -- This is the point at which committed txs become queryable.
-    -- durable_tx is the highest tx key in the promoted batch.
-    when: PromoteStaging(index, durable_tx)
+rule PromoteNext {
+    -- The RESOLVER promotes on the persist-result back-edge, ONE TX AT A TIME in send
+    -- order. It peeks the oldest staged tx in the committing sequence, imports its
+    -- rows into the durable live tables (advancing the durable basis to that tx),
+    -- THEN drops it from committing and closes its OpenTx — import-before-drop is what
+    -- makes a partial failure safe (see below). Refreshing the external shared snapshot
+    -- and notifying watchers happen per promoted tx, driven by the resolver in
+    -- db.allium. This is the point at which a committed tx becomes queryable.
+    --
+    -- Partial-failure safety — the WHY for per-tx: if importing a tx faults partway
+    -- through the batch (e.g. OOM), the txs already promoted are durable in the live
+    -- tables and the durable basis sits at the last tx that ACTUALLY imported; the
+    -- un-imported tail stays parked in committing (freed by CloseStagingIndex, never
+    -- double-closed). A follower resuming from the apply cursor — which db.allium
+    -- advances per promoted tx to that tx's replica-log position — re-applies only the
+    -- un-imported tail and never double-imports the durable prefix. Promoting the whole
+    -- batch atomically would leave the cursor un-advanced after a mid-batch fault, so a
+    -- follower would re-import the durable prefix → duplicate rows / corrupt block.
+    when: PromoteNext(staging)
 
-    requires: index.staging != null
-    requires: index.staging.committing != null
+    requires: staging.committing.count > 0
+
+    let index = staging.index
+    let staged_tx = staging.committing.first
 
     ensures:
-        -- Move each staged table's rows into the (possibly new) durable live table.
-        for staging_table in index.staging.committing.tables where staging_table.rows.count > 0:
+        -- Import this tx's rows into the (possibly new) durable live tables.
+        for staged_table in staged_tx.tables:
             let live_table =
-                let existing = index.tables.find(t => t.table_ref = staging_table.table_ref)
+                let existing = index.tables.find(t => t.table_ref = staged_table.table_ref)
                 if existing != null:
                     existing
                 else:
                     LiveTable.created(
                         index: index,
-                        table_ref: staging_table.table_ref,
+                        table_ref: staged_table.table_ref,
                         rows: {}
                     )
-            live_table.rows.addAll(staging_table.rows)
+            live_table.rows.addAll(staged_table.rows)
 
-        -- The committing slot is now empty; drop it (no batch in flight).
-        index.staging.committing = null
-
-        -- Advance the durable basis (the durable live index's own
-        -- latest_completed_tx) and refresh the external snapshot to reflect the
-        -- newly-durable txs.
-        index.latest_completed_tx = durable_tx
+        -- Advance the durable basis to this tx (the durable live index's own
+        -- latest_completed_tx) and refresh the external snapshot to reflect it.
+        index.latest_completed_tx = staged_tx.tx_key
         RefreshSharedSnapshot(index)
-        -- Watcher notification (post-durable, not at resolution time) is driven
-        -- by the replica-writer in db.allium, which orchestrates promotion.
+
+        -- Drop this tx from the committing sequence — AFTER importing it — and
+        -- discard the staged record. When the sequence empties the derived in_flight
+        -- becomes false and the resolver may seal the next batch.
+        staging.committing = staging.committing.drop(1)
+        not exists staged_tx
 }
 
 rule AbortTransaction {
     when: AbortTransaction(tx)
 
     requires: tx.status = active
-    -- Staging only exists on a leader; resolution runs there.
-    requires: tx.index.staging != null
 
     ensures: tx.status = aborted
     -- The applied head tracks "resolved up to", not "successfully committed up
     -- to" — even aborted transactions consume a tx_id and advance the staging
     -- area's marker, so the next tx_id is correct.
-    ensures: tx.index.staging.latest_completed_tx = tx.tx_key
+    ensures: tx.staging.latest_completed_tx = tx.tx_key
     -- tx rows are discarded (not staged); new tables are not created
 }
 
@@ -499,7 +606,7 @@ rule OpenExternalSnapshot {
     -- The index publishes a single shared Snapshot whose basis is
     -- latest_completed_tx (durable) and whose layers are the DURABLE live segments only
     -- — no staging. It is refreshed on each durable confirmation (see
-    -- PromoteStaging / RefreshSharedSnapshot). Each external opener retains
+    -- PromoteNext / RefreshSharedSnapshot). Each external opener retains
     -- the current shared snapshot rather than building a fresh one, and
     -- releases it on close. The underlying segments are freed when the last
     -- holder releases.
@@ -519,21 +626,21 @@ rule OpenTransactionSnapshot {
     --
     -- A resolving tx must read all prior txs whether DURABLE or merely STAGED,
     -- plus its own uncommitted writes. So each TableSnapshot layers, bottom to
-    -- top: the durable live segment ⊕ the staging segments (accumulating, and
-    -- the committing slot if a batch is in flight) ⊕ the tx's own segment.
+    -- top: the durable live segment ⊕ the staging segments (the committing
+    -- batch's StagedTxTables, oldest→newest, if a batch is in flight, then the
+    -- accumulating slot's StagingTable) ⊕ the tx's own segment.
     when: OpenSnapshot(tx)
 
     requires: tx.status = active
-    -- Resolution only runs on a leader, where staging exists.
-    requires: tx.index.staging != null
 
     ensures:
         let snap = Snapshot.created(basis_tx: tx.tx_key, ref_count: 1)
-        let staging = tx.index.staging
+        let staging = tx.staging
 
         -- One TableSnapshot per table touched by the tx: durable live segment
         -- from the existing LiveTable (if any), the staging segments for the
-        -- table from each occupied slot, and the tx segment from this OpenTx.
+        -- table (committing StagedTxTables oldest→newest, below the accumulating
+        -- slot's StagingTable), and the tx segment from this OpenTx.
         for table_tx in tx.table_txs:
             let live_seg = if table_tx.live_table != null: MemorySegment.for(table_tx.live_table) else: null
             let tx_seg = if table_tx.rows.count > 0: MemorySegment.for(table_tx) else: null
@@ -596,32 +703,37 @@ rule RefreshSharedSnapshot {
 ------------------------------------------------------------
 
 rule FinishBlock {
-    when: FinishBlock(index, block_idx)
+    -- staging is the resolver's staging index on a leader, or null on a
+    -- follower/transition (which have no staging — they import already-durable
+    -- messages).
+    when: FinishBlock(index, staging, block_idx)
 
     -- Staging MUST be drained before the block is written: all in-flight
     -- commits promoted, nothing accumulated or committing. Otherwise a durable
-    -- L0 block could contain non-durable rows. ("BlockBoundary closes the
-    -- batch": the replica-writer flushes and promotes the pending batch before
-    -- the boundary, leaving staging drained.) On followers/transition there is
-    -- no staging, so this is trivially satisfied.
-    requires: index.staging = null or index.staging.is_drained
+    -- L0 block could contain non-durable rows. On a leader, the resolver cuts a
+    -- block at a tx boundary by first draining (awaiting the in-flight persist
+    -- and promoting), then sending a boundary-batch, so staging is drained by the
+    -- time the block is written. On followers/transition staging is null, so this
+    -- is trivially satisfied.
+    requires: staging = null or staging.is_drained
 
     -- Writes current (durable) live table contents to block storage.
     -- Rows remain in memory until NextBlock.
     ensures: BlockWritten(index, block_idx)
 }
 
-rule DropStaging {
-    -- Leader → follower demotion: the staging index is discarded wholesale.
-    -- The uncommitted txs it held will be re-read from the source log and
-    -- re-resolved by the next leader. The DURABLE live index is untouched —
-    -- only staged, not-yet-durable rows are lost, and those were never visible
-    -- to external queries.
-    when: DropStaging(index)
+rule CloseStagingIndex {
+    -- Leader → follower demotion is exactly the leader's two-phase close — there
+    -- is NO separate runtime drop. Phase 1 (cancelAndJoin the resolver + replica
+    -- job tree) ensures nothing live still touches staging; phase 2 (this) frees
+    -- the staging index synchronously, closing any un-promoted slot buffers, before
+    -- the allocator is closed. Any staged-but-not-yet-durable txs are discarded
+    -- (they were never visible to external queries) and will be re-read from the
+    -- source log and re-resolved by the next leader. The durable LiveIndex is
+    -- untouched. See db.allium TransitionToFollower; commit ec0f3947e.
+    when: CloseStagingIndex(staging)
 
-    requires: index.staging != null
-
-    ensures: index.staging = null
+    ensures: not exists staging
 }
 
 rule NextBlock {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -147,66 +147,78 @@ class LeaderLogProcessor(
     private val gcCh =
         Channel<GcTask>(onUndeliveredElement = { it.onComplete.cancel() })
 
-    // proc 1 resolves a record into a ReplicaTask and hands it to proc 2 (the replica-writer, sole
-    // owner of `replicaProducer`), then awaits the ack. RENDEZVOUS for now → fully serial, so runtime
-    // behaviour matches the single-loop persister; the seam is here for later batching/pipelining.
+    // The resolver (proc 1) owns the staging index: it resolves each tx, applies it to staging, and
+    // hands the durable replica-log write to the replica writer (proc 2, sole owner of
+    // `replicaProducer`) over `replicaCh`, awaiting confirmation on the `persistResultCh` back-edge.
+    // Once durable, the resolver promotes the tx into the live index and notifies. Under this commit
+    // the resolver awaits the back-edge per tx, so it stays fully serial and behaviour matches the
+    // single-loop persister; the pipelining increment drops that per-tx await.
     private sealed interface ReplicaTask {
-        val onApplied: CompletableDeferred<Unit>
+        // append a batch of resolved txs (source-log, ext-source, or attach/detach) to the replica log
+        data class AppendTx(val batch: List<ReplicaMessage.ResolvedTx>) : ReplicaTask
 
-        data class ResolvedTx(val resolvedTx: ReplicaMessage.ResolvedTx, val srcMsgId: MessageId?) : ReplicaTask {
-            override val onApplied = CompletableDeferred<Unit>()
-        }
-
-        data class DbOpTx(val resolvedTx: ReplicaMessage.ResolvedTx) : ReplicaTask {
-            override val onApplied = CompletableDeferred<Unit>()
-        }
-
-        data class Forward(val message: ReplicaMessage, val srcMsgId: MessageId) : ReplicaTask {
-            override val onApplied = CompletableDeferred<Unit>()
-        }
+        data class Forward(val message: ReplicaMessage, val srcMsgId: MessageId) : ReplicaTask
 
         data class FlushBlockFinish(
             val latestProcessedMsgId: MessageId, val externalSourceToken: ExternalSourceToken?
-        ) : ReplicaTask {
-            override val onApplied = CompletableDeferred<Unit>()
-        }
+        ) : ReplicaTask
 
-        data class TriesDeleted(val tableName: TableRef, val trieKeys: Set<TrieKey>) : ReplicaTask {
-            override val onApplied = CompletableDeferred<Unit>()
-        }
+        data class TriesDeleted(val tableName: TableRef, val trieKeys: Set<TrieKey>) : ReplicaTask
 
-        data class NotifyMsg(val msgId: MessageId) : ReplicaTask {
-            override val onApplied = CompletableDeferred<Unit>()
-        }
+        data class NotifyMsg(val msgId: MessageId) : ReplicaTask
     }
 
-    private val replicaCh = Channel<ReplicaTask>(onUndeliveredElement = { it.onApplied.cancel() })
+    // Seeded from the durable head so a new leader continues tx-ids from where the previous one left
+    // off (rather than restarting from 0 and colliding with already-replicated tx-ids).
+    private val staging = StagingIndex(liveIndex.latestCompletedTx)
+
+    // resolver → replica writer: the durable-write work for a task.
+    private val replicaCh = Channel<ReplicaTask>()
+    // replica writer → resolver: the msgIds the writer appended for a task, one per appended message —
+    // a batch of txs yields one per tx, in order — rendezvous. The resolver advances the apply cursor
+    // `latestReplicaMsgId` per tx as it promotes, so a partial promote leaves the cursor at what
+    // actually imported. At most one task is in flight. Failure propagates by cancellation, not by
+    // closing this channel: the resolver and writer share a coroutineScope (see `termJob`), so when one
+    // fails the other is cancelled and its parked `send`/`receive` throws `CancellationException`; the
+    // failing loop is the one that calls `notifyError`, so it fires once.
+    private val persistResultCh = Channel<List<MessageId>>()
 
     private suspend fun handleSourceLogBatch(records: List<Log.Record<SourceMessage>>) {
         for (record in records) {
             LOG.trace { "[$dbName] leader: message ${record.msgId} (${record.message::class.simpleName})" }
             handleSourceLogRecord(record)
         }
+        // Drain the poll batch's tail so processRecords returns with the persister quiescent (#5741).
+        drainBatch()
     }
 
     private suspend fun handleSourceLogRecord(record: Log.Record<SourceMessage>) {
         val msgId = record.msgId
 
         when (val msg = record.message) {
-            is SourceMessage.Tx, is SourceMessage.LegacyTx ->
-                dispatch(ReplicaTask.ResolvedTx(resolveTx(msgId, record, msg), msgId))
+            is SourceMessage.Tx, is SourceMessage.LegacyTx -> {
+                // source-log txs carry their own source position, so the replicated record and the
+                // notify both stamp `msgId`. Accumulate into the batch and keep the writer fed — settle
+                // a ready ack, then send if the writer's free; the tail drains in handleSourceLogBatch.
+                val resolved = resolveTx(msgId, record, msg)
+                staging.apply(resolved.resolvedTx.copy(srcMsgId = msgId), resolved.openTx, notifyMsgId = msgId)
+                settleIfReady(finishBlockIfFull = true)
+                if (!staging.inFlight) sendAccumulated()
+            }
 
             is SourceMessage.FlushBlock -> {
+                drainBatch() // flush accumulated txs first, so the flush follows them on the log
                 val expectedBlockIdx = msg.expectedBlockIdx
                 if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L)) {
-                    dispatch(ReplicaTask.FlushBlockFinish(msgId, watchers.externalSourceToken))
+                    latestReplicaMsgId = sendAndSettle(ReplicaTask.FlushBlockFinish(msgId, watchers.externalSourceToken))
                 } else {
                     // see #5680
-                    dispatch(ReplicaTask.Forward(ReplicaMessage.NoOp(srcMsgId = msgId), msgId))
+                    latestReplicaMsgId = sendAndSettle(ReplicaTask.Forward(ReplicaMessage.NoOp(srcMsgId = msgId), msgId))
                 }
             }
 
             is SourceMessage.AttachDatabase -> {
+                drainBatch() // isolate the DDL tx: flush accumulated data txs first
                 val txKey = TransactionKey(msgId, record.logTimestamp)
                 val error = if (dbCatalog != null) {
                     try {
@@ -218,13 +230,18 @@ class LeaderLogProcessor(
                     }
                 } else null
 
-                val resolvedTx = openTx(txKey, null).use { it.commitTx(error).copy(srcMsgId = msgId) }
-                    .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
+                val openTx = openTx(txKey, null)
+                val resolvedTx = try {
+                    openTx.commitTx(error).copy(srcMsgId = msgId)
+                        .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
+                } catch (e: Throwable) { openTx.close(); throw e }
 
-                dispatch(ReplicaTask.DbOpTx(resolvedTx))
+                // attach/detach notify with the tx-id and never finish a block (asymmetry preserved).
+                persistResolvedTx(resolvedTx, openTx, notifyMsgId = resolvedTx.txId, finishBlockIfFull = false)
             }
 
             is SourceMessage.DetachDatabase -> {
+                drainBatch() // isolate the DDL tx: flush accumulated data txs first
                 val txKey = TransactionKey(msgId, record.logTimestamp)
                 val error = if (dbCatalog != null) {
                     try {
@@ -236,20 +253,24 @@ class LeaderLogProcessor(
                     }
                 } else null
 
-                val resolvedTx = openTx(txKey, null).use { it.commitTx(error).copy(srcMsgId = msgId) }
-                    .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
+                val openTx = openTx(txKey, null)
+                val resolvedTx = try {
+                    openTx.commitTx(error).copy(srcMsgId = msgId)
+                        .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
+                } catch (e: Throwable) { openTx.close(); throw e }
 
-                dispatch(ReplicaTask.DbOpTx(resolvedTx))
+                persistResolvedTx(resolvedTx, openTx, notifyMsgId = resolvedTx.txId, finishBlockIfFull = false)
             }
 
             is SourceMessage.TriesAdded -> {
+                drainBatch() // flush accumulated txs first, so TriesAdded follows them on the log
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch) {
                     msg.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
                         trieCatalog.addTries(TableRef.parse(tableName), tries, record.logTimestamp)
                     }
                 }
 
-                dispatch(
+                latestReplicaMsgId = sendAndSettle(
                     ReplicaTask.Forward(
                         TriesAdded(msg.storageVersion, msg.storageEpoch, msg.tries, sourceMsgId = msgId), msgId
                     )
@@ -257,65 +278,109 @@ class LeaderLogProcessor(
             }
 
             // TODO this one's going after 2.2
-            is SourceMessage.BlockUploaded ->
-                dispatch(ReplicaTask.NotifyMsg(msgId))
+            is SourceMessage.BlockUploaded -> {
+                drainBatch() // flush accumulated txs first, so this follows them on the log
+                sendAndSettle(ReplicaTask.NotifyMsg(msgId))
+            }
         }
     }
 
-    // Dispatch a resolved task to proc 2 and await its ack — keeps proc 1 and proc 2 in lock-step
-    // (fully serial) for now. If proc 2 fails applying this task it completes `onApplied` exceptionally,
-    // so the `await` rethrows the cause into proc 1's per-task catch (and any later `send` onto the
-    // now-closed channel throws it too).
-    private suspend fun dispatch(task: ReplicaTask) {
+    // Hand the durable-write work to the replica writer and await its confirmation — keeps the resolver
+    // and writer in lock-step (fully serial). If the writer fails, the shared coroutineScope cancels
+    // the resolver, so this `receive` (or a later `send`) throws `CancellationException` and the loop
+    // unwinds; the writer reports the root cause via `notifyError`.
+    private suspend fun sendAndSettle(task: ReplicaTask): MessageId {
         replicaCh.send(task)
-        task.onApplied.await()
+        // control tasks append a single message; its msgId is the cursor position.
+        return persistResultCh.receive().last()
     }
 
-    // proc 2: append + import + notify for a source-log/ext-source tx.
-    private suspend fun applyResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx, srcMsgId: MessageId?) {
-        val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
-        val txResult = if (resolvedTx.committed) Committed(txKey) else Aborted(txKey, resolvedTx.error)
+    // Resolver: apply the resolved tx to staging, hand the durable write to the writer, then — once
+    // it's durable — promote it into the live index and notify. The writer only appends to the replica
+    // log; the import/notify/block-finish live here, downstream of the durable write, so dropping the
+    // per-tx await later (pipelining) doesn't move them.
+    // --- the resolver's send/settle pipeline over the staging index ---
+    //
+    // Resolved txs accumulate in the staging index; the resolver seals a batch and hands it to the
+    // writer (`sendAccumulated`, fire-and-forget), then keeps resolving while the writer appends, and
+    // on the writer's ack promotes the batch into the durable index (`settle`). At most one batch is in
+    // flight. Because `processRecords` awaits the whole poll batch draining (`drainBatch`) before it
+    // returns, the persister is quiescent whenever the poll thread is back in `poll()` — so a rebalance
+    // transition's cancel-join finds nothing in flight (#5741); the resolver never runs ahead of a poll.
 
-        // Ext-source txs carry no source-log position of their own (`srcMsgId == null` on the way in)
-        // and track progress via `externalSourceToken`, so they don't advance the leader's
-        // `latestSourceMsgId` (which is driven by the source log). We do stamp the current source-log
-        // watermark onto the replicated record, though: without it a follower's `latestSourceMsgId`
-        // lags between block boundaries, and on promotion it resumes the source log from a stale point
-        // and replays an already-covered block boundary.
-        val effectiveSrcMsgId = srcMsgId ?: watchers.latestSourceMsgId
-
-        appendToReplica(resolvedTx.copy(srcMsgId = effectiveSrcMsgId))
-        liveIndex.importTx(resolvedTx)
-
-        watchers.notifyTx(txResult, effectiveSrcMsgId, resolvedTx.externalSourceToken)
-
-        if (liveIndex.isFull())
-            finishBlock(effectiveSrcMsgId, resolvedTx.externalSourceToken)
+    // Seal the accumulated txs and hand the batch to the writer; its ack is settled later.
+    private suspend fun sendAccumulated() {
+        replicaCh.send(ReplicaTask.AppendTx(staging.seal()))
     }
 
-    // proc 2: append + import + notify for an attach/detach. No isFull/finishBlock — preserving the
-    // attach/detach asymmetry against `applyResolvedTx`.
-    private suspend fun applyDbOpTx(resolvedTx: ReplicaMessage.ResolvedTx) {
-        appendToReplica(resolvedTx)
-        liveIndex.importTx(resolvedTx)
+    // Promote the in-flight batch into the live index, advancing the apply cursor and notifying per tx,
+    // and cut a block if the batch filled one. Runs on the ack — the durable index is accurate here, so
+    // the block-full check needs no stage-time row-counting. The cursor advances per tx (not once at the
+    // batch end) so a partial promote leaves it at the last imported tx — see `promoteNext`.
+    private suspend fun settle(replicaMsgIds: List<MessageId>, finishBlockIfFull: Boolean) {
+        var last: StagingIndex.Staged? = null
+        var i = 0
+        while (true) {
+            val staged = staging.promoteNext(liveIndex) ?: break
+            // i-th tx ↔ i-th appended msgId (both in send order).
+            latestReplicaMsgId = replicaMsgIds[i++]
+            val tx = staged.resolvedTx
+            val txKey = TransactionKey(tx.txId, tx.systemTime)
+            val txResult = if (tx.committed) Committed(txKey) else Aborted(txKey, tx.error)
+            watchers.notifyTx(txResult, staged.notifyMsgId, tx.externalSourceToken)
+            last = staged
+        }
 
-        val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
-        val result = if (resolvedTx.committed) Committed(txKey) else Aborted(txKey, resolvedTx.error)
-        watchers.notifyTx(result, resolvedTx.txId, null)
+        if (finishBlockIfFull && liveIndex.isFull()) last?.let { l ->
+            latestReplicaMsgId =
+                sendAndSettle(ReplicaTask.FlushBlockFinish(l.notifyMsgId, l.resolvedTx.externalSourceToken))
+        }
+    }
+
+    // Await the in-flight batch's ack and settle it.
+    private suspend fun settleInFlight(finishBlockIfFull: Boolean) =
+        settle(persistResultCh.receive(), finishBlockIfFull)
+
+    // Settle the in-flight batch if its ack has already arrived (non-blocking) — keeps the writer fed
+    // while the resolver works through the rest of the poll batch.
+    private suspend fun settleIfReady(finishBlockIfFull: Boolean) {
+        if (staging.inFlight) persistResultCh.tryReceive().getOrNull()?.let { settle(it, finishBlockIfFull) }
+    }
+
+    // Flush and settle everything staged, blocking until the staging index is empty. Used before a
+    // control message that must follow the accumulated txs on the replica log, and at the end of the
+    // poll batch (so `processRecords` returns only once the persister is quiescent — see above).
+    private suspend fun drainBatch() {
+        while (staging.inFlight || staging.hasAccumulated) {
+            if (staging.inFlight) settleInFlight(finishBlockIfFull = true)
+            else sendAccumulated()
+        }
+    }
+
+    // Resolve a single tx synchronously (batch-of-one): ext-source txs and attach/detach, which sit
+    // outside the source-log poll-batch pipeline. Staging takes ownership of [openTx] at `apply` — it's
+    // closed on promote (in `settle`) or on teardown (staging.close), never by the caller once handed over.
+    private suspend fun persistResolvedTx(
+        resolvedTx: ReplicaMessage.ResolvedTx, openTx: OpenTx, notifyMsgId: MessageId, finishBlockIfFull: Boolean,
+    ) {
+        staging.apply(resolvedTx, openTx, notifyMsgId)
+        sendAccumulated()
+        settleInFlight(finishBlockIfFull)
     }
 
     private suspend fun handleIndexTx(task: ExtSourceTask.IndexTx) {
         val txKey = TransactionKey(
-            (liveIndex.latestCompletedTx?.txId ?: -1) + 1,
+            (staging.latestCompletedTx?.txId ?: -1) + 1,
             smoothSystemTime(task.systemTime ?: instantSource.instant())
         )
 
         var openTx = openTx(txKey, task.externalSourceToken)
 
-        @Suppress("ConvertTryFinallyToUseCall") // because openTx is a var
+        val writerResult: TxResult
+        val resolvedTx: ReplicaMessage.ResolvedTx
         try {
-            val writerResult = task.writer(openTx)
-            val resolvedTx = when (writerResult) {
+            writerResult = task.writer(openTx)
+            resolvedTx = when (writerResult) {
                 is TxResult.Committed ->
                     openTx.commitTx(error = null, writerResult.userMetadata)
 
@@ -327,12 +392,24 @@ class LeaderLogProcessor(
                     openTx.commitTx(writerResult.error, writerResult.userMetadata)
                 }
             }
-
-            dispatch(ReplicaTask.ResolvedTx(resolvedTx, srcMsgId = null))
-            task.result.complete(writerResult)
-        } finally {
+        } catch (e: Throwable) {
+            // failed before handing the openTx to staging — free it here (staging owns it after apply)
             openTx.close()
+            throw e
         }
+
+        // Ext-source txs carry no source-log position of their own and track progress via
+        // `externalSourceToken`, so they don't advance the leader's `latestSourceMsgId` (driven by
+        // the source log). We do stamp the current source-log watermark onto the replicated record
+        // and the notify: without it a follower's `latestSourceMsgId` lags between block
+        // boundaries, and on promotion it resumes the source log from a stale point and replays an
+        // already-covered block boundary.
+        val effectiveSrcMsgId = watchers.latestSourceMsgId
+        persistResolvedTx(
+            resolvedTx.copy(srcMsgId = effectiveSrcMsgId), openTx,
+            notifyMsgId = effectiveSrcMsgId, finishBlockIfFull = true
+        )
+        task.result.complete(writerResult)
     }
 
     // Hand the task to the persister and return its completion handle. The caller decides whether to
@@ -380,107 +457,120 @@ class LeaderLogProcessor(
 
     private val txErrorCounter: Counter? = nodeBase.meterRegistry?.let { Counter.builder("tx.error").register(it) }
 
+    // proc 1: the resolver. Serialises source-log / ext-source / GC, resolves each, and hands the
+    // durable-write work to the writer. On a task failure it fails that task's awaiter and rethrows —
+    // which cancels the writer through the enclosing coroutineScope (see `termJob`).
+    private suspend fun resolverLoop() {
+        while (true) {
+            val task: PersisterTask = selectUnbiased {
+                sourceLogCh.onReceive { it }
+                extSourceCh.onReceive { it }
+                gcCh.onReceive { it }
+            }
+            try {
+                when (task) {
+                    is SourceLogTask.Batch -> handleSourceLogBatch(task.records)
+                    is ExtSourceTask.IndexTx -> handleIndexTx(task)
+                    is GcTask.TriesDeleted ->
+                        latestReplicaMsgId = sendAndSettle(ReplicaTask.TriesDeleted(task.tableName, task.trieKeys))
+                }
+                task.onComplete.complete(Unit)
+            } catch (e: CancellationException) {
+                task.onComplete.cancel(e)
+                throw e
+            } catch (e: InterruptedException) {
+                task.onComplete.completeExceptionally(e)
+                throw e
+            } catch (e: Interrupted) {
+                task.onComplete.completeExceptionally(e)
+                throw e
+            } catch (e: Throwable) {
+                watchers.notifyError(e)
+                task.onComplete.completeExceptionally(e)
+                throw e
+            }
+        }
+    }
+
+    // proc 2: the replica-writer. Sole owner of `replicaProducer` — it only writes to the replica log;
+    // the resolver does the staging promote / live-index import / notify downstream of the durable
+    // write. Reports each task's applied replica position on `persistResultCh`. On its own failure it
+    // notifies and rethrows — which cancels the resolver through the enclosing coroutineScope.
+    private suspend fun writerLoop() {
+        try {
+            for (task in replicaCh) {
+                // Append + apply each task, then report the replica position it lands at on the
+                // back-edge. The writer never touches `latestReplicaMsgId`: the resolver advances that
+                // apply cursor in ack-order (after promote for a tx, on the ack for a control message),
+                // so the cursor stays a gap-free prefix even once the resolver runs ahead of it.
+                val replicaMsgIds: List<MessageId> = when (task) {
+                    is ReplicaTask.AppendTx -> appendBatchToReplica(task.batch)
+
+                    is ReplicaTask.Forward -> {
+                        val msgId = appendToReplica(task.message).msgId
+                        watchers.notifyMsg(task.srcMsgId)
+                        listOf(msgId)
+                    }
+
+                    is ReplicaTask.FlushBlockFinish -> {
+                        val msgId = finishBlock(task.latestProcessedMsgId, task.externalSourceToken)
+                        watchers.notifyMsg(task.latestProcessedMsgId)
+                        listOf(msgId)
+                    }
+
+                    is ReplicaTask.TriesDeleted -> {
+                        val msgId = appendToReplica(ReplicaMessage.TriesDeleted(task.tableName.schemaAndTable, task.trieKeys)).msgId
+                        trieCatalog.deleteTries(task.tableName, task.trieKeys)
+                        listOf(msgId)
+                    }
+
+                    is ReplicaTask.NotifyMsg -> {
+                        watchers.notifyMsg(task.msgId)
+                        // NotifyMsg moves only the source watermark, not the replica apply cursor;
+                        // the resolver discards this ack value.
+                        listOf(task.msgId)
+                    }
+                }
+                persistResultCh.send(replicaMsgIds)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            throw e
+        } catch (e: Interrupted) {
+            throw e
+        } catch (e: Throwable) {
+            watchers.notifyError(e)
+            throw e
+        }
+    }
+
     private val termJob: Job = scope.launch {
-        // supervisorScope so an ext-source crash doesn't kill the persister.
+        // The external source is isolated under the supervisorScope so its crash doesn't kill the
+        // persister. The persister's two halves — resolver and replica-writer — are lock-step and
+        // useless apart, so they run in a plain coroutineScope and fail together: a crash in either
+        // cancels the other. Neither closes the coordination channels (`replicaCh`/`persistResultCh`)
+        // on the way out — cancellation reaps both halves — so only the source channels are closed here.
         supervisorScope {
             launch {
-                // Close the channels with the failure cause so a subsequent `enqueue` send throws it rather
-                // than a bare ClosedSendChannelException. An awaiting caller (`executeTx`, GC, `processRecords`)
-                // sees the cause through its `await`; this close-with-cause is the safety net for fire-and-forget
-                // `submitTx`, and for any caller's next send once the persister loop has exited.
                 var cause: Throwable? = null
                 try {
-                    while (true) {
-                        val task: PersisterTask = selectUnbiased {
-                            sourceLogCh.onReceive { it }
-                            extSourceCh.onReceive { it }
-                            gcCh.onReceive { it }
-                        }
-                        try {
-                            when (task) {
-                                is SourceLogTask.Batch -> handleSourceLogBatch(task.records)
-                                is ExtSourceTask.IndexTx -> handleIndexTx(task)
-                                is GcTask.TriesDeleted -> dispatch(ReplicaTask.TriesDeleted(task.tableName, task.trieKeys))
-                            }
-                            task.onComplete.complete(Unit)
-                        } catch (e: CancellationException) {
-                            task.onComplete.cancel(e)
-                            throw e
-                        } catch (e: InterruptedException) {
-                            task.onComplete.completeExceptionally(e)
-                            throw e
-                        } catch (e: Interrupted) {
-                            task.onComplete.completeExceptionally(e)
-                            throw e
-                        } catch (e: Throwable) {
-                            watchers.notifyError(e)
-                            task.onComplete.completeExceptionally(e)
-                            throw e
-                        }
+                    coroutineScope {
+                        launch { resolverLoop() }
+                        launch { writerLoop() }
                     }
                 } catch (e: CancellationException) {
-                    // term cancellation: close the channels without an error cause
+                    // term cancellation: close the source channels without an error cause
                 } catch (t: Throwable) {
                     cause = t
                 } finally {
+                    // A subsequent `enqueue` send then throws the cause rather than a bare
+                    // ClosedSendChannelException; an awaiting caller (`executeTx`, GC, `processRecords`)
+                    // sees it through its `await`. This is also the safety net for fire-and-forget
+                    // `submitTx`, and for any caller's next send once the persister has exited.
                     sourceLogCh.close(cause)
                     extSourceCh.close(cause)
                     gcCh.close(cause)
-                }
-            }
-
-            // proc 2: the replica-writer. Sole owner of `replicaProducer` — proc 1 resolves and hands off
-            // here, then awaits the ack. On failure, close `replicaCh` with the cause so proc 1's next
-            // `send` throws it (mirroring how the persister loop closes the source channels).
-            launch {
-                var cause: Throwable? = null
-                try {
-                    for (task in replicaCh) {
-                        try {
-                            when (task) {
-                                is ReplicaTask.ResolvedTx -> applyResolvedTx(task.resolvedTx, task.srcMsgId)
-                                is ReplicaTask.DbOpTx -> applyDbOpTx(task.resolvedTx)
-                                is ReplicaTask.Forward -> {
-                                    appendToReplica(task.message)
-                                    watchers.notifyMsg(task.srcMsgId)
-                                }
-
-                                is ReplicaTask.FlushBlockFinish -> {
-                                    finishBlock(task.latestProcessedMsgId, task.externalSourceToken)
-                                    watchers.notifyMsg(task.latestProcessedMsgId)
-                                }
-
-                                is ReplicaTask.TriesDeleted -> {
-                                    appendToReplica(ReplicaMessage.TriesDeleted(task.tableName.schemaAndTable, task.trieKeys))
-                                    trieCatalog.deleteTries(task.tableName, task.trieKeys)
-                                }
-
-                                is ReplicaTask.NotifyMsg -> watchers.notifyMsg(task.msgId)
-                            }
-                            task.onApplied.complete(Unit)
-                        } catch (e: CancellationException) {
-                            task.onApplied.cancel(e)
-                            throw e
-                        } catch (e: InterruptedException) {
-                            task.onApplied.completeExceptionally(e)
-                            throw e
-                        } catch (e: Interrupted) {
-                            task.onApplied.completeExceptionally(e)
-                            throw e
-                        } catch (e: Throwable) {
-                            // Don't notifyError here: proc 1 awaits onApplied, so completing it
-                            // exceptionally surfaces the failure in the persister loop's own catch,
-                            // which is the single notifyError + source-channel teardown point.
-                            task.onApplied.completeExceptionally(e)
-                            throw e
-                        }
-                    }
-                } catch (e: CancellationException) {
-                    // term cancellation: close the channel without an error cause
-                } catch (t: Throwable) {
-                    cause = t
-                } finally {
-                    replicaCh.close(cause)
                 }
             }
 
@@ -499,13 +589,15 @@ class LeaderLogProcessor(
     }
 
     private fun smoothSystemTime(systemTime: Instant): Instant {
-        val lct = liveIndex.latestCompletedTx?.systemTime ?: return systemTime
+        val lct = staging.latestCompletedTx?.systemTime ?: return systemTime
         val floor = fromMicros(lct.asMicros + 1)
         return if (systemTime.isBefore(floor)) floor else systemTime
     }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
         OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer)
+            // resolution reads see durable ⊕ staged ⊕ own — the resolver is staging's sole accessor.
+            .also { it.staging = staging }
 
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
@@ -532,11 +624,20 @@ class LeaderLogProcessor(
         }
     }
 
+    // Append to the replica log and return the metadata. Does NOT advance `latestReplicaMsgId` — that
+    // is the apply cursor, advanced by the caller once the message is applied locally (the writer for
+    // control / block-boundary messages, the resolver after promote for txs).
     private suspend fun appendToReplica(message: ReplicaMessage): Log.MessageMetadata =
         replicaProducer.withTx { tx -> tx.appendMessage(message) }.await()
-            .also { latestReplicaMsgId = it.msgId }
 
-    private suspend fun finishBlock(latestProcessedMsgId: MessageId, externalSourceToken: ExternalSourceToken?) {
+    // Append a batch of resolved txs in one atomic transaction; returns the appended msgId per tx, in
+    // order, so the resolver can advance the apply cursor per tx as it promotes them.
+    private suspend fun appendBatchToReplica(batch: List<ReplicaMessage.ResolvedTx>): List<MessageId> =
+        replicaProducer.withTx { tx -> batch.map { tx.appendMessage(it) } }.awaitAll().map { it.msgId }
+
+    // Returns the replica msgId the block upload lands at; the writer hands it back to the resolver,
+    // which advances the apply cursor in ack-order, like every other task.
+    private suspend fun finishBlock(latestProcessedMsgId: MessageId, externalSourceToken: ExternalSourceToken?): MessageId {
         val boundaryMsg =
             BlockBoundary((blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, externalSourceToken)
 
@@ -545,7 +646,7 @@ class LeaderLogProcessor(
 
         pendingBlock = PendingBlock(boundaryMsgId, boundaryMsg)
 
-        latestReplicaMsgId = blockUploader.uploadBlock(replicaProducer, boundaryMsgId, boundaryMsg)
+        val uploadedMsgId = blockUploader.uploadBlock(replicaProducer, boundaryMsgId, boundaryMsg)
         pendingBlock = null
 
         // Safe to call from inside a Persister task: signal() just enqueues a cycle on the GC's
@@ -553,7 +654,13 @@ class LeaderLogProcessor(
         // until this one returns.
         blockGc.signal()
         trieGc.signal()
+
+        return uploadedMsgId
     }
+
+    // A resolved source-log tx: its serialized form plus the OpenTx holding its (queryable) writes,
+    // returned open — staging takes ownership of the OpenTx at `persistResolvedTx`.
+    private class Resolved(val resolvedTx: ReplicaMessage.ResolvedTx, val openTx: OpenTx)
 
     private fun indexSourceLogTx(
         msgId: MessageId,
@@ -563,12 +670,12 @@ class LeaderLogProcessor(
         defaultTz: ZoneId?,
         user: String?,
         userMetadata: Any?,
-    ): ReplicaMessage.ResolvedTx = tracer.withSpan(
+    ): Resolved = tracer.withSpan(
         "xtdb.transaction",
         attributes = mapOf("operations.count" to (txOps?.valueCount ?: 0).toString()),
     ) {
         val userMetadataMap = userMetadata as? Map<*, *>
-        val lcTx = liveIndex.latestCompletedTx
+        val lcTx = staging.latestCompletedTx
 
         // If lc-tx's systemTime >= msgTimestamp, bump past it by 1µs; otherwise use msgTimestamp.
         // (`+1000ns` is `+1µs`.)
@@ -591,19 +698,22 @@ class LeaderLogProcessor(
             )
             LOG.warn { "specified system-time '$systemTime' older than current tx '$lcTx'" }
 
-            return@withSpan openTx(txKey, null).use { openTx ->
+            return@withSpan openTx(txKey, null).closeOnCatch { openTx ->
                 txErrorCounter?.increment()
-                openTx.commitTx(err, userMetadataMap)
+                Resolved(openTx.commitTx(err, userMetadataMap), openTx)
             }
         }
 
         val effectiveSystemTime = systemTime ?: defaultSystemTime
         val txKey = TransactionKey(msgId, effectiveSystemTime)
 
-        openTx(txKey, null).use { openTx ->
-            if (txOps == null) {
-                return@withSpan openTx.commitTx(SKIPPED_EXN, userMetadataMap)
-            }
+        // Handed to staging open (parked for resolution reads, closed on promote), so we close the
+        // OpenTx here only on the failure paths: an indexing/commit error, or an abort — whose partial
+        // writes are discarded, the abort row resolving on a fresh tx.
+        val openTx = openTx(txKey, null)
+        val result: TxResult = try {
+            if (txOps == null)
+                return@withSpan Resolved(openTx.commitTx(SKIPPED_EXN, userMetadataMap), openTx)
 
             val opts = SourceLogTxIndexer.TxOpts(
                 txKey = txKey,
@@ -613,16 +723,27 @@ class LeaderLogProcessor(
                 user = user,
             )
 
-            when (val result = sourceLogTxIndexer.ForTx(txOps, opts).indexTx(openTx)) {
-                is TxResult.Committed -> openTx.commitTx(null, userMetadataMap)
+            sourceLogTxIndexer.ForTx(txOps, opts).indexTx(openTx)
+        } catch (e: Throwable) {
+            openTx.close()
+            throw e
+        }
 
-                is TxResult.Aborted -> {
-                    LOG.debug(result.error) { "aborted tx" }
-                    // Open a fresh tx for the abort row — the original openTx may have partial writes.
-                    return@withSpan openTx(txKey, null).use { abortTx ->
-                        txErrorCounter?.increment()
-                        abortTx.commitTx(result.error, userMetadataMap)
-                    }
+        when (result) {
+            is TxResult.Committed ->
+                try {
+                    Resolved(openTx.commitTx(null, userMetadataMap), openTx)
+                } catch (e: Throwable) {
+                    openTx.close()
+                    throw e
+                }
+
+            is TxResult.Aborted -> {
+                LOG.debug(result.error) { "aborted tx" }
+                openTx.close()
+                openTx(txKey, null).closeOnCatch { abortTx ->
+                    txErrorCounter?.increment()
+                    Resolved(abortTx.commitTx(result.error, userMetadataMap), abortTx)
                 }
             }
         }
@@ -630,7 +751,7 @@ class LeaderLogProcessor(
 
     private fun resolveTx(
         msgId: MessageId, record: Log.Record<SourceMessage>, msg: SourceMessage
-    ): ReplicaMessage.ResolvedTx {
+    ): Resolved {
         if (skipTxs.isNotEmpty() && skipTxs.contains(msgId)) {
             LOG.warn("[$dbName] Skipping transaction id $msgId - within XTDB_SKIP_TXS")
 
@@ -708,6 +829,7 @@ class LeaderLogProcessor(
     override fun close() {
         extSource?.close()
         replicaProducer.close()
+        staging.close() // standing state the resolver owned; freed here, before the allocator
         allocator.close() // last: Arrow won't close it while a child buffer is live
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -71,6 +71,10 @@ class OpenTx(
     val systemTime get() = txKey.systemTime
     val systemTimeMicros = systemTime.asMicros
 
+    // Set by the resolver's factory for resolution OpenTxs, so read-your-writes layers the in-flight
+    // staged txs (durable ⊕ staged ⊕ own). Null for external / non-resolution snapshots.
+    internal var staging: StagingIndex? = null
+
     private val tableTxs = HashMap<TableRef, Table>()
 
     internal fun table(table: TableRef): Table = tableTxs.getOrPut(table) { Table(table) }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -87,12 +87,19 @@ class Snapshot(
                 val openTxTables: Map<TableRef, OpenTx.Table> =
                     openTx?.tables?.associate { it.key to it.value }.orEmpty()
 
+                // The resolver's staging index, for resolution snapshots: the in-flight committed-but-
+                // not-yet-durable txs, layered between durable and this tx's own writes. Null for
+                // external snapshots (which see durable only — strict visibility).
+                val staging = openTx?.staging
+
                 fun addSnap(tableRef: TableRef, ts: TableSnapshot) {
                     allSnaps.add(ts)
                     byTable.getOrPut(tableRef) { mutableListOf() }.add(ts)
                 }
 
-                for (tableRef in openTxTables.keys + liveIndex.tableRefs) {
+                // Precedence is list order: durable first, then staged (oldest→newest), then this tx's
+                // own writes last — so the resolving tx reads durable ⊕ staged ⊕ own, newest winning.
+                for (tableRef in openTxTables.keys + staging?.tableRefs.orEmpty() + liveIndex.tableRefs) {
                     liveIndex.table(tableRef)?.let { liveTable ->
                         // Skip live-tables already covered by a published L0 — they'd duplicate the
                         // L0's data. The watermark is monotonic, so once L0_N exists we drop the
@@ -100,6 +107,7 @@ class Snapshot(
                         if (liveTable.blockIdx > trieCatSnap.l0MaxBlockIdx(tableRef))
                             addSnap(tableRef, TableSnapshot.open(al, liveTable))
                     }
+                    staging?.table(tableRef)?.openSnapshots(al)?.forEach { addSnap(tableRef, it) }
                     openTxTables[tableRef]?.let { tx -> TableSnapshot.openTx(al, tx)?.let { addSnap(tableRef, it) } }
                 }
 

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -1,0 +1,137 @@
+package xtdb.indexer
+
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.TransactionKey
+import xtdb.api.log.MessageId
+import xtdb.api.log.ReplicaMessage
+import xtdb.table.TableRef
+import xtdb.util.closeAll
+import xtdb.util.closeAllOnCatch
+
+/**
+ * The leader resolver's staging index: committed-but-not-yet-durable transactions, held between the
+ * resolver applying a tx and the replica writer confirming the batch durable on the replica log. The
+ * resolver is the sole accessor, so no lock is needed — single-threaded by construction.
+ *
+ * Standing state owned by [LeaderLogProcessor]: created when it becomes leader, freed in its `close()`
+ * (phase two of the two-phase teardown), not by the resolver coroutine.
+ *
+ * Two views of the same in-flight txs:
+ *
+ *  - a per-tx queue ([accumulating] takes newly-resolved txs; [committing] is the batch handed to the
+ *    replica writer, awaiting its durable confirmation) — drives seal / promote / the replica write.
+ *  - a denormalised per-table index ([tables]) — drives resolution read-your-writes: a resolving tx
+ *    reads `durable ⊕ staged ⊕ its own writes`, and the staged layer is the parked txs' writes.
+ *
+ * The resolver hands staging the tx's [OpenTx] at [apply]; staging owns it from then on and closes it
+ * on [promote] (once durable) or on [close] (teardown). Its relations are read (copied) on demand by
+ * [Table.openSnapshots], so the OpenTx must stay alive until it's promoted.
+ */
+internal class StagingIndex(latestCompletedTx: TransactionKey?) : AutoCloseable {
+
+    // A staged tx: its serialized form (for the replica write + promote), the OpenTx holding its
+    // (queryable) writes, and the msgId to notify on once durable. Staging owns the OpenTx once applied.
+    class Staged(
+        val resolvedTx: ReplicaMessage.ResolvedTx,
+        internal val openTx: OpenTx,
+        val notifyMsgId: MessageId,
+    )
+
+    /** The staged writes to one table, across the in-flight txs, oldest→newest (precedence order). */
+    class Table {
+        // Borrowed OpenTx.Table refs — the OpenTxs own them; deindexed before the OpenTx is closed.
+        internal val txTables = ArrayDeque<OpenTx.Table>()
+
+        internal fun add(tableTx: OpenTx.Table) = txTables.addLast(tableTx)
+        internal fun remove(tableTx: OpenTx.Table) = txTables.remove(tableTx)
+        internal val isEmpty get() = txTables.isEmpty()
+
+        /**
+         * Fresh, caller-owned [TableSnapshot]s of this table's staged writes, oldest→newest. Copied off
+         * the borrowed OpenTx relations, so they outlive them and are closed by the enclosing [Snapshot].
+         */
+        fun openSnapshots(al: BufferAllocator): List<TableSnapshot> =
+            mutableListOf<TableSnapshot>().closeAllOnCatch { snaps ->
+                for (tableTx in txTables) TableSnapshot.openTx(al, tableTx)?.let(snaps::add)
+                snaps
+            }
+    }
+
+    private val accumulating = ArrayDeque<Staged>()
+
+    // The batch handed to the replica writer, awaiting durable confirmation; empty when idle.
+    private var committing: List<Staged> = emptyList()
+
+    private val tables = HashMap<TableRef, Table>()
+
+    /**
+     * The staging index's own latest-completed-tx — the applied / resolution head. Drives the next
+     * external-source tx-id and system-time smoothing. Seeded from the durable head
+     * ([LiveIndex.latestCompletedTx]) when the index is created, then advanced as txs are applied; it
+     * leads the durable head by the in-flight txs, and is equal to it under the serial commit.
+     */
+    var latestCompletedTx: TransactionKey? = latestCompletedTx
+        private set
+
+    /** True while a batch is in flight to the replica writer. */
+    val inFlight get() = committing.isNotEmpty()
+
+    /** True while there are resolved txs not yet sealed into a batch. */
+    val hasAccumulated get() = accumulating.isNotEmpty()
+
+    private fun indexTables(openTx: OpenTx) {
+        for ((tableRef, tableTx) in openTx.tables)
+            tables.getOrPut(tableRef) { Table() }.add(tableTx)
+    }
+
+    private fun deindexTables(openTx: OpenTx) {
+        for ((tableRef, tableTx) in openTx.tables)
+            tables[tableRef]?.let { if (it.apply { remove(tableTx) }.isEmpty) tables.remove(tableRef) }
+    }
+
+    fun apply(resolvedTx: ReplicaMessage.ResolvedTx, openTx: OpenTx, notifyMsgId: MessageId) {
+        accumulating.addLast(Staged(resolvedTx, openTx, notifyMsgId))
+        indexTables(openTx)
+        latestCompletedTx = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
+    }
+
+    /** Seal the accumulated txs into the committing batch, to be written to the replica log. */
+    fun seal(): List<ReplicaMessage.ResolvedTx> {
+        check(committing.isEmpty()) { "a batch is already in flight" }
+        committing = accumulating.toList()
+        accumulating.clear()
+        return committing.map { it.resolvedTx }
+    }
+
+    /**
+     * Promote the next staged tx into the durable live index and close its OpenTx; returns it (so the
+     * caller can advance the apply cursor and notify), or null once the committing batch is drained.
+     *
+     * Promoting one at a time — rather than all-then-return — is what keeps a partial failure safe. The
+     * tx is imported before it's removed from [committing], so if [LiveIndex.importTx] throws, the
+     * un-imported tail stays in [committing] (freed by [close]) and none is double-closed; and the
+     * caller has advanced the cursor only over what actually imported, so a follower resuming from it
+     * re-applies only the tail rather than double-importing the head.
+     */
+    fun promoteNext(liveIndex: LiveIndex): Staged? {
+        val staged = committing.firstOrNull() ?: return null
+        liveIndex.importTx(staged.resolvedTx)
+        committing = committing.drop(1)
+        deindexTables(staged.openTx)
+        staged.openTx.close()
+        return staged
+    }
+
+    /** Table refs with staged writes, for the resolution snapshot's per-table build. */
+    val tableRefs: Set<TableRef> get() = tables.keys
+
+    /** The staged writes to [tableRef], or null if none are in flight for it. */
+    fun table(tableRef: TableRef): Table? = tables[tableRef]
+
+    override fun close() {
+        (accumulating.map { it.openTx } + committing.map { it.openTx }).closeAll()
+        accumulating.clear()
+        committing = emptyList()
+        tables.clear()
+    }
+}

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -16,21 +16,37 @@
 -- A single LiveIndex sits outside the processor as shared state.
 -- Leader mode feeds it from source processing; follower mode feeds it from replica processing.
 --
--- Leader pipelining (see live-index.allium): on a leader, resolution runs ahead
--- of the replica-log write, modelled as two cooperating processes:
---   Resolver (proc 1)       — serialises source-log / external-source messages,
---                             resolves each, writes it to the staging accumulating
---                             slot (advancing the staging area's own
---                             latest_completed_tx, the applied head), and hands it
---                             downstream. No watcher notify here.
---   Replica-writer (proc 2) — sole owner of the replica-log producer. Seals the
---                             staged batch, writes it to the replica log; on durable
---                             confirmation, promotes staging → durable live tables,
---                             advances the durable LiveIndex.latest_completed_tx,
---                             refreshes the shared snapshot, and notifies watchers.
+-- Leader pipelining (see live-index.allium) — resolver-dominion model: on a
+-- leader, resolution runs ahead of the replica-log write, modelled as two
+-- cooperating processes joined by two channels:
+--   Resolver (proc 1)  — OWNS the staging index outright (sole accessor, so staging
+--                        needs no lock). Serialises source-log / external-source
+--                        messages, resolves each (reading durable ⊕ its own staging
+--                        for read-your-writes), applies it to the accumulating slot
+--                        (advancing the staging index's own latest_completed_tx, the
+--                        applied head), and at each tx boundary decides whether to
+--                        seal+send a batch and whether to cut a block. On the
+--                        back-edge (a persist-result that a prior batch is durable)
+--                        it PROMOTES the committing batch → durable live tables ONE
+--                        TX AT A TIME in send order, advancing the durable
+--                        LiveIndex.latest_completed_tx and the apply cursor per tx,
+--                        refreshing the shared snapshot, and notifying watchers
+--                        POST-DURABLE.
+--   Replica (proc 2)   — a PURE WRITER: owns only the replica-log producer. Receives
+--                        a batch's bytes, durably appends them (plus a BlockBoundary
+--                        + uploadBlock when the batch carries a block cut), and posts
+--                        a persist-result back on the back-edge — the PER-TX replica-
+--                        log positions it appended (i-th ↔ i-th tx, send order), so
+--                        the resolver can advance the apply cursor tx-by-tx on
+--                        promote. Touches NEITHER staging NOR the durable index.
+--   Two channels       — resolver→replica carries batches; replica→resolver carries
+--                        persist-results (the per-tx replica-log positions). No CompletableDeferred. At-most-one-batch-
+--                        in-flight is enforced by the resolver (the staging index's
+--                        in_flight flag), not channel capacity. Errors propagate via
+--                        channel close-with-cause.
 -- A query MUST NEVER see a tx that isn't yet durably on the replica log: external
 -- snapshots open at the durable LiveIndex.latest_completed_tx. The applied head is
--- the staging area's own latest_completed_tx — callers choose which to read.
+-- the staging index's own latest_completed_tx — callers choose which to read.
 -- Followers/transition have no staging — they import already-durable replica
 -- messages straight into the durable live index.
 -- A single Watchers instance tracks both txId and sourceMsgId for client correlation,
@@ -53,7 +69,8 @@ use "./compaction.allium" as compaction
 given {
     database: Database
     log_processor: LogProcessor
-    replica_writer: ReplicaWriter      -- leader-only (proc 2); absent in follower/transition modes
+    staging_index: StagingIndex?       -- leader-only (resolver-owned); absent in follower/transition modes
+    replica: Replica?                  -- leader-only (proc 2, pure writer); absent in follower/transition modes
     live_index: LiveIndex              -- shared across leader/follower modes
     watchers: Watchers                 -- single instance: correlates source msg_ids and tx_ids with client futures
     block_catalog: BlockCatalog
@@ -101,8 +118,8 @@ entity LiveIndex {
     --   durable live tables. External snapshots open at this. On a leader it is
     --   advanced by promotion from staging; on a follower/transition by importTx.
     -- The APPLIED/resolution head (next external-source tx_id, system-time
-    --   smoothing) is NOT a field here: on a leader it lives in the staging area
-    --   (the staging area's own latest_completed_tx, see live-index.allium
+    --   smoothing) is NOT a field here: on a leader it lives in the staging index
+    --   (the staging index's own latest_completed_tx, see live-index.allium
     --   StagingIndex), which db.allium does not import and therefore cannot read
     --   directly. Resolution that needs the next tx key delegates id-assignment to
     --   the staging layer via beginStagedTx (below); external queries read the
@@ -193,34 +210,46 @@ variant Transition : LogProcessor {
     -- See: indexer/TransitionLogProcessor.kt
 }
 
-entity ReplicaWriter {
-    -- The leader's replica-writer (proc 2): sole owner of the replica-log
-    -- transactional producer and the staging area's write lifecycle. Exists only
-    -- on a leader (client-driven Leader or ExternalSourceLeader); followers and
-    -- the transition processor have no staging and no writer.
-    -- See: indexer/LeaderLogProcessor.kt (replica-write half), live-index.allium.
+entity StagingIndex {
+    -- The resolver-owned staging index for a leader term. Its full structure
+    -- (slots, staged tables, the applied head) lives in live-index.allium; here it
+    -- is an opaque handle so db.allium's rules can name the resolver's apply /
+    -- seal / promote operations. db.allium does not `use` live-index.allium, so it
+    -- cannot name StagingSlot directly. Exists only on a leader (Leader or
+    -- ExternalSourceLeader); absent on followers and the transition processor.
     --
-    -- A STATE STORE, not a state machine. It owns the staging area (whose
-    -- structure lives under LiveIndex in live-index.allium so the resolution
-    -- snapshots can see it) and the replica producer; it has no idle/committing
-    -- FSM. The "one batch in flight at a time" property comes from the
-    -- single-threaded proviso below, not from a modelled state.
+    -- Standing state the LeaderLogProcessor owns from construction and frees in
+    -- its two-phase close (see TransitionToFollower). NOT a field on LiveIndex —
+    -- the resolver is its sole accessor, so it needs no lock.
     --
-    -- SINGLE-THREADED (like the live-index single-writer thread): the writer
-    -- handles one event to completion before the next. So a batch is sealed,
-    -- durably written, awaited, and promoted within a single event-handling —
-    -- there is never a second batch in flight, and any txs the resolver stages
-    -- meanwhile simply coalesce into the next batch. This is the proviso that
-    -- replaces the FSM gate.
+    -- APPLIED head: the staging index's own latest_completed_tx (next tx_id,
+    -- system-time smoothing). See live-index.allium StagingIndex.
+    latest_completed_tx: TransactionKey?
+
+    -- in_flight is true exactly while a sealed batch is being written to the
+    -- replica log and promoted (between seal and the last per-tx promote on the
+    -- persist-result back-edge). The resolver checks it to enforce at-most-one-batch
+    -- in flight.
+    in_flight: Boolean
+}
+
+entity Replica {
+    -- The leader's replica (proc 2): a PURE WRITER, sole owner of the replica-log
+    -- transactional producer. Exists only on a leader (client-driven Leader or
+    -- ExternalSourceLeader); followers and the transition processor have no
+    -- replica writer. See: indexer/LeaderLogProcessor.kt (replica-write half).
+    --
+    -- It touches NEITHER the staging index NOR the durable live index. It receives
+    -- a batch's bytes on the resolver→replica channel, durably appends them (plus a
+    -- BlockBoundary + uploadBlock when the batch carries a block cut), and posts a
+    -- persist-result back on the replica→resolver back-edge channel — the per-tx
+    -- replica-log positions it appended, one per tx in send order. Promotion is the
+    -- resolver's job, done on that back-edge — not the replica's.
     --
     -- Both the client-driven leader and the external-source leader share this one
     -- writer: the resolved txs in a batch carry their own external_source_token
     -- (null for the client-driven leader, the LSN for an external source), so the
     -- writer threads whatever the batch carries.
-    --
-    -- The in-flight batch and the staging slots are reached only via opaque
-    -- live_index calls — db.allium does not `use` live-index.allium, so it cannot
-    -- name StagingSlot directly.
 
     -- Highest replica-log message id this writer has durably written.
     -- Monotonicity (advances, never decreases) is a runtime/temporal property,
@@ -626,10 +655,16 @@ rule TransitionToLeader {
         log_processor.mode = Leader
         log_processor.start(source_resume, after_replica_msg_id: replay_target)
 
-        -- Stand up the replica-writer (proc 2) for this leader term, owning the
-        -- transactional producer opened above. It is torn down on revocation
-        -- (TransitionToFollower drops staging).
-        ReplicaWriter.created(
+        -- Stand up the leader term's pipeline: the resolver-owned staging index
+        -- (applied head seeded from the durable head; see live-index BeginStagedTx)
+        -- and the pure replica writer (proc 2), owning the transactional producer
+        -- opened above. Both are torn down on revocation by the two-phase close
+        -- (TransitionToFollower).
+        StagingIndex.created(
+            latest_completed_tx: live_index.latest_completed_tx,
+            in_flight: false
+        )
+        Replica.created(
             latest_replica_msg_id: replay_target
         )
 
@@ -644,16 +679,21 @@ rule TransitionToFollower {
     requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
 
     ensures:
-        -- close() completes any in-flight commit, then stops.
-        -- Capture the leader's positions and pending block before switching.
+        -- Two-phase close (per commit ec0f3947e). Phase 1: cancelAndJoin the
+        -- leader's job tree (resolver + replica) so nothing live still touches
+        -- staging — close() completes any in-flight commit, joins both coroutines,
+        -- then stops the subscription.
         let leader = log_processor as Leader
         leader.close()
 
-        -- Drop the leader-term-scoped staging index wholesale: any staged-but-
-        -- not-yet-durable txs are discarded (they were never visible to external
-        -- queries) and will be re-read from the source log and re-resolved by the
-        -- next leader. The durable live index is untouched (live-index DropStaging).
-        live_index.dropStaging()
+        -- Phase 2: synchronously free the leader-term staging index (closing any
+        -- un-promoted slot buffers) BEFORE the allocator. Demotion IS this teardown
+        -- — there is no separate runtime drop. Any staged-but-not-yet-durable txs
+        -- are discarded (they were never visible to external queries) and will be
+        -- re-read from the source log and re-resolved by the next leader. The
+        -- durable live index is untouched (live-index CloseStagingIndex).
+        if staging_index != null:
+            CloseStagingIndex(staging_index)
 
         -- The leader's pending_block is passed to the new follower.
         -- If the leader was mid-block-flush when revoked (between BlockBoundary
@@ -704,13 +744,16 @@ rule ClientSubmitsTransactionToExternalSourceDb {
 
 ---- Rules: Leader Mode — Resolver (proc 1, source processing)
 
--- The leader subscribes to the source log. The RESOLVER resolves each message
--- and writes the result to the STAGING accumulating slot (live_index.applyToStaging),
--- advancing the staging area's own latest_completed_tx (the applied head). It does
--- NOT write to the replica log and does NOT notify watchers — those are the replica-writer's job
--- (proc 2). It then wakes the writer with StagedTxReady (a bare signal — the writer
--- seals whatever staging holds, not a specific tx). Resolution runs AHEAD of the
--- durable write: later txs resolve against staging.
+-- The leader subscribes to the source log. The RESOLVER, sole accessor of its
+-- staging index, resolves each message (reading durable ⊕ its own staging) and
+-- applies the result to the STAGING accumulating slot
+-- (live_index.applyToStaging), advancing the staging index's own
+-- latest_completed_tx (the applied head). It does NOT write to the replica log
+-- and does NOT notify watchers — those follow from the durable write (proc 2) and
+-- the resolver's own post-durable promotion. At each tx boundary it decides
+-- whether to seal+send a batch downstream (MaybeSealAndSend): only if no batch is
+-- in flight and work has accumulated. Resolution runs AHEAD of the durable write:
+-- later txs resolve against staging.
 -- At the start of each processRecords batch, the leader checks the block flush
 -- timeout via BlockFlusher.
 
@@ -721,15 +764,15 @@ rule LeaderProcessesTx {
     requires: msg.msg_id > log_processor.latest_source_msg_id
 
     ensures:
-        -- Resolve and apply to staging (advances latest_completed_tx).
+        -- Resolve and apply to the resolver-owned staging index (advances the
+        -- applied head latest_completed_tx).
         let resolved = IndexTransaction(msg)
-        live_index.applyToStaging(resolved)
+        live_index.applyToStaging(staging_index, resolved)
         log_processor.latest_source_msg_id = msg.msg_id
 
-        -- Hand downstream to the replica-writer (proc 2). No replica-log write
-        -- and no watcher notify here.
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        -- Tx-boundary decision: seal+send a batch downstream if appropriate. No
+        -- replica-log write and no watcher notify here.
+        MaybeSealAndSend(staging_index)
 }
 
 rule LeaderProcessesAttachDb {
@@ -740,11 +783,10 @@ rule LeaderProcessesAttachDb {
 
     ensures:
         let resolved = ResolveAttach(msg)
-        live_index.applyToStaging(resolved)
+        live_index.applyToStaging(staging_index, resolved)
         log_processor.latest_source_msg_id = msg.msg_id
 
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        MaybeSealAndSend(staging_index)
 }
 
 rule LeaderProcessesDetachDb {
@@ -755,75 +797,124 @@ rule LeaderProcessesDetachDb {
 
     ensures:
         let resolved = ResolveDetach(msg)
-        live_index.applyToStaging(resolved)
+        live_index.applyToStaging(staging_index, resolved)
         log_processor.latest_source_msg_id = msg.msg_id
 
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        MaybeSealAndSend(staging_index)
 }
 
----- Rules: Leader Mode — Replica-writer (proc 2, durable write + promotion)
+---- Rules: Leader Mode — Resolver seal+send and back-edge promotion
 
--- The REPLICA-WRITER (entity ReplicaWriter, proc 2) is the sole owner of the
--- replica-log transactional producer and the staging area's write lifecycle. It
--- is SINGLE-THREADED, not a state machine: each event is handled to completion
--- before the next, so a batch is sealed, durably written, awaited, and promoted
--- within one handling — there is never a second batch in flight, and txs the
--- resolver stages meanwhile coalesce into the next batch.
---
--- Both the client-driven leader and the external-source leader use this one
--- writer. The resolved txs in a batch carry their own external_source_token (null
--- for the client-driven leader, the LSN for an external source); the writer
--- threads whatever the batch carries — there is no separate external-source
--- variant of the writer.
---
--- Handoff: the resolver emits StagedTxReady as it stages txs; the writer coalesces
--- whatever has accumulated into one batch when it next handles the signal (the
--- coalescing policy — batch size / linger — is a pipelining concern below this
--- contract-level model). The spec asserts only the ordering and durability
--- invariants, not the batching mechanics.
+-- The resolver-side half of the pipeline. The resolver, at a tx boundary, seals
+-- the accumulating slot into the committing sequence (live-index SealStagingBatch)
+-- and sends the batch's bytes to the pure Replica writer (proc 2). At-most-one-
+-- batch-in-flight is enforced here by the staging index's in_flight flag, not by
+-- channel capacity. When the Replica posts a persist-result on the back-edge (the
+-- per-tx replica-log positions, via BatchPersisted), the resolver PROMOTES the
+-- committing batch → durable ONE TX AT A TIME, advancing the durable basis and the
+-- apply cursor per tx, refreshing the shared snapshot and notifying watchers
+-- POST-DURABLE — and then may seal+send the next accumulated batch.
 
-rule WriteStagedBatch {
-    -- The writer's event handler. Single-threaded, so this runs start-to-finish
-    -- per batch: seal the staged batch, write its resolved txs durably to the
-    -- replica log, await durable confirmation INLINE (the transactional commit
-    -- ack — not a separate event), promote staging → durable, notify watchers
-    -- POST-DURABLE, and finish the block if the durable live index is now full.
-    --
-    -- The triggering StagedTxReady's per-tx payload is NOT read: the writer seals
-    -- whatever the staging accumulating slot holds (possibly several txs coalesced
-    -- since the last write). resolved_batch is the ordered list of resolved txs in
-    -- the sealed slot, each carrying its own external_source_token (null for the
-    -- client-driven leader). durable_tx is the highest tx key in the batch;
-    -- durable_token is the token as of its last tx.
-    when: StagedTxReady(database)
+rule MaybeSealAndSend {
+    -- Tx-boundary decision: seal+send only when no batch is in flight and work has
+    -- accumulated. If a batch is already in flight, the newly-staged txs simply
+    -- coalesce into the accumulating slot and are sent once the in-flight batch is
+    -- promoted (see ResolverPromotesBatch).
+    when: MaybeSealAndSend(staging_index)
+
+    requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
+    requires: not staging_index.in_flight
+
+    ensures:
+        -- Seal the accumulating slot into the committing sequence (double-buffer) and
+        -- take the batch's resolved txs in send order (live-index SealStagingBatch). If
+        -- the accumulating slot was empty, sealStagingBatch is a no-op (see its
+        -- requires) and nothing is sent.
+        let resolved_batch = live_index.sealStagingBatch(staging_index)
+        staging_index.in_flight = true
+
+        -- Send the batch's bytes to the pure Replica writer on the resolver→replica
+        -- channel. The Replica writes them durably and posts a persist-result back.
+        -- Each resolved tx carries its own external_source_token (null for the
+        -- client-driven leader); the batch carries a block cut only when the
+        -- resolver decided to cut one at this boundary.
+        SendBatch(replica, resolved_batch)
+}
+
+rule ReplicaWritesBatch {
+    -- The pure Replica writer (proc 2): receives a batch's bytes, durably appends
+    -- each resolved tx to the replica log via its transactional producer, then
+    -- posts a persist-result on the replica→resolver back-edge. It touches NEITHER
+    -- the staging index NOR the durable live index — promotion is the resolver's
+    -- job.
+    when: SendBatch(replica, resolved_batch)
 
     requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
 
     ensures:
-        -- Seal the accumulating slot into the committing slot (double-buffer) and
-        -- take the batch.
-        let resolved_batch = live_index.sealStagingBatch()
-        let durable_tx = resolved_batch.last.tx_key
-        let durable_token = resolved_batch.last.external_source_token
-
-        -- Write each resolved tx to the replica log via the transactional producer
-        -- and await durable confirmation inline. WriteResolvedToReplica builds the
-        -- per-tx ResolvedTxMessage (incl. the abort-error projection and the tx's
-        -- own external_source_token).
-        for resolved in resolved_batch:
+        -- Append each resolved tx to the replica log via the transactional producer,
+        -- collecting the PER-TX replica-log positions in send order: the i-th appended
+        -- msg_id corresponds to the i-th tx in the batch. WriteResolvedToReplica builds
+        -- the per-tx ResolvedTxMessage (incl. the abort-error projection and the tx's
+        -- own external_source_token) and returns its appended replica-log msg_id.
+        let replica_msg_ids = for resolved in resolved_batch:
             WriteResolvedToReplica(database, resolved)
 
-        -- Durable: promote staging → durable, advancing the durable basis and
-        -- refreshing the external snapshot (live-index PromoteStaging).
-        live_index.promoteStaging(durable_tx)
+        -- The apply cursor (the follower's resume point, latest_replica_msg_id) is NOT
+        -- advanced by the writer — it only appends. The resolver advances it per tx as
+        -- it promotes (see ResolverPromotesBatch), using these per-tx replica-log
+        -- positions: the i-th promoted tx moves the cursor to replica_msg_ids[i]. These
+        -- are replica-LOG positions, distinct from the tx-id (a source-log position).
 
-        -- Notify watchers POST-DURABLE, threading each tx's own external_source_token
-        -- so restarts can resume the external source.
-        for resolved in resolved_batch:
-            watchers.notifyTx(resolved.result, resolved.tx_key.tx_id, resolved.external_source_token)
+        -- Post the persist-result back to the resolver, carrying the per-tx replica-log
+        -- positions so the resolver can advance the apply cursor tx-by-tx on promote.
+        BatchPersisted(staging_index, resolved_batch, replica_msg_ids)
+}
 
-        replica_writer.latest_replica_msg_id = durable_tx.tx_id
+rule ResolverPromotesBatch {
+    -- The resolver handles the persist-result back-edge: the committing batch is
+    -- durable. It promotes the batch → durable ONE TX AT A TIME, in send order (via
+    -- live-index PromoteNext, which imports the tx into the durable live tables,
+    -- advances the durable basis to that tx, and refreshes the shared snapshot). For
+    -- each promoted tx it advances the apply cursor (latest_replica_msg_id, the
+    -- follower's resume point) to that tx's replica-log position — the i-th promoted
+    -- tx takes replica_msg_ids[i] — and notifies watchers POST-DURABLE. Once the batch
+    -- is drained no batch is in flight, so it finishes the block if the durable live
+    -- index is now full and seals+sends the next accumulated batch if any.
+    --
+    -- Per-tx (not wholesale) promotion + per-tx cursor advance is what makes a partial
+    -- failure safe: if importTx faults mid-batch, the imported prefix is durable, the
+    -- cursor sits at the last tx that ACTUALLY imported, and the un-imported tail stays
+    -- parked in committing (freed by CloseStagingIndex on teardown). A follower
+    -- resuming from that cursor re-applies only the tail — never double-importing the
+    -- durable prefix.
+    --
+    -- replica_msg_ids are the per-tx replica-log positions from the writer, i-th ↔ i-th
+    -- tx in send order. durable_token is the token as of the batch's last tx.
+    when: BatchPersisted(staging_index, resolved_batch, replica_msg_ids)
+
+    requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
+
+    let durable_token = resolved_batch.last.external_source_token
+
+    ensures:
+        -- Promote each tx in send order, paired with its replica-log position (zip
+        -- keeps the pairing: i-th tx ↔ i-th replica msg_id, both in send order).
+        -- PromoteNext imports the tx into the durable live tables, advances the durable
+        -- basis to it, and refreshes the shared snapshot. Advance the apply cursor to
+        -- this tx's replica-log position, then notify watchers POST-DURABLE, threading
+        -- the tx's own external_source_token so restarts can resume the external source.
+        -- If PromoteNext faults partway, the cursor is left at the last tx that actually
+        -- imported (partial-failure safety).
+        for pair in zip(resolved_batch, replica_msg_ids):
+            live_index.promoteNext(staging_index)
+            log_processor.latest_replica_msg_id = pair.replica_msg_id
+            watchers.notifyTx(pair.resolved.result, pair.resolved.tx_key.tx_id, pair.resolved.external_source_token)
+
+        -- The committing sequence is now drained; no batch is in flight.
+        staging_index.in_flight = false
+
+        let durable_tx = resolved_batch.last.tx_key
 
         -- BlockBoundary closes the batch: finish the block once durable and full,
         -- by which point staging is drained (see live-index FinishBlock). An
@@ -835,12 +926,16 @@ rule WriteStagedBatch {
                 ExternalSourceFinishesBlock(durable_tx.tx_id, durable_token)
             else:
                 LeaderFinishesBlock(durable_tx.tx_id)
+
+        -- Now no batch is in flight; seal+send the next accumulated batch if any.
+        MaybeSealAndSend(staging_index)
 }
 
 rule LeaderProcessesFlushBlock {
-    -- Source-log coordination message, handled on the resolver thread. Block
-    -- finishing itself is a replica-writer (proc 2) operation: it drains staging
-    -- first (see live-index FinishBlock).
+    -- Source-log coordination message, handled on the resolver thread. The block
+    -- cut itself is a resolver decision: it drains staging (awaits the in-flight
+    -- persist and promotes), then the block is finished with staging drained (see
+    -- live-index FinishBlock).
     when: msg: FlushBlockMessage consumed from database.source_log
     requires: log_processor.mode = Leader
 
@@ -861,7 +956,7 @@ rule LeaderProcessesFlushBlock {
 rule LeaderProcessesTriesAdded {
     -- L1+ from compactor. The leader needs these in its trie catalog
     -- for correct partition info at block time, and forwards them to the replica
-    -- log (a replica-writer / proc-2 op, since it owns the producer).
+    -- log via the Replica's producer (proc 2 owns the producer).
     when: msg: TriesAddedMessage consumed from database.source_log
     requires: log_processor.mode = Leader
 
@@ -901,18 +996,18 @@ rule LeaderProcessesBlockUploaded {
 
 ---- Rules: Leader Block Finishing
 
--- The leader finishes blocks via BlockUploader, on the replica-writer (proc 2)
--- side: by the time we get here the in-flight batch has been promoted and
--- staging is drained, so the durable block never contains non-durable rows
--- (see live-index FinishBlock, which requires staging drained).
+-- The leader finishes blocks via BlockUploader: by the time we get here the
+-- resolver has drained staging (the in-flight batch promoted), so the durable
+-- block never contains non-durable rows (see live-index FinishBlock, which
+-- requires staging drained).
 -- The leader sets pending_block between writing BlockBoundary and BlockUploaded.
 -- If the leader is revoked during this window, the pending block gets passed
 -- to the follower (see TransitionToFollower).
 --
 -- Double-finish is not possible: LeaderFinishesBlock is fired by either
--- WriteStagedBatch (when live_index.is_full, post-promotion) or
+-- ResolverPromotesBatch (when live_index.is_full, post-promotion) or
 -- LeaderProcessesFlushBlock.
--- These are processed sequentially on the source log subscription thread.
+-- These are processed sequentially on the resolver thread.
 -- If a batch flush triggers a block finish, it calls
 -- nextBlock() — the live index is no longer full. If a FlushBlock message
 -- arrives later for the same block_index, its CAS (expected_block_idx ==
@@ -1013,32 +1108,34 @@ rule ExternalSourceIndexesTx {
     -- result, which is caller-side and below this spec's abstraction level.
     --
     -- Unlike the client-driven leader, tx_id here is assigned off the STAGING
-    -- head (the staging area's own latest_completed_tx), NOT a source-log
-    -- position and NOT the durable basis. db.allium does not import the staging
-    -- area, so it cannot read that head; id-assignment is delegated to the
+    -- head (the staging index's own latest_completed_tx), NOT a source-log
+    -- position and NOT the durable basis. id-assignment is delegated to the
     -- staging layer via live_index.beginStagedTx, which assigns the next tx_id
     -- (staging-head tx_id + 1), smooths system_time strictly greater than the
-    -- previous tx's, applies the resolved data to staging, and returns the
-    -- assigned TransactionKey. (See live-index.allium BeginStagedTx / deferred
-    -- below.)
+    -- previous tx's, applies the resolved data to the resolver's staging index, and
+    -- returns the assigned TransactionKey. (See live-index.allium BeginStagedTx /
+    -- deferred below.)
     --
     -- The resulting ResolvedTx carries the external_source_token all the way
     -- through watchers, so block boundaries and restarts can resume from it.
     --
-    -- This is the RESOLVER (proc 1): resolve and apply to staging, then hand
-    -- downstream. The durable replica-log write, promotion and watcher notify are
-    -- done by the replica-writer (proc 2): WriteStagedBatch.
+    -- This is the RESOLVER (proc 1): resolve and apply to its staging index, then
+    -- decide at this tx boundary whether to seal+send. The durable replica-log
+    -- write is the pure Replica writer's job (proc 2: ReplicaWritesBatch); the
+    -- promotion and post-durable watcher notify are the resolver's own, on the
+    -- back-edge (ResolverPromotesBatch).
     when: ExternalSourceIndexTx(external_source_token, system_time, writer)
     requires: log_processor.mode = ExternalSourceLeader
 
     ensures:
         -- Delegate id-assignment and the staging apply to the staging layer.
         -- beginStagedTx assigns tx_id off the staging head, smooths system_time,
-        -- applies the writer's resolved data to staging, and returns the key.
-        let tx_key = live_index.beginStagedTx(system_time, external_source_token, writer)
+        -- applies the writer's resolved data to the resolver's staging index, and
+        -- returns the key.
+        let tx_key = live_index.beginStagedTx(staging_index, system_time, external_source_token, writer)
 
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        -- Tx-boundary decision: seal+send a batch downstream if appropriate.
+        MaybeSealAndSend(staging_index)
 }
 
 rule ExternalSourceProcessesFlushBlock {
@@ -1098,9 +1195,9 @@ rule ExternalSourceFinishesBlock {
     -- Mirror of LeaderFinishesBlock for the external-source leader. The
     -- BlockBoundary and the persisted Block both carry the
     -- external_source_token so that a restart can resume the external source
-    -- from the last durably persisted position. Driven by the replica-writer
-    -- (proc 2) after the in-flight batch is promoted, so staging is drained
-    -- before the block is written.
+    -- from the last durably persisted position. Driven by the resolver
+    -- (ResolverPromotesBatch) after the in-flight batch is promoted, so staging
+    -- is drained before the block is written.
     when: ExternalSourceFinishesBlock(latest_processed_msg_id, external_source_token)
 
     let block_index = (block_catalog.current_block_index ?? -1) + 1
@@ -1399,13 +1496,32 @@ deferred IndexTransaction           -- transaction resolution (put/delete/erase 
 deferred ResolveAttach              -- attach database resolution
 deferred ResolveDetach              -- detach database resolution
 deferred WriteResolvedToReplica     -- builds the per-tx ResolvedTxMessage (incl. abort-error
-                                    -- projection and external_source_token) and appends it to
-                                    -- the replica log via the transactional producer
-deferred BeginStagedTx              -- live_index.beginStagedTx(system_time, token, writer): the
-                                    -- staging layer assigns the next external-source tx_id off the
+                                    -- projection and external_source_token), appends it to the
+                                    -- replica log via the Replica's transactional producer, and
+                                    -- returns its appended replica-log msg_id (the resolver uses
+                                    -- these per-tx positions to advance the apply cursor on promote)
+deferred BeginStagedTx              -- live_index.beginStagedTx(staging_index, system_time, token, writer):
+                                    -- the staging layer assigns the next external-source tx_id off the
                                     -- staging head (head tx_id + 1), smooths system_time strictly
                                     -- greater than the previous tx's, applies the writer's resolved
-                                    -- data to staging, and returns the assigned TransactionKey.
-                                    -- db.allium delegates here rather than reading the staging head
-                                    -- (which it cannot — it does not use live-index.allium).
+                                    -- data to the resolver's staging index, and returns the assigned
+                                    -- TransactionKey. db.allium delegates here rather than reading the
+                                    -- staging head (which it cannot — it does not use live-index.allium).
                                     -- See: live-index.allium BeginStagedTx
+deferred ApplyToStaging             -- live_index.applyToStaging(staging_index, resolved): the resolver
+                                    -- appends a resolved tx into the accumulating slot and advances the
+                                    -- staging index's applied head. See: live-index.allium CommitTransaction
+deferred SealStagingBatch           -- live_index.sealStagingBatch(staging_index): seals the accumulating
+                                    -- slot into the committing sequence (no-op if empty) and returns
+                                    -- the batch's resolved txs in send order. See: live-index.allium
+                                    -- SealStagingBatch
+deferred PromoteNext                -- live_index.promoteNext(staging_index): on the back-edge, the
+                                    -- resolver promotes the OLDEST staged tx in the committing
+                                    -- sequence — imports its rows into the durable live tables,
+                                    -- advances the durable basis to it, refreshes the shared snapshot,
+                                    -- then drops it. Called once per tx, in send order.
+                                    -- See: live-index.allium PromoteNext
+deferred CloseStagingIndex           -- live-index.allium CloseStagingIndex(staging_index): phase-2 of the
+                                    -- leader's two-phase close frees the staging index; demotion is
+                                    -- exactly this teardown (no separate runtime drop).
+                                    -- See: live-index.allium CloseStagingIndex


### PR DESCRIPTION
Part of #5507.

Batches — and pipelines within a poll batch — the leader's replica-log writes. The leader used to resolve, append, import, notify and finish-block for each tx on one coroutine, coupling transaction resolution (the heavy DML work) to the replica-log commit's latency. This PR splits that into a resolver that owns a staging index and a pure replica-log writer, then batches a poll batch's txs into one atomic append with the resolver running ahead of the writer within the batch. Running ahead *across* polls is deferred (see Out of scope).

## What's here

The resolver (proc 1) owns a `StagingIndex` — committed-but-not-yet-durable txs — as its sole accessor, so it needs no lock; the replica writer (proc 2) is a pure replica-log writer.

Resolution reads `durable ⊕ staged ⊕ own`: `Snapshot.open` layers the in-flight staged txs' tables between the durable index and the resolving tx's own writes, so a tx resolving behind earlier staged txs in the same batch sees them (read-your-writes across the batch). External snapshots carry no openTx, so they still see durable only — strict visibility is unchanged.

Batching: a source-log poll batch's txs accumulate in staging; the resolver seals a batch, hands it to the writer, keeps resolving while the writer appends, and on the writer's ack promotes the batch into the durable index — a send-on-ack pipeline (many txs, one atomic append, resolution hidden behind the write). Block cuts are decided on the ack, post-promote, where `liveIndex.isFull()` is accurate — no stage-time row-counting. Control messages (`FlushBlock`, `TriesAdded`, `BlockUploaded`) and attach/detach drain the accumulated batch first, so they keep replica-log order. Ext-source (CDC) txs arrive one at a time through `executeTx`, so they stay batch-of-one.

## Decision rationale

Several mechanisms make this correct — each hard-won through the concurrency dead ends #5507 records:

Two-homes watermark, no new field. `LiveIndex.latestCompletedTx` is the durable / query basis (advanced by promote); the staging index carries its own `latestCompletedTx` as the applied / resolution head, seeded from the durable head — without the seeding a new leader restarted ext-source tx-ids at zero and collided, throwing `notifyTx`'s strictly-increasing check.

The apply cursor (`latestReplicaMsgId`, the follower's resume point) advances only when a message is applied locally, and — under batching — per tx as each is promoted, not once at the batch's end. So a partial promote (an `importTx` fault mid-batch) leaves the cursor at the last tx that actually imported; a follower resuming from it re-applies only the un-imported tail rather than double-importing the head. This is the general transition-safety mechanism: an appended-but-unpromoted tx is replayed from the log on the next term, never re-resolved and duplicated.

Batching stays bounded to the poll batch, which keeps it #5741-safe with no Kafka-consumer change: `processRecords` still awaits the whole batch draining before returning, so the persister is quiescent whenever the poll thread is back in `poll()` — where a Kafka rebalance runs the leader/follower transition under `runBlocking` — and the transition's cancel-join finds nothing in flight (the deadlock #5741's await originally fixed).

Teardown is structured: resolver and writer run in one `coroutineScope` and fail together; only the external source is isolated under the `supervisorScope`. Staging is standing state the leader term owns, freed in its two-phase `close()` — the resolved OpenTxs it parks are closed on promote, or on teardown.

## Out of scope

Running the resolver ahead **across** polls — the unbounded pipeline — is deferred: it removes the quiescent-at-poll invariant, so it needs the leader/follower transition moved off the synchronous rebalance callback, the follow-up #5741 itself names. The allium models the full target including that, so `weed` shows divergence until it lands.

## Test plan

Behaviour-preserving groundwork (the resolver/writer split and the batch-capable staging shape) plus the batching itself. The existing indexer / log / node / api / live-index suites pass unchanged, and `LogProcessorSimTest` exercises the batching across 500 iterations — the sim delivers random-sized poll batches, so batches larger than one are hit. The sql / indexer / api / node suites (286 tests) pass: replica-tx monotonicity, contiguous block boundaries, action completeness, cross-node watermark convergence, and DML read-your-writes all hold. No Arrow leaks, no reflection or boxed-math warnings.

Generated with [Claude Code](https://claude.com/claude-code)