### PR TITLE
fix(database): bound DatabaseCatalog teardown so a stalled cancel-join fails loud, not hung (#5711)

### DIFF
--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -5,14 +5,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.time.withTimeout
 import xtdb.NodeBase
 import xtdb.compactor.Compactor
 import xtdb.database.proto.DatabaseConfig
+import xtdb.diagnostics.TeardownStall
 import xtdb.error.Conflict
+import xtdb.error.Fault
 import xtdb.error.Incorrect
 import xtdb.error.NotFound
 import xtdb.table.DatabaseName
@@ -22,9 +26,14 @@ import xtdb.util.debug
 import xtdb.util.error
 import xtdb.util.logger
 import xtdb.util.warn
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
 private val LOG = DatabaseCatalog::class.logger
+
+// A cancellation-immune wait in some database's tree (xtdb#5711) would otherwise hang teardown
+// forever. Generous vs a real teardown (seconds).
+private val CLOSE_TIMEOUT: Duration = Duration.ofSeconds(60)
 
 class DatabaseCatalog @JvmOverloads constructor(
     private val base: NodeBase,
@@ -132,12 +141,31 @@ class DatabaseCatalog @JvmOverloads constructor(
     }
 
     override fun close() {
-        runBlocking {
-            // In-flight detaches own their database's teardown — let them finish before we cancel.
-            closerJob.children.toList().forEach { it.join() }
-            // One cancel stops every remaining database's job tree (Phase 1); free synchronously below.
-            dbJob.cancelAndJoin()
+        val stalled = runBlocking {
+            try {
+                withTimeout(CLOSE_TIMEOUT) {
+                    // Let in-flight detaches finish their own teardown before we cancel the tree.
+                    closerJob.children.toList().forEach { it.join() }
+                    dbJob.cancelAndJoin()
+                }
+                false
+            } catch (_: TimeoutCancellationException) {
+                true
+            }
         }
+
+        if (stalled) {
+            // Can't free a wedged tree — closing its allocator under a live coroutine is a
+            // use-after-free — so leak it and fail loud. Dump first; the fast return leaves the
+            // watchdog nothing to catch.
+            TeardownStall.onStall("DatabaseCatalog.close exceeded ${CLOSE_TIMEOUT.toSeconds()}s")
+            throw Fault(
+                "database catalog did not shut down within ${CLOSE_TIMEOUT.toSeconds()}s",
+                "xtdb/db-close-timeout"
+            )
+        }
+
+        // Phase 1 joined — no coroutine is still using this state.
         databases.values.closeAll()
     }
 

--- a/core/src/main/kotlin/xtdb/diagnostics/TeardownStall.kt
+++ b/core/src/main/kotlin/xtdb/diagnostics/TeardownStall.kt
@@ -1,0 +1,24 @@
+package xtdb.diagnostics
+
+import java.util.ServiceLoader
+
+/**
+ * Fired when a bounded teardown wait gives up — e.g. `DatabaseCatalog.close` abandoning a job tree
+ * that didn't respond to cancellation (xtdb#5711). The point is to capture the stalled coroutine
+ * state *before* the escape proceeds, since the escape turns the hang into a fast return and so the
+ * test-plan hang-watchdog (which only fires on a stalled test) never gets the chance to dump it.
+ *
+ * No-op unless an impl is on the classpath: the `xtdb-test-watchdog` module provides one (via
+ * ServiceLoader) that dumps coroutines + threads. Production carries no impl.
+ */
+fun interface TeardownStallProbe {
+    fun onStall(reason: String)
+}
+
+object TeardownStall {
+    private val probe: TeardownStallProbe? = ServiceLoader.load(TeardownStallProbe::class.java).firstOrNull()
+
+    fun onStall(reason: String) {
+        probe?.onStall(reason)
+    }
+}

--- a/modules/test-watchdog/build.gradle.kts
+++ b/modules/test-watchdog/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 
 dependencies {
+    // for the TeardownStallProbe SPI (xtdb#5711) — WatchdogStallProbe implements the interface,
+    // which lives in :xtdb-core.
+    implementation(project(":xtdb-core"))
+
     implementation(libs.kotlinx.coroutines)
     implementation(libs.kotlinx.coroutines.debug)
     implementation(libs.junit.platform.launcher)

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
@@ -107,10 +107,28 @@ class HangWatchdog : TestExecutionListener {
             }
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         private fun dump(o: HangTracker.Overdue) {
             out.println("=== [hang-watchdog] no test activity for ${TimeUnit.NANOSECONDS.toSeconds(o.quietNanos)}s (report ${o.report}; last event: ${o.lastEvent}) ===")
+            dumpDiagnostics()
+            out.println("=== [hang-watchdog] end of dump (report ${o.report}) ===")
+            out.flush()
+        }
 
+        /**
+         * On-demand dump for a stall the test-plan scanner can't see — e.g. a bounded teardown
+         * escape (`DatabaseCatalog.close`, xtdb#5711) that returns instead of hanging, so the test
+         * never goes quiet for the scanner to catch. Routed here via the `TeardownStallProbe` SPI.
+         */
+        @JvmStatic
+        fun dumpNow(reason: String) {
+            out.println("=== [hang-watchdog] on-demand dump: $reason ===")
+            dumpDiagnostics()
+            out.println("=== [hang-watchdog] end of dump ===")
+            out.flush()
+        }
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private fun dumpDiagnostics() {
             if (probesInstalled) {
                 try {
                     DebugProbes.dumpCoroutines(out)
@@ -130,8 +148,6 @@ class HangWatchdog : TestExecutionListener {
                 ti.stackTrace.forEach { out.println("\tat $it") }
                 out.println()
             }
-            out.println("=== [hang-watchdog] end of dump (report ${o.report}) ===")
-            out.flush()
         }
     }
 }

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/WatchdogStallProbe.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/WatchdogStallProbe.kt
@@ -1,0 +1,15 @@
+package xtdb.test.watchdog
+
+import xtdb.diagnostics.TeardownStallProbe
+
+/**
+ * Routes a teardown stall (e.g. `DatabaseCatalog.close` abandoning a wedged job tree, xtdb#5711) into the
+ * watchdog's coroutine + thread dump. The bounded escape stops the test hanging, so the test-plan
+ * scanner never fires — this captures the stalled state at the moment of the stall instead.
+ *
+ * Discovered via ServiceLoader; this module rides every project's testRuntimeOnly classpath, so it
+ * wires up with no per-project config. Absent in production, where `TeardownStall` is a no-op.
+ */
+class WatchdogStallProbe : TeardownStallProbe {
+    override fun onStall(reason: String) = HangWatchdog.dumpNow(reason)
+}

--- a/modules/test-watchdog/src/main/resources/META-INF/services/xtdb.diagnostics.TeardownStallProbe
+++ b/modules/test-watchdog/src/main/resources/META-INF/services/xtdb.diagnostics.TeardownStallProbe
@@ -1,0 +1,1 @@
+xtdb.test.watchdog.WatchdogStallProbe


### PR DESCRIPTION
Since "lift the teardown scope tree to DatabaseCatalog", node shutdown cancel-joins the whole catalog job tree in one step — `DatabaseCatalog.close`'s `dbJob.cancelAndJoin()`. A wait in some database's tree that cancellation can't reach (the #5711 class) hangs that join forever, and the JVM only dies at the CI action timeout hours later.

Bound the cancel-join with a generous 60s timeout. On a stall we skip Phase 2 and raise a `Fault`: freeing a database's Arrow allocator while a live, wedged coroutine still holds its buffers would be a use-after-free (or an allocator "leaked memory" throw that masks the real timeout), so we abandon the trees — their state leaks, unavoidable while a coroutine is stuck — rather than free under them. A stall becomes a fast, loud, diagnosable failure. The healthy path is unchanged: Phase 1 joins, then Phase 2 `closeAll` frees state as before.

The escape would otherwise cost the diagnostic: a bounded teardown makes the test *finish*, so the watchdog's no-activity scanner never trips and the coroutine dump naming the stuck wait is lost. So the timeout fires the dump itself, through a `TeardownStallProbe` SPI — a no-op in production, implemented by the test-watchdog (reusing its `DebugProbes` dump). The interface lives in `:xtdb-core` alongside the other SPIs (`ExternalSource`, `ObjectStore`); the watchdog depends on `:xtdb-core` to implement it.

Scope: this bounds and surfaces the stall; it doesn't remove the immune waits — those are the per-instance fixes tracked on the issue. `IngestNode.close` carries the same unbounded `rootJob.cancelAndJoin()` and is left as-is (test-only in-repo; the same bound applies if it surfaces). With no watchdog in production a stall throws without a coroutine dump.

Refs #5711