### PR TITLE
fix(arrow): reconcile null DUV legs instead of failing the merge (#5714)

### DIFF
--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -261,7 +261,21 @@ class DenseUnionVector private constructor(
         for (i in legVectors.indices) {
             val leg = legVectors[i]
             if (leg.name == name) {
-                if (leg.arrowType != arrowType) throw Unsupported("cannot promote DUV leg")
+                // `op` keys legs by operation, so `put` is a Struct where a segment has documents and
+                // Null in a put-less one. Null is the lattice bottom — reconcile rather than throw. We
+                // deliberately don't assert nullability: an incoming Null yields to the existing type,
+                // and real nulls (if any) fold in via writeNull, which auto-nullables. So op.put's
+                // zero-row Null leg leaves `put` a non-nullable Mono(STRUCT) — the shape logRelTypes
+                // asserts and the #4467 Nothing work relies on — rather than spuriously widening it.
+                // Two genuinely-distinct non-null types have no single-leg join. #5714
+                if (leg.arrowType != arrowType) {
+                    when {
+                        arrowType == NULL_TYPE -> {} // incoming Null yields to the existing typed leg
+                        leg.arrowType == NULL_TYPE -> legVectors[i] = leg.maybePromote(allocator, arrowType, nullable)
+                        else -> throw Unsupported("cannot promote DUV leg: '$name' (existing ${leg.arrowType}, incoming $arrowType)")
+                    }
+                    return LegVector(i.toByte(), legVectors[i])
+                }
                 leg.nullable = leg.nullable || nullable
 
                 return LegVector(i.toByte(), leg)

--- a/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/DenseUnionVectorTest.kt
@@ -4,9 +4,12 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import xtdb.TaggedValue
+import xtdb.kw
 
 class DenseUnionVectorTest {
     private lateinit var allocator: BufferAllocator
@@ -214,6 +217,71 @@ class DenseUnionVectorTest {
 
                 assertEquals(listOf(1, 0, 1).map { it.toByte() }, duv.typeIds())
                 assertEquals(listOf(obj1, null, obj2), mono.asList)
+            }
+        }
+    }
+
+    // a put-less segment (e.g. erase-only) writes its `op` union with a Null `put` leg
+    // alongside delete/erase; three legs, so a copy goes through rowCopier0/legVectorFor
+    // rather than the single-leg `rowCopier` shortcut that bypasses it.
+    private fun putLessOpDuv() =
+        DenseUnionVector(allocator, "op",
+            listOf(NullVector("put"), NullVector("delete"), NullVector("erase")))
+
+    private fun structPutOpDuv() =
+        DenseUnionVector(allocator, "op",
+            listOf(StructVector(allocator, "put", true,
+                linkedMapOf("a" to IntVector.open(allocator, "i32", true))),
+                NullVector("delete"), NullVector("erase")))
+
+    @Test
+    fun `merging a put-less op-union into a Struct-put one reconciles the Null put leg #5714`() {
+        structPutOpDuv().use { dest ->
+            structPutOpDuv().use { withPut ->
+                withPut.vectorFor("put").writeObject(mapOf("a" to 1))
+
+                putLessOpDuv().use { putLess ->
+                    putLess.vectorFor("erase").writeNull()
+
+                    withPut.rowCopier(dest).copyRange(0, withPut.valueCount)
+                    putLess.rowCopier(dest).copyRange(0, putLess.valueCount)
+
+                    assertEquals(2, dest.valueCount)
+                    assertEquals(TaggedValue("put".kw, mapOf("a" to 1)), dest.getObject(0))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `merging a Struct-put op-union into a put-less one promotes the Null put leg #5714`() {
+        putLessOpDuv().use { dest ->
+            structPutOpDuv().use { withPut ->
+                withPut.vectorFor("put").writeObject(mapOf("a" to 7))
+                withPut.rowCopier(dest).copyRange(0, withPut.valueCount)
+
+                assertEquals(1, dest.valueCount)
+                assertEquals(TaggedValue("put".kw, mapOf("a" to 7)), dest.getObject(0))
+            }
+        }
+    }
+
+    @Test
+    fun `merging a put-less op-union keeps a non-nullable put leg non-nullable #5714`() {
+        // non-nullable Struct put, mirroring a compaction output
+        val putLeg = StructVector(allocator, "put", false,
+            linkedMapOf("a" to IntVector.open(allocator, "i32", true)))
+
+        DenseUnionVector(allocator, "op", listOf(putLeg, NullVector("delete"), NullVector("erase"))).use { dest ->
+            dest.vectorFor("put").writeObject(mapOf("a" to 1))
+
+            putLessOpDuv().use { putLess ->
+                putLess.vectorFor("delete").writeNull()
+                putLess.rowCopier(dest).copyRange(0, putLess.valueCount)
+
+                assertEquals(2, dest.valueCount)
+                assertEquals(TaggedValue("put".kw, mapOf("a" to 1)), dest.getObject(0))
+                assertFalse(putLeg.nullable)
             }
         }
     }


### PR DESCRIPTION
Compaction merges that combined a put-less trie with one that still had documents threw `cannot promote DUV leg`, and the table stopped compacting. The `op` dense-union keys its legs by operation, so the `put` leg's type is data-dependent: `Struct` where a segment has documents, but `Null` once a put-less segment (deletes/erases only) is compacted — `dataRelSchema(mergeFields(...))` mints a present-but-`Null` `put` leg when no input carries a put schema. Merging that into a `Struct`-put trie reached `DenseUnionVector.legVectorFor`, which rejected any same-named leg whose arrow type differed.

`Null` is the bottom of the type lattice, though — always reconcilable, never a real clash. An existing `Null` leg promotes to the incoming type; an incoming `Null` leg yields to the existing one *without* widening it to nullable. Nullability tracks the nulls actually written (`writeNull` auto-nullables), not a leg's declared type — and a `put` row is never null, so `op.put`'s `Null` leg is always empty. The reconciled `put` thus stays a non-nullable `Mono(STRUCT)`, the shape `logRelTypes` requires of it and the direction the #4467 `Nothing` work is taking, rather than a nullable struct no value justifies — one that would contradict that invariant and, once written, stick across re-merges via `mergeFields`. Two genuinely-distinct non-null types stay unpromotable — a `toLeg` naming collision handled elsewhere — and that throws with the leg name and both types, so it's diagnosable.

The same null-handling gap has a second call site: the scan reconciling a `Null`-put trie against a `Struct`-put one, which threw `vectorFor unsupported on NullVector` — the permanently-unreadable table in #5714. That read path was hardened separately between 2.1.0 and main; this commit fixes the compaction call site, and the e2e test guards both — a read across the un-merged tries, and the L2 merge that folds them together.

Refs #5714