### PR TITLE
feat(table): parse dot-separated schema in TableRef

### DIFF
--- a/api/src/main/kotlin/xtdb/table/TableRef.kt
+++ b/api/src/main/kotlin/xtdb/table/TableRef.kt
@@ -1,6 +1,7 @@
 package xtdb.table
 
 import clojure.lang.Symbol
+import xtdb.error.Incorrect
 
 typealias DatabaseName = String
 typealias SchemaName = String
@@ -15,11 +16,18 @@ data class TableRef(val schemaName: SchemaName = DEFAULT_SCHEMA, val tableName: 
     val schemaAndTable get() = "$schemaName/$tableName"
 
     companion object {
+        private val PARSE_REGEX = Regex("(?:([^/]+)[./])?([^./]+)")
+
         @JvmStatic
         fun parse(str: String): TableRef {
-            val sym = Symbol.intern(str)
+            val (schema, table) = PARSE_REGEX.matchEntire(str)?.destructured
+                ?: throw Incorrect(
+                    "Invalid table reference: '$str'",
+                    errorCode = "xtdb.table/invalid-table-ref",
+                    data = mapOf("table-ref" to str)
+                )
 
-            return TableRef(sym.namespace ?: DEFAULT_SCHEMA, sym.name)
+            return TableRef(schema.ifEmpty { DEFAULT_SCHEMA }, table)
         }
     }
 }

--- a/api/src/test/kotlin/xtdb/table/TableRefTest.kt
+++ b/api/src/test/kotlin/xtdb/table/TableRefTest.kt
@@ -1,0 +1,38 @@
+package xtdb.table
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
+import xtdb.error.Incorrect
+
+class TableRefTest {
+
+    @Test
+    fun `bare name goes in the default schema`() {
+        assertEquals(TableRef(DEFAULT_SCHEMA, "foo"), TableRef.parse("foo"))
+    }
+
+    @Test
+    fun `slash separates schema from table`() {
+        assertEquals(TableRef("myschema", "foo"), TableRef.parse("myschema/foo"))
+    }
+
+    @Test
+    fun `dot separates schema from table`() {
+        assertEquals(TableRef("information_schema", "columns"), TableRef.parse("information_schema.columns"))
+    }
+
+    @Test
+    fun `schema may contain dots`() {
+        assertEquals(TableRef("foo.bar", "the-docs"), TableRef.parse("foo.bar/the-docs"))
+        assertEquals(TableRef("a.b", "c"), TableRef.parse("a.b.c"))
+        assertEquals(TableRef("a.b", "c"), TableRef.parse("a.b/c"))
+    }
+
+    @Test
+    fun `rejects embedded separators and empty segments`() {
+        for (str in listOf("", "/foo", "foo/", ".foo", "foo.", "a/b/c", "public/foo.bar")) {
+            assertThrows<Incorrect>("expected '$str' to be rejected") { TableRef.parse(str) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`TableRef.parse` now accepts the dotted `schema.table` form as well as the slash `schema/table` form, so `information_schema.columns` parses as schema `information_schema`, table `columns`. This is a **breaking change**: it only accepts a clean `$schema[./]$table` (schema optional), and rejects inputs the old parser tolerated — dotted table names, empty segments, and multi-segment strings now throw.

## Context

This is pre-work for the Kafka Connect source (KC-source). We want its connector config to expose a single `table` value that accepts the dotted `schema.table` form and parses straight into a `TableRef`, rather than making the user supply schema and table as separate settings. For that, `TableRef.parse` first has to understand the dot.

Today it doesn't. `parse` delegated to Clojure's `Symbol.intern`, which splits on the first `/` and never treats `.` specially, so `information_schema.columns` came back as a single table named `information_schema.columns` in `public`.

## Implementation

`parse` now matches against `(?:([^./]+)[./])?([^./]+)` — an optional schema and a table, separated by `.` or `/`, with neither part containing a `.` or `/`. A non-match throws `xtdb.error/incorrect`.

I looked at reusing the SQL grammar's `targetTable` rule (`(schemaName '.')? tableName`), which is the same shape, but it isn't reachable: it's generated into `core`, and `core` depends on `api` (not the reverse), so `TableRef.parse` can't see it. It also only knows the `.` separator, not the `/` form the internal round-trip uses, and its `identifier` permits quoted names with embedded dots — broader than we want. A regex in `api` is the right home.

## Decision: knowingly too strict

Postgres permits dotted table names via quoted identifiers (`CREATE TABLE "foo.bar"`). This parser rejects them — including on the internal `schemaAndTable` round-trip form `public/foo.bar`, so a persisted dotted name would fail to parse on reload. We're accepting that over-restriction deliberately rather than carry the "is this dot a separator or part of the name?" ambiguity, and will revisit if a user actually comes to us needing a dot in a table name.

Enforcing the matching restriction on the *create* side (rejecting dotted/slashed names at `CREATE TABLE` / delimited-identifier time) is out of scope here; today the two ends are inconsistent (create allows, parse rejects).

## Test plan

New `TableRefTest` covers: bare name into the default schema, the slash split, the dot split, a `schemaAndTable` round-trip for non-dotted refs, and rejection of embedded separators / empty segments (`""`, `/foo`, `foo/`, `.foo`, `foo.`, `a/b/c`, `a.b.c`, `a.b/c`, `public/foo.bar`). All pass.
