### PR TITLE
feat(kafka-connect-source): parse the !Docs table field, dropping the separate schema field

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
@@ -20,7 +20,6 @@ import xtdb.indexer.TxIndexer.TxResult
 import xtdb.kafka.connectsrc.proto.DocsIndexerConfig
 import xtdb.kafka.connectsrc.proto.docsIndexerConfig
 import xtdb.kafka.connectsrc.proto.kafkaConnectSourceToken
-import xtdb.table.DEFAULT_SCHEMA
 import xtdb.table.TableRef
 import xtdb.util.asIid
 import java.math.BigDecimal
@@ -37,11 +36,10 @@ class DocsIndexer(internal val table: TableRef) : RecordIndexer {
     @SerialName("!Docs")
     data class Factory(
         val table: String,
-        val schema: String = DEFAULT_SCHEMA,
     ) : RecordIndexer.Factory {
 
         override fun open(): RecordIndexer =
-            DocsIndexer(TableRef(schema, table))
+            DocsIndexer(TableRef.parse(table))
 
         class Registration : RecordIndexer.Registration<Factory> {
             override val protoTag: String
@@ -53,14 +51,13 @@ class DocsIndexer(internal val table: TableRef) : RecordIndexer {
                 ProtoAny.pack(
                     docsIndexerConfig {
                         table = factory.table
-                        schema = factory.schema
                     },
                     PROTO_TAG_PREFIX,
                 )
 
             override fun fromProto(msg: ProtoAny): Factory {
                 val config = msg.unpack(DocsIndexerConfig::class.java)
-                return Factory(table = config.table, schema = config.schema.ifEmpty { DEFAULT_SCHEMA })
+                return Factory(table = config.table)
             }
 
             override fun registerSerde(builder: PolymorphicModuleBuilder<RecordIndexer.Factory>) {

--- a/modules/kafka/src/main/proto/kafka_connect_source.proto
+++ b/modules/kafka/src/main/proto/kafka_connect_source.proto
@@ -21,8 +21,6 @@ message KafkaConnectSourceToken {
 }
 
 message DocsIndexerConfig {
+    // $schema.$table, or bare $table for the default schema
     string table = 1;
-
-    // unset ("") means the default schema, "public"
-    string schema = 2;
 }

--- a/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/DocsIndexerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/DocsIndexerTest.kt
@@ -34,17 +34,12 @@ class DocsIndexerTest {
         get() = data.valAt(Keyword.intern("xtdb.error", "code")) as? Keyword
 
     @Test
-    fun `table field names the table only, in the public schema`() {
-        val indexer = DocsIndexer.Factory(table = "analytics/events").open() as DocsIndexer
+    fun `table field parses through TableRef`() {
+        fun tableOf(table: String) = (DocsIndexer.Factory(table = table).open() as DocsIndexer).table
 
-        assertEquals(TableRef("public", "analytics/events"), indexer.table)
-    }
-
-    @Test
-    fun `schema field resolves alongside the table`() {
-        val indexer = DocsIndexer.Factory(table = "events", schema = "analytics").open() as DocsIndexer
-
-        assertEquals(TableRef("analytics", "events"), indexer.table)
+        assertEquals(TableRef("public", "events"), tableOf("events"))
+        assertEquals(TableRef("analytics", "events"), tableOf("analytics.events"))
+        assertEquals(TableRef("analytics", "events"), tableOf("analytics/events"))
     }
 
     @Test

--- a/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/KafkaConnectSourceFactoryTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/KafkaConnectSourceFactoryTest.kt
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xtdb.database.Database
 import xtdb.error.Incorrect
-import xtdb.kafka.connectsrc.proto.docsIndexerConfig
-import com.google.protobuf.Any as ProtoAny
 
 class KafkaConnectSourceFactoryTest {
 
@@ -30,7 +28,7 @@ class KafkaConnectSourceFactoryTest {
                 "transforms.unwrap.type" to "org.apache.kafka.connect.transforms.ExtractField\$Value",
                 "transforms.unwrap.field" to "payload",
             ),
-            indexer = DocsIndexer.Factory(table = "orders", schema = "analytics"),
+            indexer = DocsIndexer.Factory(table = "analytics.orders"),
         )
 
         val restored = protoRoundTrip(original)
@@ -41,8 +39,7 @@ class KafkaConnectSourceFactoryTest {
         assertEquals("http://schema-registry:8081", restored.connectConfig["value.converter.schema.registry.url"])
         assertEquals("unwrap", restored.connectConfig["transforms"])
         val docs = restored.indexer as DocsIndexer.Factory
-        assertEquals("orders", docs.table)
-        assertEquals("analytics", docs.schema)
+        assertEquals("analytics.orders", docs.table)
     }
 
     @Test
@@ -107,8 +104,8 @@ class KafkaConnectSourceFactoryTest {
     }
 
     @Test
-    fun `YAML schema field decodes, defaulting to public when omitted`() {
-        fun docsFor(indexerYaml: String): DocsIndexer.Factory {
+    fun `YAML !Docs table decodes verbatim, including a qualified name`() {
+        fun tableFor(tableYaml: String): String {
             val yaml = """
                 externalSource: !KafkaConnect
                   remote: k
@@ -117,27 +114,14 @@ class KafkaConnectSourceFactoryTest {
                     key.converter: org.apache.kafka.connect.storage.StringConverter
                     value.converter: org.apache.kafka.connect.json.JsonConverter
                   indexer: !Docs
-$indexerYaml
+                    table: $tableYaml
             """.trimIndent()
 
             val factory = Database.Config.fromYaml(yaml).externalSource as KafkaConnectSource.Factory
-            return factory.indexer as DocsIndexer.Factory
+            return (factory.indexer as DocsIndexer.Factory).table
         }
 
-        val qualified = docsFor("                    table: events\n                    schema: analytics")
-        assertEquals("events", qualified.table)
-        assertEquals("analytics", qualified.schema)
-
-        val unqualified = docsFor("                    table: events")
-        assertEquals("public", unqualified.schema)
-    }
-
-    @Test
-    fun `proto without a schema field grandfathers to public`() {
-        val preSchemaProto = ProtoAny.pack(docsIndexerConfig { table = "orders" }, "proto.xtdb.com")
-
-        val docs = DocsIndexer.Factory.Registration().fromProto(preSchemaProto)
-
-        assertEquals("public", docs.schema)
+        assertEquals("events", tableFor("events"))
+        assertEquals("analytics.events", tableFor("analytics.events"))
     }
 }


### PR DESCRIPTION
## Summary

The `!Docs` Kafka Connect source indexer now takes a single `table` config value in `schema.table` form, parsed via `TableRef.parse`, instead of separate `table` and `schema` fields.

## Context

The `!Docs` indexer briefly grew a dedicated `schema` field. That was a workaround: at the time `TableRef.parse` used `Symbol.intern` semantics that split on `/` but not `.`, so a dotted `analytics.events` would have landed as a table literally named `analytics.events` in `public`, and a `/` would have split silently. Rather than reinvent identifier rules in a config-time dot-split, the schema became its own YAML field.

`TableRef.parse` has since been fixed (#5775) to handle the dotted `schema.table` form properly — it splits on the `.`, allows dots in the schema (keyword namespaces like `foo.bar`), and rejects a dotted table *name* outright rather than mis-splitting it. That removes the reason the fields were separate, so they collapse back into one.

## Usage

```yaml
externalSource: !KafkaConnect
  remote: my-kafka
  topic: orders
  indexer: !Docs
    table: analytics.orders   # schema.table; bare `orders` targets the default `public` schema
```

## Decisions and scope

The proto's `schema` field (tag 2) is removed, and the tag is intentionally *not* reserved. This KC-source feature is unreleased (2-NEXT only) and nothing persisted has ever set the field, so there's no compatibility surface to protect — reserving would be ceremony for a risk that can't occur.

A table whose literal name contains a `.` or `/` can't be targeted through this field — `table: foo.bar` resolves to schema `foo`, table `bar`. That's the intended semantics inherited from `TableRef.parse`; there's no escape hatch for a literal dot in a table name, and we'll revisit only if a real need surfaces.

`TableRef.parse` also accepts the `/` form (`analytics/orders`) — it's XT's internal `schema/table` representation — so it parses here too. That path is incidental: we don't expect operators to use it, and the documentation will cover only the `.` form.

Malformed `table` values (e.g. `a/b/c`, empty) now throw at indexer open rather than being silently accepted — a bad config fails fast instead of writing to a surprising table.

## Test plan

`DocsIndexerTest` checks the field routes through `TableRef.parse` across bare, dotted, and slash forms. `KafkaConnectSourceFactoryTest` round-trips a qualified name through both the proto and YAML. The removed schema-field and proto-grandfather tests went with the field. All 14 tests green.
