### PR TITLE
refactor(query): type the IQuerySource prepare boundary

### DIFF
--- a/api/src/main/clojure/xtdb/protocols.clj
+++ b/api/src/main/clojure/xtdb/protocols.clj
@@ -8,8 +8,7 @@
   (^xtdb.api.Xtdb$Connection open-connection [node db-name]))
 
 (defprotocol PLocalNode
-  (^xtdb.query.PreparedQuery prepare-sql [node query query-opts])
-  (^xtdb.query.PreparedQuery prepare-ra [node ra-plan query-opts]))
+  (^xtdb.query.PreparedQuery prepare-sql [node query query-opts]))
 
 (defprotocol PStatus
   (latest-submitted-msg-ids [node])

--- a/core/src/main/clojure/xtdb/antlr.clj
+++ b/core/src/main/clojure/xtdb/antlr.clj
@@ -6,7 +6,7 @@
 (defn parse-where [sql] (SqlParser/parseWhere sql))
 
 (defn parse-statement ^xtdb.antlr.Sql$DirectlyExecutableStatementContext [sql]
-  (SqlParser/parseStatement sql))
+  (SqlParser/parseStatementAst sql))
 
 (defn parse-multi-statement [sql]
   (SqlParser/parseMultiStatement sql))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -27,7 +27,7 @@
            xtdb.api.module.XtdbModule$Factory
            (xtdb.database Database Database$Catalog DatabasePartition)
            xtdb.error.Anomaly
-           (xtdb.query IQuerySource PreparedQuery QueryOpts SqlParser SqlPlanner)))
+           (xtdb.query IQuerySource PrepareOpts PreparedQuery QueryOpts SqlParser SqlPlanner)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -134,9 +134,10 @@
          (some #(when (instance? clazz %) %))))
 
   (^PreparedQuery prepareSql [this ^String sql query-opts]
-    (let [{:keys [await-token tx-timeout] :as query-opts} (-> query-opts (with-query-opts-defaults this))]
+    (let [{:keys [await-token tx-timeout default-tz default-db current-time]} (-> query-opts (with-query-opts-defaults this))]
       (.awaitAll db-cat await-token tx-timeout)
-      (.prepareQuery q-src (SqlParser/parseStatement sql) db-cat query-opts)))
+      (.prepareQuery q-src (SqlParser/parseStatement sql) db-cat
+                     (PrepareOpts. default-tz default-db current-time nil))))
 
   (submitTx [this db-name tx-ops tx-opts]
     (.submitTx (xtp/open-connection this db-name) tx-ops tx-opts))
@@ -226,13 +227,6 @@
   xtp/PLocalNode
   (prepare-sql [this query query-opts]
     (.prepareSql this ^String query query-opts))
-
-  (prepare-ra [this plan query-opts]
-    (let [{:keys [await-token tx-timeout] :as query-opts} (-> query-opts (with-query-opts-defaults this))]
-
-      (.awaitAll db-cat await-token tx-timeout)
-
-      (.prepareRa q-src plan db-cat query-opts)))
 
   Closeable
   (close [_]

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -1,7 +1,6 @@
 (ns xtdb.node.impl
   (:require [clojure.pprint :as pp]
             [integrant.core :as ig]
-            [xtdb.antlr :as antlr]
             [xtdb.api :as api]
             [xtdb.basis :as basis]
             [xtdb.error :as err]
@@ -24,12 +23,11 @@
            [java.util.concurrent.atomic AtomicReference]
            (org.apache.arrow.memory BufferAllocator)
            xtdb.NodeBase
-           (xtdb.antlr Sql$DirectlyExecutableStatementContext)
            (xtdb.api DataSource TransactionKey TransactionResult TransactionResult$Committed TransactionResult$Aborted Xtdb Xtdb$CompactorNode Xtdb$Config Xtdb$Connection Xtdb$XtdbInternal)
            xtdb.api.module.XtdbModule$Factory
            (xtdb.database Database Database$Catalog DatabasePartition)
            xtdb.error.Anomaly
-           (xtdb.query IQuerySource PreparedQuery QueryOpts SqlPlanner)))
+           (xtdb.query IQuerySource PreparedQuery QueryOpts SqlParser SqlPlanner)))
 
 (set! *unchecked-math* :warn-on-boxed)
 
@@ -136,12 +134,9 @@
          (some #(when (instance? clazz %) %))))
 
   (^PreparedQuery prepareSql [this ^String sql query-opts]
-    (.prepareSql this (antlr/parse-statement sql) (assoc query-opts :query-text sql)))
-
-  (^PreparedQuery prepareSql [this ^Sql$DirectlyExecutableStatementContext ast query-opts]
     (let [{:keys [await-token tx-timeout] :as query-opts} (-> query-opts (with-query-opts-defaults this))]
       (.awaitAll db-cat await-token tx-timeout)
-      (.prepareQuery q-src ast db-cat query-opts)))
+      (.prepareQuery q-src (SqlParser/parseStatement sql) db-cat query-opts)))
 
   (submitTx [this db-name tx-ops tx-opts]
     (.submitTx (xtp/open-connection this db-name) tx-ops tx-opts))
@@ -230,21 +225,14 @@
 
   xtp/PLocalNode
   (prepare-sql [this query query-opts]
-    (cond
-      (instance? Sql$DirectlyExecutableStatementContext query)
-      (.prepareSql this ^Sql$DirectlyExecutableStatementContext query query-opts)
-
-      (string? query)
-      (.prepareSql this ^String query query-opts)
-
-      :else (throw (err/incorrect :xtdb/unsupported-query-type (format "Unsupported SQL query type: %s" (type query))))))
+    (.prepareSql this ^String query query-opts))
 
   (prepare-ra [this plan query-opts]
     (let [{:keys [await-token tx-timeout] :as query-opts} (-> query-opts (with-query-opts-defaults this))]
 
       (.awaitAll db-cat await-token tx-timeout)
 
-      (.prepareQuery q-src plan db-cat query-opts)))
+      (.prepareRa q-src plan db-cat query-opts)))
 
   Closeable
   (close [_]

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -771,7 +771,7 @@
 (defn- conn-db-name ^String [{:keys [conn-state]}]
   (.getDbName ^Xtdb$Connection (:node-conn @conn-state)))
 
-(defn- prep-stmt [{:keys [node conn-state] :as conn} {:keys [param-oids ^ParsedStatement parsed] :as stmt}]
+(defn- prep-stmt [{:keys [conn-state] :as conn} {:keys [param-oids ^ParsedStatement parsed] :as stmt}]
   ;; query/execute prepare the AST; show-variable prepares a synthetic RA query; everything else passes through.
   (letfn [(finish [^PreparedQuery pq param-types]
             (when-let [warnings (.getWarnings pq)]
@@ -813,10 +813,7 @@
                    (let [^Xtdb$Connection node-conn (:node-conn @conn-state)
                          variable (.getVariable ps)]
                      (finish (with-auth-check conn
-                               (xtp/prepare-ra node (show-var-query variable)
-                                               {:await-token (.getAwaitToken node-conn)
-                                                :default-tz (.getDefaultTz node-conn)
-                                                :default-db (.getDbName node-conn)}))
+                               (.prepareRa node-conn (show-var-query variable)))
                              (show-var-param-types variable))))
                  (visitOther [_ _] stmt)))
 

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -5,7 +5,6 @@
             [cognitect.anomalies :as-alias anom]
             [cognitect.transit :as transit]
             [integrant.core :as ig]
-            [xtdb.antlr :as antlr]
             [xtdb.api :as xt]
             [xtdb.authn :as authn]
             [xtdb.db-catalog :as db]
@@ -800,7 +799,7 @@
 
           (prepare-ast [^ParsedStatement ps]
             (finish (with-auth-check conn
-                      (.prepareSql ^Xtdb$Connection (:node-conn @conn-state) (.getAst ps) (.getOriginalSql ps)))
+                      (.prepareSql ^Xtdb$Connection (:node-conn @conn-state) ps))
                     nil))]
 
     (if (nil? parsed)                   ; :empty? / :canned-response markers carry no parsed statement
@@ -1132,8 +1131,7 @@
     (when (empty? param-oids)
       (try
         (let [^PreparedQuery pq (with-auth-check conn
-                                  (xtp/prepare-sql node
-                                                   (antlr/parse-statement query)
+                                  (xtp/prepare-sql node query
                                                    {:default-db (conn-db-name conn)}))]
 
           ;; Send any warnings to the client

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -42,6 +42,7 @@
            [java.util.concurrent.atomic AtomicBoolean]
            (java.util.function Function)
            [java.util.stream Stream StreamSupport]
+           (org.antlr.v4.runtime.misc Interval)
            (org.apache.arrow.memory BufferAllocator RootAllocator)
            org.apache.arrow.vector.types.pojo.Field
            (xtdb ICursor ResultCursor ResultCursor$ErrorTrackingCursor PagesCursor)
@@ -276,18 +277,22 @@
 
     (vec (->results cursor 0))))
 
+(defn- ast-source-text [^Sql$DirectlyExecutableStatementContext ast]
+  (let [start (.getStart ast)]
+    (.getText (.getInputStream start)
+              (Interval/of (.getStartIndex start) (.getStopIndex (.getStop ast))))))
+
 (defn- ->prepare-opts-map
-  "Prepare-time opts reach the planner as a Clojure map. Kotlin callers pass a typed [PrepareOpts];
-  translate it here, at the planner's edge. Real maps (the Clojure node's path) pass straight through,
-  so callers can migrate to the typed form one at a time."
-  [opts]
-  (if (instance? PrepareOpts opts)
-    (let [^PrepareOpts opts opts]
-      (cond-> {}
-        (.getDefaultTz opts) (assoc :default-tz (.getDefaultTz opts))
-        (.getDefaultDb opts) (assoc :default-db (.getDefaultDb opts))
-        (.getCurrentTime opts) (assoc :current-time (.getCurrentTime opts))))
-    opts))
+  "Prepare-time opts reach the planner as a Clojure map; translate the typed [PrepareOpts] here, at the
+  planner's edge."
+  [^PrepareOpts opts]
+  (cond-> {}
+    (.getDefaultTz opts) (assoc :default-tz (.getDefaultTz opts))
+    (.getDefaultDb opts) (assoc :default-db (.getDefaultDb opts))
+    (.getCurrentTime opts) (assoc :current-time (.getCurrentTime opts))
+    (.getArgFields opts) (assoc :arg-fields (.getArgFields opts))
+    (.getExplain opts) (assoc :explain? true)
+    (.getExplainAnalyze opts) (assoc :explain-analyze? true)))
 
 (defprotocol PQuerySource
   (-plan-query [q-src parsed-query query-opts table-info]))
@@ -330,9 +335,11 @@
   (prepareRa [this parsed-query db-cat query-opts]
     (let [^ParsedStatement stmt (when (instance? ParsedStatement parsed-query) parsed-query)
           parsed-query (if stmt (.getAst stmt) parsed-query)
+          qtext (cond stmt (.getOriginalSql stmt)
+                      (instance? Sql$DirectlyExecutableStatementContext parsed-query) (ast-source-text parsed-query))
           {:keys [default-tz query-text] :as query-opts} (-> (->prepare-opts-map query-opts)
                                                               (update :default-tz (fnil identity expr/*default-tz*))
-                                                              (cond-> stmt (assoc :query-text (.getOriginalSql stmt)))
+                                                              (cond-> qtext (assoc :query-text qtext))
                                                               (assoc :db-names (vec (sort (.getDatabaseNames db-cat)))))]
       (letfn [(open-snaps []
                 ;; TODO this opens up a snapshot for *every* db in the catalog
@@ -458,7 +465,7 @@
 
   (prepareTxSql [this sql db-cat opts]
     (let [[q-tag {:keys [stmt table message user role col-names]}]
-          (parse-sql/parse-statement sql {:default-db (:default-db opts)})]
+          (parse-sql/parse-statement sql {:default-db (.getDefaultDb opts)})]
       (case q-tag
         :grant-role (SqlStatement$GrantRole. user role)
         :revoke-role (SqlStatement$RevokeRole. user role)
@@ -476,7 +483,7 @@
                                   {:query sql})))))))
 
   (preparePatchDocsQuery [this table valid-from valid-to db-cat opts]
-    (let [default-db (:default-db opts)
+    (let [default-db (.getDefaultDb opts)
           table-info (-> (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat default-db))]
                            (.tableInfo snap))
                          (sql/xform-table-info [default-db] default-db))

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -2,7 +2,6 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [xtdb.antlr :as antlr]
             [xtdb.basis :as basis]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
@@ -52,7 +51,7 @@
            (xtdb.indexer DatabaseSnapshot Snapshot)
            xtdb.NodeBase
            xtdb.operator.scan.IScanEmitter
-           (xtdb.query IQuerySource IQuerySource$Factory PrepareOpts PreparedQuery SqlStatement$Assert SqlStatement$CreateTable SqlStatement$Delete SqlStatement$Erase SqlStatement$GrantRole SqlStatement$Patch SqlStatement$Put SqlStatement$RevokeRole)
+           (xtdb.query IQuerySource IQuerySource$Factory ParsedStatement PrepareOpts PreparedQuery SqlStatement$Assert SqlStatement$CreateTable SqlStatement$Delete SqlStatement$Erase SqlStatement$GrantRole SqlStatement$Patch SqlStatement$Put SqlStatement$RevokeRole)
            xtdb.util.RefCounter))
 
 (defn- wrap-result-types [^ICursor cursor, result-types]
@@ -163,15 +162,6 @@
          [db-name sys-times])
        (into {})
        (not-empty)))
-
-(defn- parse-query [query]
-  (cond
-    (vector? query) query
-    (string? query) (antlr/parse-statement query)
-    (instance? Sql$DirectlyExecutableStatementContext query) query
-
-    :else (throw (err/incorrect :unknown-query-type "Unknown query type"
-                                {:query query, :type (type query)}))))
 
 (defn- plan-query [parsed-query query-opts]
   (cond
@@ -296,7 +286,6 @@
       (cond-> {}
         (.getDefaultTz opts) (assoc :default-tz (.getDefaultTz opts))
         (.getDefaultDb opts) (assoc :default-db (.getDefaultDb opts))
-        (.getQueryText opts) (assoc :query-text (.getQueryText opts))
         (.getCurrentTime opts) (assoc :current-time (.getCurrentTime opts))))
     opts))
 
@@ -336,9 +325,14 @@
 
   IQuerySource
   (prepareQuery [this query db-cat query-opts]
-    (let [parsed-query (parse-query query)
+    (.prepareRa this query db-cat query-opts))
+
+  (prepareRa [this parsed-query db-cat query-opts]
+    (let [^ParsedStatement stmt (when (instance? ParsedStatement parsed-query) parsed-query)
+          parsed-query (if stmt (.getAst stmt) parsed-query)
           {:keys [default-tz query-text] :as query-opts} (-> (->prepare-opts-map query-opts)
                                                               (update :default-tz (fnil identity expr/*default-tz*))
+                                                              (cond-> stmt (assoc :query-text (.getOriginalSql stmt)))
                                                               (assoc :db-names (vec (sort (.getDatabaseNames db-cat)))))]
       (letfn [(open-snaps []
                 ;; TODO this opens up a snapshot for *every* db in the catalog
@@ -470,7 +464,7 @@
         :revoke-role (SqlStatement$RevokeRole. user role)
         :create-table (SqlStatement$CreateTable. table (or col-names []))
 
-        (let [pq (.prepareQuery this stmt db-cat opts)]
+        (let [pq (.prepareRa this stmt db-cat opts)]
           (case q-tag
             (:insert :update) (SqlStatement$Put. pq table)
             :patch (SqlStatement$Patch. pq table)
@@ -495,7 +489,7 @@
                                                                           :param ?patch_docs}]
                                                                 '[_iid doc])})
                    lp/rewrite-plan)]
-      (.prepareQuery this plan db-cat opts)))
+      (.prepareRa this plan db-cat opts)))
 
   AutoCloseable
   (close [_]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -23,7 +23,6 @@ import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ICursor
 import xtdb.ResultCursor
 import xtdb.ZoneIdSerde
-import xtdb.antlr.Sql
 import xtdb.api.Authenticator.Factory.SingleRootUser
 import xtdb.api.log.Log
 import xtdb.api.log.MessageId
@@ -87,7 +86,6 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
     override fun connect(): Connection
 
     fun prepareSql(sql: String, opts: Any?): PreparedQuery
-    fun prepareSql(sql: Sql.DirectlyExecutableStatementContext, opts: Any?): PreparedQuery
 
     data class SubmittedTx(val txId: MessageId)
 
@@ -277,20 +275,20 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         fun prepareSql(sql: String, defaultDb: DatabaseName = dbName): PreparedQuery {
             dbCat.awaitAll(awaitToken, awaitTimeout)
             return qSrc.prepareQuery(
-                sql,
+                parseStatement(sql),
                 dbCat,
-                PrepareOpts(defaultTz = defaultTz, defaultDb = defaultDb, queryText = sql)
+                PrepareOpts(defaultTz = defaultTz, defaultDb = defaultDb)
             )
         }
 
-        // pgwire parses once for dispatch, so it prepares from the AST and supplies the original text; tz, db,
-        // await-token and await bound all come from the connection. EXPLAIN is read off the AST, not passed in.
-        fun prepareSql(ast: Sql.DirectlyExecutableStatementContext, queryText: String): PreparedQuery {
+        // pgwire (and ADBC) parse once for dispatch, so they prepare from the classified statement; its query text
+        // and EXPLAIN flag derive from the AST. tz, db, await-token and await bound come from the connection.
+        fun prepareSql(stmt: ParsedStatement): PreparedQuery {
             dbCat.awaitAll(awaitToken, awaitTimeout)
             return qSrc.prepareQuery(
-                ast,
+                stmt,
                 dbCat,
-                PrepareOpts(defaultTz = defaultTz, defaultDb = dbName, queryText = queryText)
+                PrepareOpts(defaultTz = defaultTz, defaultDb = dbName)
             )
         }
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -292,6 +292,13 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             )
         }
 
+        // A synthetic RA-plan (pgwire's SHOW) prepared against this connection — awaits like [prepareSql] so the
+        // read sees the connection's own writes.
+        fun prepareRa(plan: Any): PreparedQuery {
+            dbCat.awaitAll(awaitToken, awaitTimeout)
+            return qSrc.prepareRa(plan, dbCat, PrepareOpts(defaultTz = defaultTz, defaultDb = dbName))
+        }
+
         fun openSqlQuery(sql: String): ResultCursor =
             openQuery(prepareSql(sql), null)
 

--- a/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
+++ b/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
@@ -3,6 +3,7 @@ package xtdb.authz
 import xtdb.query.IQuerySource
 import xtdb.query.PrepareOpts
 import xtdb.query.QueryOpts
+import xtdb.query.parseStatement
 import xtdb.table.TableRef
 import java.nio.ByteBuffer
 import java.security.MessageDigest
@@ -49,10 +50,10 @@ object RoleMembership {
         if (!exists) return emptyList()
 
         val now = Instant.now()
-        val prepareOpts = PrepareOpts(defaultDb = PRIMARY_DB, queryText = SCAN_SQL, currentTime = now)
+        val prepareOpts = PrepareOpts(defaultDb = PRIMARY_DB, currentTime = now)
 
         val out = ArrayList<List<String>>()
-        querySource.prepareQuery(SCAN_SQL, dbCat, prepareOpts)
+        querySource.prepareQuery(parseStatement(SCAN_SQL), dbCat, prepareOpts)
             .openQuery(null, QueryOpts(currentTime = now)).use { cursor ->
                 cursor.forEachRemaining { rel ->
                     val userRdr = rel.vectorFor("user")

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -23,6 +23,7 @@ import xtdb.kw
 import xtdb.query.IQuerySource
 import xtdb.query.PrepareOpts
 import xtdb.query.SqlStatement
+import xtdb.query.parseStatement
 import xtdb.table.DEFAULT_SCHEMA
 import xtdb.table.SchemaName
 import xtdb.table.TableName
@@ -165,11 +166,11 @@ class OpenTx(
         val currentTime = opts.currentTime ?: txKey.systemTime
 
         val prepareOpts = PrepareOpts(
-            defaultTz = opts.defaultTz, defaultDb = dbState.name, queryText = sql, currentTime = currentTime,
+            defaultTz = opts.defaultTz, defaultDb = dbState.name, currentTime = currentTime,
         )
 
         return nodeBase.querySource
-            .prepareQuery(sql, queryCatalog, prepareOpts)
+            .prepareQuery(parseStatement(sql), queryCatalog, prepareOpts)
             .openQuery(args, xtdb.query.QueryOpts(currentTime, opts.defaultTz, tracer = tracer))
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -1,6 +1,5 @@
 package xtdb.indexer
 
-import clojure.lang.PersistentArrayMap
 import io.micrometer.tracing.Tracer
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
@@ -19,7 +18,6 @@ import xtdb.database.DatabaseStorage
 import xtdb.database.ExternalSourceToken
 import xtdb.error.Conflict
 import xtdb.error.Incorrect
-import xtdb.kw
 import xtdb.query.IQuerySource
 import xtdb.query.PrepareOpts
 import xtdb.query.SqlStatement
@@ -185,14 +183,9 @@ class OpenTx(
         val currentTimeMicros = currentTime.asMicros
         val qOpts = xtdb.query.QueryOpts(currentTime, opts.defaultTz, tracer = tracer)
 
-        val prepareOpts = PersistentArrayMap.create(
-            mapOf(
-                "current-time".kw to currentTime,
-                "default-tz".kw to opts.defaultTz,
-                "default-db".kw to dbState.name,
-                "query-text".kw to sql,
-                "arg-fields".kw to args?.schema?.fields,
-            )
+        val prepareOpts = PrepareOpts(
+            defaultTz = opts.defaultTz, defaultDb = dbState.name, currentTime = currentTime,
+            argFields = args?.schema?.fields,
         )
 
         when (val stmt = nodeBase.querySource.prepareTxSql(sql, queryCatalog, prepareOpts)) {
@@ -639,12 +632,9 @@ class OpenTx(
         fun patchDocs(docs: RelationReader, validFromMicros: Long, validToMicros: Long) {
             checkNotForbidden(ref)
 
-            val prepareOpts = PersistentArrayMap.create(
-                mapOf(
-                    "current-time".kw to txKey.systemTime,
-                    "default-db".kw to dbState.name,
-                    "arg-fields".kw to docs.schema.fields,
-                )
+            val prepareOpts = PrepareOpts(
+                defaultDb = dbState.name, currentTime = txKey.systemTime,
+                argFields = docs.schema.fields,
             )
 
             // The planner (plan-patch in sql.clj) requires concrete Instant bounds — no nil support.

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -21,10 +21,10 @@ interface IQuerySource : AutoCloseable {
         val queryState: DatabaseState
     }
 
-    fun prepareQuery(query: ParsedStatement, dbs: QueryCatalog, opts: Any?): PreparedQuery
-    fun prepareRa(plan: Any, dbs: QueryCatalog, opts: Any?): PreparedQuery
-    fun prepareTxSql(sql: String, dbs: QueryCatalog, opts: Any?): SqlStatement
-    fun preparePatchDocsQuery(table: TableRef, validFrom: Instant?, validTo: Instant?, dbs: QueryCatalog, opts: Any?): PreparedQuery
+    fun prepareQuery(query: ParsedStatement, dbs: QueryCatalog, opts: PrepareOpts): PreparedQuery
+    fun prepareRa(plan: Any, dbs: QueryCatalog, opts: PrepareOpts): PreparedQuery
+    fun prepareTxSql(sql: String, dbs: QueryCatalog, opts: PrepareOpts): SqlStatement
+    fun preparePatchDocsQuery(table: TableRef, validFrom: Instant?, validTo: Instant?, dbs: QueryCatalog, opts: PrepareOpts): PreparedQuery
 
     fun interface Factory {
         fun create(allocator: BufferAllocator, meterRegistry: MeterRegistry?, scanEmitter: Any): IQuerySource

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -21,7 +21,8 @@ interface IQuerySource : AutoCloseable {
         val queryState: DatabaseState
     }
 
-    fun prepareQuery(query: Any, dbs: QueryCatalog, opts: Any?): PreparedQuery
+    fun prepareQuery(query: ParsedStatement, dbs: QueryCatalog, opts: Any?): PreparedQuery
+    fun prepareRa(plan: Any, dbs: QueryCatalog, opts: Any?): PreparedQuery
     fun prepareTxSql(sql: String, dbs: QueryCatalog, opts: Any?): SqlStatement
     fun preparePatchDocsQuery(table: TableRef, validFrom: Instant?, validTo: Instant?, dbs: QueryCatalog, opts: Any?): PreparedQuery
 

--- a/core/src/main/kotlin/xtdb/query/QueryOpts.kt
+++ b/core/src/main/kotlin/xtdb/query/QueryOpts.kt
@@ -1,6 +1,7 @@
 package xtdb.query
 
 import io.micrometer.tracing.Tracer
+import org.apache.arrow.vector.types.pojo.Field
 import xtdb.database.DatabaseName
 import java.time.Instant
 import java.time.ZoneId
@@ -22,4 +23,9 @@ data class PrepareOpts @JvmOverloads constructor(
     val defaultTz: ZoneId? = null,
     val defaultDb: DatabaseName? = null,
     val currentTime: Instant? = null,
+    // arg types for a parameterised DML/patch prepare — the planner keys its cache on them.
+    val argFields: List<Field>? = null,
+    // explain a raw RA-plan prepare; for SQL the flag is read off the parse tree instead.
+    val explain: Boolean = false,
+    val explainAnalyze: Boolean = false,
 )

--- a/core/src/main/kotlin/xtdb/query/QueryOpts.kt
+++ b/core/src/main/kotlin/xtdb/query/QueryOpts.kt
@@ -21,6 +21,5 @@ data class QueryOpts @JvmOverloads constructor(
 data class PrepareOpts @JvmOverloads constructor(
     val defaultTz: ZoneId? = null,
     val defaultDb: DatabaseName? = null,
-    val queryText: String? = null,
     val currentTime: Instant? = null,
 )

--- a/core/src/main/kotlin/xtdb/query/SqlParser.kt
+++ b/core/src/main/kotlin/xtdb/query/SqlParser.kt
@@ -75,7 +75,7 @@ private val multiQueryCache =
             sql.parseWithFallback { it.multiSqlStatement().directlyExecutableStatement() }
         })
 
-fun String.parseStatement() = singleQueryCache[this]
+fun String.parseStatementAst() = singleQueryCache[this]
 
 fun String.parseMultiStatement() = multiQueryCache[this]
 
@@ -242,3 +242,6 @@ private class ParsedStatementVisitor : SqlBaseVisitor<ParsedStatement>() {
  */
 fun parseStatements(sql: String): List<ParsedStatement> =
     ParsedStatementVisitor().let { v -> sql.parseMultiStatement().map { it.accept(v) } }
+
+/** Classifies a single-statement SQL string into a [ParsedStatement] without planning (the single-statement grammar rule). */
+fun parseStatement(sql: String): ParsedStatement = sql.parseStatementAst().accept(ParsedStatementVisitor())

--- a/src/test/clojure/xtdb/oidc_integration_test.clj
+++ b/src/test/clojure/xtdb/oidc_integration_test.clj
@@ -123,16 +123,12 @@
                                      (.build))))))))
 
 (t/deftest ^:integration test-oidc-client-credentials-token-expiry
+  ;; access-token-lifespan is 2s (see seed-container), so a token minted at T expires at T+2s.
+  ;; We drive logical time through a settable clock so the test asserts on time, not on the exact
+  ;; number of clock reads the pgwire auth path happens to make.
   (let [{:keys [client-id client-secret]} (:test *clients*)
-        mock-instant-source (tu/->mock-clock
-                             [#inst "2020-01-01T12:00:00Z" ; initial connection time
-                              #inst "2020-01-01T12:00:00Z" ; used to calculate token expiry for connection
-                              #inst "2020-01-01T12:00:01Z" ; used to validate if token expired within :msg-parse (not yet expired)
-                              #inst "2020-01-01T12:00:01Z" ; used to validate if token expired within :msg-bind (not yet expired)
-                              #inst "2020-01-01T12:00:05Z" ; used to validate if token expired within :msg-parse (expired)
-                              #inst "2020-01-01T12:00:05Z" ; used to calculate refreshed-token expiry time
-                              #inst "2020-01-01T12:00:06Z" ; used to validate if token expired within :msg-bind (refreshed)
-                              ])]
+        !now (atom #inst "2020-01-01T12:00:00Z")
+        mock-instant-source (tu/->settable-clock !now)]
     (with-open [node (xtn/start-node {:authn [:openid-connect {:issuer-url (str (.getAuthServerUrl authn-test/container) "/realms/master")
                                                                :client-id "xtdb"
                                                                :client-secret "xtdb-secret"
@@ -143,11 +139,14 @@
                                           (.password (format "%s:%s" client-id client-secret)))]
 
         (t/testing "token expiry and automatic refresh works"
+          ;; connection mints a token expiring at 12:00:02
           (with-open [conn (.build client-connection-builder)]
             (t/testing "initial connection and first revalidate"
+              (reset! !now #inst "2020-01-01T12:00:01Z") ; before expiry
               (let [result (jdbc/execute-one! conn ["SELECT 'initial' as status"])]
                 (t/is (= "initial" (:status result)))))
 
             (t/testing "after first expiry, token is refreshed"
+              (reset! !now #inst "2020-01-01T12:00:05Z") ; past expiry -> revalidate refreshes
               (let [result (jdbc/execute-one! conn ["SELECT 'after-expiry' as status"])]
                 (t/is (= "after-expiry" (:status result)))))))))))

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -246,7 +246,7 @@
                                                true])]
 
      (try
-       (let [^PreparedQuery pq (.prepareQuery q-src query (or (db/<-node node) Database$Catalog/EMPTY) query-opts)]
+       (let [^PreparedQuery pq (.prepareRa q-src query (or (db/<-node node) Database$Catalog/EMPTY) query-opts)]
 
          (util/with-open [^RelationReader args-rel (if args
                                                      (vw/open-args allocator args)

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -113,6 +113,14 @@
          (assert (.hasNext it) "out of insts!")
          (time/->instant (.next it)))))))
 
+(defn ->settable-clock
+  "A mock clock backed by `!inst` (an atom holding an instant-coercible value).
+   Each read returns the atom's current value, so logical time is controlled by
+   `reset!`ing the atom rather than by pinning the exact number of clock reads."
+  ^java.time.InstantSource [!inst]
+  (reify InstantSource
+    (instant [_] (time/->instant @!inst))))
+
 (defn with-mock-clock [f]
   (with-opts {:log [:in-memory {:instant-src (->mock-clock)}]} f))
 

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -39,7 +39,7 @@
            (xtdb.indexer LiveIndex LiveTable OpenTx)
            (xtdb.trie Trie)
            (xtdb.log.proto TemporalMetadata TemporalMetadata$Builder)
-           (xtdb.query IQuerySource PreparedQuery QueryOpts)
+           (xtdb.query IQuerySource PrepareOpts PreparedQuery QueryOpts)
            xtdb.storage.BufferPool
            (xtdb.tx TxOpts TxWriter)
            xtdb.types.ZonedDateTimeRange
@@ -246,7 +246,9 @@
                                                true])]
 
      (try
-       (let [^PreparedQuery pq (.prepareRa q-src query (or (db/<-node node) Database$Catalog/EMPTY) query-opts)]
+       (let [^PreparedQuery pq (.prepareRa q-src query (or (db/<-node node) Database$Catalog/EMPTY)
+                                           (PrepareOpts. (:default-tz query-opts) (:default-db query-opts) (:current-time query-opts) nil
+                                                         (boolean (:explain? query-opts)) (boolean (:explain-analyze? query-opts))))]
 
          (util/with-open [^RelationReader args-rel (if args
                                                      (vw/open-args allocator args)


### PR DESCRIPTION
## Summary

Types the `IQuerySource` prepare boundary end-to-end: `prepareQuery` takes a `ParsedStatement`, a new `prepareRa` takes an RA-plan, and all the prepare methods take a typed `PrepareOpts` (was `Any`/`Any?`). Behaviour-preserving apart from one intentional await bound.

## Context

`prepareQuery` accepted `query: Any` — a SQL string, a bare ANTLR ast, or an RA-plan vector, disambiguated at runtime — and `opts: Any?`, which was a typed `PrepareOpts` from the Kotlin callers but a hand-built Clojure `PersistentArrayMap` from the node's embedded path and from `OpenTx`'s DML/patch. Meanwhile pgwire and ADBC already parse SQL into a classified `ParsedStatement` (via `SqlParser`), then unwrapped it back into `(ast, originalSql)` to feed the connection. Typing the boundary lets the classified statement and the typed opts flow straight through, and deletes the raw maps.

This is also groundwork for the in-progress "answer SHOW from the connection" work: it lands `Connection.prepareSql(parsed)` and `Connection.prepareRa`, so that branch attaches its statement/plan to the prepared query directly rather than smuggling it through `PrepareOpts`.

## Changes

1. **`prepareQuery` takes a `ParsedStatement`.** Adds `prepareRa(plan)` for RA-plans (RA isn't SQL, so it can't be a `ParsedStatement`); adds `SqlParser.parseStatement(sql)` — a single-statement classified parse over the single-statement grammar rule (so single-statement callers stop doing `parseStatements(sql).single()`); migrates callers (`Connection.prepareSql`, pgwire's `prep-stmt`, the node's embedded `prepareSql`, `OpenTx.openQuery`, `RoleMembership`); removes the `Xtdb.prepareSql(ast)` overload (the pgwire DML-warnings probe, its sole ast caller, now passes a string).

2. **Type the prepare opts as `PrepareOpts`.** Adds `argFields` (DML/patch arg types, keyed into the plan cache) and `explain`/`explainAnalyze` (for a raw RA-plan prepare — for SQL the flags are read off the parse tree); converts the node's embedded path and `OpenTx`'s DML/patch off raw maps; drops `->prepare-opts-map`'s map passthrough. Query-text now derives from the query (a `ParsedStatement`'s `originalSql`, or the bare ast on the DML path), not from opts. Routes pgwire's SHOW prepare through a new `Connection.prepareRa` — retiring `xtp/prepare-ra` (SHOW was its only caller) — which brings SHOW's prepare-await under the connection's one-minute bound (previously unbounded). The DML-warnings probe deliberately stays on the node with no await.

## Behaviour preservation

Pure boundary typing, with one intentional change: SHOW's prepare-await is now bounded at 1 minute via the connection, consistent with the query-prepare path. Query-text and plan-cache keys are otherwise unchanged.

## Test plan

Full `./gradlew test`: 1599 tests, 0 failures, no reflection or boxed-math warnings. Code-review pass over each commit: clean.