### PR TITLE
refactor(pgwire): answer SHOW from the connection

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -5,7 +5,6 @@
             [cognitect.anomalies :as-alias anom]
             [cognitect.transit :as transit]
             [integrant.core :as ig]
-            [xtdb.api :as xt]
             [xtdb.authn :as authn]
             [xtdb.db-catalog :as db]
             [xtdb.error :as err]
@@ -741,80 +740,45 @@
                   [{:canned-response canned-response}]
                   (mapv (fn [ps] {:parsed ps}) (SqlParser/parseStatements sql))))))))
 
-(defn- show-var-query [variable]
-  (case variable
-    ("latest_completed_txs" "latest_submitted_msg_ids" "latest_processed_msg_ids")
-    (-> '[:table {:param ?_0}]
-        (with-meta {:param-count 1}))
-
-    "latest_submitted_tx" (-> '[:select {:predicate (not (nil? tx_id))}
-                                [:table {:rows [{:tx_id ?_0, :system_time ?_1,
-                                                 :committed ?_2, :error ?_3,
-                                                 :await_token ?_4}]}]]
-                              (with-meta {:param-count 5}))
-
-    (-> (xt/template [:table {:rows [{~(keyword variable) ?_0}]}])
-        (with-meta {:param-count 1}))))
-
-(defn- show-var-param-types [variable]
-  (case variable
-    "latest_completed_txs" [#xt/type [:list [:struct {"db_name" :utf8, "part" :i32, "tx_id" :i64, "system_time" :instant}]]]
-    ("latest_submitted_msg_ids" "latest_processed_msg_ids") [#xt/type [:list [:struct {"db_name" :utf8
-                                                                                       "part" :i32
-                                                                                       "msg_id" :i64}]]]
-    "latest_submitted_tx" [#xt/type :i64, #xt/type :instant, #xt/type :bool, #xt/type :transit, #xt/type :utf8]
-    "await_token" [#xt/type :utf8]
-    "standard_conforming_strings" [#xt/type :bool]
-
-    [#xt/type :utf8]))
-
 (defn- conn-db-name ^String [{:keys [conn-state]}]
   (.getDbName ^Xtdb$Connection (:node-conn @conn-state)))
 
 (defn- prep-stmt [{:keys [conn-state] :as conn} {:keys [param-oids ^ParsedStatement parsed] :as stmt}]
-  ;; query/execute prepare the AST; show-variable prepares a synthetic RA query; everything else passes through.
-  (letfn [(finish [^PreparedQuery pq param-types]
-            (when-let [warnings (.getWarnings pq)]
-              (doseq [warning warnings]
-                (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning)))))
+  ;; queries, EXECUTE and SHOW all prepare through the connection; everything else passes through.
+  (letfn [(prepare-parsed []
+            (let [^PreparedQuery pq (with-auth-check conn
+                                      (.prepare ^Xtdb$Connection (:node-conn @conn-state) parsed))]
+              (when-let [warnings (.getWarnings pq)]
+                (doseq [warning warnings]
+                  (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning)))))
 
-            (let [param-oids (->> (concat param-oids (repeat 0))
-                                  (into [] (take (.getParamCount pq))))
-                  param-types (or param-types (map #(some-> (PgType/fromOid %) .getXtType) param-oids))
-                  pg-cols (if (some nil? param-types)
-                            ;; if we're unsure on some of the col-types, return all output cols as the fallback type (#4455)
-                            (for [col-name (map str (.getColumnNames pq))]
-                              {:pg-type PgType/PG_DEFAULT, :col-name col-name})
+              (let [param-oids (->> (concat param-oids (repeat 0))
+                                    (into [] (take (.getParamCount pq))))
+                    param-types (map #(some-> (PgType/fromOid %) .getXtType) param-oids)
+                    pg-cols (if (some nil? param-types)
+                              ;; if we're unsure on some of the col-types, return all output cols as the fallback type (#4455)
+                              (for [col-name (map str (.getColumnNames pq))]
+                                {:pg-type PgType/PG_DEFAULT, :col-name col-name})
 
-                            (->> (.getColumnFields pq (->> param-types
-                                                           (into [] (comp (map types/->nullable-type)
-                                                                          (map-indexed (fn [idx vt]
-                                                                                         (types/->field (str "?_" idx) vt)))))))
-                                 (mapv field->pg-col)))]
-              (assoc stmt
-                     :prepared-query pq
-                     :param-oids param-oids
-                     :prepared-pg-cols pg-cols
-                     :pg-cols pg-cols)))
-
-          (prepare-ast [^ParsedStatement ps]
-            (finish (with-auth-check conn
-                      (.prepareSql ^Xtdb$Connection (:node-conn @conn-state) ps))
-                    nil))]
+                              (->> (.getColumnFields pq (->> param-types
+                                                             (into [] (comp (map types/->nullable-type)
+                                                                            (map-indexed (fn [idx vt]
+                                                                                           (types/->field (str "?_" idx) vt)))))))
+                                   (mapv field->pg-col)))]
+                (assoc stmt
+                       :prepared-query pq
+                       :param-oids param-oids
+                       :prepared-pg-cols pg-cols
+                       :pg-cols pg-cols))))]
 
     (if (nil? parsed)                   ; :empty? / :canned-response markers carry no parsed statement
       stmt
       (try
        (.accept parsed
                (reify ParsedStatement$Visitor
-                 (visitQuery [_ ps] (prepare-ast ps))
-                 (visitExecute [_ ps] (prepare-ast ps))
-                 (visitShowVariable [_ ps]
-                   (let [^Xtdb$Connection node-conn (:node-conn @conn-state)
-                         variable (.getVariable ps)]
-                     (finish (with-auth-check conn
-                               (.prepareRa node-conn (show-var-query variable)))
-                             (show-var-param-types variable))))
+                 (visitQuery [_ _] (prepare-parsed))
+                 (visitExecute [_ _] (prepare-parsed))
+                 (visitShowVariable [_ _] (prepare-parsed))
                  (visitOther [_ _] stmt)))
 
       (catch IllegalArgumentException e
@@ -899,18 +863,15 @@
           pg-types
           result-formats)))
 
-(defn bind-stmt [{:keys [node conn-state ^BufferAllocator allocator] :as conn} {:keys [^ParsedStatement parsed ^PreparedQuery prepared-query args result-format] :as stmt}]
+(defn bind-stmt [{:keys [conn-state ^BufferAllocator allocator] :as conn} {:keys [^ParsedStatement parsed ^PreparedQuery prepared-query args result-format] :as stmt}]
   (let [{:keys [^Xtdb$Connection node-conn]} @conn-state
-        session-params (.getSessionParameters node-conn)
-        ;; an open tx's await-token shadows the connection's (BEGIN ... WITH (AWAIT_TOKEN …)) for SHOW
-        await-token (.getEffectiveAwaitToken node-conn)
-
         xt-args (xtify-args conn args stmt)]
 
     ;; the connection owns the QueryOpts (basis / tz / tracer) and the read access-mode gate — pgwire drives its
-    ;; own cursor but opens it through the connection. checked? reads through the gate (openQuery); a SHOW or an
-    ;; internal args-eval opens unchecked. A user query in a write tx is the pgjdbc carve-out that
-    ;; verify-permissibility let through, so it too opens unchecked (openQuery would reject it).
+    ;; own cursor but opens it through the connection. checked? reads through the gate (openQuery); an internal
+    ;; args-eval opens unchecked. A user query in a write tx is the pgjdbc carve-out that verify-permissibility
+    ;; let through, so it too opens unchecked (openQuery would reject it). SHOW opens checked but the connection
+    ;; gate-exempts it off its parsed statement.
     (letfn [(->cursor ^xtdb.ResultCursor [^PreparedQuery pq xt-args checked?]
               (with-auth-check conn
                 (util/with-close-on-catch [args-rel (vw/open-args allocator xt-args)]
@@ -930,54 +891,21 @@
                                        #_ ; FIXME: these break because of PgType not being serializable
                                        {:prepared-cols prepared-pg-cols
                                         :resolved-cols resolved-pg-cols})))
-                (with-result-formats prepared-pg-cols result-format)))]
+                (with-result-formats prepared-pg-cols result-format)))
+
+            (bind-query-portal []
+              (util/with-close-on-catch [cursor (->cursor prepared-query xt-args true)]
+                (-> stmt
+                    (assoc :cursor cursor,
+                           :pg-cols (->pg-cols (:pg-cols stmt) cursor)))))]
 
       (if (nil? parsed)                 ; :empty? / :canned-response markers carry no parsed statement
         (-> stmt (assoc :args xt-args))
         (.accept parsed
                (reify ParsedStatement$Visitor
-                 (visitQuery [_ _]
-                   (util/with-close-on-catch [cursor (->cursor prepared-query xt-args true)]
-                     (-> stmt
-                         (assoc :cursor cursor,
-                                :pg-cols (->pg-cols (:pg-cols stmt) cursor)))))
-
-                 (visitShowVariable [_ ps]
-                   (let [variable (.getVariable ps)]
-                     (util/with-close-on-catch [cursor (->cursor prepared-query
-                                                                 (case variable
-                                                                   "await_token" [await-token]
-                                                                   "latest_completed_txs" [(for [[db-name parts] (xtp/latest-completed-txs node)
-                                                                                                 [part-idx {:keys [tx-id system-time]}] (map vector (range) parts)]
-                                                                                             {:db_name db-name
-                                                                                              :part (int part-idx)
-                                                                                              :tx_id tx-id
-                                                                                              :system_time system-time})]
-                                                                   "latest_submitted_msg_ids" [(for [[db-name parts] (xtp/latest-submitted-msg-ids node)
-                                                                                                     [part-idx msg-id] (map vector (range) parts)]
-                                                                                                 {:db_name db-name
-                                                                                                  :part (int part-idx)
-                                                                                                  :msg_id msg-id})]
-
-                                                                   "latest_processed_msg_ids" [(for [[db-name parts] (xtp/latest-processed-msg-ids node)
-                                                                                                     [part-idx msg-id] (map vector (range) parts)]
-                                                                                                 {:db_name db-name
-                                                                                                  :part (int part-idx)
-                                                                                                  :msg_id msg-id})]
-
-                                                                   "latest_submitted_tx" (let [lst (.getLastSubmittedTx node-conn)]
-                                                                                           [(some-> lst .getTxId) (some-> lst .getSystemTime)
-                                                                                            (some-> lst .getCommitted) (some-> lst .getError)
-                                                                                            await-token])
-                                                                   ;; declared :bool (show-var-param-types) — the raw stored string is interpreted here
-                                                                   "standard_conforming_strings" [(contains? #{"on" "true" "yes" "1"} (some-> (get session-params variable) str/lower-case))]
-                                                                   [(get session-params variable)])
-                                                                 false)]
-
-                       (-> stmt
-                           (assoc :cursor cursor,
-                                  :pg-cols (-> (:pg-cols stmt)
-                                               (with-result-formats result-format)))))))
+                 ;; queries and SHOW open the same way — the connection gate-exempts SHOW off its parsed statement
+                 (visitQuery [_ _] (bind-query-portal))
+                 (visitShowVariable [_ _] (bind-query-portal))
 
                  (visitExecute [_ ps]
                    (util/with-open [^ResultCursor args-cursor (->cursor prepared-query xt-args false)]

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -366,6 +366,7 @@
           (reify PreparedQuery
             (getParamCount [_] (:param-count (plan-query* @!table-info)))
             (getColumnNames [_] (:col-names (plan-query* @!table-info)))
+            (getParsed [_] stmt)
 
             (getColumnFields [_ param-fields]
               (let [planned-query (plan-query* @!table-info)]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -19,6 +19,7 @@ import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.VectorUnloader
 import org.apache.arrow.vector.complex.DenseUnionVector
 import org.apache.arrow.vector.ipc.ArrowReader
+import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ICursor
 import xtdb.ResultCursor
@@ -36,6 +37,7 @@ import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.database.Database
 import xtdb.database.DatabaseName
+import xtdb.database.DatabasePartition
 import xtdb.database.encodeTxBasisToken
 import xtdb.database.mergeTxBasisTokens
 import xtdb.error.Anomaly
@@ -292,12 +294,14 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             )
         }
 
-        // A synthetic RA-plan (pgwire's SHOW) prepared against this connection — awaits like [prepareSql] so the
-        // read sees the connection's own writes.
-        fun prepareRa(plan: Any): PreparedQuery {
-            dbCat.awaitAll(awaitToken, awaitTimeout)
-            return qSrc.prepareRa(plan, dbCat, PrepareOpts(defaultTz = defaultTz, defaultDb = dbName))
-        }
+        // Prepare a pre-classified statement (pgwire's dispatch path), so queries and SHOWs prepare through one
+        // entry — SHOW bypasses the access-mode gate off [PreparedQuery.parsed] in [openQuery].
+        fun prepare(parsed: ParsedStatement): PreparedQuery =
+            when (parsed) {
+                is ParsedStatement.Query, is ParsedStatement.Execute -> prepareSql(parsed)
+                is ParsedStatement.ShowVariable -> showPreparedQuery(parsed)
+                else -> throw Incorrect("not a preparable query: ${parsed::class.simpleName}", "xtdb/not-a-query")
+            }
 
         fun openSqlQuery(sql: String): ResultCursor =
             openQuery(prepareSql(sql), null)
@@ -371,8 +375,10 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 // SHOW is answered from connection state, ahead of the access-mode gate — it is session
                 // introspection, valid in any transaction (pgwire's verify-permissibility doesn't gate it).
                 if (prepared == null)
-                    (parseStatements(sql).singleOrNull() as? ParsedStatement.ShowVariable)
-                        ?.let { return showVariable(it.variable) }
+                    (parseStatements(sql).singleOrNull() as? ParsedStatement.ShowVariable)?.let { stmt ->
+                        val cursor = openQuery(prepare(stmt), null)
+                        return QueryResult(-1, cursorToArrowReader(cursor, Schema(cursor.resultTypes.map { (n, t) -> t.toField(n) })))
+                    }
                 if (prepared == null && args != null)
                     throw Incorrect(
                         "call prepare() before executeQuery() when parameters are bound",
@@ -731,14 +737,19 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             QueryOpts(b?.currentTime ?: clock.instant(), t?.txDefaultTz ?: defaultTz, b?.snapshotToken, b?.snapshotTime, tracer)
         }
 
-        // Open a cursor on an already-prepared query: first resolves the tx's access mode and basis (rejecting
-        // a read in a write tx, resolving an unresolved tx to read-only), then opens at the connection's basis,
-        // tz and tracer. A frontend owns the cursor for wire serialization, but the gate and the QueryOpts stay
-        // the connection's — no callsite reconstructs them, nor decides the gate.
-        fun openQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor {
-            resolveForQuery()
-            return pq.openQuery(args, queryOpts())
-        }
+        // Open a cursor on an already-prepared query: resolves the tx's access mode and basis (rejecting a read
+        // in a write tx, resolving an unresolved tx to read-only), then opens at the connection's basis, tz and
+        // tracer. SHOW bypasses the gate — it's session introspection, valid in any tx — dispatched on the
+        // originating statement, not the pq's concrete type. A frontend owns the cursor for wire serialization,
+        // but the gate and QueryOpts stay the connection's — no callsite reconstructs them, nor decides the gate.
+        fun openQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor =
+            when (pq.parsed) {
+                is ParsedStatement.ShowVariable -> openUncheckedQuery(pq, args)
+                else -> {
+                    resolveForQuery()
+                    pq.openQuery(args, queryOpts())
+                }
+            }
 
         // Open a read WITHOUT the access-mode gate — for a frontend's driver-compatibility probe that must be
         // permitted in any transaction (pgwire allows the pgjdbc type-metadata query inside a write tx, where
@@ -746,56 +757,111 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // is latest-committed data, not the tx's buffered writes.
         fun openUncheckedQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor = pq.openQuery(args, queryOpts())
 
-        // Answer a SHOW from connection state. SHOW LATEST_SUBMITTED_TX reports this connection's own last write;
-        // SHOW AWAIT_TOKEN reads the connection's await-token; SHOW of any other identifier reads a session
-        // parameter. (SHOW TIME ZONE / SNAPSHOT_TOKEN / CLOCK_TIME are grammar `showVariable`s — classified as
-        // Query and answered by the engine from the basis, not here.) The node-level status SHOWs
-        // (latest_completed_txs, …) are node introspection, not connection state — they stay in pgwire for now.
-        private fun showVariable(variable: String): QueryResult =
-            when (variable) {
-                // 0 rows until this connection has submitted a tx (matches the `tx_id IS NOT NULL` filter);
-                // system-time/committed/error are null for a fire-and-forget submit. error is a Throwable → transit.
-                "latest_submitted_tx" -> showResult(
+        // A SHOW answered from connection / catalog state as a zero-param [PreparedQuery]. [rows] is a thunk so
+        // values snapshot at openQuery; [parsed] drives the gate exemption in [openQuery].
+        private class ShowPreparedQuery(
+            override val parsed: ParsedStatement.ShowVariable,
+            private val types: SequencedMap<String, VectorType>,
+            private val allocator: BufferAllocator,
+            private val rows: () -> List<Map<String, Any?>>,
+        ) : PreparedQuery {
+            override val paramCount get() = 0
+            override val columnNames get() = types.keys.toList()
+            override fun getColumnFields(paramFields: List<Field>) = types.map { (name, type) -> type.toField(name) }
+            override val warnings get() = emptyList<String>()
+
+            override fun openQuery(args: RelationReader?, opts: QueryOpts): ResultCursor {
+                // SHOW is zero-param, but by the openQuery contract the returned cursor owns the args slice and
+                // closes it (on failure it stays the caller's). args are unused otherwise.
+                val rel = Relation(allocator, types).closeOnCatch { r -> rows().forEach { r.writeRow(it) }; r }
+                return object : ResultCursor {
+                    override val resultTypes get() = types
+                    override val cursorType get() = "show"
+                    override val childCursors get() = emptyList<ICursor>()
+
+                    private var done = false
+                    override fun tryAdvance(c: Consumer<in RelationReader>): Boolean {
+                        if (done) return false
+                        done = true
+                        c.accept(rel)
+                        return true
+                    }
+
+                    override fun close() {
+                        rel.close()
+                        args?.close()
+                    }
+                }
+            }
+        }
+
+        private fun showPreparedQuery(stmt: ParsedStatement.ShowVariable): PreparedQuery {
+            fun show(types: SequencedMap<String, VectorType>, rows: () -> List<Map<String, Any?>>) =
+                ShowPreparedQuery(stmt, types, allocator, rows)
+
+            fun show1(col: String, value: () -> String?) =
+                show(linkedMapOf(col to VectorType.maybe(VectorType.UTF8))) { listOf(mapOf(col to value())) }
+
+            // awaitAll first, so node-status reflects this connection's own writes
+            fun byPartition(msgIdCol: SequencedMap<String, VectorType>, read: (Database, DatabasePartition) -> Map<String, Any?>) =
+                show(msgIdCol) {
+                    dbCat.awaitAll(awaitToken, awaitTimeout)
+                    dbCat.databaseNames.flatMap { dbName ->
+                        val db = dbCat.databaseOrNull(dbName) ?: return@flatMap emptyList()
+                        db.partitions.toSortedMap().map { (part, partition) ->
+                            mapOf("db_name" to dbName, "part" to part) + read(db, partition)
+                        }
+                    }
+                }
+
+            val msgIdCols = linkedMapOf("db_name" to VectorType.UTF8, "part" to VectorType.I32,
+                                        "msg_id" to VectorType.maybe(VectorType.I64))
+
+            return when (val variable = stmt.variable) {
+                // 0 rows until this connection's first submit; system_time/committed/error null for a fire-and-forget submit
+                "latest_submitted_tx" -> show(
                     linkedMapOf("tx_id" to VectorType.maybe(VectorType.I64),
                                 "system_time" to VectorType.maybe(VectorType.INSTANT),
                                 "committed" to VectorType.maybe(VectorType.BOOL),
                                 "error" to VectorType.maybe(VectorType.TRANSIT),
-                                "await_token" to VectorType.maybe(VectorType.UTF8)),
+                                "await_token" to VectorType.maybe(VectorType.UTF8))) {
                     lastSubmittedTx?.let {
                         listOf(mapOf("tx_id" to it.txId, "system_time" to it.systemTime,
                                      "committed" to it.committed, "error" to it.error,
                                      "await_token" to effectiveAwaitToken))
-                    } ?: emptyList())
-
-                "await_token" -> showResult(variable, effectiveAwaitToken)
-                else -> showResult(variable, sessionParameters[variable])
-            }
-
-        // A one-row, single-(nullable-utf8)-column result — the common SHOW shape.
-        private fun showResult(col: String, value: String?): QueryResult =
-            showResult(linkedMapOf(col to VectorType.maybe(VectorType.UTF8)), listOf(mapOf(col to value)))
-
-        // A SHOW result of arbitrary typed columns and 0-or-more rows — the SHOW counterpart of the query
-        // engine's cursor, so executeQuery can return connection state as an Arrow result set.
-        private fun showResult(types: SequencedMap<String, VectorType>, rows: List<Map<String, Any?>>): QueryResult {
-            val rel = Relation(allocator, types).closeOnCatch { r -> rows.forEach { r.writeRow(it) }; r }
-            val cursor = object : ResultCursor {
-                override val resultTypes get() = types
-                override val cursorType get() = "show"
-                override val childCursors get() = emptyList<ICursor>()
-
-                private var done = false
-                override fun tryAdvance(c: Consumer<in RelationReader>): Boolean {
-                    if (done) return false
-                    done = true
-                    c.accept(rel)
-                    return true
+                    } ?: emptyList()
                 }
 
-                override fun close() = rel.close()
+                "await_token" -> show1(variable) { effectiveAwaitToken }
+
+                // declared :bool — interpret the raw session-param string
+                "standard_conforming_strings" -> show(linkedMapOf(variable to VectorType.maybe(VectorType.BOOL))) {
+                    val v = sessionParameters[variable]?.lowercase()
+                    listOf(mapOf(variable to (v in setOf("on", "true", "yes", "1"))))
+                }
+
+                "latest_completed_txs" -> show(
+                    linkedMapOf("db_name" to VectorType.UTF8, "part" to VectorType.I32,
+                                "tx_id" to VectorType.maybe(VectorType.I64),
+                                "system_time" to VectorType.maybe(VectorType.INSTANT))) {
+                    dbCat.awaitAll(awaitToken, awaitTimeout)
+                    dbCat.databaseNames.flatMap { dbName ->
+                        val db = dbCat.databaseOrNull(dbName) ?: return@flatMap emptyList()
+                        db.partitions.toSortedMap().map { (part, partition) ->
+                            val txKey = partition.liveIndex.latestCompletedTx
+                            mapOf("db_name" to dbName, "part" to part,
+                                  "tx_id" to txKey?.txId, "system_time" to txKey?.systemTime)
+                        }
+                    }
+                }
+
+                // #5557 unit 5: source log's latestSubmittedMsgId is database-level for now, so the same value
+                // appears in every partition slot.
+                "latest_submitted_msg_ids" -> byPartition(msgIdCols) { db, _ -> mapOf("msg_id" to db.sourceLog.latestSubmittedMsgId) }
+                "latest_processed_msg_ids" -> byPartition(msgIdCols) { _, partition -> mapOf("msg_id" to partition.watchers.latestSourceMsgId) }
+
+                else -> show1(variable) { sessionParameters[variable] }
             }
-            val schema = Schema(cursor.resultTypes.map { (name, type) -> type.toField(name) })
-            return QueryResult(-1, cursorToArrowReader(cursor, schema))
         }
 
         override fun setAutoCommit(autoCommit: Boolean) {

--- a/core/src/main/kotlin/xtdb/query/PreparedQuery.kt
+++ b/core/src/main/kotlin/xtdb/query/PreparedQuery.kt
@@ -12,5 +12,9 @@ interface PreparedQuery {
 
     val warnings: List<String>
 
+    // the statement this was prepared from, when there is one (null for embedded RA / `xt/q`). Lets the
+    // connection gate a read on its statement kind — e.g. SHOW bypasses the access-mode gate.
+    val parsed: ParsedStatement? get() = null
+
     fun openQuery(args: RelationReader?, opts: QueryOpts): ResultCursor
 }


### PR DESCRIPTION
Behaviour-preserving for pgwire; a fix for ADBC.

## Summary

`SHOW <var>` is now answered entirely by the connection. pgwire treats it like any other query — prepare, then execute the cursor — instead of reimplementing it.

## Context

pgwire reimplemented every state-dependent `SHOW` as a synthetic relational-algebra query: a per-variable RA template, a per-variable column-type table, and a bind-time step that injected the values as query args. The connection meanwhile carried a second, half-built SHOW implementation for its ADBC path — it covered the connection-state variables but not the node-status ones (`latest_completed_txs`, `latest_submitted_msg_ids`, `latest_processed_msg_ids`), which fell through to a session-parameter lookup and answered wrong over ADBC.

The parser already sorts SHOWs: the ones the engine can answer from the query basis (`TIMEZONE`, `SNAPSHOT_TOKEN`, `CLOCK_TIME`) are classified `Query` and were never pgwire's to special-case; the state-dependent ones are `ParsedStatement.ShowVariable`. Those turn out to be answerable entirely from the connection — the node-status readers only need `Database.Catalog`, which the connection already holds, not a node handle.

## What changes

`Connection.prepare(parsed)` is the single entry pgwire uses for queries, `EXECUTE` and `SHOW` alike. A query-like statement plans through the engine; a `ShowVariable` builds a zero-param `ShowPreparedQuery` whose column types are fixed per variable and whose rows snapshot connection/catalog state at open time. pgwire hands over the `ParsedStatement` it already parsed and drives the resulting cursor exactly as it drives a query — so `prep-stmt` and `bind-stmt` collapse the query / execute / show branches into one, and the synthetic-RA path, the per-variable type table and the bind-time injection are deleted.

As a side effect, the node-status SHOWs now answer correctly over ADBC/Flight SQL, not just pgwire.

## Gate exemption

`SHOW` is introspection, not a basis read, so it must stay valid in any transaction and bypass the access-mode gate. Rather than have the gate sniff a concrete prepared-query type or carry a bespoke flag, a `PreparedQuery` now remembers the `ParsedStatement` it was prepared from, and `openQuery` gates on that kind: a `ShowVariable` opens unchecked, everything else resolves as before. The distinction lives with the classification that already draws it.

## What stays pgwire's

Statement dispatch (which wire sequence to run), the wire framing (RowDescription, DataRow, command tags, ParameterStatus), and the SET / tx-control acknowledgements — none of it SHOW-specific.

## Test plan

Full unit suite green (1,599 tests, 0 failures, no reflection / boxed-math warnings). The pgwire, playground (multi-db `SHOW LATEST_COMPLETED_TXS`), types, pg2, `ConnectionTest` and `InProcessAdbcTest` suites exercise the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)