### PR TITLE
docs: external source pages (Postgres + Kafka Connect)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -205,6 +205,29 @@ export default defineConfig({
                             ]
                         },
                         {
+                            label: 'External Sources',
+                            collapsed: true,
+                            items: [
+                                { label: 'Overview', link: '/ops/external-sources/overview' },
+                                {
+                                    label: 'Postgres External Source',
+                                    collapsed: true,
+                                    items: [
+                                        { label: 'Setup guide', link: '/ops/external-sources/postgres/setup' },
+                                        { label: 'Reference', link: '/ops/external-sources/postgres/reference' },
+                                    ],
+                                },
+                                {
+                                    label: 'Kafka Connect External Source',
+                                    collapsed: true,
+                                    items: [
+                                        { label: 'Setup guide', link: '/ops/external-sources/kafka-connect/setup' },
+                                        { label: 'Reference', link: '/ops/external-sources/kafka-connect/reference' },
+                                    ],
+                                },
+                            ],
+                        },
+                        {
                             label: 'Authentication',
                             collapsed: true,
                             items: [

--- a/docs/src/content/docs/ops/external-sources/kafka-connect/reference.md
+++ b/docs/src/content/docs/ops/external-sources/kafka-connect/reference.md
@@ -1,0 +1,192 @@
+---
+title: Kafka Connect External Source
+---
+
+## Prerequisites
+
+A Kafka topic carrying the records you want to sync to XTDB.
+
+:::caution
+Records on partitions other than partition 0 are not consumed, so the topic should have a single partition.
+:::
+
+## Configuration
+
+Configured by [attaching a secondary database](/about/dbs-in-xtdb#attachingdetaching-secondary-databases-v21) with the additional `externalSource` options.
+It consumes a topic via a [`!Kafka` remote](#remote), applies a [Connect config](#connect-config) to each record, and writes through an [indexer](#indexers):
+
+```sql
+ATTACH DATABASE my_db WITH $$
+externalSource: !KafkaConnect
+  # The alias of the !Kafka remote holding the cluster connection details.
+  remote: my_kafka_remote
+
+  # The Kafka topic to consume records from.
+  topic: my_upstream_topic
+
+  # Kafka Connect converter and transform options.
+  # key.converter and value.converter are required.
+  connectConfig:
+    key.converter: org.apache.kafka.connect.storage.StringConverter
+    value.converter: org.apache.kafka.connect.json.JsonConverter
+    value.converter.schemas.enable: "false"
+    transforms: unwrap
+    transforms.unwrap.type: org.apache.kafka.connect.transforms.ExtractField$Value
+    transforms.unwrap.field: payload
+
+  # The indexer used to index records.
+  indexer: !Docs
+    table: my_table
+$$
+```
+
+### Remote
+
+Kafka cluster connection details are stored in a `!Kafka` [remote](/ops/config#remotes).
+See the [Kafka](/ops/config/log/kafka) documentation for the available options.
+
+```yaml
+remotes:
+  my_kafka_remote: !Kafka
+    bootstrapServers: "localhost:9092"
+```
+
+### Connect config
+
+`connectConfig` is a map of [Kafka Connect](https://kafka.apache.org/documentation/#connect) options applied to each record before it is indexed.
+XTDB accepts the keys below; any other key is rejected.
+
+```yaml
+connectConfig:
+  # Required: the fully-qualified converter class for record keys and values.
+  key.converter: <converter class>
+  value.converter: <converter class>
+
+  # Options passed to a converter, with the key.converter./value.converter. prefix stripped.
+  value.converter.<option>: <value>
+
+  # A comma-separated list of transform aliases, applied in order.
+  transforms: <alias>
+
+  # The fully-qualified transform class.
+  transforms.<alias>.type: <transform class>
+
+  # Options passed to the transform.
+  transforms.<alias>.<option>: <value>
+
+  # Optional: the alias of a predicate (declared in `predicates`) that gates whether the transform applies.
+  transforms.<alias>.predicate: <predicate alias>
+
+  # Optional: apply the transform only when the predicate does not match. Requires `predicate`.
+  transforms.<alias>.negate: "true"
+
+  # A comma-separated list of predicate aliases.
+  predicates: <alias>
+
+  # The fully-qualified predicate class.
+  predicates.<alias>.type: <predicate class>
+
+  # Options passed to the predicate.
+  predicates.<alias>.<option>: <value>
+```
+
+See [Included Kafka Connect classes](#included-kafka-connect-classes) for the bundled classes and the interfaces a custom class must implement.
+
+XTDB runs converters, transforms, and predicates itself rather than in a Kafka Connect worker, so some Kafka Connect features are unavailable:
+- Classes are loaded from the JVM classpath by name; there is no `plugin.path` isolation.
+- Header conversion is fixed and cannot be configured.
+
+:::caution
+There is no error tolerance, dead-letter queue, or skip-and-continue, matching Kafka Connect's `errors.tolerance=none`.
+A record that fails to convert or transform halts the source, and so does any record an indexer cannot process or declines to.
+:::
+
+## Included Kafka Connect classes
+
+Converters, transforms, and predicates are loaded from the node's classpath by their fully-qualified class name.
+The classes listed below are bundled with XTDB.
+
+To use any other Kafka Connect class, for example [`io.confluent.connect.json.JsonSchemaConverter`](https://docs.confluent.io/platform/current/connect/userguide.html#json-schema-and-protobuf), add its jar to the node's classpath.
+How you add a jar to the classpath depends on how you deploy XTDB, for example as a dependency in your build or bundled into your XTDB image.
+
+A custom class must implement the relevant Kafka Connect interface.
+
+Converters
+:   Deserialize record keys and values — implement `org.apache.kafka.connect.storage.Converter`.
+    XTDB bundles [`StringConverter`](https://docs.confluent.io/platform/current/connect/userguide.html#string-format-and-raw-bytes), [`JsonConverter`](https://docs.confluent.io/platform/current/connect/userguide.html#json-without-sr), and [`AvroConverter`](https://docs.confluent.io/platform/current/connect/userguide.html#avro).
+
+Transforms
+:   Single Message Transforms that modify each record before it is indexed — implement `org.apache.kafka.connect.transforms.Transformation<SinkRecord>`.
+    XTDB bundles those that ship with [Kafka Connect 4.1.1](https://kafka.apache.org/41/kafka-connect/user-guide/#included-transformations).
+    The target table is set by the [indexer](#indexers), so a transform that changes a record's topic has no effect on where it is written.
+
+Predicates
+:   Predicates that gate whether a transform applies to a record — implement `org.apache.kafka.connect.transforms.predicates.Predicate<SinkRecord>`.
+    XTDB bundles those that ship with [Kafka Connect 4.1.1](https://kafka.apache.org/41/kafka-connect/user-guide/#predicates).
+
+## Indexers
+
+The following indexers are built into XTDB:
+- Docs
+
+### Docs
+
+Maps each record to a document in the configured table.
+
+#### Configuration
+
+```yaml
+indexer: !Docs
+  # The XTDB table to write to, as `schema.table`.
+  # An unqualified name is taken as the table, in the `public` schema.
+  # The table part must not itself contain a `.`.
+  table: my_table
+```
+
+#### Document `_id`
+
+The `_id` of each document is derived from the record key; an `_id` field in the value is overwritten.
+A single-field Struct key is unwrapped to its inner value automatically.
+A record with no usable key (none at all, a multi-field key, or a binary key) halts the source.
+
+For a topic whose id lives in the value, promote it to the key with the standard Connect transforms:
+
+```yaml
+connectConfig:
+  # ...
+  transforms: keyFromValue,extractKey
+  transforms.keyFromValue.type: org.apache.kafka.connect.transforms.ValueToKey
+  transforms.keyFromValue.fields: id
+  transforms.extractKey.type: org.apache.kafka.connect.transforms.ExtractField$Key
+  transforms.extractKey.field: id
+```
+
+#### Deletes
+
+A tombstone (a record with a null value) is indexed as a delete of the document with that key.
+
+#### Document values
+
+A non-null value must convert to a Struct or Map at the top level; a scalar or array value halts the source.
+
+Record values are translated into XTDB [types](/reference/main/data-types) as follows:
+
+| Kafka Connect type | XTDB type |
+| --- | --- |
+| Struct | nested document |
+| Map | nested document (keys converted to text) |
+| Array | list |
+| Decimal | `DECIMAL` |
+| Timestamp | `TIMESTAMP WITH TIMEZONE` |
+| Date | `DATE` |
+| Time | `TIME` |
+| Bytes | `VARBINARY` |
+| int, long, float, double, boolean, string | the corresponding XTDB scalar |
+
+#### Errors
+
+The `!Docs` indexer halts on any record it can't index, such as one with an unusable key or a non-document value.
+
+#### System time
+
+The system time of each row is the timestamp of the Kafka record, so ensure the topic carries meaningful timestamps — for example by setting `message.timestamp.type=LogAppendTime` on the topic, or by having producers set an explicit timestamp.

--- a/docs/src/content/docs/ops/external-sources/kafka-connect/setup.md
+++ b/docs/src/content/docs/ops/external-sources/kafka-connect/setup.md
@@ -1,0 +1,82 @@
+---
+title: Setting up a Kafka Connect external source
+---
+
+In this guide we will set up a [Kafka Connect external source](/ops/external-sources/kafka-connect/reference) from the Kafka topic `orders` into a database in XTDB called `kc_orders`.
+Along the way we will apply a transform to mask the `email` field, gated by a predicate so it skips tombstones.
+
+To do so we will:
+
+1. Configure the Kafka cluster credentials on the XTDB node and redeploy
+1. Run `ATTACH DATABASE` in XTDB
+
+## Prerequisites
+
+As with other [external sources](/ops/external-sources/overview) you will need:
+
+- A [transaction log](/ops/config/log)
+- An [object store](/ops/config/storage)
+
+:::caution
+Ensure that you have a transaction log and object store that do not conflict with other databases.
+:::
+
+Additionally you will need a single-partition Kafka topic carrying the records to sync.
+
+## Deploy the Kafka cluster credentials
+
+Configured under the [`remotes`](/ops/config#remotes) section of the node config like so:
+
+```yaml
+remotes:
+  kafka_remote: !Kafka
+    bootstrapServers: "localhost:9092"
+```
+
+For nodes to pick up this config change a rolling re-deploy is required.
+
+:::note
+If your [transaction log](/ops/config/log/kafka) is already a `!Kafka` remote, you can reuse those credentials for the source rather than declaring a new remote — and since the config is unchanged, no rolling re-deploy is needed.
+:::
+
+## Run `ATTACH DATABASE` in XTDB
+
+Finally to attach the secondary database with the external source:
+
+```sql
+ATTACH DATABASE kc_orders WITH $$
+# Set up in the prerequisites
+log: !Local
+  path: 'kc-orders/log'
+storage: !Local
+  path: 'kc-orders/storage'
+
+externalSource: !KafkaConnect
+  remote: kafka_remote
+  topic: orders
+  connectConfig:
+    key.converter: org.apache.kafka.connect.storage.StringConverter
+    value.converter: org.apache.kafka.connect.json.JsonConverter
+    value.converter.schemas.enable: "false"
+    transforms: mask
+    transforms.mask.type: org.apache.kafka.connect.transforms.MaskField$Value
+    transforms.mask.fields: email
+    transforms.mask.replacement: REDACTED
+    transforms.mask.predicate: notTombstone
+    transforms.mask.negate: "true"
+    predicates: notTombstone
+    predicates.notTombstone.type: org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
+  indexer: !Docs
+    table: orders
+$$
+```
+
+You can now query the database by connecting to the `kc_orders` database and running:
+```sql
+SELECT * FROM orders;
+```
+
+Or from another database in XTDB by running:
+```sql
+SELECT * FROM kc_orders.public.orders;
+```

--- a/docs/src/content/docs/ops/external-sources/overview.md
+++ b/docs/src/content/docs/ops/external-sources/overview.md
@@ -1,0 +1,24 @@
+---
+title: External Sources
+---
+
+A secondary database can be backed by an external source.
+Rather than accepting transactions from clients, it subscribes to an upstream feed and records what it reads as XTDB transactions.
+
+The database is then a read-only mirror of that upstream — it rejects writes from the [Postgres wire-compatible server](/ops/config#postgres-wire-compatible-server) and the [Flight SQL server](/ops/config#flight-sql-server), and tracks the upstream as it changes.
+
+## Supported sources
+
+Postgres
+
+: Change-data-capture from a Postgres database — see [Postgres External Source](/ops/external-sources/postgres/setup).
+
+Kafka Connect
+
+: Records from a Kafka Connect topic — see [Kafka Connect External Source](/ops/external-sources/kafka-connect/setup).
+
+## Configuring an external source
+
+An external source is set up when you [attach the secondary database](/about/dbs-in-xtdb#attachingdetaching-secondary-databases-v21): add an `externalSource:` entry to the `ATTACH DATABASE` config, alongside its `log:` and `storage:`.
+
+See each source's setup guide for the specifics.

--- a/docs/src/content/docs/ops/external-sources/postgres/reference.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/reference.md
@@ -1,0 +1,107 @@
+---
+title: Postgres External Source
+---
+
+## Prerequisites
+
+A [role](https://www.postgresql.org/docs/current/user-manag.html) with the following attributes and privileges:
+- The [`LOGIN`](https://www.postgresql.org/docs/current/role-attributes.html) attribute. Allows opening a session in Postgres.
+- The [`REPLICATION`](https://www.postgresql.org/docs/current/role-attributes.html) attribute. Allows opening a replication-mode connection to Postgres.
+- The [`CONNECT`](https://www.postgresql.org/docs/current/ddl-priv.html#DDL-PRIV-CONNECT) privilege on the database being connected to. Allows opening a connection to Postgres.
+- The [`USAGE`](https://www.postgresql.org/docs/current/ddl-priv.html#DDL-PRIV-USAGE) privilege on all schemas of tables in the publication. Used during snapshotting.
+- The [`SELECT`](https://www.postgresql.org/docs/current/ddl-priv.html#DDL-PRIV-SELECT) privilege on all tables in the publication. Used during snapshotting.
+
+A publication enumerating the tables to sync to XTDB, it's table set is the only filter on what gets synced.
+
+:::caution
+Adding non-empty tables to a publication after the initial snapshot is currently unsupported.
+Doing so will leave the table in an inconsistent state in XTDB.
+
+This feature is tracked [here](https://github.com/xtdb/xtdb/issues/5497)
+:::
+
+
+## Configuration
+
+Configured by [attaching a secondary database](/about/dbs-in-xtdb#attachingdetaching-secondary-databases-v21) with the additional `externalSource` options.
+It reads from a Postgres [publication](https://www.postgresql.org/docs/current/sql-createpublication.html) via a [`!Postgres` remote](#remote), and writes through an [indexer](#indexers):
+
+```sql
+ATTACH DATABASE my_db WITH $$
+externalSource: !Postgres
+  # The alias of the !Postgres remote holding the connection details.
+  remote: my_pg_remote
+
+  # The Postgres publication to replicate from.
+  publicationName: my_db_to_xtdb
+
+  # The replication slot XTDB creates.
+  slotName: my_db_to_xtdb
+
+  # The indexer used to index Postgres transactions.
+  indexer: !DirectMirror {}
+$$
+```
+
+### Remote
+
+Postgres connection details are stored in a `!Postgres` [remote](/ops/config#remotes):
+
+```yaml
+remotes:
+  my_pg_remote: !Postgres
+    # The hostname of the Postgres to connect to.
+    hostname: my.pg.host
+
+    # The port of the Postgres to connect to. Defaults to 5432.
+    port: 5433
+
+    # The Postgres database to connect to.
+    database: my_upstream_db
+
+    # The username of the role to authenticate with Postgres.
+    username: my_role
+
+    # The password for the role connecting to Postgres.
+    password: !ENV PG_PASSWORD
+```
+
+## Phases
+
+This external source works in two phases:
+
+snapshot
+:   The initial mode of a Postgres External Source.
+    Scans all rows for tables in the publication into XTDB.
+    :::caution
+    If interrupted, snapshotting can fail requiring a DETACH then re-ATTACH
+    :::
+
+streaming
+:   Translates transactions from Postgres into XTDB transactions.
+
+## System Time
+
+The system time of rows depends on the phase of the Postgres External Source.
+
+| Phase | System Time |
+| --- | --- |
+| Snapshot | XTDB's internal system time (i.e. it is unrelated to the upstream Postgres' system clock) |
+| Streaming | The timestamp of the Postgres transaction (the timestamp on the `commit` message) |
+
+
+## Indexers
+
+The following indexers are built into XTDB:
+- DirectMirror
+
+### DirectMirror
+
+Mirrors tables & transactions from Postgres directly into XTDB.
+
+Additional properties are required from the tables replicated using this indexer:
+- `_id` is a required column, used as the primary key for the row
+- If set, the `_valid_from` and `_valid_to` columns must be of type `TIMESTAMPTZ`
+  - Like in XTDB, it is incorrect to specify a `_valid_to` without a `_valid_from`
+
+No configuration properties are provided.

--- a/docs/src/content/docs/ops/external-sources/postgres/setup.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/setup.md
@@ -1,0 +1,102 @@
+---
+title: Setting up a Postgres external source
+---
+
+In this guide we will set up a [Postgres external source](/ops/external-sources/postgres/reference) from the Postgres database `test_db` to sync all tables in the `public` schema into a database in XTDB called `pg_test_db`.
+
+To do so we will:
+
+1. Create a role with the appropriate permissions on Postgres
+1. Create a publication on Postgres
+1. Configure Postgres credentials on the XTDB node and redeploy
+1. Run `ATTACH DATABASE` in XTDB
+
+## Prerequisites
+
+As with other [external sources](/ops/external-sources/overview) you will need:
+
+- A [transaction log](/ops/config/log)
+- An [object store](/ops/config/storage)
+
+:::caution
+Ensure that you have a transaction log and object store that do not conflict with other databases.
+:::
+
+Additionally you will need to ensure that Postgres is configured with [`wal_level=logical`](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-WAL-LEVEL).
+
+## Create the Postgres role
+
+You will need a [role](https://www.postgresql.org/docs/current/user-manag.html) with the permissions from [here](/ops/external-sources/postgres/reference#prerequisites).
+
+This can be set up with the following commands:
+```sql
+CREATE ROLE my_role WITH LOGIN REPLICATION PASSWORD 'changeme';
+GRANT CONNECT ON DATABASE test_db TO my_role;
+GRANT USAGE ON SCHEMA public TO my_role;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO my_role;
+```
+
+## Create the publication
+
+Please use the publication to filter the tables or schemas that you want to sync to XTDB, for example:
+```sql
+CREATE PUBLICATION xtdb
+-- FOR ALL TABLES
+-- FOR TABLE test_table
+FOR TABLES IN SCHEMA public;
+```
+
+:::caution[Don't add tables with existing data after attaching]
+Adding a non-empty table to the publication after attaching leaves it in an inconsistent state in XTDB.
+Rows that existed before the `ALTER PUBLICATION` are never snapshotted, only later changes are captured.
+
+Tracked in [this ticket](https://github.com/xtdb/xtdb/issues/5497)
+:::
+
+## Deploy the Postgres credentials
+
+Configured under the [`remotes`](/ops/config#remotes) section of the node config like so:
+
+```yaml
+remotes:
+  pg_remote: !Postgres
+    hostname: pg_hostname
+    port: 5432
+    database: test_db
+    username: !Env PGUSER
+    password: !Env PGPASSWORD
+```
+
+For nodes to pick up this config change a rolling re-deploy is required.
+
+## Run `ATTACH DATABASE` in XTDB
+
+Finally to attach the secondary database with the external source:
+
+```sql
+ATTACH DATABASE pg_test_db WITH $$
+# Use what you set up in the prerequisites
+log: !Local
+  path: 'pg_test_db/log'
+storage: !Local
+  path: 'pg_test_db/storage'
+
+externalSource: !Postgres
+  remote: pg_remote
+  publicationName: xtdb
+  slotName: xtdb
+  indexer: !DirectMirror {}
+$$
+```
+
+Note that XTDB creates and manages a replication slot named `slotName`, streaming the tables in `publicationName`.
+
+You can now query the database by connecting to the `pg_test_db` database and running:
+```sql
+SELECT * FROM test_table;
+```
+
+Or from another database in XTDB by running:
+```sql
+SELECT * FROM pg_test_db.public.test_table;
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ exposed = "0.61.0"
 google-cloud-storage = "2.60.0"
 guava = "33.4.7-jre"
 confluent = "7.8.0"
+# On bump: update docs/src/content/docs/ops/kafka-connect-external-source.md — it names this version and links kafka.apache.org/<NN>/ docs.
 kafka = "4.1.1"
 kotest = "6.1.11"
 kotlin = "2.3.0"


### PR DESCRIPTION
Documents XTDB's external sources — secondary databases that mirror an upstream feed rather than accepting client writes — which had shipped without user-facing docs.

## Summary

Adds documentation for both external sources, organised under `ops/external-sources/` with one directory per source and wired into the ops sidebar:

- `external-sources/overview` — what an external source is (a read-only mirror of an upstream) and how you attach one.
- `external-sources/postgres/` — the Postgres CDC source: a setup guide and a reference.
- `external-sources/kafka-connect/` — the Kafka Connect source: a setup guide and a reference.

## Shape

The pages follow the docs' Diataxis split: the overview is explanation (no task), each reference is the exhaustive lookup (config surface, indexers, type mappings), and each setup guide walks one concrete path end to end — e.g. topic `orders` into a `kc_orders` database, masking the `email` field via a transform gated by a tombstone predicate.

The per-source directory layout mirrors the nav tree, following the `ops/backup-and-restore/` precedent (a feature directory with an overview plus its sub-pages) rather than splitting how-tos into `ops/guides/`.

## Conventions

Config is shown as inline-commented YAML — the field docs live in comments inside a copy-pasteable block, matching the other config pages (`ops/config/log/kafka` and friends) rather than a separate definition list or table.

The bundled transforms and predicates defer to the versioned Kafka Connect docs (`kafka.apache.org/41/…`), which document each class with its config; the version catalog carries a note to update the page on a Kafka bump. Converters stay listed with links, since Kafka has no per-converter config page whereas Confluent's guide documents each.

## Accuracy

The pages track the config as it currently stands, including the `!Docs` indexer's single dotted `table` (`schema.table`) value after that field settled from an earlier separate schema/table shape. The Kafka Connect pages were reviewed against the source code twice, so the `connectConfig` key space, the `_id` derivation rules, and the type mappings all match the implementation.
