### PR TITLE
fix(compactor): omit the put leg for put-less segments (#5714)

### DIFF
--- a/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
+++ b/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
@@ -206,15 +206,17 @@ internal class SegmentMerge(private val al: BufferAllocator) : AutoCloseable {
         recencyPartitioning: RecencyPartitioning,
         recencyPartition: RecencyPartition? = WEEK
     ): Results {
-        val mergedPutField = mergeFields(
-            segments.mapNotNull { seg ->
-                seg.schema
-                    .findField("op")
-                    .children
-                    .find { it.name == "put" && it.children.isNotEmpty() }
-            })
+        val putFields = segments.mapNotNull { seg ->
+            seg.schema
+                .findField("op")
+                .children
+                .find { it.name == "put" && it.children.isNotEmpty() }
+        }
 
-        val schema = dataRelSchema(mergedPutField.withName("put"))
+        // an all-put-less merge (deletes/erases only) contributes no put fields — omit the put leg
+        // rather than minting a present Null one, matching a raw L0 block. dataRelSchema drops a null
+        // putDocField from the op union. #5714
+        val schema = dataRelSchema(putFields.takeIf { it.isNotEmpty() }?.let { mergeFields(it).withName("put") })
 
         val outWriter = when (recencyPartitioning) {
             RecencyPartitioning.Partition -> outWriters.PartitionedOutWriter(schema, recencyPartition)

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -330,6 +330,37 @@
              (->> (xt/q node "SELECT foo FROM foo")
                   (into #{} (map :foo)))))))
 
+(t/deftest compaction-settles-merging-null-put-leg-5714
+  (binding [c/*page-size* 8
+            cat/*file-size-target* 16
+            c/*ignore-signal-block?* true]
+    (let [node-dir (util/->path "target/compactor/null-put-leg-5714")]
+      (util/delete-dir node-dir)
+      (util/with-open [node (tu/->local-node {:node-dir node-dir, :rows-per-block 10})]
+        ;; with a tiny file-size-target each block completes its own L1 file: a put block gives a
+        ;; Struct-put L1, a delete-only block a put-less one whose op union omits the put leg.
+        (letfn [(put! [ids]
+                  (xt/submit-tx node [(into [:put-docs :recs] (for [i ids] {:xt/id i, :v (str "v" i)}))])
+                  (tu/flush-block! node)
+                  (c/compact-all! node #xt/duration "PT2S"))
+                (del! [ids]
+                  (xt/submit-tx node [(into [:delete-docs :recs] (vec ids))])
+                  (tu/flush-block! node)
+                  (c/compact-all! node #xt/duration "PT2S"))]
+          (put! (range 0 10))
+          (del! (range 0 10))
+          (put! (range 10 20))
+
+          ;; put-less L1s coexist with Struct-put L1s before branch-factor triggers the L2 merge;
+          ;; the scan reads across them - a put-less L1 has no put leg, so contributes no rows
+          (t/is (= 10 (count (xt/q node "SELECT _id, v FROM recs"))))
+
+          ;; the fourth L1 reaches branch-factor and triggers the L2 merge; without omitting the put
+          ;; leg the put-less L1s carry a Null one that fails the merge ('cannot promote DUV leg')
+          (del! (range 10 20))
+
+          (t/is (= 0 (-> (xt/q node "SELECT count(*) c FROM recs") first :c))))))))
+
 (t/deftest test-compaction-with-erase-4017
   (binding [c/*ignore-signal-block?* true]
     (let [node-dir (util/->path "target/compactor/compaction-with-erase")]


### PR DESCRIPTION
Compaction minted a present, nullable-`Null` `put` leg for a put-less segment (deletes/erases only): `mergeFields` over segments with no put documents yields an empty field, and `dataRelSchema` carried that into the `op` union as a `Null`-typed `put` leg. That diverges from a raw L0 block, where the `put` leg is simply absent — the put vector is created lazily, so a no-puts block never materialises it. When such a `Null`-put trie later merged with a `Struct`-put one, `DenseUnionVector.legVectorFor` rejected the same-named leg whose arrow type differed — `cannot promote DUV leg` — and the table's compaction wedged (#5714).

Omit the `put` leg entirely when no segment in the merge carries puts, rather than minting a `Null` one. This is not a new shape to reason about: L0 delete-only blocks already produce a put-less op union, and the whole read/scan/compaction pipeline consumes them — every reader takes `put` via `vectorForOrNull` (`BitemporalConsumer`, `HllCalculator`, the merge itself), so an absent leg is already handled. Compaction was the odd one out in minting a present `Null` leg; matching L0 (and the default `dataRelSchema(null)` writer) makes the unpromotable-merge state unreachable for newly-compacted data — and a put-less segment has no put rows, so dropping the leg loses nothing.

This corrects the mint for new data only. Existing on-disk `Null`-put tries still carry the leg and rely on the complementary `legVectorFor` reconciliation — which absorbs a `Null` leg leniently instead of failing — until they're recompacted; both are needed for full coverage of #5714.

Refs #5714