### PR TITLE
feat(kafka-connect-source)!: derive _id solely from the record key

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
@@ -21,6 +21,7 @@ import xtdb.kafka.connectsrc.proto.DocsIndexerConfig
 import xtdb.kafka.connectsrc.proto.docsIndexerConfig
 import xtdb.kafka.connectsrc.proto.kafkaConnectSourceToken
 import xtdb.table.TableRef
+import xtdb.util.asIid
 import java.math.BigDecimal
 import java.nio.ByteBuffer
 import java.time.Instant
@@ -81,22 +82,15 @@ class DocsIndexer(private val table: TableRef) : RecordIndexer {
         }
     }
 
-    private fun coordsFor(rec: SinkRecord): Map<String, Any?> =
-        mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset())
-
     private fun writeRecord(openTx: OpenTx, rec: SinkRecord) {
         val openTxTable = openTx.table(table.schemaName, table.tableName)
+
+        val id = resolveId(rec)
         val value = rec.value()
 
         if (value == null) {
-            val id = rec.key() ?: throw Incorrect(
-                "tombstone has no key — can't resolve _id",
-                "xtdb.kafka-connect-source/docs-no-id-on-tombstone",
-                mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset()),
-            )
-
             openTxTable.apply {
-                writeId(unwrapKeyForId(id))
+                writeId(id)
                 writeDefaultValidTime()
                 endDelete()
             }
@@ -119,13 +113,7 @@ class DocsIndexer(private val table: TableRef) : RecordIndexer {
                 ),
             )
 
-        val id = docMap["_id"]
-            ?: rec.key()?.let { unwrapKeyForId(it) }?.also { docMap["_id"] = it }
-            ?: throw Incorrect(
-                "no _id on doc and no record key — can't resolve _id",
-                "xtdb.kafka-connect-source/docs-no-id",
-                mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset()),
-            )
+        docMap["_id"] = id
 
         openTxTable.apply {
             writeId(id)
@@ -136,8 +124,36 @@ class DocsIndexer(private val table: TableRef) : RecordIndexer {
     }
 }
 
-// AvroConverter et al may yield a single-field Struct as the key — unwrap to the inner value.
-private fun unwrapKeyForId(key: Any): Any =
+private fun coordsFor(rec: SinkRecord): Map<String, Any?> =
+    mapOf("topic" to rec.topic(), "partition" to rec.kafkaPartition(), "offset" to rec.kafkaOffset())
+
+// Kafka's compaction, per-key ordering and tombstones all hang off the key, so it's the
+// sole source of `_id` — deriving from the value would let upsert- and delete-identity diverge.
+internal fun resolveId(rec: SinkRecord): Any {
+    val id = rec.key()?.let { unwrapKeyForId(it) } ?: throw Incorrect(
+        "record has no usable key — can't resolve _id (use the ValueToKey SMT to derive a key from the value)",
+        "xtdb.kafka-connect-source/docs-no-key",
+        coordsFor(rec),
+    )
+
+    // Probe rather than duplicate the whitelist, so the accepted key types can't drift from `asIid`.
+    try {
+        id.asIid
+    } catch (e: Incorrect) {
+        throw Incorrect(
+            "record key of type ${id.javaClass.name} can't be used as _id (use the ExtractField SMT to extract a scalar key field)",
+            "xtdb.kafka-connect-source/docs-invalid-key",
+            coordsFor(rec) + ("keyType" to id.javaClass.name),
+            e,
+        )
+    }
+
+    return id
+}
+
+// AvroConverter et al may yield a single-field Struct as the key — unwrap to the inner value,
+// which may itself be null (a nullable key field): the caller treats that as no usable key.
+private fun unwrapKeyForId(key: Any): Any? =
     if (key is Struct && key.schema()?.fields()?.size == 1)
         key.get(key.schema().fields()[0])
     else key

--- a/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/DocsIndexerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/DocsIndexerTest.kt
@@ -1,9 +1,17 @@
 package xtdb.kafka.connectsrc
 
+import clojure.lang.Keyword
+import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.data.Timestamp as ConnectTimestamp
+import org.apache.kafka.connect.sink.SinkRecord
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.error.Anomaly
+import xtdb.error.Incorrect
 import java.time.Instant
 import java.util.Date
 
@@ -16,5 +24,63 @@ class DocsIndexerTest {
         val connectValue = Date.from(expected)
 
         assertEquals(expected, convertValue(connectValue, schema))
+    }
+
+    private fun recWithKey(key: Any?, keySchema: Schema? = null) =
+        SinkRecord("t", 0, keySchema, key, null, mapOf("name" to "x"), 42)
+
+    private val Anomaly.errorCode: Keyword?
+        get() = data.valAt(Keyword.intern("xtdb.error", "code")) as? Keyword
+
+    @Test
+    fun `resolveId passes a String key through`() {
+        assertEquals("k1", resolveId(recWithKey("k1")))
+    }
+
+    @Test
+    fun `resolveId unwraps a single-field Struct key`() {
+        val keySchema = SchemaBuilder.struct().field("id", Schema.STRING_SCHEMA).build()
+        val key = Struct(keySchema).put("id", "k1")
+
+        assertEquals("k1", resolveId(recWithKey(key, keySchema)))
+    }
+
+    @Test
+    fun `keyless record is rejected with docs-no-key`() {
+        val e = assertThrows<Incorrect> { resolveId(recWithKey(null)) }
+
+        assertEquals(Keyword.intern("xtdb.kafka-connect-source", "docs-no-key"), e.errorCode)
+    }
+
+    @Test
+    fun `multi-field Struct key is rejected with docs-invalid-key`() {
+        val keySchema = SchemaBuilder.struct()
+            .field("region", Schema.STRING_SCHEMA)
+            .field("id", Schema.STRING_SCHEMA)
+            .build()
+        val key = Struct(keySchema).put("region", "eu").put("id", "k1")
+
+        val e = assertThrows<Incorrect> { resolveId(recWithKey(key, keySchema)) }
+
+        assertEquals(Keyword.intern("xtdb.kafka-connect-source", "docs-invalid-key"), e.errorCode)
+        assertTrue(e.message!!.contains("ExtractField"), "error should point at the SMT remedy, got: ${e.message}")
+    }
+
+    @Test
+    fun `byte array key is rejected with docs-invalid-key`() {
+        val e = assertThrows<Incorrect> { resolveId(recWithKey("k1".toByteArray(), Schema.BYTES_SCHEMA)) }
+
+        assertEquals(Keyword.intern("xtdb.kafka-connect-source", "docs-invalid-key"), e.errorCode)
+    }
+
+    @Test
+    fun `single-field Struct key with a null value reports an unusable key`() {
+        val keySchema = SchemaBuilder.struct().field("id", Schema.OPTIONAL_STRING_SCHEMA).build()
+        val key = Struct(keySchema)
+
+        val e = assertThrows<Incorrect> { resolveId(recWithKey(key, keySchema)) }
+
+        assertEquals(Keyword.intern("xtdb.kafka-connect-source", "docs-no-key"), e.errorCode)
+        assertTrue(e.message!!.contains("no usable key"), "message shouldn't claim the key is absent, got: ${e.message}")
     }
 }

--- a/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/KafkaConnectSourceIntegrationTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/KafkaConnectSourceIntegrationTest.kt
@@ -150,7 +150,7 @@ class KafkaConnectSourceIntegrationTest {
         createTopic(sourceTopic)
 
         produceBytes(sourceTopic, "k1", """{"name":"Alice","age":30}""".toByteArray())
-        produceBytes(sourceTopic, "k2", """{"_id":"explicit","name":"Bob"}""".toByteArray())
+        produceBytes(sourceTopic, "k2", """{"_id":"from-value","name":"Bob"}""".toByteArray())
 
         openNode("xt-log-${UUID.randomUUID()}").use { node ->
             attach(node, "events", """
@@ -176,9 +176,10 @@ class KafkaConnectSourceIntegrationTest {
             assertEquals(1, k1.size)
             assertEquals("Alice", k1[0]["name"])
 
-            val k2 = xtQueryDb(node, "events", "SELECT _id, name FROM public.events WHERE _id = 'explicit'")
-            assertEquals(1, k2.size)
+            val k2 = xtQueryDb(node, "events", "SELECT _id, name FROM public.events WHERE _id = 'k2'")
+            assertEquals(1, k2.size, "key-derived _id wins — the value's _id is overwritten")
             assertEquals("Bob", k2[0]["name"])
+            assertTrue(xtQueryDb(node, "events", "SELECT _id FROM public.events WHERE _id = 'from-value'").isEmpty())
 
             produceBytes(sourceTopic, "k3", """{"name":"Charlie"}""".toByteArray())
             awaitCondition("streamed record appears") {
@@ -411,8 +412,8 @@ class KafkaConnectSourceIntegrationTest {
         createTopic(sourceTopic)
 
         produceBytes(
-            sourceTopic, "k1",
-            """{"op":"c","payload":{"_id":"alice","name":"Alice","age":30}}""".toByteArray(),
+            sourceTopic, "alice",
+            """{"op":"c","payload":{"name":"Alice","age":30}}""".toByteArray(),
         )
 
         openNode("xt-log-${UUID.randomUUID()}").use { node ->
@@ -454,12 +455,12 @@ class KafkaConnectSourceIntegrationTest {
         val sourceTopic = "events-${UUID.randomUUID()}"
         createTopic(sourceTopic)
 
-        // Envelope-shaped: { meta, payload: { _id, name, email } }
+        // Envelope-shaped: { meta, payload: { name, email } }
         // Chain: unwrap (ExtractField -> payload) THEN mask (MaskField -> email).
         // Order matters: mask must run on the unwrapped payload, not the outer envelope.
         produceBytes(
-            sourceTopic, "k1",
-            """{"meta":{"op":"c"},"payload":{"_id":"alice","name":"Alice","email":"a@example.com"}}""".toByteArray(),
+            sourceTopic, "alice",
+            """{"meta":{"op":"c"},"payload":{"name":"Alice","email":"a@example.com"}}""".toByteArray(),
         )
 
         openNode("xt-log-${UUID.randomUUID()}").use { node ->
@@ -505,7 +506,7 @@ class KafkaConnectSourceIntegrationTest {
         //   - bob:   tombstone     — predicate.test=true on this, negate→false, mask SKIPPED,
         //                             record reaches indexer unmolested (no aborted tx, no row
         //                             since there's nothing to delete).
-        produceBytes(sourceTopic, "alice", """{"_id":"alice","email":"a@example.com"}""".toByteArray())
+        produceBytes(sourceTopic, "alice", """{"email":"a@example.com"}""".toByteArray())
         produceBytes(sourceTopic, "bob", null)
 
         openNode("xt-log-${UUID.randomUUID()}").use { node ->
@@ -614,7 +615,6 @@ class KafkaConnectSourceIntegrationTest {
             sourceTopic, "all-types",
             """
             {
-              "_id": "all-types",
               "string_val": "hello",
               "int_val": 42,
               "long_val": 9999999999,
@@ -685,7 +685,6 @@ class KafkaConnectSourceIntegrationTest {
               "${'$'}schema": "http://json-schema.org/draft-07/schema#",
               "type": "object",
               "properties": {
-                "_id":           { "type": "string" },
                 "string_val":    { "type": "string" },
                 "int_val":       { "type": "integer" },
                 "double_val":    { "type": "number" },
@@ -727,7 +726,6 @@ class KafkaConnectSourceIntegrationTest {
 
         val payloadJson = mapper.readTree("""
             {
-              "_id": "all-types",
               "string_val": "hello",
               "int_val": 42,
               "double_val": 3.14,
@@ -820,7 +818,6 @@ class KafkaConnectSourceIntegrationTest {
               "${'$'}schema": "http://json-schema.org/draft-07/schema#",
               "type": "object",
               "properties": {
-                "_id":  { "type": "string" },
                 "name": { "type": "string" }
               }
             }
@@ -829,7 +826,7 @@ class KafkaConnectSourceIntegrationTest {
         val mapper = com.fasterxml.jackson.databind.ObjectMapper()
         val jsonSchema = io.confluent.kafka.schemaregistry.json.JsonSchema(schemaStr)
         val envelope = io.confluent.kafka.schemaregistry.json.JsonSchemaUtils.toObject(
-            mapper.readTree("""{"_id":"k1","name":"Alice"}"""),
+            mapper.readTree("""{"name":"Alice"}"""),
             jsonSchema,
         )
 
@@ -881,14 +878,12 @@ class KafkaConnectSourceIntegrationTest {
             {
               "type":"record","name":"Person","namespace":"xtdb.test",
               "fields":[
-                {"name":"_id","type":"string"},
                 {"name":"name","type":"string"}
               ]
             }
         """.trimIndent())
 
         val rec = GenericData.Record(avroSchema).apply {
-            put("_id", "k1")
             put("name", "Alice")
         }
         produceAvro(sourceTopic, "k1", rec)
@@ -934,7 +929,6 @@ class KafkaConnectSourceIntegrationTest {
             {
               "type": "record", "name": "OrderEnvelope", "namespace": "xtdb.test",
               "fields": [
-                {"name": "_id", "type": "string"},
                 {"name": "header", "type": {
                   "type": "record", "name": "Header",
                   "fields": [
@@ -997,7 +991,6 @@ class KafkaConnectSourceIntegrationTest {
         }
 
         val envelope = GenericData.Record(avroSchema).apply {
-            put("_id", "nested")
             put("header", headerRec)
             put("delivery_attempts", listOf(attempt1.toEpochMilli(), attempt2.toEpochMilli()))
             put("lines_by_sku", mapOf("SKU-A" to lineRec(lineA), "SKU-B" to lineRec(lineB)))
@@ -1068,7 +1061,6 @@ class KafkaConnectSourceIntegrationTest {
               "name": "AllTypes",
               "namespace": "xtdb.test",
               "fields": [
-                {"name": "_id",          "type": "string"},
                 {"name": "bool_val",     "type": "boolean"},
                 {"name": "int_val",      "type": "int"},
                 {"name": "long_val",     "type": "long"},
@@ -1114,7 +1106,6 @@ class KafkaConnectSourceIntegrationTest {
         val nestedSchema = avroSchema.getField("nested_val").schema()
 
         val rec = GenericData.Record(avroSchema).apply {
-            put("_id", "all-types")
             put("bool_val", true)
             put("int_val", 42)
             put("long_val", 9999999999L)


### PR DESCRIPTION
Part of #5561. Settles the `_id`-resolution question on the `!Docs` indexer's API surface ahead of the freeze tracked in #5725.

## Summary

The Kafka Connect source's `!Docs` indexer now derives `_id` solely from the record key. Previously an `_id` field in the value took precedence, with the key as fallback — the behaviour documented in #5561, which this PR deliberately supersedes.

## Context

A tombstone has no value, so it can only ever delete by key — a value-derived `_id` therefore lets upsert-identity and delete-identity diverge. Concretely: produce `key="k2"` with `{"_id": "explicit", ...}` and doc `explicit` is upserted; a later tombstone for `k2` deletes doc `k2` — which never existed — leaving `explicit` undeletable via the topic. Kafka's compaction, partitioning, and per-key ordering also all treat the key as the entity identity, so a value-derived `_id` was silently misaligned with what the broker guarantees.

## Usage

Topics whose id lives in the payload use the standard Connect idiom via `connectConfig` transforms: `ValueToKey` + `ExtractField$Key`. Rerouting the id into the key also aligns the topic's compaction and ordering with document identity, rather than papering over the mismatch.

A value that carries an `_id` field still ingests — the field is unconditionally overwritten with the key-derived id.

## Changes

1. `feat!` — the key is the sole source of `_id`; keyless records error with `docs-no-key` (pointing at the `ValueToKey` SMT), replacing the `docs-no-id` / `docs-no-id-on-tombstone` codes.
2. `tidy` — extract `resolveId` so id resolution is unit-testable with plain `SinkRecord`s, no `OpenTx` needed; characterisation tests pin the contract.
3. `fix` — docs-scoped errors for unusable keys, driven test-first.

## Implementation notes

- Considered erroring when a value `_id` conflicts with the key instead of overwriting; rejected in favour of the simpler unconditional rule — the key wins.
- A review pass over the feat commit found two bad failure modes for key shapes that were previously unconsulted (whenever the value carried `_id`): a composite (multi-field Struct) or `byte[]` key surfaced core's generic `xtdb/invalid-id` — halting the source with an error that names neither the record key nor the remedy — and a single-field Struct key with a null inner value tripped Kotlin's null-check intrinsic for a raw NPE. Both now fail with docs-scoped errors: `docs-invalid-key` naming the key type and the `ExtractField` remedy, and `docs-no-key` ("no usable key") for the null unwrap.
- `resolveId` probes `id.asIid` rather than duplicating core's id-type whitelist, so the accepted key types can't drift; the cost is one extra SHA-256 per record, noise next to the per-record value conversion.
- The source hasn't shipped in a release, so the removed error codes and the stricter keyless behaviour need no migration story.

## Test plan

- New `DocsIndexerTest` unit tests over `resolveId`: String passthrough, single-field-Struct unwrap, keyless, multi-field-Struct, `byte[]`, and null-inner-field keys.
- Integration suite updated: the happy-path test asserts the key-derived id overwrites a value `_id`; mirror-only `_id`s stripped from all other test data (JSON payloads, JSON Schemas, Avro schemas/records). Full `KafkaConnectSourceIntegrationTest` class passes — one transient `database catalog did not shut down in time` teardown stall (pre-existing, fails loud per #5711) passed on an isolated rerun.

Generated with [Claude Code](https://claude.com/claude-code)