### PR TITLE
fix(database): bound DatabaseCatalog teardown under test so a stalled cancel-join fails loud, not hung (#5711)

### DIFF
--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -7,12 +7,13 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import xtdb.NodeBase
 import xtdb.compactor.Compactor
 import xtdb.database.proto.DatabaseConfig
+import xtdb.diagnostics.TeardownStall
 import xtdb.error.Conflict
+import xtdb.error.Fault
 import xtdb.error.Incorrect
 import xtdb.error.NotFound
 import xtdb.table.DatabaseName
@@ -132,12 +133,18 @@ class DatabaseCatalog @JvmOverloads constructor(
     }
 
     override fun close() {
-        runBlocking {
-            // In-flight detaches own their database's teardown — let them finish before we cancel.
+        val stalled = TeardownStall.runBounded("DatabaseCatalog.close") {
+            // Let in-flight detaches finish their own teardown before we cancel the tree.
             closerJob.children.toList().forEach { it.join() }
-            // One cancel stops every remaining database's job tree (Phase 1); free synchronously below.
             dbJob.cancelAndJoin()
         }
+
+        if (stalled) {
+            // Skip Phase 2: freeing an allocator while the wedged tree is still live is a
+            // use-after-free. Leak it and fail loud (runBounded already dumped).
+            throw Fault("database catalog did not shut down in time", "xtdb/db-close-timeout")
+        }
+
         databases.values.closeAll()
     }
 

--- a/core/src/main/kotlin/xtdb/diagnostics/TeardownStall.kt
+++ b/core/src/main/kotlin/xtdb/diagnostics/TeardownStall.kt
@@ -1,0 +1,36 @@
+package xtdb.diagnostics
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.time.withTimeout
+import java.time.Duration
+import java.util.ServiceLoader
+
+/**
+ * Bounds a teardown that a cancellation-immune wait would otherwise hang forever (xtdb#5711). A probe
+ * — provided by `xtdb-test-watchdog` via ServiceLoader — supplies the timeout and dumps the wedged
+ * coroutines on a stall. Production ships no impl, so teardown runs unbounded there.
+ */
+interface TeardownStallProbe {
+    val timeout: Duration
+    fun onStall(reason: String)
+}
+
+object TeardownStall {
+    private val probe: TeardownStallProbe? = ServiceLoader.load(TeardownStallProbe::class.java).firstOrNull()
+
+    /** Runs [teardown] — bounded + dumped-on-stall under test (probe present), unbounded otherwise; returns true iff it stalled. */
+    fun runBounded(reason: String, teardown: suspend () -> Unit): Boolean = runBlocking {
+        val p = probe
+        if (p == null) {
+            teardown()
+            false
+        } else try {
+            withTimeout(p.timeout) { teardown() }
+            false
+        } catch (_: TimeoutCancellationException) {
+            p.onStall("$reason exceeded ${p.timeout.toSeconds()}s")
+            true
+        }
+    }
+}

--- a/modules/test-watchdog/build.gradle.kts
+++ b/modules/test-watchdog/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 
 dependencies {
+    // for the TeardownStallProbe SPI (xtdb#5711) — interface lives in :xtdb-core.
+    implementation(project(":xtdb-core"))
+
     implementation(libs.kotlinx.coroutines)
     implementation(libs.kotlinx.coroutines.debug)
     implementation(libs.junit.platform.launcher)

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/HangWatchdog.kt
@@ -10,6 +10,7 @@ import java.io.FileDescriptor
 import java.io.FileOutputStream
 import java.io.PrintStream
 import java.lang.management.ManagementFactory
+import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -65,6 +66,11 @@ class HangWatchdog : TestExecutionListener {
         private val enabled = System.getProperty("xtdb.test.hang-watchdog.enabled", "true").toBoolean()
         private val timeoutSeconds = System.getProperty("xtdb.test.hang-watchdog.timeout-seconds", "240").toLong()
 
+        // Teardown-stall bound (xtdb#5711): how long DatabaseCatalog.close waits before it's stalled.
+        @JvmStatic
+        val teardownTimeout: Duration =
+            Duration.ofSeconds(System.getProperty("xtdb.test.teardown-timeout-seconds", "60").toLong())
+
         private val tracker = HangTracker(TimeUnit.SECONDS.toNanos(timeoutSeconds))
 
         // NOT System.out/err: Gradle's test workers replace those to capture per-test output, and
@@ -107,10 +113,27 @@ class HangWatchdog : TestExecutionListener {
             }
         }
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         private fun dump(o: HangTracker.Overdue) {
             out.println("=== [hang-watchdog] no test activity for ${TimeUnit.NANOSECONDS.toSeconds(o.quietNanos)}s (report ${o.report}; last event: ${o.lastEvent}) ===")
+            dumpDiagnostics()
+            out.println("=== [hang-watchdog] end of dump (report ${o.report}) ===")
+            out.flush()
+        }
 
+        /**
+         * On-demand dump for a stall the scanner can't catch: a bounded teardown (xtdb#5711) returns
+         * instead of hanging, so the test never goes quiet. Routed via the `TeardownStallProbe` SPI.
+         */
+        @JvmStatic
+        fun dumpNow(reason: String) {
+            out.println("=== [hang-watchdog] on-demand dump: $reason ===")
+            dumpDiagnostics()
+            out.println("=== [hang-watchdog] end of dump ===")
+            out.flush()
+        }
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        private fun dumpDiagnostics() {
             if (probesInstalled) {
                 try {
                     DebugProbes.dumpCoroutines(out)
@@ -130,8 +153,6 @@ class HangWatchdog : TestExecutionListener {
                 ti.stackTrace.forEach { out.println("\tat $it") }
                 out.println()
             }
-            out.println("=== [hang-watchdog] end of dump (report ${o.report}) ===")
-            out.flush()
         }
     }
 }

--- a/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/WatchdogStallProbe.kt
+++ b/modules/test-watchdog/src/main/kotlin/xtdb/test/watchdog/WatchdogStallProbe.kt
@@ -1,0 +1,13 @@
+package xtdb.test.watchdog
+
+import xtdb.diagnostics.TeardownStallProbe
+import java.time.Duration
+
+/**
+ * The test-side `TeardownStallProbe` (ServiceLoader-discovered): supplies the bound and routes the
+ * stall dump to the watchdog. Present on any test runtime, absent in production.
+ */
+class WatchdogStallProbe : TeardownStallProbe {
+    override val timeout: Duration get() = HangWatchdog.teardownTimeout
+    override fun onStall(reason: String) = HangWatchdog.dumpNow(reason)
+}

--- a/modules/test-watchdog/src/main/resources/META-INF/services/xtdb.diagnostics.TeardownStallProbe
+++ b/modules/test-watchdog/src/main/resources/META-INF/services/xtdb.diagnostics.TeardownStallProbe
@@ -1,0 +1,1 @@
+xtdb.test.watchdog.WatchdogStallProbe


### PR DESCRIPTION
Since "lift the teardown scope tree to DatabaseCatalog", node shutdown cancel-joins the whole catalog job tree in one step — `DatabaseCatalog.close`'s `dbJob.cancelAndJoin()`. A wait in some database's tree that cancellation can't reach (the #5711 class) hangs that join forever; on CI the job then dies only at the action timeout, hours later.

Bound the cancel-join — but only under test. The bound is worthwhile only alongside a coroutine dump naming the stuck wait, and that dump is test-only: it needs the `-javaagent` coroutine probes and the watchdog's real-stdout-FD plumbing. Production ships no dumper, so a bound there would fail loud blindly while aborting integrant's `halt!` and leaking `:xtdb/base` — worse than the current hang, which an orchestrator bounds via SIGKILL regardless. So the bound lives where its payoff does.

The `TeardownStallProbe` SPI supplies both the timeout (`Duration`) and the dump; the `xtdb-test-watchdog` impl returns 60s (configurable via `xtdb.test.teardown-timeout-seconds`). `TeardownStall.runBounded` applies it — bounded + dump-on-stall when a probe is present (on the classpath), unbounded otherwise. `DatabaseCatalog.close` delegates to it and, on a stall, skips Phase 2 — freeing an allocator while the wedged tree is still live would be a use-after-free — and throws a `Fault`. With no probe, `close` runs unbounded exactly as before.

Scope: bounds and surfaces the stall under test; it doesn't remove the immune waits, which are the per-instance fixes tracked on the issue. `IngestNode.close` carries the same unbounded `rootJob.cancelAndJoin()` and is left as-is.

Refs #5711