### PR TITLE
fix(kafka): run the leader transition off the shared poll thread

### DIFF
--- a/allium/log-processor-lifecycle.allium
+++ b/allium/log-processor-lifecycle.allium
@@ -1,0 +1,538 @@
+-- allium: 3
+-- log-processor-lifecycle.allium
+--
+-- Scope: the per-database leader-election lifecycle in XTDB's LogProcessor. A
+--   node following a database's replica log can be promoted to LEADER (the sole
+--   writer of that database's replica log) and demoted back. Promotion is a
+--   multi-step transition; the point of this design is to let the expensive,
+--   unbounded part run OFF the transport's shared serialization point while
+--   keeping the committed role change on that single serialization point.
+-- Includes: the Following / Prepared / Leading state machine; the split between
+--   launching the transition (off the serialization point) and committing the
+--   leader (cheap, at the serialization point); the six steps the transition runs
+--   and which one needs the live follower; the fence that enforces one leader per
+--   database; the transport's own guarantees (modelled as an external actor).
+-- Excludes: live-index internals (see live-index.allium), record processing,
+--   block lifecycle, the transport wire protocol, the ExternalSource lifecycle.
+--
+-- Complementarity with live-index.allium:
+--   live-index.allium owns "whichever LogProcessor variant owns the live index
+--   drives it as a single-threaded writer", treating WHICH variant is in play as
+--   a given. This spec fills that gap: how the committed role is selected and
+--   swapped. Reference live-index where relevant; do not duplicate its internals.
+--
+-- The motivating split: the launched transition does the unbounded work (a
+--   catch-up await) but MUST NOT commit the role, because it runs off the
+--   serialization point and could race a concurrent revoke. Only committing the
+--   leader or demoting commit the role, and only at the serialization point. See
+--   SingleWriterCommittedRole (I1).
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity Database {
+    -- The database whose replica log this listener follows or leads. Its name is
+    -- the stem of the leader producer's fencing token. Its lifecycle governs the
+    -- in-flight transition and the terms: tearing the database down tears the
+    -- in-flight transition and the term down (so the transport does NOT demote on
+    -- unregister).
+    name: String
+}
+
+external entity FencedLeaderProducer {
+    -- A writer for the replica log, opened with the per-database fencing token
+    -- (${db_name}${leader_txn_id_suffix}). The token is the fence: at most one
+    -- live producer per database -- a later opening on the same token fences the
+    -- earlier producer, whose next replica write then fails and resigns it to
+    -- follower.
+    transactional_id: String
+    fenced: Boolean   -- true once a newer producer with the same token has opened
+}
+
+external entity FollowerTerm {
+    -- A live follower: consumes the replica log to build local queryable state.
+    -- It is the SOLE consumer of its node's replica log. Its catch-up (await up to
+    -- a target msg id) is the launched transition's only unbounded step. See:
+    -- live-index.allium.
+    replica_pos: MessageId
+    mid_block: Boolean   -- true if an old leader died before uploading its block
+}
+
+external entity LeaderTerm {
+    -- A leader: consumes the SOURCE log, resolves client txs and writes the
+    -- replica log through the fenced producer. Built by the launched transition
+    -- (uncommitted while the role is Prepared) and installed when the leader is
+    -- committed. See: live-index.allium (Leader variant).
+    producer: FencedLeaderProducer
+    replay_target: MessageId
+}
+
+external entity RecordProcessor {
+    -- The record processor handed back when the leader is committed: the sink the
+    -- transport feeds source-log records to once the leader is committed.
+}
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value MessageId {
+    -- A replica-log message offset. Encoded here as a plain integer position.
+    offset: Integer
+}
+
+value TailSpec {
+    -- The result of committing the leader. The source-log offset to resume from
+    -- and the record processor to feed. The transport resumes from after_msg_id
+    -- and delivers records into processor.
+    after_msg_id: MessageId
+    processor: RecordProcessor
+}
+
+------------------------------------------------------------
+-- Contracts
+------------------------------------------------------------
+
+contract SubscriptionListener {
+    -- The obligation the LogProcessor fulfils toward the transport. The three
+    -- operations -- launch the transition, commit the leader, demote -- plus the
+    -- ordering / fencing / atomicity properties that cannot be expressed as
+    -- single-point-in-time state assertions. Launching the transition returns a
+    -- handle: the transition runs off the serialization point, and the transport
+    -- joins or cancels that handle.
+    launch_transition: (listener: Listener) -> Listener
+    commit_leader: (listener: Listener) -> TailSpec
+    demote_leader: (listener: Listener) -> Listener
+
+    @invariant SingleWriterCommittedRole
+        -- I1. The committed role (the Following/Prepared/Leading state) is mutated
+        -- ONLY at the transport's serialization point. The launched transition
+        -- builds the leader term but does not commit; committing the leader and
+        -- demoting are the only committers, and they run at the serialization point.
+        -- This is what prevents the off-serialization-point transition from racing a
+        -- concurrent revoke -- the motivating reason for splitting the transition
+        -- from commit.
+
+    @invariant ExactlyOneLeaderPerDatabase
+        -- I2. At most one committed leader per database, enforced by the fence: a
+        -- newly-promoting node fences the prior leader on opening its producer; a
+        -- fenced leader fails its next replica write and resigns to follower.
+
+    @invariant FollowerIsSoleReplicaConsumer
+        -- A follower is the sole replica-log consumer for its node; the leader
+        -- consumes the source log and writes the replica log.
+
+    @invariant FollowerDrainsGapBeforeLead
+        -- I3 / the rationale for step 3. The catch-up await (step 3) is the only
+        -- step requiring the live follower and the only unbounded one. Because the
+        -- follower is the sole replica-log consumer and the leader consumes the
+        -- source log instead, any replica records in [follower-pos, replay_target)
+        -- would be silently skipped if the listener switched to leader without
+        -- draining them first. So the launched transition must await the follower
+        -- reaching replay_target BEFORE stopping it.
+
+    @invariant LiveTermBackingCommittedRole
+        -- I4. The committed role is ALWAYS backed by a LIVE term -- a follower whose
+        -- replica consumer is running, or a live leader -- never a torn-down one.
+        -- This is stronger than CommittedRoleHasItsTerm (which asserts the term is
+        -- merely present): the launched transition stops its follower (step 4)
+        -- before committing the leader (step 6), so a revoke's cancel-and-join
+        -- (RevokeCancelsInFlightTransition) can land while Following holds a
+        -- torn-down follower. The failure path re-opens a live follower
+        -- (RecoverFollowerOnTransitionCancelled) so the next transition's step-3
+        -- await never hangs on a follower that can no longer advance. To keep this
+        -- robust, the follower teardown and the recovery decision are atomic with
+        -- respect to cancellation, so a cancel landing mid-teardown never leaves the
+        -- committed role backing a dead term.
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    -- Suffix appended to the database name to form the leader producer's fencing
+    -- token (${db_name}${leader_txn_id_suffix}).
+    leader_txn_id_suffix: String = "-leader"
+}
+
+------------------------------------------------------------
+-- Entities
+------------------------------------------------------------
+
+entity Listener {
+    -- The per-database SubscriptionListener state machine. This is the spec's view
+    -- of a LogProcessor's role lifecycle. Starts Following.
+    --
+    -- The committed role is the `state` field: it is mutated ONLY at the
+    -- transport's serialization point (committing the leader / demoting). The
+    -- launched transition runs off that point and moves state to `prepared`, but
+    -- the prepared leader is not the committed role until it is committed -- see
+    -- SingleWriterCommittedRole (I1). Modelled as a single writer of `state`.
+    database: Database
+
+    -- The committed role.
+    --   following  -- holds a live follower term.
+    --   prepared   -- holds a built-but-not-yet-committed leader term; the follower
+    --                 has already been stopped. Transient: committing the leader or
+    --                 demoting leaves it promptly.
+    --   leading    -- holds the committed, live leader term.
+    state: following | prepared | leading
+
+    transitions state {
+        following -> prepared    -- launch the transition: built the leader term, not committed
+        prepared -> leading      -- commit the leader: install the prepared leader
+        prepared -> following    -- demote: abandon an uncommitted leader
+        leading -> following     -- demote: genuine revoke
+        -- No terminal state: a listener cycles following/leading indefinitely.
+    }
+
+    -- The live follower term, present while Following. The launched transition
+    -- reads its catch-up target (step 3) and stops it (step 4).
+    follower_term: FollowerTerm when state = following
+
+    -- The built-but-not-committed leader term, present while Prepared. Produced by
+    -- the launched transition's six steps; installed as leader_term when the leader
+    -- is committed, or discarded on demote.
+    prepared_leader: LeaderTerm when state = prepared
+
+    -- The committed, live leader term, present while Leading.
+    leader_term: LeaderTerm when state = leading
+
+    -- Derived: this listener is the committed leader for its database.
+    is_leading: state = leading
+}
+
+------------------------------------------------------------
+-- Rules
+--
+-- Operations and where they run:
+--   - launch the transition (LaunchTransition): off the serialization point. The
+--     launched work runs the six steps and builds the leader term; does NOT commit
+--     the role.
+--   - commit the leader (CommitLeader): at the serialization point. Cheap.
+--     Installs the prepared leader and returns a TailSpec.
+--   - demote (DemoteLeader, AbandonPreparedLeader): at the serialization point.
+--     Tears the leader/prepared term down and re-opens a follower.
+--     following -> following is a no-op (RevokeWhileFollowing).
+------------------------------------------------------------
+
+------------------------------------------------------------
+-- Rule: launch the transition (runs off the serialization point)
+--
+-- The six steps, and their key property: only step 3 needs the follower alive,
+-- and it is the only UNBOUNDED step. The launched transition builds the leader
+-- term but does not commit -- the state moves to `prepared` as the transition's
+-- result, but the committed role change happens when the leader is committed (I1).
+------------------------------------------------------------
+
+rule LaunchTransition {
+    when: LaunchTransitionRequested(transport, listener)
+
+    requires: listener.state = following
+    requires: listener.follower_term != null
+
+    ensures:
+        -- Step 1: open the fenced leader producer, which fences any prior leader (I2).
+        let producer = FencedLeaderProducer.created(
+            transactional_id: listener.database.name + config.leader_txn_id_suffix,
+            fenced: false
+        )
+
+        -- Step 2: write a no-op through it to learn a known, consumer-deliverable
+        -- replay target. A no-op is used (not the log's latest-submitted offset)
+        -- because the log's end offset can include positions a consumer never
+        -- delivers -- we need a position the follower can actually await.
+        let target = NoOpAppended(producer: producer)
+
+        -- Step 3: await the follower catching up to the replay target. The ONLY
+        -- step needing the follower alive and the ONLY unbounded step. Rationale
+        -- captured as FollowerDrainsGapBeforeLead (I3): the follower is the sole
+        -- replica-log consumer; the leader consumes the source log instead, so any
+        -- replica records in [follower-pos, replay_target) would be silently
+        -- skipped if we switched to leader without draining them first.
+        FollowerCaughtUp(follower_term: listener.follower_term, target: target)
+
+        -- Step 4: stop the follower (cancel + close its term).
+        FollowerStopped(follower_term: listener.follower_term)
+
+        -- Step 5: finish any dangling block. If the follower was mid-block (an old
+        -- leader died before uploading it), upload the block and replay its
+        -- buffered records through a transient transition processor, with
+        -- leader-upload semantics. Requires the follower stopped (step 4) so it
+        -- cannot double-process.
+        if listener.follower_term.mid_block:
+            DanglingBlockFinished(follower_term: listener.follower_term)
+
+        -- Step 6: build the leader term (uncommitted).
+        listener.prepared_leader = LeaderTerm.created(
+            producer: producer,
+            replay_target: target
+        )
+        listener.follower_term = null
+        listener.state = prepared
+}
+
+------------------------------------------------------------
+-- Rule: commit the leader (serialization point)
+--
+-- Cheap. Installs the prepared leader as the committed role and returns a
+-- TailSpec(after_msg_id, processor). One of only two committers (with demote),
+-- both at the serialization point -- this is what prevents the
+-- off-serialization-point transition from racing a concurrent revoke (I1).
+------------------------------------------------------------
+
+rule CommitLeader {
+    when: CommitLeaderRequested(transport, listener)
+
+    requires: listener.state = prepared
+
+    ensures:
+        listener.leader_term = listener.prepared_leader
+        listener.prepared_leader = null
+        listener.state = leading
+
+        -- Return the TailSpec: resume from just after the replay target, feeding
+        -- the leader's record processor.
+        TailSpecReturned(
+            listener: listener,
+            tail_spec: TailSpec{
+                after_msg_id: listener.leader_term.replay_target,
+                processor: RecordProcessor.created()
+            }
+        )
+}
+
+------------------------------------------------------------
+-- Rule: demote (serialization point)
+--
+-- Tears down the leader term and re-opens a follower. Fires for a genuine revoke
+-- (leading -> following) AND to abandon an uncommitted prepared leader
+-- (prepared -> following) -- same teardown. following -> following is a no-op.
+------------------------------------------------------------
+
+rule DemoteLeader {
+    -- Genuine leadership revoke while the node stays up -- NOT on shutdown, where
+    -- tearing the database down tears the term down (see NoDemoteOnShutdown).
+    when: DemoteLeaderRequested(transport, listener)
+
+    requires: listener.state = leading
+
+    ensures:
+        -- Re-open a follower seeded from the leader's replica position (the durable
+        -- live index is untouched; see live-index.allium). RHS reads the pre-rule
+        -- leader_term, captured before the field is cleared.
+        listener.follower_term = FollowerTerm.created(
+            replica_pos: listener.leader_term.replay_target,
+            mid_block: false
+        )
+        listener.leader_term = null
+        listener.state = following
+}
+
+rule AbandonPreparedLeader {
+    -- Abandon an uncommitted leader: same teardown, reached from Prepared. Its
+    -- fenced producer is closed; leadership is non-resumable, so a later promotion
+    -- opens a fresh one.
+    when: DemoteLeaderRequested(transport, listener)
+
+    requires: listener.state = prepared
+
+    ensures:
+        not exists listener.prepared_leader.producer
+        listener.follower_term = FollowerTerm.created(
+            replica_pos: listener.prepared_leader.replay_target,
+            mid_block: false
+        )
+        listener.prepared_leader = null
+        listener.state = following
+}
+
+rule RevokeWhileFollowing {
+    -- Demote on an already-following listener is a no-op: no committed leader term
+    -- to tear down.
+    when: DemoteLeaderRequested(transport, listener)
+
+    requires: listener.state = following
+
+    ensures:
+        listener.state = following
+}
+
+------------------------------------------------------------
+-- Rule: recover the follower when an in-flight transition is cancelled
+--
+-- OQ2 resolution, recovery half. The launched transition stops its follower
+-- (step 4) BEFORE it commits the leader (step 6). If the revoke's cancel-and-join
+-- (RevokeCancelsInFlightTransition) lands in that window, the committed role is
+-- still `following` but its follower term has been torn down -- its replica
+-- consumer is gone. The failure path re-opens a live follower so `state` never
+-- holds a torn-down follower; otherwise the next transition's step-3 catch-up
+-- await would wait forever on a follower that can no longer advance. See
+-- LiveTermBackingCommittedRole (I4).
+------------------------------------------------------------
+
+rule RecoverFollowerOnTransitionCancelled {
+    when: TransitionCancelled(transport, listener)
+
+    -- The cancel lands while still Following (the transition never reached its
+    -- atomic step-6 result); its follower may already be torn down (step 4).
+    requires: listener.state = following
+
+    ensures:
+        -- Re-open a live follower seeded from the (now stale) follower position, so
+        -- the committed role is backed by a live replica consumer again.
+        listener.follower_term = FollowerTerm.created(
+            replica_pos: listener.follower_term.replica_pos,
+            mid_block: false
+        )
+        listener.state = following
+}
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant CommittedRoleHasItsTerm {
+    -- Structural counterpart of the single-writer discipline: whatever committed
+    -- role the listener holds, it holds the matching term. A committed leader has
+    -- a live leader term; a follower has a live follower term. (The single-writer
+    -- property itself -- that only the serialization point mutates `state` -- is a
+    -- temporal/threading property; see SingleWriterCommittedRole below.)
+    for listener in Listeners:
+        (listener.state = leading implies listener.leader_term != null)
+        and (listener.state = following implies listener.follower_term != null)
+        and (listener.state = prepared implies listener.prepared_leader != null)
+}
+
+-- The serialization, fencing and delivery-ordering properties (I1, I2, the sole-
+-- consumer topology, and step 3's drain rationale) are not expressible as
+-- single-point-in-time assertions over entity state -- they constrain WHO mutates
+-- state and WHEN, a cross-node fence, and record-delivery ordering across a role
+-- switch. They live as prose @invariants on the SubscriptionListener contract.
+
+------------------------------------------------------------
+-- Actor Declarations
+------------------------------------------------------------
+
+actor Transport {
+    -- The log's group-subscription driver (Kafka's shared consumer is one
+    -- instance). It launches the transition, commits the leader and demotes, and
+    -- keeps its own mirror of which partitions it leads. Modelled as the external
+    -- actor that drives the listener's role changes. Its serialization point is the
+    -- single point at which the committed role is mutated. Identified by the
+    -- database it is driving.
+    identified_by: Database where name != ""
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface SubscriptionListenerInterface {
+    -- The SubscriptionListener boundary: the three operations the transport calls
+    -- to drive the per-database role. Committing the leader and demoting run at the
+    -- transport's serialization point; launching the transition runs it off that
+    -- point and returns a handle the transport joins or cancels.
+    facing transport: Transport
+
+    context listener: Listener
+
+    exposes:
+        listener.state
+        listener.is_leading
+
+    provides:
+        LaunchTransitionRequested(transport, listener) when listener.state = following
+        CommitLeaderRequested(transport, listener) when listener.state = prepared
+        DemoteLeaderRequested(transport, listener)
+        -- The revoke's cancel-and-join of an in-flight transition, driving its
+        -- failure path (RevokeCancelsInFlightTransition). Only meaningful while the
+        -- committed role is still following (the transition has not committed).
+        TransitionCancelled(transport, listener) when listener.state = following
+
+    contracts:
+        fulfils SubscriptionListener
+
+    @guarantee CommitAtSerializationPoint
+        -- Committing the leader and demoting are the only operations that commit a
+        -- role change, and the transport calls them only at its serialization point.
+        -- Launching the transition runs it off that point.
+
+    @guarantee PrepareDoesNotCommit
+        -- The launched transition builds the leader term but does not install it as
+        -- the committed role; a subsequent commit (or, on revoke, a demote) decides
+        -- its fate at the serialization point.
+
+    @guarantee OneLeaderViaFence
+        -- Exactly one leader per database is enforced by the producer fence, not by
+        -- this interface: promoting fences the prior leader, whose next replica
+        -- write fails and resigns it.
+}
+
+surface TransportGuarantees {
+    -- The transport's own little state machine. The group subscriber keeps a
+    -- mirror of which partitions it leads and guarantees the invariants below.
+    -- Modelled as a boundary the transport must honour toward the listener; it
+    -- provides no operations here (the operations are on
+    -- SubscriptionListenerInterface).
+    facing transport: Transport
+
+    context listener: Listener
+
+    exposes:
+        listener.state
+
+    @guarantee AtMostOneTransitionInFlight
+        -- The transport allows at most one leadership transition in flight per
+        -- partition at a time.
+
+    @guarantee NoRePrepareWhileLeading
+        -- The transport does not re-launch the transition for a partition it
+        -- already leads. A retained partition under cooperative rebalancing fires
+        -- no callback; the transport guards on its own "am I leading" state.
+
+    @guarantee NoDemoteOnShutdown
+        -- The transport does NOT demote on unregister/shutdown. Tearing the database
+        -- down tears the term down, and because the transition runs under the same
+        -- database lifecycle, that teardown joins the in-flight transition too, not
+        -- just the terms -- so an in-flight transition needs no separate
+        -- cancellation on teardown. Demote is only for a genuine leadership revoke
+        -- while the node stays up.
+
+    @guarantee RevokeCancelsInFlightTransition
+        -- OQ2 resolution (a). On a genuine revoke (NOT unregister -- see
+        -- NoDemoteOnShutdown), the transport cancel-and-joins the in-flight
+        -- transition BEFORE demoting. This is bounded: the only unbounded step is
+        -- step 3's catch-up await, which is cancellable and unwinds promptly. So the
+        -- cancel-and-join is itself the teardown stop step, not an unbounded block on
+        -- the serialization point. After the join, the demote runs against the
+        -- settled committed role (Prepared -> abandon, Leading -> genuine teardown,
+        -- Following -> no-op).
+
+    @guarantee TransitionIdentityDropsSupersededCompletions
+        -- OQ2 resolution (b). Per-transition identity is the transition's own
+        -- identity, not a generation token. A completion or failure posted back to
+        -- the serialization point for a superseded assignment finds the
+        -- subscription's state is no longer that transition and is dropped -- so a
+        -- late completion cannot commit over a role the transport has already moved
+        -- on from. No token threads through the interface.
+}
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "Phase 1 (current) vs Phase 2 (target) sequencing. Phase 1: the transport launches the transition then commits the leader synchronously, back to back, at the serialization point (behaviour-preserving). Phase 2: the transport pauses the partition, launches the transition off the serialization point, and on its completion commits the leader and resumes delivery at the serialization point; a revoke cancels the in-flight transition. This spec models the operations and their commit discipline (I1) uniformly; the phase is a sequencing choice over the same interface. Should the two phases be distinguished in the spec (e.g. a config flag or documented variant), or does the interface model suffice with the phase left to the transport?"
+
+-- (OQ2 resolved: the Phase-2 race between an in-flight off-serialization-point
+--  transition and a revoke at the serialization point is locked. The revoke
+--  cancel-and-joins the in-flight transition (RevokeCancelsInFlightTransition) --
+--  bounded, because step 3's catch-up await is cancellable, so the cancel-and-join
+--  IS the teardown stop step, not an unbounded block -- and per-transition identity
+--  (TransitionIdentityDropsSupersededCompletions) drops a late completion posted
+--  for a superseded assignment. Both are transport-internal; the interface is
+--  unchanged. The cancel can land after the transition stopped its follower but
+--  before commit, so the failure path re-opens a live follower
+--  (LiveTermBackingCommittedRole / RecoverFollowerOnTransitionCancelled).)

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -149,14 +149,9 @@ class InMemoryLog<M>(
     }
 
     override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) {
-        val spec = listener.onPartitionsAssigned(listOf(0))
-        if (spec != null) {
-            try {
-                tailAll(spec.afterMsgId, spec.processor)
-            } finally {
-                listener.onPartitionsRevoked(listOf(0))
-            }
-        }
+        listener.launchTransition(listOf(0)).await()
+        val spec = listener.commitLeader(listOf(0))
+        tailAll(spec.afterMsgId, spec.processor)
     }
 
     override fun close() {}

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -334,14 +334,9 @@ class LocalLog<M>(
     }
 
     override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) {
-        val spec = listener.onPartitionsAssigned(listOf(0))
-        if (spec != null) {
-            try {
-                tailAll(spec.afterMsgId, spec.processor)
-            } finally {
-                listener.onPartitionsRevoked(listOf(0))
-            }
-        }
+        listener.launchTransition(listOf(0)).await()
+        val spec = listener.commitLeader(listOf(0))
+        tailAll(spec.afterMsgId, spec.processor)
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -3,6 +3,7 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
@@ -156,13 +157,25 @@ interface Log<M> : AutoCloseable {
     suspend fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>)
     suspend fun openGroupSubscription(listener: SubscriptionListener<M>)
 
+    /**
+     * The transport's handle on a partition's leader election, driven as a three-step state
+     * machine (follower → prepared → leading). See allium/log-processor-lifecycle.allium.
+     *
+     * Each method takes the partition(s) the event is for — a single partition today, but the parameter
+     * is kept so a listener can route per-partition as Kafka's partition guards relax (#5557).
+     *
+     * [launchTransition] launches the follower→leader transition on the listener's *own* scope and
+     * returns its [Deferred] — it builds the leader term but does NOT commit the role, so it runs off the
+     * transport's thread (which joins/cancels the handle) and, because it runs under the listener's
+     * scope, is torn down by that scope's cancellation on shutdown. [commitLeader] installs the prepared
+     * leader and hands back the offset to resume from and the processor to feed; it (and [demoteLeader])
+     * are the only committers, run at the transport's serialization point. This split keeps the
+     * committed role single-writer while the unbounded catch-up runs off the poll thread.
+     */
     interface SubscriptionListener<M> {
-        suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<M>?
-        fun onPartitionsAssignedSync(partitions: Collection<Int>): TailSpec<M>? = runBlocking { onPartitionsAssigned(partitions) }
-        suspend fun onPartitionsRevoked(partitions: Collection<Int>)
-        fun onPartitionsRevokedSync(partitions: Collection<Int>) = runBlocking { onPartitionsRevoked(partitions) }
-        suspend fun onPartitionsLost(partitions: Collection<Int>) = onPartitionsRevoked(partitions)
-        fun onPartitionsLostSync(partitions: Collection<Int>) = runBlocking { onPartitionsLost(partitions) }
+        fun launchTransition(partitions: Collection<Int>): Deferred<Unit>
+        fun commitLeader(partitions: Collection<Int>): TailSpec<M>
+        suspend fun demoteLeader(partitions: Collection<Int>)
     }
 
     data class TailSpec<M>(val afterMsgId: MessageId, val processor: RecordProcessor<M>)

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -173,14 +173,9 @@ class ReadOnlyLocalLog<M>(
     }
 
     override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {
-        val spec = listener.onPartitionsAssigned(listOf(0))
-        if (spec != null) {
-            try {
-                tailAll(spec.afterMsgId, spec.processor)
-            } finally {
-                listener.onPartitionsRevoked(listOf(0))
-            }
-        }
+        listener.launchTransition(listOf(0)).await()
+        val spec = listener.commitLeader(listOf(0))
+        tailAll(spec.afterMsgId, spec.processor)
     }
 
     private suspend fun readNewMessages(currentOffset: LogOffset, ch: Channel<Log.Record<M>>): LogOffset? {

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -361,13 +361,17 @@ class Database(
             )
 
             if (indexerConfig.enabled && !readOnly) {
+                // Route each partition's leader-election events to that partition's own LogProcessor.
+                // One partition today (index 0); #5557 grows `db.partitions` and this fans out to N.
                 val listener = object : Log.SubscriptionListener<SourceMessage> {
-                    override suspend fun onPartitionsAssigned(partitions: Collection<Int>) =
-                        partitions.singleOrNull()
-                            ?.let { db.partitions[it]?.logProcessor?.onPartitionsAssigned(listOf(it)) }
+                    override fun launchTransition(partitions: Collection<Int>) =
+                        db.partitions.getValue(partitions.single()).logProcessor!!.launchTransition(partitions)
 
-                    override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
-                        for (idx in partitions) db.partitions[idx]?.logProcessor?.onPartitionsRevoked(listOf(idx))
+                    override fun commitLeader(partitions: Collection<Int>) =
+                        db.partitions.getValue(partitions.single()).logProcessor!!.commitLeader(partitions)
+
+                    override suspend fun demoteLeader(partitions: Collection<Int>) {
+                        for (idx in partitions) db.partitions[idx]?.logProcessor?.demoteLeader(listOf(idx))
                     }
                 }
                 scope.launch { storage.sourceLog.openGroupSubscription(listener) }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -1,9 +1,14 @@
 package xtdb.indexer
 
 import io.micrometer.core.instrument.Gauge
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.api.log.*
@@ -13,6 +18,7 @@ import xtdb.database.Database
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.database.ExternalSource
+import xtdb.error.Fault
 import xtdb.error.Interrupted
 import xtdb.util.closeOnCatch
 import xtdb.util.debug
@@ -62,6 +68,20 @@ class LogProcessor(
         override suspend fun cancelAndJoin() = proc.cancelAndJoin()
         override fun close() = proc.close()
     }
+
+    // The committed-role state machine — see allium/log-processor-lifecycle.allium.
+    // `state` is written from two places: the transport's serialization point (commitLeader /
+    // demoteLeader) and the off-thread transition coroutine (cutoverToLeader → Prepared, or its catch
+    // → Following). They don't race: a revoke cancel-and-joins the transition before demoteLeader reads
+    // `state`, and the transport commits a leader only for the transition instance it still holds — so the
+    // *committed* role change still happens only at the serialization point.
+    private sealed interface State {
+        val system: SubSystem
+    }
+
+    private class Following(override val system: FollowerSystem) : State
+    private class Prepared(override val system: LeaderSystem, val resumeAfterMsgId: MessageId) : State
+    private class Leading(override val system: LeaderSystem) : State
 
     private fun openLeader(
         replicaProducer: Log.AtomicProducer<ReplicaMessage>,
@@ -118,106 +138,142 @@ class LogProcessor(
     }
 
     @Volatile
-    private var sys: SubSystem =
-        openFollowerSystem(dbState.blockCatalog.boundaryReplicaMsgId ?: -1)
+    private var state: State =
+        Following(openFollowerSystem(dbState.blockCatalog.boundaryReplicaMsgId ?: -1))
 
     init {
         base.meterRegistry?.let { reg ->
-            Gauge.builder("xtdb.log.leader", this) { if (it.sys is LeaderSystem) 1.0 else 0.0 }
+            Gauge.builder("xtdb.log.leader", this) { if (it.state is Leading) 1.0 else 0.0 }
                 .description("1 if this node is the log leader, 0 if follower")
                 .tag("db", dbState.name)
                 .register(reg)
         }
     }
 
-    override suspend fun onPartitionsAssigned(partitions: Collection<Int>): Log.TailSpec<SourceMessage>? {
-        return when (val oldSys = sys) {
-            is LeaderSystem -> {
-                LOG.info("[$dbName] partitions assigned: $partitions — already leader, no transition needed")
-                null
+    override fun launchTransition(partitions: Collection<Int>): Deferred<Unit> {
+        // Transport contract: transition only from Following (see SubscriptionListener). A raw cast
+        // would surface an out-of-order call as a cryptic ClassCastException; name it instead.
+        val followerSys = (state as? Following)?.system
+            ?: throw Fault("[$dbName] launchTransition while not following (${state::class.simpleName})", "xtdb/log-prepare-not-following")
+
+        // Launched on the database scope (not the caller's): the transition is a child of the db job
+        // tree, so the transport joins/cancels this handle while db teardown cancels-and-joins it
+        // before close(). See dev/doc/coroutines.adoc and allium/log-processor-lifecycle.allium.
+        return scope.async { runTransition(followerSys) }
+    }
+
+    private suspend fun runTransition(followerSys: FollowerSystem) {
+        try {
+            replicaLog.openAtomicProducer("$dbName-leader").closeOnCatch { replicaProducer ->
+                val followerProc = followerSys.proc
+
+                // NoOp to get a known msgId we can await — latestSubmittedMsgId won't do, because Kafka's
+                // endOffsets counts transaction-marker offsets that consumers never deliver.
+                val replayTarget = replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp()) }.await().msgId
+
+                // The only step needing the follower alive, and the only unbounded one: as the sole
+                // replica-log consumer it must drain up to the leadership-claim point before we stop it.
+                // A failure here leaves the follower untouched — `state` still holds a live term, nothing
+                // to recover — which is why cutover, the phase that re-follows on exit, only starts here.
+                followerProc.awaitReplicaMsgId(replayTarget)
+
+                cutoverToLeader(followerSys, replicaProducer, replayTarget)
+            }
+        } catch (e: Throwable) {
+            // Cutover already restored a live `state` if it had to; here we only report. Cancellation and
+            // interruption aren't leader-prep failures, so they don't poison watchers — only a genuine one.
+            if (e !is CancellationException && e !is InterruptedException && e !is Interrupted) {
+                LOG.error(e, "[$dbName] transition: failed to prepare leader")
+                watchers.notifyError(e)
+            }
+            throw e
+        }
+    }
+
+    // The point of no return: stop the follower, finish its pending block, build the leader. Once the
+    // follower is stopped, `state` references a dead term until we publish Prepared — so any early exit
+    // (a revoke cancelling us mid-cutover) re-opens a live follower from the catch, seeded from where the
+    // follower got to, and `state` never keeps a corpse. Recovery is structural, not flag-guarded:
+    // reaching the catch *is* "the follower was stopped", and `state` is exclusively ours until Prepared
+    // (the transport writes it only at its serialization point, after joining us), so no staleness guard
+    // is needed. NonCancellable guards only the resource release — the follower's allocator must close
+    // cleanly once teardown begins, whatever the cancellation (bounded: the follower's coroutines just
+    // unwind). Watermark/pendingBlock stay readable after close (not allocator-backed).
+    private suspend fun cutoverToLeader(
+        followerSys: FollowerSystem,
+        replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+        replayTarget: MessageId,
+    ) {
+        val followerProc = followerSys.proc
+        val pendingBlock = followerProc.pendingBlock
+        try {
+            LOG.debug("[$dbName] transition: closing follower system")
+            withContext(NonCancellable) {
+                followerSys.cancelAndJoin()
+                followerSys.close()
             }
 
-            is FollowerSystem -> {
-                LOG.info("[$dbName] partitions assigned: $partitions — transitioning to leader")
-
-                try {
-                    replicaLog.openAtomicProducer("${dbState.name}-leader").closeOnCatch { replicaProducer ->
-                        val followerProc = oldSys.proc
-
-                        // Send a NoOp to get a known msgId we can await —
-                        // we can't use latestSubmittedMsgId because Kafka's endOffsets
-                        // includes transaction marker offsets that consumers never deliver.
-                        val replayTarget =
-                            replicaProducer.withTx { it.appendMessage(ReplicaMessage.NoOp()) }.await().msgId
-
-                        followerProc.awaitReplicaMsgId(replayTarget)
-                        LOG.debug("[$dbName] transition: closing follower system")
-                        oldSys.cancelAndJoin()
-                        oldSys.close()
-
-                        val pendingBlock = followerProc.pendingBlock
-
-                        openTransition(replicaProducer, followerProc.latestReplicaMsgId).use { transition ->
-                            if (pendingBlock != null) {
-                                LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
-                                blockUploader.uploadBlock(
-                                    replicaProducer, pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage,
-                                )
-                                LOG.debug("[$dbName] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
-                                transition.processRecords(pendingBlock.bufferedRecords)
-                            }
-
-                            LOG.debug("[$dbName] transition: opening leader processor")
-
-                            val leaderSys = LeaderSystem(openLeader(replicaProducer, replayTarget))
-                            this.sys = leaderSys
-
-                            val resumeMsgId = watchers.latestSourceMsgId
-                            LOG.info("[$dbName] leader startup complete, resuming after $resumeMsgId")
-                            Log.TailSpec(resumeMsgId, leaderSys.proc)
-                        }
-                    }
-                } catch (e: InterruptedException) {
-                    throw e
-                } catch (e: Interrupted) {
-                    throw e
-                } catch (e: Throwable) {
-                    LOG.error(e, "[$dbName] transition: failed to transition to leader")
-                    watchers.notifyError(e)
-                    throw e
+            openTransition(replicaProducer, followerProc.latestReplicaMsgId).use { transition ->
+                if (pendingBlock != null) {
+                    LOG.debug("[$dbName] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
+                    blockUploader.uploadBlock(
+                        replicaProducer, pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage,
+                    )
+                    LOG.debug("[$dbName] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records through transition processor")
+                    transition.processRecords(pendingBlock.bufferedRecords)
                 }
             }
+
+            LOG.debug("[$dbName] transition: building leader processor")
+            val resumeAfterMsgId = watchers.latestSourceMsgId
+
+            // Built, not committed: `state` moves to Prepared but no records flow as leader until
+            // commitLeader installs it at the serialization point.
+            state = Prepared(LeaderSystem(openLeader(replicaProducer, replayTarget)), resumeAfterMsgId)
+        } catch (e: Throwable) {
+            state = Following(openFollowerSystem(followerProc.latestReplicaMsgId, pendingBlock))
+            throw e
         }
     }
 
-    override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
-        when (val oldSys = sys) {
-            is LeaderSystem -> {
-                LOG.info("[$dbName] partitions revoked: $partitions — was leader, transitioning to follower")
-                // Cancel first: Kafka guarantees no concurrent processing during rebalance. The
-                // leader's watermark fields stay readable after the cancel/close — they're not
-                // allocator-backed — so we free the old term before reading them to seed the follower.
-                oldSys.cancelAndJoin()
-                oldSys.close()
-                val proc = oldSys.proc
-                this.sys = openFollowerSystem(proc.latestReplicaMsgId, proc.pendingBlock)
-            }
-
-            is FollowerSystem -> {
-                LOG.debug("[$dbName] partitions revoked: $partitions — already follower, no transition needed")
-            }
-        }
+    override fun commitLeader(partitions: Collection<Int>): Log.TailSpec<SourceMessage> {
+        val prepared = (state as? Prepared)
+            ?: throw Fault("[$dbName] commitLeader without a prepared leader (${state::class.simpleName})", "xtdb/log-commit-not-prepared")
+        state = Leading(prepared.system)
+        LOG.info("[$dbName] leader startup complete, resuming after ${prepared.resumeAfterMsgId}")
+        return Log.TailSpec(prepared.resumeAfterMsgId, prepared.system.proc)
     }
 
-    override fun close() = sys.close()
+    override suspend fun demoteLeader(partitions: Collection<Int>) {
+        // Genuine revoke (Leading) and abandoning an uncommitted leader (Prepared) tear down the
+        // same way; an already-following listener is a no-op.
+        val leaderSys = when (val s = state) {
+            is Following -> {
+                LOG.debug("[$dbName] demote — already follower, no transition needed")
+                return
+            }
+
+            is Prepared -> s.system
+            is Leading -> s.system
+        }
+
+        LOG.info("[$dbName] demote — tearing down leader, re-opening follower")
+        // Cancel first: the watermark fields stay readable after the cancel/close — they're not
+        // allocator-backed — so we free the old term before reading them to seed the follower.
+        leaderSys.cancelAndJoin()
+        leaderSys.close()
+        state = Following(openFollowerSystem(leaderSys.proc.latestReplicaMsgId, leaderSys.proc.pendingBlock))
+    }
+
+    override fun close() = state.system.close()
 
     /**
      * Run one cycle of every garbage collector owned by the leader (block + trie) and wait for
-     * both. No-op on follower systems — GC only runs on the leader. Bypasses the collectors'
+     * both. No-op unless leading — GC only runs on the leader. Bypasses the collectors'
      * `enabled` flag (which gates the auto-signal from the block-boundary path, not direct calls).
      */
     fun gcAll() {
-        val proc = (sys as? LeaderSystem)?.proc ?: return
+        val proc = (state as? Leading)?.system?.proc ?: return
         proc.blockGc.awaitNoGarbageBlocking()
         proc.trieGc.awaitNoGarbageBlocking()
     }

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -132,7 +132,7 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
 
         leader?.let { old ->
             LOG.debug("$name/chooseLeader: revoking old leader")
-            old.listener.onPartitionsRevoked(listOf(0))
+            old.listener.demoteLeader(listOf(0))
             old.tailSpec = null
             leader = null
         }
@@ -140,12 +140,11 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
         if (groupConsumers.isNotEmpty()) {
             val newLeader = groupConsumers.random(rand)
             LOG.debug("$name/chooseLeader: assigning new leader")
-            val tailSpec = newLeader.listener.onPartitionsAssigned(listOf(0))
+            newLeader.listener.launchTransition(listOf(0)).await()
+            val tailSpec = newLeader.listener.commitLeader(listOf(0))
             newLeader.tailSpec = tailSpec
-            if (tailSpec != null) {
-                val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
-                newLeader.nextOffset = startOffset
-            }
+            val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
+            newLeader.nextOffset = startOffset
             leader = newLeader
             wakeLeader.send(Unit)
         } else {

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -37,6 +37,9 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
      */
     class PlainConsumer<M>(val proc: Log.RecordProcessor<M>, var nextOffset: Int, val job: Job)
 
+    /** The consumer being promoted plus its in-flight transition handle — see [pending]. */
+    class Pending<M>(val leader: GroupConsumer<M>, val transition: Deferred<Unit>)
+
     val groupConsumers = mutableSetOf<GroupConsumer<M>>()
     val plainConsumers = mutableSetOf<PlainConsumer<M>>()
 
@@ -47,6 +50,12 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
     val rebalanceTrigger = Channel<Unit>(Channel.CONFLATED)
 
     var leader: GroupConsumer<M>? = null
+
+    // An in-flight follower→leader transition (the consumer being promoted + its transition handle) —
+    // one field so the two can't drift. Launched off the serialization point (mirroring Kafka's
+    // off-poll-thread transition), installed by commitPendingLeader when it completes, and
+    // cancel-and-joined by the next rebalance — which drives the LogProcessor's own recovery (re-follow).
+    var pending: Pending<M>? = null
 
     /**
      * Unified group loop: delivers records and handles rebalances in a single coroutine.
@@ -60,6 +69,9 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
             select {
                 rebalanceTrigger.onReceive { doRebalance() }
                 wakeLeader.onReceive { deliverGroupRecords() }
+                // Install the pending leader once its off-thread transition completes (the sim's
+                // equivalent of Kafka's TransitionComplete arriving back on the poll thread).
+                pending?.let { it.transition.onAwait { commitPendingLeader() } }
             }
             yield()
         }
@@ -130,26 +142,41 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
     private suspend fun doRebalance() {
         LOG.debug("$name/chooseLeader: rebalance triggered (${groupConsumers.size} consumers)")
 
+        // Tear down whatever we hold — a committed leader, or an in-flight/Prepared transition. For the
+        // pending one, cancel-and-join (bounded; drives the LogProcessor's recovery) then demote, which
+        // abandons a Prepared leader or is a no-op if recovery already re-followed. Mirrors Kafka revoke.
+        pending?.let { p ->
+            p.transition.cancelAndJoin()
+            p.leader.listener.demoteLeader(listOf(0))
+        }
         leader?.let { old ->
             LOG.debug("$name/chooseLeader: revoking old leader")
             old.listener.demoteLeader(listOf(0))
             old.tailSpec = null
-            leader = null
         }
+        pending = null
+        leader = null
 
         if (groupConsumers.isNotEmpty()) {
             val newLeader = groupConsumers.random(rand)
-            LOG.debug("$name/chooseLeader: assigning new leader")
-            newLeader.listener.launchTransition(listOf(0)).await()
-            val tailSpec = newLeader.listener.commitLeader(listOf(0))
-            newLeader.tailSpec = tailSpec
-            val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
-            newLeader.nextOffset = startOffset
-            leader = newLeader
-            wakeLeader.send(Unit)
+            LOG.debug("$name/chooseLeader: launching transition for new leader")
+            pending = Pending(newLeader, newLeader.listener.launchTransition(listOf(0)))
+            // installed by commitPendingLeader (group-loop select clause) once the transition completes
         } else {
             LOG.debug("$name/chooseLeader: no consumers, no leader elected")
         }
+    }
+
+    // Group loop (serialization point): install the pending leader once its transition has completed.
+    private fun commitPendingLeader() {
+        val newLeader = pending?.leader ?: return
+        pending = null
+        LOG.debug("$name/chooseLeader: committing new leader")
+        val tailSpec = newLeader.listener.commitLeader(listOf(0))
+        newLeader.tailSpec = tailSpec
+        newLeader.nextOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
+        leader = newLeader
+        wakeLeader.trySend(Unit)
     }
 
     companion object {

--- a/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -40,10 +41,11 @@ class SimLogTest : SimulationTestBase() {
 
                     launch {
                         log.openGroupSubscription(object : Log.SubscriptionListener<String> {
-                            override suspend fun onPartitionsAssigned(partitions: Collection<Int>) =
+                            override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
+                            override fun commitLeader(partitions: Collection<Int>) =
                                 Log.TailSpec<String>(afterMsgId = -1L) { _ -> error("groupConsumer failure") }
 
-                            override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+                            override suspend fun demoteLeader(partitions: Collection<Int>) {}
                         })
                     }
 

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -170,15 +170,23 @@ class KafkaCluster(
             // expecting a load of change here for multi-part.
 
             suspend fun onPartitionAssigned(tp: TopicPartition) {
-                listener.onPartitionsAssigned(listOf(tp.partition()))
-                    ?.let { tailSpec ->
-                        processor = tailSpec.processor
-                        consumer.seekToAfterMsgId(tp, epoch, tailSpec.afterMsgId)
-                    }
+                // Retained partitions (CooperativeStickyAssignor) fire no callback; a callback while
+                // we already lead would rewind the source tail, so only transition+commit from follower.
+                if (processor != null) return
+
+                // Phase 1: still synchronous on the poll thread (the deadlock this leaves in place is
+                // fixed in phase 2, which stops awaiting here). await() propagates the transition's own
+                // failure so a failed promotion tanks the poll loop with its cause, rather than surfacing
+                // later as a commit-without-a-prepared-leader.
+                listener.launchTransition(listOf(tp.partition())).await()
+
+                val tailSpec = listener.commitLeader(listOf(tp.partition()))
+                processor = tailSpec.processor
+                consumer.seekToAfterMsgId(tp, epoch, tailSpec.afterMsgId)
             }
 
             suspend fun onPartitionRevoked(tp: TopicPartition) {
-                listener.onPartitionsRevoked(listOf(tp.partition()))
+                listener.demoteLeader(listOf(tp.partition()))
                 processor = null
             }
 
@@ -245,18 +253,16 @@ class KafkaCluster(
                 }
 
                 is GroupCommand.Unregister -> {
-                    subscriptions.remove(cmd.topic)?.let { sub ->
-                        sub.listener.onPartitionsRevokedSync(listOf(0))
-                        sub.completion.complete(Unit)
-                    }
+                    // No demote here: the database's scope cancel tears the leader term down (#5773).
+                    subscriptions.remove(cmd.topic)?.completion?.complete(Unit)
                     applySubscriptions()
                     cmd.cont.resume(Unit)
                 }
             }
         }
 
-        // Deliberately no `onPartitionsRevokedSync` — would trigger LogProcessor's
-        // leader→follower transition during a Failed-state cleanup.
+        // Deliberately no `demoteLeader` — would trigger LogProcessor's leader→follower
+        // transition during a Failed-state cleanup.
         private fun evictSubscriptions(topics: Collection<String>, cause: Throwable) {
             for (topic in topics) {
                 subscriptions.remove(topic)?.completion?.let { completion ->

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -6,10 +6,13 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.onClosed
 import kotlinx.coroutines.channels.onSuccess
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
@@ -57,6 +60,7 @@ import java.time.Instant.ofEpochMilli
 import java.util.*
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.collections.remove
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.io.path.inputStream
@@ -150,9 +154,27 @@ class KafkaCluster(
     private sealed interface GroupCommand {
         class Register(val topic: String, val subscription: SharedGroupConsumer.TopicSubscription<*>) : GroupCommand
         class Unregister(val topic: String, val cont: CancellableContinuation<Unit>) : GroupCommand
+
+        // Posted by a transition's off-thread joiner back onto the poll thread, so the committed role
+        // change (commitLeader/seek/resume, or eviction on failure) happens at the poll thread's
+        // serialization point. Carries the Transitioning state it ran for: if the subscription has since
+        // moved on (revoke, reassign) its state is no longer that instance, and the post is dropped (#5773).
+        class TransitionComplete(val tp: TopicPartition, val transitioning: Transitioning<*>) : GroupCommand
+        class TransitionFailed(val tp: TopicPartition, val transitioning: Transitioning<*>, val cause: Throwable) : GroupCommand
     }
 
-    @Suppress("UNCHECKED_CAST")
+    // The per-subscription leader-election state, held on TopicSubscription (not a side map) so the states
+    // and their data are checked by the type system rather than tracked by hand. At this level (not in the
+    // inner SharedGroupConsumer) because Kotlin forbids a nested class inside an inner class.
+    //   Following       — not leading, no transition in flight (initial, and after a demote/recovery).
+    //   Transitioning   — an off-thread follower→leader transition is running; the instance is its own
+    //                     identity token, so a stale completion for a superseded transition is dropped.
+    //   LeaderCommitted — committed leader; holds the record processor the poll loop feeds.
+    private sealed interface ListenerState<M>
+    private class Following<M> : ListenerState<M>
+    private class Transitioning<M>(val transition: Deferred<Unit>) : ListenerState<M>
+    private class LeaderCommitted<M>(val processor: Log.RecordProcessor<M>) : ListenerState<M>
+
     private inner class SharedGroupConsumer : AutoCloseable {
         private val subscriptions = mutableMapOf<String, TopicSubscription<*>>()
         private val commandCh = Channel<GroupCommand>(Channel.UNLIMITED)
@@ -164,39 +186,109 @@ class KafkaCluster(
             val codec: MessageCodec<M>,
             val epoch: Int,
             val listener: Log.SubscriptionListener<M>,
-            var processor: Log.RecordProcessor<M>?,
-            val completion: CompletableDeferred<Unit> = CompletableDeferred(),
         ) {
+            private val completion = CompletableDeferred<Unit>()
+            private var listenerState: ListenerState<M> = Following()
+
             // expecting a load of change here for multi-part.
 
-            suspend fun onPartitionAssigned(tp: TopicPartition) {
-                // Retained partitions (CooperativeStickyAssignor) fire no callback; a callback while
-                // we already lead would rewind the source tail, so only transition+commit from follower.
-                if (processor != null) return
+            fun onPartitionsAssigned(partitions: Collection<TopicPartition>) {
+                val tp = partitions.single()
+                when (val s = listenerState) {
+                    // Retained partitions (CooperativeStickyAssignor) fire no callback; a callback while
+                    // we already lead would rewind the source tail, so only transition from Following.
+                    is LeaderCommitted -> return
+                    is Transitioning -> s.transition.cancel()   // supersede an unexpected in-flight transition
+                    is Following -> {}
+                }
 
-                // Phase 1: still synchronous on the poll thread (the deadlock this leaves in place is
-                // fixed in phase 2, which stops awaiting here). await() propagates the transition's own
-                // failure so a failed promotion tanks the poll loop with its cause, rather than surfacing
-                // later as a commit-without-a-prepared-leader.
-                listener.launchTransition(listOf(tp.partition())).await()
+                consumer.pause(listOf(tp))
+                // A freshly-assigned partition has no fetch position, and poll() throws
+                // NoOffsetForPartitionException for it (auto.offset.reset=none) even while paused — pause
+                // suppresses fetching, not position validation. Park it at the end as a placeholder: it's
+                // paused (never fetched) and re-seeked to the real offset before resume at commit.
+                consumer.seekToEnd(listOf(tp))
 
-                val tailSpec = listener.commitLeader(listOf(tp.partition()))
-                processor = tailSpec.processor
-                consumer.seekToAfterMsgId(tp, epoch, tailSpec.afterMsgId)
+                val transition = listener.launchTransition(listOf(tp.partition()))
+                val transitioning = Transitioning<M>(transition)
+                listenerState = transitioning
+
+                scope.launch {
+                    val outcome: GroupCommand? =
+                        try {
+                            transition.await()
+                            GroupCommand.TransitionComplete(tp, transitioning)
+                        } catch (_: CancellationException) {
+                            null   // revoked / torn down — nothing to commit
+                        } catch (e: Throwable) {
+                            GroupCommand.TransitionFailed(tp, transitioning, e)
+                        }
+
+                    // Only wake the consumer if the command was queued — a closed channel means we're
+                    // shutting down, and waking a closing consumer would race its close().
+                    if (outcome != null && commandCh.trySend(outcome).isSuccess) consumer.wakeup()
+                }
             }
 
-            suspend fun onPartitionRevoked(tp: TopicPartition) {
-                listener.demoteLeader(listOf(tp.partition()))
-                processor = null
+            suspend fun onPartitionRevoked(partitions: Collection<TopicPartition>) {
+                // Abandon any in-flight transition first — cancel-and-join is bounded (the catch-up await
+                // is cancellable) and lets the transition's own recovery settle `state`. Then demote:
+                // Prepared→abandon, Leading→teardown, Following→no-op. Back to Following either way.
+                (listenerState as? Transitioning)?.transition?.cancelAndJoin()
+                listener.demoteLeader(listOf(partitions.single().partition()))
+                listenerState = Following()
             }
 
             suspend fun processRecords(records: List<ConsumerRecord<*, ByteArray>>) {
-                processor!!.processRecords(
+                // Only a committed leader has a processor; while Following/Transitioning the partition is
+                // paused, so this guard is belt-and-braces.
+                val proc = (listenerState as? LeaderCommitted)?.processor ?: return
+
+                proc.processRecords(
                     records.mapNotNull { rec ->
                         codec.decode(rec.value())
                             ?.let { msg -> Log.Record(epoch, rec.offset(), ofEpochMilli(rec.timestamp()), msg) }
                     })
             }
+
+            // Poll thread, at the serialization point: install the prepared leader, seek, resume. Drops a
+            // stale completion whose state has moved on (revoke / reassign) — it is no longer this
+            // Transitioning instance.
+            fun onTransitionComplete(cmd: GroupCommand.TransitionComplete) {
+                if (listenerState !== cmd.transitioning) return
+
+                val tailSpec = listener.commitLeader(listOf(cmd.tp.partition()))
+                listenerState = LeaderCommitted(tailSpec.processor)
+                consumer.seekToAfterMsgId(cmd.tp, epoch, tailSpec.afterMsgId)   // seek before resume — #5633
+                consumer.resume(listOf(cmd.tp))
+            }
+
+            // Poll thread: a transition failed. Isolate it — evict only this subscription, leaving siblings
+            // on the shared consumer running. Its watchers were already poisoned by the transition body.
+            fun onTransitionFailed(cmd: GroupCommand.TransitionFailed) {
+                if (listenerState !== cmd.transitioning) return
+                LOG.error(cmd.cause) { "leader transition failed for ${cmd.tp} — evicting its subscription" }
+                evictSubscriptions(listOf(cmd.tp.topic()), cmd.cause)
+            }
+
+            // On unregister: complete the subscription so openGroupSubscription returns. Any in-flight
+            // transition is a child of the database scope, which is being cancelled — left to it (#5773).
+            fun cancel() {
+                if (completion.isActive) completion.complete(Unit)
+            }
+
+            // Poll thread: abandon this subscription with a failure cause (a failed transition, or poll-loop
+            // teardown). Cancel — never join, the poll thread must not block — any in-flight transition, and
+            // fail the completion so openGroupSubscription unwinds with the cause. Deliberately no
+            // demoteLeader: that would drive a leader→follower transition mid-teardown.
+            fun evict(cause: Throwable) {
+                (listenerState as? Transitioning)?.transition?.cancel()
+                if (completion.isActive) completion.completeExceptionally(cause)
+            }
+
+            // Suspend until this subscription ends — normally via cancel (unregister), or exceptionally with
+            // the eviction cause, which then propagates out of openGroupSubscription.
+            suspend fun await() = completion.await()
         }
 
 
@@ -207,41 +299,29 @@ class KafkaCluster(
                 throw InterruptException(e)
             }
 
+        private val listener = object : ConsumerRebalanceListener {
+
+            override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
+                launderInterruptedException {
+                    for ((topic, tps) in partitions.groupBy { it.topic() }) {
+                        subscriptions[topic]?.onPartitionsAssigned(tps)
+                    }
+                }
+
+            override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
+                launderInterruptedException {
+                    runBlocking {
+                        for ((topic, tps) in partitions.groupBy { it.topic() }) {
+                            subscriptions[topic]?.onPartitionRevoked(tps)
+                        }
+                    }
+                }
+        }
 
         private fun applySubscriptions() {
             val topics = subscriptions.keys.toList()
 
-            if (topics.isEmpty()) consumer.unsubscribe()
-            else consumer.subscribe(topics, object : ConsumerRebalanceListener {
-                override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) =
-                    launderInterruptedException {
-                        runBlocking {
-                            for ((topic, tps) in partitions.groupBy { it.topic() }) {
-                                val sub = subscriptions[topic] as? TopicSubscription<Any?> ?: continue
-                                try {
-                                    sub.onPartitionAssigned(tps.single())
-                                } catch (e: Throwable) {
-                                    LOG.error(e) { "onPartitionsAssigned($partitions): failed handling assignment for topic '$topic' ($tps)" }
-                                    throw e
-                                }
-                            }
-                        }
-                    }
-
-                override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) =
-                    launderInterruptedException {
-                        runBlocking {
-                            for ((topic, tps) in partitions.groupBy { it.topic() }) {
-                                try {
-                                    subscriptions[topic]?.onPartitionRevoked(tps.single())
-                                } catch (e: Throwable) {
-                                    LOG.error(e) { "onPartitionsRevoked($partitions): failed handling revocation for topic '$topic' ($tps)" }
-                                    throw e
-                                }
-                            }
-                        }
-                    }
-            })
+            if (topics.isEmpty()) consumer.unsubscribe() else consumer.subscribe(topics, listener)
         }
 
         private fun processCommand(cmd: GroupCommand) {
@@ -253,22 +333,23 @@ class KafkaCluster(
                 }
 
                 is GroupCommand.Unregister -> {
-                    // No demote here: the database's scope cancel tears the leader term down (#5773).
-                    subscriptions.remove(cmd.topic)?.completion?.complete(Unit)
+                    // No demote here: the database's scope cancel tears the leader term down (#5773) —
+                    // and the in-flight transition, if any, is a child of that scope too, so it's left to it.
+                    subscriptions.remove(cmd.topic)?.cancel()
                     applySubscriptions()
                     cmd.cont.resume(Unit)
                 }
+
+                is GroupCommand.TransitionComplete ->
+                    subscriptions[cmd.tp.topic()]?.onTransitionComplete(cmd)
+
+                is GroupCommand.TransitionFailed ->
+                    subscriptions[cmd.tp.topic()]?.onTransitionFailed(cmd)
             }
         }
 
-        // Deliberately no `demoteLeader` — would trigger LogProcessor's leader→follower
-        // transition during a Failed-state cleanup.
         private fun evictSubscriptions(topics: Collection<String>, cause: Throwable) {
-            for (topic in topics) {
-                subscriptions.remove(topic)?.completion?.let { completion ->
-                    if (completion.isActive) completion.completeExceptionally(cause)
-                }
-            }
+            for (topic in topics) subscriptions.remove(topic)?.evict(cause)
             applySubscriptions()
         }
 
@@ -280,10 +361,10 @@ class KafkaCluster(
             while (true) {
                 val cmd = commandCh.tryReceive().getOrNull() ?: break
                 when (cmd) {
-                    is GroupCommand.Register -> cmd.subscription.completion.let { completion ->
-                        if (completion.isActive) completion.completeExceptionally(cause)
-                    }
+                    is GroupCommand.Register -> cmd.subscription.evict(cause)
+
                     is GroupCommand.Unregister -> cmd.cont.resume(Unit)
+                    is GroupCommand.TransitionComplete, is GroupCommand.TransitionFailed -> {}
                 }
             }
             try {
@@ -320,8 +401,9 @@ class KafkaCluster(
                             onTimeout(0.milliseconds) {
                                 consumer.pollRecords()?.let { consumerRecords ->
                                     for ((topic, recs) in consumerRecords.groupBy { it.topic() }) {
-                                        val sub = subscriptions[topic]
-                                            ?: error("Received records for unsubscribed topic $topic")
+                                        val sub = checkNotNull(subscriptions[topic]) {
+                                            "Received records for unsubscribed topic $topic"
+                                        }
 
                                         sub.processRecords(recs)
                                     }
@@ -346,7 +428,7 @@ class KafkaCluster(
             epoch: Int,
             listener: Log.SubscriptionListener<M>,
         ): TopicSubscription<M> {
-            val sub = TopicSubscription(codec, epoch, listener, null)
+            val sub = TopicSubscription(codec, epoch, listener)
             commandCh.send(GroupCommand.Register(topic, sub))
             consumer.wakeup()
             return sub
@@ -646,7 +728,7 @@ class KafkaCluster(
             val sub = sharedGroupConsumer.register(topic, codec, epoch, listener)
             LOG.info { "registered group subscription for topic '$topic'" }
             try {
-                sub.completion.await()
+                sub.await()
             } finally {
                 withContext(NonCancellable) { sharedGroupConsumer.unregister(topic) }
             }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -4,11 +4,17 @@ import com.google.protobuf.ByteString
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
@@ -341,21 +347,23 @@ class KafkaClusterTest {
     private class TrackingListener(
         private val afterMsgId: MessageId = -1L,
     ) : SubscriptionListener<SourceMessage> {
-        val assignedPartitions = CopyOnWriteArrayList<Collection<Int>>()
-        val revokedPartitions = CopyOnWriteArrayList<Collection<Int>>()
+        val assignedPartitions = CopyOnWriteArrayList<Unit>()
+        val revokedPartitions = CopyOnWriteArrayList<Unit>()
         val records = CopyOnWriteArrayList<Record<SourceMessage>>()
 
         val isAssigned get() = assignedPartitions.size > revokedPartitions.size
 
         private val processor = RecordProcessor<SourceMessage> { recs -> records.addAll(recs) }
 
-        override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> {
-            assignedPartitions.add(partitions)
+        override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
+
+        override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> {
+            assignedPartitions.add(Unit)
             return TailSpec(afterMsgId, processor)
         }
 
-        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {
-            revokedPartitions.add(partitions)
+        override suspend fun demoteLeader(partitions: Collection<Int>) {
+            revokedPartitions.add(Unit)
         }
     }
 
@@ -424,18 +432,21 @@ class KafkaClusterTest {
         }
     }
 
-    private class RacingListener : SubscriptionListener<SourceMessage> {
+    private class RacingListener(private val scope: CoroutineScope) : SubscriptionListener<SourceMessage> {
         val entered = CompletableDeferred<Unit>()
         val release = CompletableDeferred<Unit>()
         val records = CopyOnWriteArrayList<Record<SourceMessage>>()
 
-        override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> {
+        // Launch on a real scope (not the runTest virtual dispatcher): the poll thread joins this
+        // handle via runBlocking, so a virtual-dispatcher job would never get to run.
+        override fun launchTransition(partitions: Collection<Int>) = scope.async {
             entered.complete(Unit)
             release.await()
-            return TailSpec(-1L, RecordProcessor { recs -> records.addAll(recs) })
         }
 
-        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+        override fun commitLeader(partitions: Collection<Int>) = TailSpec(-1L) { recs -> records.addAll(recs) }
+
+        override suspend fun demoteLeader(partitions: Collection<Int>) {}
     }
 
     @Test
@@ -445,85 +456,101 @@ class KafkaClusterTest {
 
         withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
             val (log1, log2) = logs
-            val listener1 = RacingListener()
-            val listener2 = RacingListener()
+            val racingScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            try {
+                val listener1 = RacingListener(racingScope)
+                val listener2 = RacingListener(racingScope)
 
-            val job1 = launch { log1.openGroupSubscription(listener1) }
-            listener1.entered.await()
+                val job1 = launch { log1.openGroupSubscription(listener1) }
+                listener1.entered.await()
 
-            // second register() arms consumer.wakeup() while topic1's callback is parked.
-            val job2 = launch { log2.openGroupSubscription(listener2) }
-            yield()
+                // second register() arms consumer.wakeup() while topic1's callback is parked.
+                val job2 = launch { log2.openGroupSubscription(listener2) }
+                yield()
 
-            listener1.release.complete(Unit)
+                listener1.release.complete(Unit)
 
-            listener2.entered.await()
-            listener2.release.complete(Unit)
+                listener2.entered.await()
+                listener2.release.complete(Unit)
 
-            log1.appendMessage(txMessage(1))
-            log2.appendMessage(txMessage(2))
+                log1.appendMessage(txMessage(1))
+                log2.appendMessage(txMessage(2))
 
-            // an inner withTimeout would use the TestScope's virtual clock and trip before
-            // records flow; rely on the outer real-time runTest timeout instead.
-            while (listener1.records.isEmpty() || listener2.records.isEmpty()) delay(50.milliseconds)
+                // an inner withTimeout would use the TestScope's virtual clock and trip before
+                // records flow; rely on the outer real-time runTest timeout instead.
+                while (listener1.records.isEmpty() || listener2.records.isEmpty()) delay(50.milliseconds)
 
-            job1.cancelAndJoin()
-            job2.cancelAndJoin()
+                job1.cancelAndJoin()
+                job2.cancelAndJoin()
+            } finally {
+                racingScope.cancel()
+            }
         }
     }
 
     private class ThrowingOnAssignListener(private val toThrow: Throwable) : SubscriptionListener<SourceMessage> {
-        override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> {
-            throw toThrow
-        }
-
-        override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+        override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred<Unit>().apply { completeExceptionally(toThrow) }
+        override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> = error("unreachable")
+        override suspend fun demoteLeader(partitions: Collection<Int>) {}
     }
 
     @Test
-    fun `poll loop failure evicts all subscriptions with cause and unblocks shutdown`() = runTest(timeout = 30.seconds) {
-        val topic1 = "test-poll-fail-${UUID.randomUUID()}"
-        val topic2 = "test-poll-fail-${UUID.randomUUID()}"
+    fun `poll loop failure evicts all subscriptions with cause and unblocks shutdown`() =
+        runTest(timeout = 30.seconds) {
+            val topic1 = "test-poll-fail-${UUID.randomUUID()}"
+            val topic2 = "test-poll-fail-${UUID.randomUUID()}"
 
-        val boom = RuntimeException("listener boom")
-        val healthy = TrackingListener()
-        val throwing = ThrowingOnAssignListener(boom)
+            val boom = RuntimeException("listener boom")
+            val healthy = TrackingListener()
+            val throwing = ThrowingOnAssignListener(boom)
 
-        val caughtHealthy = AtomicReference<Throwable?>(null)
-        val caughtThrowing = AtomicReference<Throwable?>(null)
+            var caughtHealthy: Throwable? = null
+            var caughtThrowing: Throwable? = null
 
-        withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
-            val (logHealthy, logThrowing) = logs
+            withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
+                val (logHealthy, logThrowing) = logs
 
-            // register the healthy subscriber first and wait for it to be assigned —
-            // guarantees it's in the subscriptions map when the throwing one tanks the poll loop
-            val jobHealthy = launch(SupervisorJob()) {
-                try { logHealthy.openGroupSubscription(healthy) }
-                catch (e: Throwable) { caughtHealthy.set(e) }
+                supervisorScope {
+                    // register the healthy subscriber first and wait for it to be assigned —
+                    // guarantees it's in the subscriptions map when the throwing one tanks the poll loop
+                    launch(CoroutineName("job-healthy")) {
+                        try {
+                            logHealthy.openGroupSubscription(healthy)
+                        } catch (e: Throwable) {
+                            caughtHealthy = e
+                        }
+                    }
+
+                    while (!healthy.isAssigned) delay(100.milliseconds)
+
+                    launch(CoroutineName("job-throwing")) {
+                        try {
+                            logThrowing.openGroupSubscription(throwing)
+                        } catch (e: Throwable) {
+                            caughtThrowing = e
+                        }
+                    }
+
+                    // both subscribers should surface a failure (no hang) — the outer runTest timeout
+                    // is the regression canary for the pre-fix shutdown-hang behaviour
+                }
             }
-            while (!healthy.isAssigned) delay(100.milliseconds)
 
-            val jobThrowing = launch(SupervisorJob()) {
-                try { logThrowing.openGroupSubscription(throwing) }
-                catch (e: Throwable) { caughtThrowing.set(e) }
+            val exThrowing = checkNotNull(caughtThrowing) { "throwing subscriber must surface a failure, not hang" }
+
+            val exHealthy = checkNotNull(caughtHealthy) {
+                "healthy subscriber must surface a failure when the poll loop dies, not hang"
             }
 
-            // both subscribers should surface a failure (no hang) — the outer runTest timeout
-            // is the regression canary for the pre-fix shutdown-hang behaviour
-            jobHealthy.join()
-            jobThrowing.join()
+            assertTrue(
+                generateSequence(exThrowing) { it.cause }.any { it === boom },
+                "throwing subscriber must see the listener exception in its cause chain, got: $exThrowing"
+            )
+            assertTrue(
+                generateSequence(exHealthy) { it.cause }.any { it === boom },
+                "healthy subscriber must see the listener exception in its cause chain, got: $exHealthy"
+            )
         }
-
-        val exThrowing = caughtThrowing.get()
-            ?: error("throwing subscriber must surface a failure, not hang")
-        val exHealthy = caughtHealthy.get()
-            ?: error("healthy subscriber must surface a failure when the poll loop dies, not hang")
-
-        assertTrue(generateSequence<Throwable>(exThrowing) { it.cause }.any { it === boom },
-            "throwing subscriber must see the listener exception in its cause chain, got: $exThrowing")
-        assertTrue(generateSequence<Throwable>(exHealthy) { it.cause }.any { it === boom },
-            "healthy subscriber must see the listener exception in its cause chain, got: $exHealthy")
-    }
 
     @Test
     fun `database can resubscribe after unsubscribing`() = runTest(timeout = 60.seconds) {
@@ -540,8 +567,10 @@ class KafkaClusterTest {
             while (listener1.records.isEmpty()) delay(100.milliseconds)
             val firstOffset = listener1.records[0].logOffset
 
+            // cancelAndJoin resumes only once the unregister is processed (subscription removed +
+            // consumer unsubscribed), so it is a sufficient barrier before resubscribing. Unregister
+            // tears the term down via the database scope, not demoteLeader, so there is no revoke to await.
             job1.cancelAndJoin()
-            while (listener1.revokedPartitions.isEmpty()) delay(100.milliseconds)
 
             val listener2 = TrackingListener(afterMsgId = firstOffset)
             val job2 = launch { log1.openGroupSubscription(listener2) }
@@ -623,12 +652,12 @@ class KafkaClusterTest {
             node.connection.use { conn ->
                 conn.createStatement().use { stmt ->
                     stmt.execute(
-                        """
-                        ATTACH DATABASE secondary WITH ${'$'}${'$'}
+                        $$"""
+                        ATTACH DATABASE secondary WITH $$
                             log: !Kafka
                               cluster: kafka
-                              topic: $secondaryTopic
-                        ${'$'}${'$'}""".trimIndent()
+                              topic: $$secondaryTopic
+                        $$""".trimIndent()
                     )
                     stmt.execute("DETACH DATABASE secondary")
                 }
@@ -665,19 +694,29 @@ class KafkaClusterTest {
 
                         // Anchor inside the now-truncated prefix — seek lands below the earliest available offset.
                         val anchorInTruncatedPrefix = MsgIdUtil.offsetToMsgId(0, 1L)
-                        val job = launch(SupervisorJob()) {
-                            try { log.tailAll(anchorInTruncatedPrefix, subscriber) }
-                            catch (e: Throwable) { caught.set(e) }
+                        val completed = supervisorScope {
+                            val job = launch {
+                                try {
+                                    log.tailAll(anchorInTruncatedPrefix, subscriber)
+                                } catch (e: Throwable) {
+                                    caught.set(e)
+                                }
+                            }
+                            val completed = withTimeoutOrNull(3.seconds) { job.join() } != null
+
+                            job.cancel()
+
+                            completed
                         }
-                        val completed = withTimeoutOrNull(3.seconds) { job.join() } != null
-                        job.cancelAndJoin()
 
                         assertTrue(completed, "tailAll silently polled past the truncation — should have thrown")
                     }
             }
 
-        assertEquals(0, synchronized(msgs) { msgs.flatten().size },
-            "received records past a truncated anchor — silent skip is data loss")
+        assertEquals(
+            0, synchronized(msgs) { msgs.flatten().size },
+            "received records past a truncated anchor — silent skip is data loss"
+        )
         assertNotNull(caught.get(), "tailAll must throw, not silently auto-reset")
     }
 
@@ -688,9 +727,11 @@ class KafkaClusterTest {
         val anchorInTruncatedPrefix = MsgIdUtil.offsetToMsgId(0, 1L)
         val caught = AtomicReference<Throwable?>(null)
         val listener = object : SubscriptionListener<SourceMessage> {
-            override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> =
-                TailSpec(afterMsgId = anchorInTruncatedPrefix, processor = RecordProcessor { _ -> })
-            override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+            override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
+            override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> =
+                TailSpec(afterMsgId = anchorInTruncatedPrefix, processor = { _ -> })
+
+            override suspend fun demoteLeader(partitions: Collection<Int>) {}
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -701,14 +742,23 @@ class KafkaClusterTest {
                     .use { log ->
                         log.seedAndTruncate(topic, count = 5, truncateBefore = 3L)
 
-                        val job = launch(SupervisorJob()) {
-                            try { log.openGroupSubscription(listener) }
-                            catch (e: Throwable) { caught.set(e) }
-                        }
-                        val completed = withTimeoutOrNull(5.seconds) { job.join() } != null
-                        job.cancelAndJoin()
+                        supervisorScope {
+                            val job = launch {
+                                try {
+                                    log.openGroupSubscription(listener)
+                                } catch (e: Throwable) {
+                                    caught.set(e)
+                                }
+                            }
 
-                        assertTrue(completed, "openGroupSubscription silently polled past the truncation — should have thrown")
+                            val completed = withTimeoutOrNull(5.seconds) { job.join() } != null
+                            job.cancel()
+
+                            assertTrue(
+                                completed,
+                                "openGroupSubscription silently polled past the truncation — should have thrown"
+                            )
+                        }
                     }
             }
 
@@ -767,8 +817,10 @@ class KafkaClusterTest {
             while (primary.ingestionError == null && System.currentTimeMillis() < deadline) {
                 Thread.sleep(100)
             }
-            assertNotNull(primary.ingestionError,
-                "node must surface IngestionStoppedException when replica log truncated past stored boundary")
+            assertNotNull(
+                primary.ingestionError,
+                "node must surface IngestionStoppedException when replica log truncated past stored boundary"
+            )
         }
     }
 
@@ -811,11 +863,13 @@ class KafkaClusterTest {
     fun `openGroupSubscription picks up records appended past a truncated prefix when starting fresh`() = runBlocking {
         val topic = "trunc-fresh-grp-${UUID.randomUUID()}"
         val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
-        val processor = RecordProcessor<SourceMessage> { records -> msgs.add(records) }
+        val processor = RecordProcessor { records -> msgs.add(records) }
         val listener = object : SubscriptionListener<SourceMessage> {
-            override suspend fun onPartitionsAssigned(partitions: Collection<Int>): TailSpec<SourceMessage> =
+            override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
+            override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> =
                 TailSpec(afterMsgId = -1L, processor = processor)
-            override suspend fun onPartitionsRevoked(partitions: Collection<Int>) {}
+
+            override suspend fun demoteLeader(partitions: Collection<Int>) {}
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -937,8 +991,10 @@ class KafkaClusterTest {
                 }
             }
             val primary = (node as Xtdb.XtdbInternal).dbCatalog.primary
-            assertEquals(null, primary.ingestionError,
-                "a fresh node must not error when the topic's earliest offset is past 0")
+            assertEquals(
+                null, primary.ingestionError,
+                "a fresh node must not error when the topic's earliest offset is past 0"
+            )
         }
     }
 }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -495,62 +495,102 @@ class KafkaClusterTest {
     }
 
     @Test
-    fun `poll loop failure evicts all subscriptions with cause and unblocks shutdown`() =
+    fun `a failed transition evicts only its own subscription, sparing siblings (#5773)`() =
         runTest(timeout = 30.seconds) {
-            val topic1 = "test-poll-fail-${UUID.randomUUID()}"
-            val topic2 = "test-poll-fail-${UUID.randomUUID()}"
+            val topicHealthy = "test-iso-healthy-${UUID.randomUUID()}"
+            val topicThrowing = "test-iso-throwing-${UUID.randomUUID()}"
 
             val boom = RuntimeException("listener boom")
             val healthy = TrackingListener()
             val throwing = ThrowingOnAssignListener(boom)
-
-            var caughtHealthy: Throwable? = null
             var caughtThrowing: Throwable? = null
 
-            withClusterAndLogs(listOf(topic1, topic2)) { _, logs ->
+            withClusterAndLogs(listOf(topicHealthy, topicThrowing)) { _, logs ->
                 val (logHealthy, logThrowing) = logs
 
                 supervisorScope {
-                    // register the healthy subscriber first and wait for it to be assigned —
-                    // guarantees it's in the subscriptions map when the throwing one tanks the poll loop
-                    launch(CoroutineName("job-healthy")) {
-                        try {
-                            logHealthy.openGroupSubscription(healthy)
-                        } catch (e: Throwable) {
-                            caughtHealthy = e
-                        }
+                    val jobHealthy = launch(CoroutineName("job-healthy")) {
+                        logHealthy.openGroupSubscription(healthy)
                     }
-
                     while (!healthy.isAssigned) delay(100.milliseconds)
 
+                    // The throwing transition fails off the poll thread; its subscription is evicted with
+                    // the cause, but the poll loop survives — pre-#5773 a transition failure tanked the
+                    // whole shared consumer (evicting the healthy sibling too).
                     launch(CoroutineName("job-throwing")) {
-                        try {
-                            logThrowing.openGroupSubscription(throwing)
-                        } catch (e: Throwable) {
-                            caughtThrowing = e
-                        }
+                        try { logThrowing.openGroupSubscription(throwing) } catch (e: Throwable) { caughtThrowing = e }
                     }
+                    while (caughtThrowing == null) delay(100.milliseconds)
 
-                    // both subscribers should surface a failure (no hang) — the outer runTest timeout
-                    // is the regression canary for the pre-fix shutdown-hang behaviour
+                    // The healthy subscription keeps delivering AFTER its sibling failed — the isolation.
+                    logHealthy.appendMessage(txMessage(1))
+                    while (healthy.records.isEmpty()) delay(100.milliseconds)
+                    assertEquals(1, healthy.records.size)
+
+                    jobHealthy.cancelAndJoin()
                 }
             }
 
-            val exThrowing = checkNotNull(caughtThrowing) { "throwing subscriber must surface a failure, not hang" }
-
-            val exHealthy = checkNotNull(caughtHealthy) {
-                "healthy subscriber must surface a failure when the poll loop dies, not hang"
-            }
-
+            val exThrowing = checkNotNull(caughtThrowing) { "throwing subscriber must surface its failure, not hang" }
             assertTrue(
                 generateSequence(exThrowing) { it.cause }.any { it === boom },
                 "throwing subscriber must see the listener exception in its cause chain, got: $exThrowing"
             )
-            assertTrue(
-                generateSequence(exHealthy) { it.cause }.any { it === boom },
-                "healthy subscriber must see the listener exception in its cause chain, got: $exHealthy"
-            )
         }
+
+    @Test
+    fun `a parked transition does not block its own unregister (#5773)`() = runTest(timeout = 30.seconds) {
+        val topic = "test-parked-unreg-${UUID.randomUUID()}"
+
+        withClusterAndLogs(listOf(topic)) { _, logs ->
+            val log = logs[0]
+            val racingScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            try {
+                val listener = RacingListener(racingScope)
+                val job = launch { log.openGroupSubscription(listener) }
+                listener.entered.await()   // the transition is parked, off the poll thread
+
+                // Pre-#5773 the transition ran ON the poll thread, so a parked transition wedged it and
+                // the Unregister command could never be processed — cancelAndJoin would hang here. Now the
+                // poll thread is free, so unregister completes promptly (outer runTest timeout is the canary).
+                job.cancelAndJoin()
+            } finally {
+                racingScope.cancel()
+            }
+        }
+    }
+
+    @Test
+    fun `a parked transition does not block another subscription`() = runTest(timeout = 30.seconds) {
+        val topicParked = "test-parked-a-${UUID.randomUUID()}"
+        val topicOther = "test-parked-b-${UUID.randomUUID()}"
+
+        withClusterAndLogs(listOf(topicParked, topicOther)) { _, logs ->
+            val (logParked, logOther) = logs
+            val racingScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            try {
+                val parked = RacingListener(racingScope)
+                val other = TrackingListener()
+
+                val jobParked = launch { logParked.openGroupSubscription(parked) }
+                parked.entered.await()   // parked mid-transition, off the poll thread
+
+                // A second database registers, is assigned, and delivers — all while the first is parked.
+                val jobOther = launch { logOther.openGroupSubscription(other) }
+                while (!other.isAssigned) delay(100.milliseconds)
+
+                logOther.appendMessage(txMessage(1))
+                while (other.records.isEmpty()) delay(100.milliseconds)
+                assertEquals(1, other.records.size)
+
+                parked.release.complete(Unit)
+                jobParked.cancelAndJoin()
+                jobOther.cancelAndJoin()
+            } finally {
+                racingScope.cancel()
+            }
+        }
+    }
 
     @Test
     fun `database can resubscribe after unsubscribing`() = runTest(timeout = 60.seconds) {


### PR DESCRIPTION
Resolves #5773.

The Kafka shared consumer runs a single poll thread across every database on the consumer group. The follower→leader transition — whose follower catch-up await is unbounded — ran synchronously inside the rebalance callback, so a database torn down mid-transition wedged that poll thread: its `Unregister` sat unprocessed and `DatabaseCatalog.close` hit its 60s timeout. Worse, one database's slow transition stalled rebalance and command processing for *every* neighbour on the shared consumer.

## Approach

The transition now runs off the poll thread, on the LogProcessor's own database scope. On assignment the transport pauses the partition and launches the transition (`launchTransition`), returning immediately; a joiner awaits the handle and posts `TransitionComplete`/`TransitionFailed` back onto the poll thread, where the committed role change (`commitLeader` + seek + resume) happens at the single serialization point. The poll thread is never held, so teardown, rebalance and commands stay responsive.

## Implementation notes

**Transport state, by type.** Each subscription's leader-election state lives on its `TopicSubscription` as a sealed `ListenerState` (`Following` / `Transitioning(deferred)` / `LeaderCommitted(processor)`), replacing a side map plus a monotonic token plus a nullable processor. The `Transitioning` instance is its own identity, so a completion for a superseded assignment is dropped without a generation counter.

**Structural follower recovery.** The transition stops its follower before committing the leader, so a revoke cancelling it in that window would otherwise strand `state` pointing at a torn-down follower — and the *next* transition would await it forever (this bit us; the property tests caught it deterministically). The transition is split so the corpse state is unrepresentable: the cutover phase re-opens a live follower from its own `catch` on any early exit, so recovery is bound to code position, not a flag that can desync under cancellation. `NonCancellable` guards only the follower's resource release.

## Commits

1. `refactor(log)`: split the transition into `launchTransition`/`commitLeader`/`demoteLeader` — a behaviour-preserving interface reshape (Kafka still awaits synchronously at this commit).
2. `fix(kafka)`: move the transition off the poll thread — the fix itself, plus the structural recovery and the async `SimLog` mirror.

The branch sits on the recent term-lifecycle tidy-firsts (`inline ProcessorFactory`, `move term lifecycle ownership onto the processors`); the transition redesign is expressed directly on that foundation — no `openTerm`, thin `SubSystem`, processors own their terms.

## Test plan

- `LogProcessorSimTest` (property, broker-free): 300 iterations green, no hang — exercises the off-thread transition and its recovery across rebalance interleavings.
- `KafkaClusterTest` (integration, real Kafka): green — parked-transition-doesn't-block-unregister, failed-transition-isolation, `#5633` wakeup/seek.
- Full `./gradlew test`: 1599 green. No reflection or boxed-math warnings.
- `allium/log-processor-lifecycle` spec updated (OQ2 closed); `allium check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)