### PR TITLE
fix(arrow): reconcile null DUV legs instead of failing the merge (#5714)

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -261,7 +261,18 @@ class DenseUnionVector private constructor(
         for (i in legVectors.indices) {
             val leg = legVectors[i]
             if (leg.name == name) {
-                if (leg.arrowType != arrowType) throw Unsupported("cannot promote DUV leg")
+                // a DUV leg keyed by op rather than type (e.g. `op`'s `put`) can be Struct
+                // in one segment and Null in a put-less one. null is the lattice bottom, so
+                // reconcile it instead of throwing; only two distinct non-null types are
+                // genuinely unpromotable. #5714
+                if (leg.arrowType != arrowType) {
+                    when {
+                        arrowType == NULL_TYPE -> leg.nullable = true
+                        leg.arrowType == NULL_TYPE -> legVectors[i] = leg.maybePromote(allocator, arrowType, nullable)
+                        else -> throw Unsupported("cannot promote DUV leg: '$name' (existing ${leg.arrowType}, incoming $arrowType)")
+                    }
+                    return LegVector(i.toByte(), legVectors[i])
+                }
                 leg.nullable = leg.nullable || nullable
 
                 return LegVector(i.toByte(), leg)

--- a/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import xtdb.TaggedValue
+import xtdb.kw
 
 class DenseUnionVectorTest {
     private lateinit var allocator: BufferAllocator
@@ -214,6 +216,51 @@ class DenseUnionVectorTest {
 
                 assertEquals(listOf(1, 0, 1).map { it.toByte() }, duv.typeIds())
                 assertEquals(listOf(obj1, null, obj2), mono.asList)
+            }
+        }
+    }
+
+    // a put-less segment (e.g. erase-only) writes its `op` union with a Null `put` leg
+    // alongside delete/erase; three legs, so a copy goes through rowCopier0/legVectorFor
+    // rather than the single-leg `rowCopier` shortcut that bypasses it.
+    private fun putLessOpDuv() =
+        DenseUnionVector(allocator, "op",
+            listOf(NullVector("put"), NullVector("delete"), NullVector("erase")))
+
+    private fun structPutOpDuv() =
+        DenseUnionVector(allocator, "op",
+            listOf(StructVector(allocator, "put", true,
+                linkedMapOf("a" to IntVector.open(allocator, "i32", true))),
+                NullVector("delete"), NullVector("erase")))
+
+    @Test
+    fun `merging a put-less op-union into a Struct-put one reconciles the Null put leg #5714`() {
+        structPutOpDuv().use { dest ->
+            structPutOpDuv().use { withPut ->
+                withPut.vectorFor("put").writeObject(mapOf("a" to 1))
+
+                putLessOpDuv().use { putLess ->
+                    putLess.vectorFor("erase").writeNull()
+
+                    withPut.rowCopier(dest).copyRange(0, withPut.valueCount)
+                    putLess.rowCopier(dest).copyRange(0, putLess.valueCount)
+
+                    assertEquals(2, dest.valueCount)
+                    assertEquals(TaggedValue("put".kw, mapOf("a" to 1)), dest.getObject(0))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `merging a Struct-put op-union into a put-less one promotes the Null put leg #5714`() {
+        putLessOpDuv().use { dest ->
+            structPutOpDuv().use { withPut ->
+                withPut.vectorFor("put").writeObject(mapOf("a" to 7))
+                withPut.rowCopier(dest).copyRange(0, withPut.valueCount)
+
+                assertEquals(1, dest.valueCount)
+                assertEquals(TaggedValue("put".kw, mapOf("a" to 7)), dest.getObject(0))
             }
         }
     }

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -330,6 +330,38 @@
              (->> (xt/q node "SELECT foo FROM foo")
                   (into #{} (map :foo)))))))
 
+(t/deftest compaction-settles-merging-null-put-leg-5714
+  (binding [c/*page-size* 8
+            cat/*file-size-target* 16
+            c/*ignore-signal-block?* true]
+    (let [node-dir (util/->path "target/compactor/null-put-leg-5714")]
+      (util/delete-dir node-dir)
+      (util/with-open [node (tu/->local-node {:node-dir node-dir, :rows-per-block 10})]
+        ;; with a tiny file-size-target each block completes its own L1 file: a put block
+        ;; gives a Struct-put L1, a delete-only block a put-less (Null-put) L1.
+        (letfn [(put! [ids]
+                  (xt/submit-tx node [(into [:put-docs :recs] (for [i ids] {:xt/id i, :v (str "v" i)}))])
+                  (tu/flush-block! node)
+                  (c/compact-all! node #xt/duration "PT2S"))
+                (del! [ids]
+                  (xt/submit-tx node [(into [:delete-docs :recs] (vec ids))])
+                  (tu/flush-block! node)
+                  (c/compact-all! node #xt/duration "PT2S"))]
+          (put! (range 0 10))
+          (del! (range 0 10))
+          (put! (range 10 20))
+
+          ;; a Null-put L1 now coexists with Struct-put L1s, before branch-factor triggers
+          ;; the L2 merge - so the scan itself has to reconcile the Null put leg against the
+          ;; Struct ones (the read side of #5714: 'vectorFor unsupported on NullVector')
+          (t/is (= 10 (count (xt/q node "SELECT _id, v FROM recs"))))
+
+          ;; the fourth L1 reaches branch-factor and triggers the L2 merge that reconciles
+          ;; those same legs - 'cannot promote DUV leg' without the fix
+          (del! (range 10 20))
+
+          (t/is (= 0 (-> (xt/q node "SELECT count(*) c FROM recs") first :c))))))))
+
 (t/deftest test-compaction-with-erase-4017
   (binding [c/*ignore-signal-block?* true]
     (let [node-dir (util/->path "target/compactor/compaction-with-erase")]


### PR DESCRIPTION
Compaction merges that combined a put-less trie with one that still had documents threw `cannot promote DUV leg`, and the table stopped compacting. The `op` dense-union keys its legs by operation, so the `put` leg's type is data-dependent: `Struct` where a segment has documents, but `Null` once a put-less segment (deletes/erases only) is compacted — `dataRelSchema(mergeFields(...))` mints a present-but-`Null` `put` leg when no input carries a put schema. Merging that into a `Struct`-put trie reached `DenseUnionVector.legVectorFor`, which rejected any same-named leg whose arrow type differed.

`Null` is the bottom of the type lattice, though — always reconcilable, never a real clash. An incoming `Null` leg carries no typed values, so it absorbs into the existing leg; an existing `Null` leg promotes to the incoming type. Only two genuinely-distinct non-null types stay unpromotable — a `toLeg` naming collision, handled elsewhere — and that now throws with the leg name and both types so it's diagnosable.

This is the compaction-side of #5714. The read-side wedge (`vectorFor unsupported on NullVector`, the permanently-unreadable table) reproduces on 2.1.0 but not on main — already fixed between the release and now — so this covers what was still live.