### PR TITLE
fix(bench): stop autoscaler killing benchmark Kafka + report startup-failure cause to Slack

### DIFF
--- a/.github/workflows/run-nightly-benchmark.yml
+++ b/.github/workflows/run-nightly-benchmark.yml
@@ -490,22 +490,39 @@ jobs:
           set -euo pipefail
           echo "immediate_failure=false" >> "$GITHUB_OUTPUT"
 
-          # Run the check (exits non-zero on failure)
-          result=$(./modules/bench/cloud/scripts/tasks check-immediate-failure 2>&1) || {
+          # Capture stdout (clean JSON) and stderr (progress + pod logs) separately.
+          # Merging them (2>&1) corrupts the JSON so `jq` can't read .podName, which
+          # is why past startup failures reported `pod: unknown` and captured no logs.
+          set +e
+          result=$(./modules/bench/cloud/scripts/tasks check-immediate-failure 2>"$RUNNER_TEMP/check-stderr.log")
+          rc=$?
+          set -e
+
+          echo "::group::check-immediate-failure logs"
+          cat "$RUNNER_TEMP/check-stderr.log" || true
+          echo "::endgroup::"
+
+          if [ "$rc" -ne 0 ]; then
             echo "immediate_failure=true" >> "$GITHUB_OUTPUT"
-            echo "::group::check-immediate-failure output"
+            echo "::group::check-immediate-failure result (json)"
             echo "$result"
             echo "::endgroup::"
             pod_name=$(echo "$result" | jq -r '.podName // empty' 2>/dev/null || true)
-            if [ -n "$pod_name" ]; then
-              echo "immediate_failure_pod=${pod_name}" >> "$GITHUB_OUTPUT"
-              # Save log preview to file
-              log_preview=$(echo "$result" | jq -r '.logPreview // empty' 2>/dev/null || true)
-              if [ -n "$log_preview" ]; then
-                failure_log_path="$RUNNER_TEMP/immediate-failure-${pod_name}.log"
-                echo "$log_preview" | head -n 60 > "$failure_log_path"
-                echo "immediate_failure_log_path=${failure_log_path}" >> "$GITHUB_OUTPUT"
-              fi
+            echo "immediate_failure_pod=${pod_name}" >> "$GITHUB_OUTPUT"
+            # Diagnosis (container waiting/terminated reasons) — the useful signal when
+            # the pod died before logging anything, e.g. eviction or ImagePullBackOff.
+            diagnostics=$(echo "$result" | jq -r '.diagnostics // empty' 2>/dev/null || true)
+            if [ -n "$diagnostics" ]; then
+              diag_path="$RUNNER_TEMP/immediate-failure-diagnostics.txt"
+              echo "$diagnostics" > "$diag_path"
+              echo "immediate_failure_diag_path=${diag_path}" >> "$GITHUB_OUTPUT"
+            fi
+            # Container log preview, if the container got far enough to produce any.
+            log_preview=$(echo "$result" | jq -r '.logPreview // empty' 2>/dev/null || true)
+            if [ -n "$log_preview" ]; then
+              failure_log_path="$RUNNER_TEMP/immediate-failure-${pod_name:-pod}.log"
+              echo "$log_preview" | head -n 60 > "$failure_log_path"
+              echo "immediate_failure_log_path=${failure_log_path}" >> "$GITHUB_OUTPUT"
             fi
             # Check if cleanup was already triggered
             cleanup_triggered=$(echo "$result" | jq -r '.cleanupTriggered // false' 2>/dev/null || echo "false")
@@ -514,7 +531,7 @@ jobs:
               ./modules/bench/cloud/clear-bench.sh azure || true
             fi
             exit 1
-          }
+          fi
 
           echo "No immediate benchmark pod failures detected."
 
@@ -652,17 +669,25 @@ jobs:
           elif [ "${{ steps.immediate-check.outputs.immediate_failure }}" = "true" ]; then
             POD_NAME='${{ steps.immediate-check.outputs.immediate_failure_pod }}'
             LOG_PATH='${{ steps.immediate-check.outputs.immediate_failure_log_path }}'
+            DIAG_PATH='${{ steps.immediate-check.outputs.immediate_failure_diag_path }}'
             MSG_FILE="$RUNNER_TEMP/slack-immediate-failure.txt"
             : > "$MSG_FILE"
             {
               printf '*%s Benchmark* :x: Failed during startup (pod: `%s`)\n' "${SLACK_LABEL}" "${POD_NAME:-unknown}"
               echo "${GIT_INFO}"
               echo "${IMAGE_INFO}"
+              if [ -n "$DIAG_PATH" ] && [ -f "$DIAG_PATH" ]; then
+                echo
+                echo "*Reason:*"
+                echo '```'
+                cat "$DIAG_PATH"
+                echo '```'
+              fi
               if [ -n "$LOG_PATH" ] && [ -f "$LOG_PATH" ]; then
-                echo >> "$MSG_FILE"
-                echo '```' >> "$MSG_FILE"
-                cat "$LOG_PATH" >> "$MSG_FILE"
-                echo '```' >> "$MSG_FILE"
+                echo
+                echo '```'
+                cat "$LOG_PATH"
+                echo '```'
               fi
             } >> "$MSG_FILE"
 

--- a/modules/bench/cloud/helm/templates/kafka-pdb.yaml
+++ b/modules/bench/cloud/helm/templates/kafka-pdb.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: xtdb-benchmark-kafka
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/component: kafka
+spec:
+  # Single-replica broker with no redundancy: block all voluntary disruptions
+  # (node drains, upgrades, autoscaler consolidation) for the lifetime of a run.
+  # Teardown deletes the pod directly rather than evicting it, so this doesn't
+  # wedge clear-bench between runs.
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka
+      app.kubernetes.io/component: kafka

--- a/modules/bench/cloud/helm/templates/kafka-statefulset.yaml
+++ b/modules/bench/cloud/helm/templates/kafka-statefulset.yaml
@@ -18,6 +18,12 @@ spec:
       labels:
         app.kubernetes.io/name: kafka
         app.kubernetes.io/component: kafka
+      annotations:
+        # The broker holds the only copy of the log on a local PVC, so the
+        # cluster autoscaler must not evict it to consolidate nodes mid-run:
+        # doing so killed the broker, reset the topics, and left in-flight
+        # consumers with out-of-range offsets (IngestionStoppedException).
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       containers:
         - name: kafka

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/k8s.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/k8s.clj
@@ -138,6 +138,45 @@
         (some container-failing? container-statuses)
         (some container-failing? init-statuses))))
 
+(defn- container-state-summary
+  "One-line summary of a failing container's state. `kind` labels the container group
+   (e.g. \"init\")."
+  [kind {container-name :name, :keys [state]}]
+  (let [label (str kind " " container-name)
+        {:keys [waiting terminated]} state]
+    (cond
+      terminated (->> [(str label ": terminated")
+                       (:reason terminated)
+                       (when-let [c (:exitCode terminated)] (str "(exit " c ")"))
+                       (some-> (:message terminated) str/trim)]
+                      (remove nil?)
+                      (str/join " "))
+      waiting (->> [(str label ": " (:reason waiting))
+                    (some-> (:message waiting) str/trim)]
+                   (remove nil?)
+                   (str/join " — ")))))
+
+(defn- describe-pod-failure
+  "Concise diagnostic of why a pod is failing — one line per failing (init) container,
+   plus the pod phase/reason. Returns nil if nothing looks failing.
+
+   The startup-failure case (e.g. autoscaler eviction, ImagePullBackOff) often leaves
+   no container logs at all, so this pod-status view is the only signal we get."
+  [pod]
+  (let [phase (get-in pod [:status :phase])
+        pod-reason (get-in pod [:status :reason])
+        pod-message (get-in pod [:status :message])
+        init (or (get-in pod [:status :initContainerStatuses]) [])
+        main (or (get-in pod [:status :containerStatuses]) [])
+        lines (concat (->> init (filter container-failing?) (map (partial container-state-summary "init container")))
+                      (->> main (filter container-failing?) (map (partial container-state-summary "container"))))]
+    (when (or (= "Failed" phase) (seq lines))
+      (->> (cond->> (vec lines)
+             (= "Failed" phase) (into [(->> [(str "pod phase: Failed") pod-reason (some-> pod-message str/trim)]
+                                            (remove nil?)
+                                            (str/join " — "))]))
+           (str/join "\n")))))
+
 (defn- pod-running-stable?
   "Check if a pod is running with all containers started and init containers completed."
   [pod]
@@ -208,8 +247,10 @@
              (cond
                ;; Found failing pods
                (seq failing-pods)
-               (let [pod-names (mapv #(get-in % [:metadata :name]) failing-pods)
+               (let [primary-pod-obj (first failing-pods)
+                     pod-names (mapv #(get-in % [:metadata :name]) failing-pods)
                      primary-pod (first pod-names)
+                     diagnostics (describe-pod-failure primary-pod-obj)
                      log-preview (when primary-pod
                                    (some-> (get-pod-logs namespace primary-pod :tail 60)
                                            (str/split-lines)
@@ -224,8 +265,11 @@
                    (log-stderr "Pod:" pod-name)
                    (when-let [logs (get-pod-logs namespace pod-name)]
                      (log-stderr logs)))
+                 (when diagnostics
+                   (log-stderr "Diagnosis:" diagnostics))
                  {:failed true
                   :podName primary-pod
+                  :diagnostics diagnostics
                   :logPreview log-preview
                   :cleanupTriggered cleanup-triggered?})
 

--- a/modules/bench/cloud/scripts/test/xtdb/bench/cloud/scripts/tasks_test.clj
+++ b/modules/bench/cloud/scripts/test/xtdb/bench/cloud/scripts/tasks_test.clj
@@ -797,6 +797,41 @@
                         :containerStatuses [{:state {:running {:startedAt "2024-01-01"}}}]}}]
       (is (not (#'k8s/pod-failing? pod))))))
 
+(deftest describe-pod-failure-test
+  (testing "init container terminated with non-zero exit"
+    (let [pod {:status {:phase "Running"
+                        :initContainerStatuses [{:name "wait-for-kafka"
+                                                 :state {:terminated {:exitCode 1 :reason "Error"}}}]
+                        :containerStatuses [{:state {:waiting {:reason "PodInitializing"}}}]}}
+          result (#'k8s/describe-pod-failure pod)]
+      (is (str/includes? result "wait-for-kafka"))
+      (is (str/includes? result "exit 1"))
+      (is (str/includes? result "init"))))
+
+  (testing "main container waiting on image pull surfaces reason and message"
+    (let [pod {:status {:phase "Pending"
+                        :containerStatuses [{:name "xtdb-node"
+                                             :state {:waiting {:reason "ImagePullBackOff"
+                                                               :message "Back-off pulling image"}}}]}}
+          result (#'k8s/describe-pod-failure pod)]
+      (is (str/includes? result "xtdb-node"))
+      (is (str/includes? result "ImagePullBackOff"))
+      (is (str/includes? result "Back-off pulling image"))))
+
+  (testing "pod Failed by node eviction with no failing container still reports phase"
+    (let [pod {:status {:phase "Failed"
+                        :reason "Evicted"
+                        :message "Pod was terminated in response to imminent node shutdown."
+                        :containerStatuses []}}
+          result (#'k8s/describe-pod-failure pod)]
+      (is (str/includes? result "Failed"))
+      (is (str/includes? result "Evicted"))))
+
+  (testing "healthy pod yields nil"
+    (let [pod {:status {:phase "Running"
+                        :containerStatuses [{:name "xtdb-node" :state {:running {:startedAt "2024-01-01"}}}]}}]
+      (is (nil? (#'k8s/describe-pod-failure pod))))))
+
 (deftest pod-running-stable-test
   (testing "stable running pod with completed init containers"
     (let [pod {:status {:phase "Running"


### PR DESCRIPTION
## Why

Last night's nightly benchmarks failed on `main` (commit `7c26491`). Investigation showed neither failure was caused by the commit — both trace back to the shared benchmark Kafka broker.

**TPC-H** — every query completed successfully, then the run failed. The cluster autoscaler scaled down the node hosting `xtdb-benchmark-kafka-0` to consolidate capacity, killing the broker mid-run (`ScaleDown … deleting pod for node scale down`). The reschedule was delayed by a PVC `Multi-Attach error`, and when the broker returned its topics had reset, leaving the node's consumer with an out-of-range offset on `xtdb-log-0`. The node correctly stopped ingestion (`IngestionStoppedException`) and the job hit its backoff limit. Because it died before emitting the `summary` log line, the Slack report showed `Total benchmark time: N/A`.

**Yakbench** — failed during startup with a Slack alert of `Failed during startup (pod: unknown)` and an empty failure-log artifact, giving us nothing to diagnose from. The pod died before producing any container logs (plausibly collateral from the same Kafka instability ~5 min earlier), and two notifier bugs erased what signal there was.

## What

**1. Stop the autoscaler evicting Kafka** (`kafka-statefulset.yaml`, new `kafka-pdb.yaml`)
The broker is a single replica holding the only copy of the log on a local PVC — it must never be a voluntary-disruption target. Adds `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` and a `maxUnavailable: 0` PodDisruptionBudget. Teardown deletes the pod directly rather than evicting it, so neither wedges `clear-bench`.

**2. Report the startup-failure cause to Slack** (`k8s.clj`, `run-nightly-benchmark.yml`, tests)
- The workflow captured the check with `2>&1`, merging the task's stderr progress lines into the JSON on stdout so `jq` couldn't read `.podName`; the empty pod name then short-circuited the log-capture step. The streams are now captured separately, which fixes both the `unknown` pod name and the empty artifact.
- The container log preview is usually empty for a startup failure (the container never ran), so `check-immediate-failure` now derives a diagnosis from the pod's container statuses — the failing (init) container's waiting/terminated reason and exit code, or the pod phase/reason for an eviction — and the Slack alert leads with it.

## Testing
- `bb test` in `modules/bench/cloud/scripts` — 46 tests, 271 assertions, green (includes new `describe-pod-failure-test`).
- `helm template` renders the STS annotation and the PDB.
- Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)