### PR TITLE
fix(indexer): abort in-flight leader promotion when a database shuts down

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -160,7 +160,6 @@ interface Log<M> : AutoCloseable {
         suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<M>?
         fun onPartitionsAssignedSync(partitions: Collection<Int>): TailSpec<M>? = runBlocking { onPartitionsAssigned(partitions) }
         suspend fun onPartitionsRevoked(partitions: Collection<Int>)
-        fun onPartitionsRevokedSync(partitions: Collection<Int>) = runBlocking { onPartitionsRevoked(partitions) }
         suspend fun onPartitionsLost(partitions: Collection<Int>) = onPartitionsRevoked(partitions)
         fun onPartitionsLostSync(partitions: Collection<Int>) = runBlocking { onPartitionsLost(partitions) }
     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -397,10 +397,20 @@ class Database(
 
             if (indexerConfig.enabled && !readOnly) {
                 val listener = object : Log.SubscriptionListener<SourceMessage> {
+                    // Re-parent the promotion into this database's job. The Kafka shared consumer drives
+                    // rebalance callbacks from a detached `runBlocking` on its poll thread, so without this
+                    // the leader-transition await isn't in the database's cancel-join tree and a shutdown
+                    // that lands mid-promotion hangs. (In-memory/local logs already run us under `scope`,
+                    // so this is a no-op for them.)
                     override suspend fun onPartitionsAssigned(partitions: Collection<Int>) =
-                        partitions.singleOrNull()
-                            ?.let { db.partitions[it]?.logProcessor?.onPartitionsAssigned(listOf(it)) }
+                        withContext(scope.coroutineContext.job) {
+                            partitions.singleOrNull()
+                                ?.let { db.partitions[it]?.logProcessor?.onPartitionsAssigned(listOf(it)) }
+                        }
 
+                    // Deliberately NOT re-parented: revocation also runs as part of teardown (the unregister
+                    // path invokes it), by which point this job is already cancelled — re-parenting here
+                    // would throw before the unregister completes and wedge teardown.
                     override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
                         for (idx in partitions) db.partitions[idx]?.logProcessor?.onPartitionsRevoked(listOf(idx))
                     }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -2,6 +2,7 @@ package xtdb.indexer
 
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -176,6 +177,14 @@ class LogProcessor(
                 } catch (e: InterruptedException) {
                     throw e
                 } catch (e: Interrupted) {
+                    throw e
+                } catch (e: CancellationException) {
+                    // Shutdown cancelled this database's job mid-promotion — the transition runs under it
+                    // (re-parented at the Database subscription listener), so an await here was cancelled.
+                    // Rethrow rather than fall through to the notifyError catch below: a clean shutdown
+                    // must not be surfaced as an ingestion failure. The transport contains this
+                    // per-subscription so it doesn't evict a whole shared consumer — see the Kafka
+                    // SharedGroupConsumer's rebalance handler.
                     throw e
                 } catch (e: Throwable) {
                     LOG.error(e, "[$dbName] transition: failed to transition to leader")

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -47,6 +47,7 @@ import xtdb.util.MsgIdUtil.afterMsgIdToOffset
 import xtdb.util.MsgIdUtil.msgIdToEpoch
 import xtdb.util.MsgIdUtil.msgIdToOffset
 import xtdb.util.close
+import xtdb.util.debug
 import xtdb.util.error
 import xtdb.util.info
 import xtdb.util.logger
@@ -212,6 +213,14 @@ class KafkaCluster(
                                 val sub = subscriptions[topic] as? TopicSubscription<Any?> ?: continue
                                 try {
                                     sub.onPartitionAssigned(tps.single())
+                                } catch (e: CancellationException) {
+                                    // A topic's log processor aborted a leader transition because its
+                                    // database is shutting down. Swallow it here rather than let it reach
+                                    // the poll loop: this runBlocking is on the poll thread shared by every
+                                    // database on the cluster, and an exception escaping into `pollingJob`
+                                    // runs cleanupOnFailure and evicts them all. Returning frees the thread
+                                    // so this topic's queued unregister can drain and its teardown finish.
+                                    LOG.debug(e) { "onPartitionsAssigned: '$topic' assignment aborted — subscription shutting down" }
                                 } catch (e: Throwable) {
                                     LOG.error(e) { "onPartitionsAssigned($partitions): failed handling assignment for topic '$topic' ($tps)" }
                                     throw e
@@ -236,7 +245,7 @@ class KafkaCluster(
             })
         }
 
-        private fun processCommand(cmd: GroupCommand) {
+        private suspend fun processCommand(cmd: GroupCommand) {
             when (cmd) {
                 is GroupCommand.Register -> {
                     check(cmd.topic !in subscriptions) { "Topic ${cmd.topic} already registered" }
@@ -246,7 +255,7 @@ class KafkaCluster(
 
                 is GroupCommand.Unregister -> {
                     subscriptions.remove(cmd.topic)?.let { sub ->
-                        sub.listener.onPartitionsRevokedSync(listOf(0))
+                        sub.listener.onPartitionsRevoked(listOf(0))
                         sub.completion.complete(Unit)
                     }
                     applySubscriptions()
@@ -255,7 +264,7 @@ class KafkaCluster(
             }
         }
 
-        // Deliberately no `onPartitionsRevokedSync` — would trigger LogProcessor's
+        // Deliberately no `onPartitionsRevoked` — would trigger LogProcessor's
         // leader→follower transition during a Failed-state cleanup.
         private fun evictSubscriptions(topics: Collection<String>, cause: Throwable) {
             for (topic in topics) {


### PR DESCRIPTION
Related to #5711 — the bounded-teardown safety net whose trigger this removes.

## Summary

A node could hang on close when shutdown raced a follower→leader promotion. `DatabaseCatalog.close`'s cancel-join never completed, timed out, and faulted with "database catalog did not shut down in time". This removes the underlying deadlock.

## Context

Surfaced while investigating hangs in `PostgresSourceIntegrationTest`, which hangs the whole class indefinitely. It's amplified by the tests sharing one Kafka consumer group (the default `xtdb`): a single wedged teardown leaves a zombie node that starves every subsequent node in the group, so one stuck test cascades into a whole-suite hang. The deadlock itself is per-node and independent of the shared group.

## Root cause

Shutdown races a follower→leader promotion:

```
[poll]  Kafka fires onPartitionsAssigned in a detached runBlocking
        (a root coroutine — not in any database's cancel-join tree)
          └─ LogProcessor promotion → awaitReplicaMsgId   ← SUSPENDED, awaiting replica catch-up

[close] node.close() → dbJob.cancelAndJoin()
          ├─ cancels the db's own coroutines: follower tail, source-log subscription, term
          └─ does NOT reach the promotion — it's on the detached [poll] coroutine   ← divergence

[poll]  still wedged in awaitReplicaMsgId → never returns to its select loop
          └─ never drains the queued Unregister command

[close] source-log openGroupSubscription's finally → NonCancellable unregister
          └─ awaits the poll loop that will never run it → cancelAndJoin blocks forever
```

Kafka drives its rebalance callbacks from a `runBlocking` on the shared consumer's poll thread — a root coroutine with no parent, so the promotion (its `awaitReplicaMsgId`, and the preceding replica-log `withTx { NoOp }.await()`) isn't in any database's cancel-join tree. `dbJob.cancelAndJoin()` walks the database's own coroutines but never reaches that await. The poll thread stays wedged, so it never drains the queued group-unregister, whose `NonCancellable` wait is the child `cancelAndJoin` is actually stuck on.

## The fix

Re-parent the promotion into the database's job at the transport→database boundary, so ordinary structured cancellation reaches it:

1. The `Database` subscription listener runs `onPartitionsAssigned` under `withContext(scope.coroutineContext.job)`. A shutdown mid-promotion now cancels its awaits. Revocation is deliberately left unwrapped — it also runs as part of teardown (the unregister invokes it), when that job is already cancelled, so re-parenting it would throw before the unregister completes and wedge teardown instead.

2. `LogProcessor.onPartitionsAssigned` rethrows the `CancellationException` rather than routing it through `watchers.notifyError` — that would wrap it in an `IngestionStoppedException`, log "ingestion stopping" at ERROR and permanently fail the watcher, relabelling a clean shutdown as an ingestion failure and hiding the type from awaiters. Matches the existing leader/follower convention.

3. The Kafka rebalance handler contains the `CancellationException` per-subscription so it doesn't reach `SharedGroupConsumer.pollingJob`, whose `cleanupOnFailure` would evict every database on the shared consumer. Freeing the poll thread lets the queued unregister drain; whole-node shutdown stops the poll loop through its own channel-close path regardless.

Also folds in a small tidy: `processCommand` is now `suspend` and calls `onPartitionsRevoked` directly, dropping the now-unused `onPartitionsRevokedSync` `runBlocking` bridge.

## Implementation notes

- **Why re-parent at the `Database` listener, not deeper.** It's the transport→database boundary and the first frame with the db `scope`; it's the single chokepoint for every log type and normalises the invocation context (in-memory/local logs already run under `scope`, so it's a no-op there; only Kafka's detached poll-thread `runBlocking` needs it). Burying it in `awaitReplicaMsgId` would leave the preceding `withTx().await()` exposed to the same hang.
- **The assign/revoke asymmetry is deliberate.** The revoke path *is* teardown — tying it to the job teardown cancels is self-defeating. An earlier attempt that wrapped it wedged the unregister (confirmed via coroutine dump: `openGroupSubscription` stuck in a `NonCancellable` unregister that `onPartitionsRevoked` never let complete).
- **Cancellation isn't laundered through `notifyError`.** `notifyError` wraps into `IngestionStoppedException`, hiding the `CancellationException` type from downstream `catch (CancellationException)` sites — so a clean shutdown would masquerade as an ingestion failure. Handling it separately is the existing house convention.

## Test plan

- Core transition suite (`xtdb.indexer.*`, `ExternalSourceTest`): 35/35 pass — no regression on the normal leader↔follower path.
- `PostgresSourceIntegrationTest`: 20/20 pass, class completes in ~2m14s (previously hung forever), with the shared consumer group still in place — confirming the fix removes the cascade at its root.
- No reflection / boxed-math warnings.

## Out of scope

- The tests' shared Kafka consumer group is a separate test-hygiene issue (a unique `groupId` per node would isolate them); unnecessary once the deadlock is fixed, so left as-is.
- `onPartitionsAssignedSync` / `onPartitionsLostSync` are pre-existing dead code (no callers); left for a separate tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
