### PR TITLE
fix(compactor): surface failed jobs from compactAll instead of hanging

### DIFF
--- a/core/src/main/clojure/xtdb/compactor.clj
+++ b/core/src/main/clojure/xtdb/compactor.clj
@@ -19,7 +19,9 @@
         Compactor/NOOP))))
 
 (defn compact-all!
-  "`timeout` is now required, explicitly specify `nil` if you want to wait indefinitely."
+  "Compacts until idle. `timeout` is required; pass `nil` to wait indefinitely for
+   pending work. A failed compaction job is surfaced (thrown) rather than waited on,
+   so this won't hang (or time out) on a job that can never complete."
   [node timeout]
 
   (-> (.getCompactor (db/primary-db node))

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -18,6 +18,7 @@ import xtdb.compactor.PageTree.Companion.asTree
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
+import xtdb.error.Fault
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.TrieMetadata
 import xtdb.segment.BufferPoolSegment
@@ -29,6 +30,13 @@ import java.time.Duration
 import kotlin.use
 
 typealias JobKey = Pair<TableRef, TrieKey>
+
+// a failed entry is kept (unlike a successful one, which is dropped) so we don't retry a poison
+// job and `compactAll` can surface its error.
+private sealed interface JobState {
+    data object InFlight : JobState
+    data class Failed(val error: Throwable) : JobState
+}
 
 private val LOGGER = Compactor::class.logger
 
@@ -176,7 +184,8 @@ interface Compactor : AutoCloseable {
             @Volatile
             private var availableJobs = emptyMap<JobKey, Job>()
 
-            private val queuedJobs = mutableSetOf<JobKey>()
+            // started jobs by disposition; touched only by the outer-loop coroutine, so unsynchronised.
+            private val jobStates = mutableMapOf<JobKey, JobState>()
 
             private val jobTimer: Timer? = meterRegistry?.let {
                 Timer.builder("compactor.job.timer")
@@ -184,7 +193,7 @@ interface Compactor : AutoCloseable {
                     .register(it)
             }
 
-            private val doneCh = Channel<JobKey>()
+            private val doneCh = Channel<Pair<JobKey, Throwable?>>()
             private val wakeupCh = Channel<Unit>(1, onBufferOverflow = DROP_OLDEST)
             private var compactAllPromise: CompletableDeferred<Unit>? = null
 
@@ -204,14 +213,35 @@ interface Compactor : AutoCloseable {
                                 jobCalculator.availableJobs(trieCatalog)
                                     .associateBy { JobKey(it.table, it.outputTrieKey.toString()) }
 
-                            if (availableJobs.isEmpty() && queuedJobs.isEmpty()) {
+                            // excluding started jobs is what stops a still-running (or failed) job
+                            // being re-launched.
+                            val pendingJobs = availableJobs.keys.filterNot { it in jobStates }
+
+                            if (pendingJobs.isEmpty() && jobStates.values.none { it is JobState.InFlight }) {
                                 LOGGER.trace("sending idle")
-                                compactAllPromise?.complete(Unit)
+
+                                val failed = jobStates.mapNotNull { (jobKey, state) ->
+                                    (state as? JobState.Failed)?.let { jobKey to it.error }
+                                }
+
+                                if (failed.isEmpty())
+                                    compactAllPromise?.complete(Unit)
+                                else
+                                    // surface *every* failed job rather than completing normally —
+                                    // otherwise the caller can't tell a drained compactor from one
+                                    // stuck on a failure, and can't see which job(s) failed. first as
+                                    // cause, rest suppressed, so a caller can find the one it induced.
+                                    compactAllPromise?.completeExceptionally(
+                                        Fault("compaction failed: ${failed.joinToString { (k, _) -> "${k.first}/${k.second}" }}",
+                                              "xtdb.compactor/jobs-failed", cause = failed.first().second)
+                                            .apply { failed.drop(1).forEach { (_, e) -> addSuppressed(e) } }
+                                    )
                             }
 
-                            availableJobs.keys.forEach { jobKey ->
-                                if (queuedJobs.add(jobKey)) {
-                                    launch(jobsDispatcher + CoroutineName("job: ${jobKey.first} / ${jobKey.second}")) {
+                            pendingJobs.forEach { jobKey ->
+                                jobStates[jobKey] = JobState.InFlight
+                                launch(jobsDispatcher + CoroutineName("job: ${jobKey.first} / ${jobKey.second}")) {
+                                    val error = try {
                                         jobsSemaphore.withPermit {
                                             // check it's still required
                                             val job = availableJobs[jobKey]
@@ -234,16 +264,23 @@ interface Compactor : AutoCloseable {
                                                 }
                                             }
                                         }
-
-                                        // intentionally outside try/finally - if the job fails, we leave it in queuedJobs
-                                        // so this node doesn't attempt it again
-                                        doneCh.send(jobKey)
+                                        null
+                                    } catch (e: CancellationException) {
+                                        throw e
+                                    } catch (e: Throwable) {
+                                        // already logged by the driver; kept to surface via compactAll
+                                        e
                                     }
+
+                                    doneCh.send(jobKey to error)
                                 }
                             }
 
                             select {
-                                doneCh.onReceive { queuedJobs.remove(it) }
+                                doneCh.onReceive { (jobKey, error) ->
+                                    if (error != null) jobStates[jobKey] = JobState.Failed(error)
+                                    else jobStates.remove(jobKey)
+                                }
 
                                 wakeupCh.onReceive {
                                     LOGGER.trace("wakey wakey")

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -31,6 +31,7 @@ import xtdb.compactor.TemporalSplitting.*
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
+import xtdb.error.Fault
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.BufferPool
 import xtdb.storage.MemoryStorage
@@ -69,7 +70,8 @@ enum class TemporalSplitting {
 data class CompactorDriverConfig(
     val temporalSplitting: TemporalSplitting = CURRENT,
     val baseTime: Instant = Instant.parse("2020-01-01T00:00:00Z"),
-    val blocksPerWeek: Long = 140
+    val blocksPerWeek: Long = 140,
+    val failJobs: Boolean = false
 )
 
 class CompactorMockDriverFactory(
@@ -82,6 +84,7 @@ class CompactorMockDriverFactory(
     private val temporalSplitting = config.temporalSplitting
     private val baseTime = config.baseTime
     private val blocksPerWeek = config.blocksPerWeek
+    private val failJobs = config.failJobs
     // Key is "tableName:trieKey" to avoid collisions between tables with the same trie key
     val trieKeyToFileSize = ConcurrentHashMap<String, Long>()
 
@@ -143,6 +146,7 @@ class CompactorMockDriverFactory(
         }
 
         override suspend fun executeJob(job: Job): TriesAdded {
+            if (failJobs) throw IllegalStateException("simulated compaction failure: ${job.table.tableName}")
             val tableName = job.table.tableName
             LOGGER.debug("[executeJob started] systemId=$systemId table=$tableName job.trieKeys=${job.trieKeys} job.outputTrieKey=${job.outputTrieKey}")
             yield() // Force suspension after executeJob has started
@@ -238,7 +242,8 @@ private const val logLevel = "WARN"
 annotation class WithCompactorDriverConfig(
     val temporalSplitting: TemporalSplitting = TemporalSplitting.CURRENT,
     val baseTime: String = "2020-01-01T00:00:00Z",
-    val blocksPerWeek: Long = 14
+    val blocksPerWeek: Long = 14,
+    val failJobs: Boolean = false
 )
 
 class DriverConfigExtension : BeforeEachCallback {
@@ -253,7 +258,8 @@ class DriverConfigExtension : BeforeEachCallback {
             CompactorDriverConfig(
                 temporalSplitting = temporalSplitting,
                 baseTime = Instant.parse(baseTime),
-                blocksPerWeek = blocksPerWeek
+                blocksPerWeek = blocksPerWeek,
+                failJobs = failJobs
             )
         }
     }
@@ -379,6 +385,45 @@ class CompactorSimulationTest : SimulationTestBase() {
     @Test
     fun singleL0CompactionNotHanging() {
         singleL0Compaction()
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @WithCompactorDriverConfig(failJobs = true)
+    fun compactAllSurfacesAFailedJob() {
+        val docsTable = TableRef("public", "docs")
+        val db = dbs[0]
+
+        db.withCompactor {
+            seedTries(docsTable, listOf(buildTrieDetails(docsTable.tableName, L0TrieKeys.first())))
+
+            // @Timeout guards a regression: a stuck job used to keep compactAll from reaching idle.
+            val e = assertThrows<Fault> { it.compactAllSync(null) }
+            assertTrue(e.cause!!.message!!.contains("simulated compaction failure"))
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @WithCompactorDriverConfig(failJobs = true)
+    fun compactAllSurfacesEveryFailedJob() {
+        val a = TableRef("public", "a")
+        val b = TableRef("public", "b")
+        val db = dbs[0]
+
+        db.withCompactor {
+            seedTries(a, listOf(buildTrieDetails(a.tableName, L0TrieKeys.first())))
+            seedTries(b, listOf(buildTrieDetails(b.tableName, L0TrieKeys.first())))
+
+            val e = assertThrows<Fault> { it.compactAllSync(null) }
+
+            // both jobs' failures are surfaced (one as cause, the rest suppressed), so a caller
+            // can find the specific one it cares about rather than getting an arbitrary single error
+            val messages = (listOf(e.cause) + e.suppressed.toList()).mapNotNull { it?.message }
+            assertEquals(2, messages.size)
+            assertTrue(messages.any { it.endsWith(": a") })
+            assertTrue(messages.any { it.endsWith(": b") })
+        }
     }
 
     @RepeatableSimulationTest


### PR DESCRIPTION
A failed compaction job was deliberately left in `queuedJobs` so the node wouldn't keep retrying a deterministically-poison job — but that set also tracked in-flight work, so once a job failed `queuedJobs` was never empty again, the idle signal `compactAll` waits on never fired, and the only way out was the caller's timeout. A caller couldn't tell a genuinely-drained compactor from one wedged on a failed job, and a `nil` (wait-indefinitely) timeout hung forever.

The single set couldn't represent "failed, and therefore no longer in-flight". `jobStates` makes a started job's disposition explicit, so a failed job can be reported like any other — leaving the in-flight set, letting idle fire — while staying out of contention so it's still never retried. At quiescence `compactAll` completes its promise exceptionally with a `Fault` aggregating every failed job, so a caller gets the whole picture and can pick out the failure it cares about rather than an arbitrary single one.

Only `compactAll` is affected — the drain-until-idle driver used by tests, benchmarks and dev. The autonomous loop never waits on idle, so it's unchanged: a failed job is still skipped and the loop carries on. The payoff is that a compaction failure surfaces as a thrown error rather than an opaque hang, which is what the new failing-driver tests pin down.