### PR TITLE
perf(indexer): batch the leader's replica-log writes (#5507)

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -21,26 +21,62 @@
 --     after each DURABLE confirmation; existing snapshots remain valid until their
 --     last holder releases them
 --
--- Pipelining (leader only):
---   On a leader, transaction RESOLUTION runs ahead of the replica-log write. A
---   resolved, committed tx is applied to a STAGING index immediately (so later
---   txs in the same stream resolve against it — read-your-writes), advancing the
---   staging area's own APPLIED head (StagingIndex.latest_completed_tx). It is
---   NOT yet visible to external queries. Only once its batch is confirmed durably
---   written to the replica log is it PROMOTED into the durable live tables,
---   advancing the DURABLE basis (LiveIndex.latest_completed_tx), refreshing the
---   shared external snapshot, and notifying watchers. Followers and the
---   transition processor have no staging index: the messages they import are
+-- Pipelining (leader only) — single-resolver model:
+--   NOTE: spec-ahead-of-code. The leader is currently a fully-synchronous single
+--   persister; the pipelined commit described here is not yet implemented.
+--
+--   On a leader, a SINGLE resolver coroutine drives the whole pipeline (see
+--   db.allium). It owns the STAGING INDEX outright (sole accessor, so staging needs
+--   no lock — single-threaded by construction) AND owns the replica-log producer's
+--   append path. As each tx resolves, the resolver applies it to the staging index's
+--   `accumulating` slot (so later txs in the same stream resolve against it —
+--   read-your-writes), advancing the staging index's own APPLIED head
+--   (StagingIndex.latest_completed_tx), AND holds the tx's resolved replica message
+--   (the ResolvedTx to be appended) in the slot in send order. It does NOT append to
+--   any producer transaction at resolve time. The tx is NOT yet visible to external
+--   queries: it is applied-to-staging but not yet on the replica log.
+--
+--   The APPENDS happen at SEAL time, not resolve time — a single Kafka transactional
+--   producer permits only ONE open transaction at a time, and commit() commits
+--   everything appended since the transaction opened (you cannot commit a prefix, nor
+--   open a second transaction — a second producer would be fenced). So appending each
+--   tx as it resolves is not realizable: while a sealed batch's producer transaction
+--   is being committed, the next tx would have nowhere to append (neither the
+--   committing transaction — it commits with the wrong batch — nor a new one —
+--   fenced). Instead, when the resolver SEALS a batch (see SealStagingBatch) it opens
+--   a FRESH producer transaction, appends the whole accumulating slot's held messages
+--   in send order (the cheap, nigh-on-free step that fixes the txs' order on the
+--   replica log), moves the slot into the `committing` sequence, and hands the
+--   OPEN-BUT-UNCOMMITTED producer transaction to a secondary COMMITTER coroutine.
+--
+--   ONLY the producer-transaction commit (the durability step — the slow Kafka
+--   round-trip) is offloaded to that committer coroutine, so the resolver's
+--   dispatcher thread is not held during it. The committer does ONLY commit() on the
+--   already-appended transaction; it does not append and touches neither staging nor
+--   the durable index. When the committer signals that a batch is durable, the
+--   RESOLVER PROMOTES the `committing` batch into the durable live tables — ONE TX AT
+--   A TIME, in send order — advancing the DURABLE basis (LiveIndex.latest_completed_tx),
+--   refreshing the shared external snapshot, and notifying watchers. Everything but
+--   the commit itself — apply, append-at-seal, import, advance the durable head +
+--   apply cursor, refresh, notify, finish blocks — stays on the resolver. Followers
+--   and the transition processor have no staging index: the messages they import are
 --   already durable, so they advance LiveIndex.latest_completed_tx directly.
 --
 --   Two heads, two homes — callers choose: the durable basis is
 --   LiveIndex.latest_completed_tx (query basis); the applied/resolution head is
 --   StagingIndex.latest_completed_tx (next tx_id, smoothing).
 --
+--   The staging index is NOT a field on LiveIndex. It is standing state the leader
+--   (LeaderLogProcessor) owns from construction and frees in its two-phase close
+--   (see CloseStagingIndex); LiveIndex stays the durable layer and stays
+--   staging-agnostic. Promotion appends into the durable LiveIndex under its
+--   existing write lock.
+--
 -- Critical invariant: External queries see only durably-replicated transactions
 --   (LiveIndex.latest_completed_tx). A query returned to a user must never
 --   include a tx that could vanish if the leader crashed before its replica-log
---   write landed. Resolution sees durable ⊕ staging.
+--   write landed. Resolution sees durable ⊕ committing ⊕ accumulating ⊕ the tx's
+--   own writes.
 
 ------------------------------------------------------------
 -- External Entities
@@ -104,6 +140,14 @@ value Put {
 value Delete { }   -- null marker in the "delete" leg
 value Erase { }    -- null marker in the "erase" leg
 
+value ResolvedTx {
+    -- A resolved tx's PENDING REPLICA MESSAGE: the message the resolver will append
+    -- onto the open producer transaction at SEAL time (not at resolve time). Held in
+    -- the accumulating slot in send order (StagingSlot.pending_messages) alongside the
+    -- StagedTx that carries the tx's row slices. See db.allium ResolvedTxMessage.
+    tx_key: TransactionKey
+}
+
 ------------------------------------------------------------
 -- Entities
 ------------------------------------------------------------
@@ -117,8 +161,9 @@ entity LiveIndex {
     --
     -- The APPLIED head (the resolution head — next external-source tx_id is
     -- head.tx_id + 1, and system-time smoothing reads it) is NOT here: on a
-    -- leader the staging area maintains its own latest_completed_tx (see
-    -- StagingIndex). Callers choose which to read — resolution reads the staging
+    -- leader the resolver-owned staging index maintains its own latest_completed_tx
+    -- (see StagingIndex). LiveIndex is staging-agnostic — it knows only the durable
+    -- layer. Callers choose which head to read — resolution reads the staging
     -- head, external queries read this durable one.
     latest_completed_tx: TransactionKey?
 
@@ -126,12 +171,6 @@ entity LiveIndex {
 
     -- Durable live tables: hold only promoted (durably-replicated) rows.
     tables: LiveTable with index = this
-
-    -- Staging index: committed-but-not-yet-durable txs. Leader-owned and
-    -- leader-term-scoped (dropped wholesale on demotion; see DropStaging).
-    -- Absent on followers and the transition processor, which only import
-    -- already-durable messages. See StagingIndex.
-    staging: StagingIndex?
 
     -- Current shared external snapshot. Refreshed on each durable confirmation
     -- (promotion) and on NextBlock (see RefreshSharedSnapshot). External readers
@@ -144,45 +183,127 @@ entity LiveIndex {
 }
 
 entity StagingIndex {
-    -- Holds committed-but-not-yet-durable transactions, double-buffered into
-    -- exactly two slots. At most one batch is ever in flight to the replica log
-    -- (the producer is single / not concurrent-safe), so two slots is optimal:
-    --   - accumulating: open, taking newly-resolved committed txs
-    --   - committing:   sealed, its batch currently being written to the
-    --                   replica log; promoted on durable confirmation
-    -- Each slot mirrors the live tables (per-table relation + trie) so it
-    -- composes with the snapshot/segment layering as an extra segment layer.
+    -- Committed-but-not-yet-durable transactions. NOT a field on LiveIndex: this
+    -- is standing state the leader (LeaderLogProcessor) owns from construction and
+    -- the RESOLVER is the sole accessor of (single-threaded by construction, so it
+    -- needs no lock). Created once per leader term and freed by the leader's
+    -- two-phase close (see CloseStagingIndex); absent on followers and the
+    -- transition processor, which only import already-durable messages.
+    --
+    -- Double-buffered: an open accumulating slot, plus a sealed committing batch.
+    -- At most one batch is ever in flight (a Kafka transactional producer allows
+    -- only one open producer transaction at a time) — the resolver enforces this via
+    -- in_flight — so this is optimal:
+    --   - accumulating: open, taking newly-resolved committed txs. Each accumulated
+    --                   tx also HOLDS its pending replica message (the ResolvedTx to
+    --                   append), in send order; nothing is appended to a producer
+    --                   transaction yet — the appends happen at seal time.
+    --   - committing:   the sealed batch whose producer transaction — opened fresh and
+    --                   appended-to at seal time — is currently being COMMITTED by the
+    --                   secondary committer coroutine, held as an ORDERED SEQUENCE of
+    --                   staged txs (oldest→newest, i.e. send order) so the resolver can
+    --                   promote it ONE TX AT A TIME once the commit lands (see
+    --                   PromoteNext); empty when no batch is in flight.
+    -- SENDS are serial but ACCUMULATION continues during a send: while the committer
+    -- commits the sealed batch's producer transaction, the resolver keeps resolving and
+    -- accumulating the NEXT slot. It cannot SEAL (and so cannot send) the next batch
+    -- until the current commit completes and the batch promotes — in_flight gates this,
+    -- matching the single open producer transaction. Run-ahead is in the accumulating
+    -- slot, not in a second producer transaction.
+    -- The accumulating slot mirrors the live tables (per-table relation + trie) so it
+    -- composes with the snapshot/segment layering as an extra segment layer; it also
+    -- records its txs' send order plus each tx's pending replica message (accumulated_txs)
+    -- so a seal appends them in order and produces the ordered committing batch.
+    --
+    -- The durable LiveIndex this staging index pipelines into. The link is one-way:
+    -- the staging index references the index, but the index does not reference the
+    -- staging index (it stays staging-agnostic).
     index: LiveIndex
 
     -- APPLIED head: the highest tx resolved and applied to staging. Drives
     -- RESOLUTION — next external-source tx_id is latest_completed_tx.tx_id + 1,
     -- and system-time smoothing reads it. Seeded from index.latest_completed_tx
-    -- (the durable head) when the staging area is created, then advanced by
+    -- (the durable head) when the staging index is created, then advanced by
     -- CommitTransaction / AbortTransaction. Always >= index.latest_completed_tx.
     latest_completed_tx: TransactionKey?
 
     accumulating: StagingSlot
-    committing: StagingSlot?   -- absent when no batch is in flight
+
+    -- The sealed batch whose producer transaction is being committed: an ordered
+    -- sequence of staged txs, oldest→newest (send order). Empty when no batch is in
+    -- flight. Promoted one tx at a time from the front (see PromoteNext).
+    committing: List<StagedTx>
+
+    -- in_flight is true exactly while a batch's producer transaction is open and
+    -- committing (between SealStagingBatch, which opens+appends+hands off, and the last
+    -- PromoteNext). The resolver checks it to enforce at-most-one-batch in flight —
+    -- matching the single open producer transaction a Kafka transactional producer
+    -- permits. Accumulation of the next slot continues while in_flight is true; only
+    -- sealing (the next send) is gated.
+    in_flight: committing.count > 0
 
     -- Derived: staging is drained when nothing is accumulated and nothing is
     -- in flight. FinishBlock requires this so a durable block never contains
     -- non-durable rows.
-    is_drained: accumulating.is_empty and committing = null
+    is_drained: accumulating.is_empty and committing.count = 0
 }
 
 entity StagingSlot {
-    -- One double-buffer slot. Mirrors the live tables structurally.
+    -- The open accumulating slot. Mirrors the live tables structurally (per-table
+    -- relation + trie, for the read-your-writes segment layering) and additionally
+    -- records the send order of the txs applied to it, plus each tx's PENDING REPLICA
+    -- MESSAGE, so a seal appends the messages in order and produces the ordered
+    -- committing batch.
     staging: StagingIndex
     tables: StagingTable with slot = this
 
+    -- The txs applied to this slot, in send order (oldest→newest). SealStagingBatch
+    -- moves these into the committing sequence.
+    accumulated_txs: List<StagedTx>
+
+    -- Each accumulated tx's pending replica message, in the SAME send order as
+    -- accumulated_txs (i-th ↔ i-th). Nothing is appended to a producer transaction at
+    -- resolve time; SealStagingBatch opens a fresh producer transaction and appends
+    -- these in order, then discards them. Held here (a parallel ordered list), not on
+    -- StagedTx, which stays durability-handle-free.
+    pending_messages: List<ResolvedTx>
+
     row_count: tables.sum(t => t.row_count)
-    is_empty: row_count = 0
+    is_empty: accumulated_txs.count = 0
 }
 
 entity StagingTable {
-    -- Per-table relation + trie within a staging slot. The staged counterpart
+    -- Per-table relation + trie within the accumulating slot. The staged counterpart
     -- of LiveTable; promoted into the matching LiveTable on durable confirmation.
     slot: StagingSlot
+    table_ref: TableRef
+    rows: Set<Row>
+
+    row_count: rows.count
+}
+
+entity StagedTx {
+    -- One resolved, committed tx held in the staging area, retaining its per-table
+    -- rows so PromoteNext can import it into the durable live tables on its own. Once
+    -- sealed into the committing sequence it is promoted (and dropped) one at a time,
+    -- in send order.
+    --
+    -- StagedTx stays DURABILITY-HANDLE-FREE: it holds only the row slices (for
+    -- read-your-writes + promote). The tx's pending replica message (the ResolvedTx to
+    -- append at seal) and — in the implementation — the append handle returned by
+    -- appendMessage (which completes at commit with the tx's replica-log position) are
+    -- held ALONGSIDE it by the resolver: the pending message in the accumulating slot's
+    -- pending_messages, the handle in the sealed batch the resolver hands the committer
+    -- (see db.allium). They are not fields on StagedTx.
+    staging: StagingIndex
+    tx_key: TransactionKey
+    tables: StagedTxTable with staged_tx = this
+}
+
+entity StagedTxTable {
+    -- One tx's rows for one table, imported into the matching durable LiveTable
+    -- when the tx is promoted (see PromoteNext).
+    staged_tx: StagedTx
     table_ref: TableRef
     rows: Set<Row>
 
@@ -200,6 +321,13 @@ entity LiveTable {
 
 entity OpenTx {
     index: LiveIndex
+
+    -- The resolver-owned staging index this tx resolves against. A resolving tx
+    -- reads durable ⊕ committing ⊕ accumulating ⊕ its own writes, so it carries
+    -- the staging index (which the resolver, its sole accessor, hands it). Always
+    -- present: open transactions exist only on a leader, where staging exists.
+    staging: StagingIndex
+
     tx_key: TransactionKey
     status: active | committed | aborted
 
@@ -272,11 +400,14 @@ entity TableSnapshot {
     -- time. This is the only layer on external snapshots.
     live_segment: MemorySegment?
 
-    -- Staging segments: slices of this table's StagingTable relations from each
-    -- occupied staging slot (committing below accumulating), layered on top of
-    -- live_segment. Empty on external snapshots (which see durable data only);
-    -- populated only on transaction snapshots so a resolving tx reads staged
-    -- prior txs. See StagingSegments.for.
+    -- Staging segments: slices of this table's staged rows, layered on top of
+    -- live_segment (committing below accumulating). Two sources, oldest→newest:
+    -- first, from the committing batch, each StagedTx's matching StagedTxTable in
+    -- send order (a just-sealed batch's rows live ONLY here until promoted);
+    -- then, on top, the accumulating slot's StagingTable for this table. Empty on
+    -- external snapshots (which see durable data only); populated only on
+    -- transaction snapshots so a resolving tx reads staged prior txs. See
+    -- StagingSegments.for.
     staging_segments: Set<MemorySegment>
 
     -- Tx segment: slice of the enclosing OpenTx.Table's txRelation paired with
@@ -297,10 +428,15 @@ default ValidTimeRange erase_valid_time = { from: MIN_TIMESTAMP, to: MAX_TIMESTA
 ------------------------------------------------------------
 
 rule StartTransaction {
-    when: StartTransaction(index, tx_key)
+    -- Started by the resolver, which supplies its staging index so the tx can
+    -- resolve against durable ⊕ staging (read-your-writes).
+    when: StartTransaction(index, staging, tx_key)
+
+    requires: staging.index = index
 
     ensures: OpenTx.created(
         index: index,
+        staging: staging,
         tx_key: tx_key,
         status: active
     )
@@ -376,27 +512,33 @@ rule LogErase {
 ------------------------------------------------------------
 
 rule CommitTransaction {
-    -- A committed tx is imported into the STAGING accumulating slot and advances
-    -- the staging area's APPLIED head (StagingIndex.latest_completed_tx). It does
-    -- NOT advance the DURABLE basis (LiveIndex.latest_completed_tx) and does NOT
-    -- refresh the external shared snapshot — those happen only on durable
-    -- confirmation (see PromoteStaging). Later txs in the same stream resolve
-    -- against staging (read-your-writes), but external queries cannot yet see it.
+    -- The resolver imports a committed tx into the STAGING accumulating slot and
+    -- advances the staging index's APPLIED head (StagingIndex.latest_completed_tx).
+    -- It does NOT append to any producer transaction here: it HOLDS the tx's pending
+    -- replica message in the accumulating slot (pending_messages, in send order); the
+    -- append happens later, at seal time (see SealStagingBatch). The applied-but-not-
+    -- appended tx is held out of the durable index here in staging.
+    -- It does NOT advance the DURABLE basis (LiveIndex.latest_completed_tx) and
+    -- does NOT refresh the external shared snapshot — those happen only when the
+    -- resolver promotes after the committer confirms the batch durable (see
+    -- PromoteNext).
+    -- Later txs in the same stream resolve against staging (read-your-writes),
+    -- but external queries cannot yet see it.
     when: CommitTransaction(tx)
 
     requires: tx.status = active
-    -- Staging only exists on a leader; resolution runs there.
-    requires: tx.index.staging != null
+
+    let staging = tx.staging
 
     ensures: tx.status = committed
-    ensures: tx.index.staging.latest_completed_tx = tx.tx_key
+    ensures: staging.latest_completed_tx = tx.tx_key
 
     -- For each touched table with tx data: import the tx rows into the
     -- (possibly new) staging table in the accumulating slot. Single path:
     -- the staging slot creates a StagingTable on demand, and tables with no tx
     -- rows are skipped entirely.
     ensures: for table_tx in tx.table_txs where table_tx.rows.count > 0:
-        let slot = tx.index.staging.accumulating
+        let slot = staging.accumulating
         let staging_table =
             let existing = slot.tables.find(st => st.table_ref = table_tx.table_ref)
             if existing != null:
@@ -408,79 +550,130 @@ rule CommitTransaction {
                     rows: {}
                 )
         staging_table.rows.addAll(table_tx.rows)
+
+    -- Record the tx in send order, retaining its per-table rows, so SealStagingBatch
+    -- can produce an ordered committing batch that PromoteNext walks one tx at a time.
+    -- Also HOLD the tx's pending replica message in the slot (same send order), to be
+    -- appended when the batch is sealed — nothing is appended to a producer
+    -- transaction yet.
+    ensures:
+        let staged_tx = StagedTx.created(
+            staging: staging,
+            tx_key: tx.tx_key
+        )
+        for table_tx in tx.table_txs where table_tx.rows.count > 0:
+            StagedTxTable.created(
+                staged_tx: staged_tx,
+                table_ref: table_tx.table_ref,
+                rows: table_tx.rows
+            )
+        staging.accumulating.accumulated_txs.add(staged_tx)
+        staging.accumulating.pending_messages.add(ResolvedTx{ tx_key: tx.tx_key })
 }
 
 rule SealStagingBatch {
-    -- The replica-writer takes the current batch in flight: the accumulating
-    -- slot is sealed and becomes the committing slot, and a fresh empty slot
-    -- takes over accumulation. Double-buffering means there are only ever two
-    -- slots; this is invoked only when no batch is already in flight (the
-    -- replica-log producer is single, so at most one batch at a time).
-    when: SealStagingBatch(index)
+    -- At a tx boundary the RESOLVER decides to close the batch. This is where the
+    -- APPENDS happen (not at resolve time): the resolver opens a FRESH producer
+    -- transaction, appends the whole accumulating slot's held pending messages in send
+    -- order (the cheap, nigh-on-free step that fixes the txs' order on the replica log
+    -- and yields the per-tx append handles used later for the follower resume cursor),
+    -- seals the slot's txs into the committing sequence (same send order), swaps in a
+    -- fresh empty slot to take over accumulation, and hands the OPEN-BUT-UNCOMMITTED
+    -- producer transaction to the secondary committer coroutine to COMMIT (the
+    -- durability step). Double-buffering means there is only ever the open slot plus
+    -- the one committing batch; the resolver only seals when no batch is already in
+    -- flight (committing empty) and work has accumulated, so at most one batch is in
+    -- flight at a time — matching the single open producer transaction a Kafka
+    -- transactional producer permits. Accumulation of the next slot continues while
+    -- that batch commits; only the next SEAL is gated (on committing being empty
+    -- again).
+    when: SealStagingBatch(staging)
 
-    requires: index.staging != null
-    requires: index.staging.committing = null
-    requires: not index.staging.accumulating.is_empty
+    requires: staging.committing.count = 0
+    requires: not staging.accumulating.is_empty
 
     ensures:
-        index.staging.committing = index.staging.accumulating
-        index.staging.accumulating = StagingSlot.created(
-            staging: index.staging,
-            tables: {}
+        -- Open a fresh producer transaction and append the slot's pending messages in
+        -- send order. appendMessage returns, per tx, a handle that completes at commit
+        -- with that tx's replica-log position (the follower resume cursor); the
+        -- resolver holds those handles on the sealed batch it hands the committer.
+        let producer_tx = OpenProducerTransaction(staging)
+        for pending in staging.accumulating.pending_messages:
+            AppendMessage(producer_tx, pending)
+
+        -- Seal the accumulated txs into the committing sequence, preserving send
+        -- order so PromoteNext walks them oldest→newest.
+        staging.committing = staging.accumulating.accumulated_txs
+        staging.accumulating = StagingSlot.created(
+            staging: staging,
+            tables: {},
+            accumulated_txs: [],
+            pending_messages: []
         )
 }
 
-rule PromoteStaging {
-    -- Durable confirmation: the committing slot's batch has been confirmed
-    -- durably written to the replica log. Promote its rows into the durable
-    -- live tables, advance the DURABLE basis, refresh the external shared
-    -- snapshot (now reflecting the newly-durable txs), and notify watchers.
-    -- This is the point at which committed txs become queryable.
-    -- durable_tx is the highest tx key in the promoted batch.
-    when: PromoteStaging(index, durable_tx)
+rule PromoteNext {
+    -- The RESOLVER promotes once the committer confirms the batch durable, ONE TX AT A
+    -- TIME in send order. It peeks the oldest staged tx in the committing sequence,
+    -- imports its rows into the durable live tables (advancing the durable basis to
+    -- that tx), THEN drops it from committing and closes its OpenTx — import-before-drop
+    -- is what makes a partial failure safe (see below). Refreshing the external shared
+    -- snapshot and notifying watchers happen per promoted tx, driven by the resolver in
+    -- db.allium. This is the point at which a committed tx becomes queryable.
+    --
+    -- Partial-failure safety — the WHY for per-tx: if importing a tx faults partway
+    -- through the batch (e.g. OOM), the txs already promoted are durable in the live
+    -- tables and the durable basis sits at the last tx that ACTUALLY imported; the
+    -- un-imported tail stays parked in committing (freed by CloseStagingIndex, never
+    -- double-closed). A follower resuming from the apply cursor — which db.allium
+    -- advances per promoted tx to that tx's replica-log position — re-applies only the
+    -- un-imported tail and never double-imports the durable prefix. Promoting the whole
+    -- batch atomically would leave the cursor un-advanced after a mid-batch fault, so a
+    -- follower would re-import the durable prefix → duplicate rows / corrupt block.
+    when: PromoteNext(staging)
 
-    requires: index.staging != null
-    requires: index.staging.committing != null
+    requires: staging.committing.count > 0
+
+    let index = staging.index
+    let staged_tx = staging.committing.first
 
     ensures:
-        -- Move each staged table's rows into the (possibly new) durable live table.
-        for staging_table in index.staging.committing.tables where staging_table.rows.count > 0:
+        -- Import this tx's rows into the (possibly new) durable live tables.
+        for staged_table in staged_tx.tables:
             let live_table =
-                let existing = index.tables.find(t => t.table_ref = staging_table.table_ref)
+                let existing = index.tables.find(t => t.table_ref = staged_table.table_ref)
                 if existing != null:
                     existing
                 else:
                     LiveTable.created(
                         index: index,
-                        table_ref: staging_table.table_ref,
+                        table_ref: staged_table.table_ref,
                         rows: {}
                     )
-            live_table.rows.addAll(staging_table.rows)
+            live_table.rows.addAll(staged_table.rows)
 
-        -- The committing slot is now empty; drop it (no batch in flight).
-        index.staging.committing = null
-
-        -- Advance the durable basis (the durable live index's own
-        -- latest_completed_tx) and refresh the external snapshot to reflect the
-        -- newly-durable txs.
-        index.latest_completed_tx = durable_tx
+        -- Advance the durable basis to this tx (the durable live index's own
+        -- latest_completed_tx) and refresh the external snapshot to reflect it.
+        index.latest_completed_tx = staged_tx.tx_key
         RefreshSharedSnapshot(index)
-        -- Watcher notification (post-durable, not at resolution time) is driven
-        -- by the replica-writer in db.allium, which orchestrates promotion.
+
+        -- Drop this tx from the committing sequence — AFTER importing it — and
+        -- discard the staged record. When the sequence empties the derived in_flight
+        -- becomes false and the resolver may seal the next batch.
+        staging.committing = staging.committing.drop(1)
+        not exists staged_tx
 }
 
 rule AbortTransaction {
     when: AbortTransaction(tx)
 
     requires: tx.status = active
-    -- Staging only exists on a leader; resolution runs there.
-    requires: tx.index.staging != null
 
     ensures: tx.status = aborted
     -- The applied head tracks "resolved up to", not "successfully committed up
     -- to" — even aborted transactions consume a tx_id and advance the staging
     -- area's marker, so the next tx_id is correct.
-    ensures: tx.index.staging.latest_completed_tx = tx.tx_key
+    ensures: tx.staging.latest_completed_tx = tx.tx_key
     -- tx rows are discarded (not staged); new tables are not created
 }
 
@@ -499,7 +692,7 @@ rule OpenExternalSnapshot {
     -- The index publishes a single shared Snapshot whose basis is
     -- latest_completed_tx (durable) and whose layers are the DURABLE live segments only
     -- — no staging. It is refreshed on each durable confirmation (see
-    -- PromoteStaging / RefreshSharedSnapshot). Each external opener retains
+    -- PromoteNext / RefreshSharedSnapshot). Each external opener retains
     -- the current shared snapshot rather than building a fresh one, and
     -- releases it on close. The underlying segments are freed when the last
     -- holder releases.
@@ -519,21 +712,21 @@ rule OpenTransactionSnapshot {
     --
     -- A resolving tx must read all prior txs whether DURABLE or merely STAGED,
     -- plus its own uncommitted writes. So each TableSnapshot layers, bottom to
-    -- top: the durable live segment ⊕ the staging segments (accumulating, and
-    -- the committing slot if a batch is in flight) ⊕ the tx's own segment.
+    -- top: the durable live segment ⊕ the staging segments (the committing
+    -- batch's StagedTxTables, oldest→newest, if a batch is in flight, then the
+    -- accumulating slot's StagingTable) ⊕ the tx's own segment.
     when: OpenSnapshot(tx)
 
     requires: tx.status = active
-    -- Resolution only runs on a leader, where staging exists.
-    requires: tx.index.staging != null
 
     ensures:
         let snap = Snapshot.created(basis_tx: tx.tx_key, ref_count: 1)
-        let staging = tx.index.staging
+        let staging = tx.staging
 
         -- One TableSnapshot per table touched by the tx: durable live segment
         -- from the existing LiveTable (if any), the staging segments for the
-        -- table from each occupied slot, and the tx segment from this OpenTx.
+        -- table (committing StagedTxTables oldest→newest, below the accumulating
+        -- slot's StagingTable), and the tx segment from this OpenTx.
         for table_tx in tx.table_txs:
             let live_seg = if table_tx.live_table != null: MemorySegment.for(table_tx.live_table) else: null
             let tx_seg = if table_tx.rows.count > 0: MemorySegment.for(table_tx) else: null
@@ -596,32 +789,37 @@ rule RefreshSharedSnapshot {
 ------------------------------------------------------------
 
 rule FinishBlock {
-    when: FinishBlock(index, block_idx)
+    -- staging is the resolver's staging index on a leader, or null on a
+    -- follower/transition (which have no staging — they import already-durable
+    -- messages).
+    when: FinishBlock(index, staging, block_idx)
 
     -- Staging MUST be drained before the block is written: all in-flight
     -- commits promoted, nothing accumulated or committing. Otherwise a durable
-    -- L0 block could contain non-durable rows. ("BlockBoundary closes the
-    -- batch": the replica-writer flushes and promotes the pending batch before
-    -- the boundary, leaving staging drained.) On followers/transition there is
-    -- no staging, so this is trivially satisfied.
-    requires: index.staging = null or index.staging.is_drained
+    -- L0 block could contain non-durable rows. On a leader, the resolver cuts a
+    -- block at a tx boundary by first draining (awaiting the in-flight persist
+    -- and promoting), then sending a boundary-batch, so staging is drained by the
+    -- time the block is written. On followers/transition staging is null, so this
+    -- is trivially satisfied.
+    requires: staging = null or staging.is_drained
 
     -- Writes current (durable) live table contents to block storage.
     -- Rows remain in memory until NextBlock.
     ensures: BlockWritten(index, block_idx)
 }
 
-rule DropStaging {
-    -- Leader → follower demotion: the staging index is discarded wholesale.
-    -- The uncommitted txs it held will be re-read from the source log and
-    -- re-resolved by the next leader. The DURABLE live index is untouched —
-    -- only staged, not-yet-durable rows are lost, and those were never visible
-    -- to external queries.
-    when: DropStaging(index)
+rule CloseStagingIndex {
+    -- Leader → follower demotion is exactly the leader's two-phase close — there
+    -- is NO separate runtime drop. Phase 1 (cancelAndJoin the resolver + committer
+    -- job tree) ensures nothing live still touches staging; phase 2 (this) frees
+    -- the staging index synchronously, closing any un-promoted slot buffers, before
+    -- the allocator is closed. Any staged-but-not-yet-durable txs are discarded
+    -- (they were never visible to external queries) and will be re-read from the
+    -- source log and re-resolved by the next leader. The durable LiveIndex is
+    -- untouched. See db.allium TransitionToFollower; commit ec0f3947e.
+    when: CloseStagingIndex(staging)
 
-    requires: index.staging != null
-
-    ensures: index.staging = null
+    ensures: not exists staging
 }
 
 rule NextBlock {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -8,6 +8,7 @@ import org.apache.arrow.memory.BufferAllocator
 import xtdb.Metrics.withSpan
 import xtdb.NodeBase
 import xtdb.api.TransactionKey
+import xtdb.api.TransactionResult
 import xtdb.api.TransactionResult.Aborted
 import xtdb.api.TransactionResult.Committed
 import xtdb.api.log.*
@@ -90,6 +91,11 @@ class LeaderLogProcessor(
 
     private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
 
+    // Resolver-owned staging area: resolved-but-not-yet-durable txs, seeded at the durable head. The
+    // resolver is its sole accessor (no lock). Freed in close() (phase 2), once the resolver job is
+    // joined so nothing live still touches it; see StagingIndex.
+    private val stagingIndex = StagingIndex(allocator, liveIndex.latestCompletedTx)
+
     private sealed interface PersisterTask {
         val onComplete: CompletableDeferred<Unit>
     }
@@ -143,8 +149,15 @@ class LeaderLogProcessor(
         val msgId = record.msgId
 
         when (val msg = record.message) {
-            is SourceMessage.Tx, is SourceMessage.LegacyTx ->
-                handleResolvedTx(resolveTx(msgId, record, msg), msgId)
+            is SourceMessage.Tx, is SourceMessage.LegacyTx -> {
+                val (resolvedTx, openTx) = resolveTx(msgId, record, msg)
+                openTx.use {
+                    stagingIndex.stage(
+                        it, resolvedTx.copy(srcMsgId = msgId), msgId, resolvedTx.txResult(it.txKey), null
+                    )
+                }
+                drainStaging()
+            }
 
             is SourceMessage.FlushBlock -> {
                 val expectedBlockIdx = msg.expectedBlockIdx
@@ -169,14 +182,12 @@ class LeaderLogProcessor(
                     }
                 } else null
 
-                val resolvedTx = openTx(txKey, null).use { it.commitTx(error).copy(srcMsgId = msgId) }
-                    .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
-
-                appendToReplica(resolvedTx)
-                liveIndex.importTx(resolvedTx)
-
-                val result = if (error == null) Committed(txKey) else Aborted(txKey, error)
-                watchers.notifyTx(result, msgId, null)
+                openTx(txKey, null).use { openTx ->
+                    val resolvedTx = openTx.commitTx(error).copy(srcMsgId = msgId)
+                        .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
+                    stagingIndex.stage(openTx, resolvedTx, msgId, resolvedTx.txResult(txKey), null)
+                }
+                drainStaging()
             }
 
             is SourceMessage.DetachDatabase -> {
@@ -191,14 +202,12 @@ class LeaderLogProcessor(
                     }
                 } else null
 
-                val resolvedTx = openTx(txKey, null).use { it.commitTx(error).copy(srcMsgId = msgId) }
-                    .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
-
-                appendToReplica(resolvedTx)
-                liveIndex.importTx(resolvedTx)
-
-                val result = if (error == null) Committed(txKey) else Aborted(txKey, error)
-                watchers.notifyTx(result, msgId, null)
+                openTx(txKey, null).use { openTx ->
+                    val resolvedTx = openTx.commitTx(error).copy(srcMsgId = msgId)
+                        .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
+                    stagingIndex.stage(openTx, resolvedTx, msgId, resolvedTx.txResult(txKey), null)
+                }
+                drainStaging()
             }
 
             is SourceMessage.TriesAdded -> {
@@ -220,30 +229,41 @@ class LeaderLogProcessor(
         }
     }
 
-    private suspend fun handleResolvedTx(resolvedTx: ReplicaMessage.ResolvedTx, srcMsgId: MessageId?) {
-        val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
-        val txResult = if (resolvedTx.committed) Committed(txKey) else Aborted(txKey, resolvedTx.error)
+    private fun ReplicaMessage.ResolvedTx.txResult(txKey: TransactionKey): TransactionResult =
+        if (committed) Committed(txKey) else Aborted(txKey, error)
 
-        // Ext-source txs carry no source-log position of their own (`srcMsgId == null` on the way in)
-        // and track progress via `externalSourceToken`, so they don't advance the leader's
-        // `latestSourceMsgId` (which is driven by the source log). We do stamp the current source-log
-        // watermark onto the replicated record, though: without it a follower's `latestSourceMsgId`
-        // lags between block boundaries, and on promotion it resumes the source log from a stale point
-        // and replays an already-covered block boundary.
-        val effectiveSrcMsgId = srcMsgId ?: watchers.latestSourceMsgId
+    // Seal the accumulated batch, make it durable, and promote it into the durable live index.
+    //
+    // Seal + commit is synchronous for now (one producer transaction per batch, committed here on the
+    // resolver); the committer-coroutine offload + cross-batch accumulation come with the pipeline step.
+    // Promotion is per-tx in send order, post-durable: a mid-batch import fault leaves the cursor at the
+    // last tx that actually imported (partial-failure safety), with the un-imported tail freed below.
+    private suspend fun drainStaging() {
+        if (stagingIndex.isEmpty) return
 
-        appendToReplica(resolvedTx.copy(srcMsgId = effectiveSrcMsgId))
-        liveIndex.importTx(resolvedTx)
+        val batch = stagingIndex.drainAccumulated()
+        try {
+            val handles = replicaProducer.withTx { tx -> batch.map { tx.appendMessage(it.message) } }
 
-        watchers.notifyTx(txResult, effectiveSrcMsgId, resolvedTx.externalSourceToken)
+            for ((pending, handle) in batch.zip(handles)) {
+                val stagedTx = pending.stagedTx
+                liveIndex.importStagedTx(stagedTx)
+                latestReplicaMsgId = handle.await().msgId
+                watchers.notifyTx(stagedTx.txResult, stagedTx.notifyMsgId, stagedTx.externalSourceToken)
+            }
 
-        if (liveIndex.isFull())
-            finishBlock(effectiveSrcMsgId, resolvedTx.externalSourceToken)
+            if (liveIndex.isFull()) {
+                val last = batch.last().stagedTx
+                finishBlock(last.notifyMsgId, last.externalSourceToken)
+            }
+        } finally {
+            batch.closeAll()
+        }
     }
 
     private suspend fun handleIndexTx(task: ExtSourceTask.IndexTx) {
         val txKey = TransactionKey(
-            (liveIndex.latestCompletedTx?.txId ?: -1) + 1,
+            (stagingIndex.latestCompletedTx?.txId ?: -1) + 1,
             smoothSystemTime(task.systemTime ?: instantSource.instant())
         )
 
@@ -265,7 +285,17 @@ class LeaderLogProcessor(
                 }
             }
 
-            handleResolvedTx(resolvedTx, srcMsgId = null)
+            // Ext-source txs carry no source-log position of their own and track progress via
+            // `externalSourceToken`, so they don't advance `latestSourceMsgId` (driven by the source log).
+            // We do stamp the current source-log watermark onto the replicated record: without it a
+            // follower's `latestSourceMsgId` lags between block boundaries, and on promotion it resumes
+            // the source log from a stale point and replays an already-covered block boundary.
+            val effectiveSrcMsgId = watchers.latestSourceMsgId
+            stagingIndex.stage(
+                openTx, resolvedTx.copy(srcMsgId = effectiveSrcMsgId), effectiveSrcMsgId,
+                resolvedTx.txResult(txKey), resolvedTx.externalSourceToken
+            )
+            drainStaging()
             task.result.complete(writerResult)
         } finally {
             openTx.close()
@@ -411,13 +441,13 @@ class LeaderLogProcessor(
     }
 
     private fun smoothSystemTime(systemTime: Instant): Instant {
-        val lct = liveIndex.latestCompletedTx?.systemTime ?: return systemTime
+        val lct = stagingIndex.latestCompletedTx?.systemTime ?: return systemTime
         val floor = fromMicros(lct.asMicros + 1)
         return if (systemTime.isBefore(floor)) floor else systemTime
     }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
-        OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer)
+        OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer, stagingIndex.stagedTxs)
 
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
@@ -467,6 +497,25 @@ class LeaderLogProcessor(
         trieGc.signal()
     }
 
+    // A fresh tx committing a single skip / abort / invalid-system-time row, returned LIVE — the caller
+    // stages it (which slices its writes) then closes it. On any failure the tx is closed here so nothing
+    // leaks. `countError` mirrors the pre-staging behaviour: skipped txs don't count as errors.
+    private fun commitStandaloneTx(
+        txKey: TransactionKey, error: Throwable, userMetadata: Map<*, *>?, countError: Boolean,
+    ): Pair<ReplicaMessage.ResolvedTx, OpenTx> {
+        if (countError) txErrorCounter?.increment()
+        val openTx = openTx(txKey, null)
+        return try {
+            openTx.commitTx(error, userMetadata) to openTx
+        } catch (e: Throwable) {
+            openTx.close(); throw e
+        }
+    }
+
+    // Resolves a source-log tx and returns its replica message alongside the LIVE OpenTx that produced it
+    // — the resolver stages that OpenTx (taking independent slices of its writes) and closes it afterwards.
+    // Any OpenTx not returned (an aborted tx's partial-write attempt, or one whose commit throws) is closed
+    // here.
     private fun indexSourceLogTx(
         msgId: MessageId,
         msgTimestamp: Instant,
@@ -475,12 +524,14 @@ class LeaderLogProcessor(
         defaultTz: ZoneId?,
         user: String?,
         userMetadata: Any?,
-    ): ReplicaMessage.ResolvedTx = tracer.withSpan(
+    ): Pair<ReplicaMessage.ResolvedTx, OpenTx> = tracer.withSpan(
         "xtdb.transaction",
         attributes = mapOf("operations.count" to (txOps?.valueCount ?: 0).toString()),
     ) {
         val userMetadataMap = userMetadata as? Map<*, *>
-        val lcTx = liveIndex.latestCompletedTx
+        // The APPLIED head (staging), not the durable head: a tx must system-time-smooth against the
+        // staged predecessors it resolves behind, which lead the durable index.
+        val lcTx = stagingIndex.latestCompletedTx
 
         // If lc-tx's systemTime >= msgTimestamp, bump past it by 1µs; otherwise use msgTimestamp.
         // (`+1000ns` is `+1µs`.)
@@ -492,7 +543,6 @@ class LeaderLogProcessor(
         // The aborted tx-key uses the *default* (smoothed) systemTime, not the rejected one,
         // so the tx-key still satisfies the monotonicity invariant.
         if (systemTime != null && lcTx != null && systemTime < lcTx.systemTime) {
-            val txKey = TransactionKey(msgId, defaultSystemTime)
             val err = Incorrect(
                 "specified system-time older than current tx",
                 "invalid-system-time",
@@ -503,20 +553,19 @@ class LeaderLogProcessor(
             )
             LOG.warn { "specified system-time '$systemTime' older than current tx '$lcTx'" }
 
-            return@withSpan openTx(txKey, null).use { openTx ->
-                txErrorCounter?.increment()
-                openTx.commitTx(err, userMetadataMap)
-            }
+            return@withSpan commitStandaloneTx(
+                TransactionKey(msgId, defaultSystemTime), err, userMetadataMap, countError = true
+            )
         }
 
         val effectiveSystemTime = systemTime ?: defaultSystemTime
         val txKey = TransactionKey(msgId, effectiveSystemTime)
 
-        openTx(txKey, null).use { openTx ->
-            if (txOps == null) {
-                return@withSpan openTx.commitTx(SKIPPED_EXN, userMetadataMap)
-            }
+        if (txOps == null)
+            return@withSpan commitStandaloneTx(txKey, SKIPPED_EXN, userMetadataMap, countError = false)
 
+        val openTx = openTx(txKey, null)
+        val result = try {
             val opts = SourceLogTxIndexer.TxOpts(
                 txKey = txKey,
                 currentTime = effectiveSystemTime,
@@ -524,25 +573,31 @@ class LeaderLogProcessor(
                 defaultTz = defaultTz,
                 user = user,
             )
+            sourceLogTxIndexer.ForTx(txOps, opts).indexTx(openTx)
+        } catch (e: Throwable) {
+            openTx.close(); throw e
+        }
 
-            when (val result = sourceLogTxIndexer.ForTx(txOps, opts).indexTx(openTx)) {
-                is TxResult.Committed -> openTx.commitTx(null, userMetadataMap)
-
-                is TxResult.Aborted -> {
-                    LOG.debug(result.error) { "aborted tx" }
-                    // Open a fresh tx for the abort row — the original openTx may have partial writes.
-                    return@withSpan openTx(txKey, null).use { abortTx ->
-                        txErrorCounter?.increment()
-                        abortTx.commitTx(result.error, userMetadataMap)
-                    }
+        when (result) {
+            is TxResult.Committed ->
+                try {
+                    openTx.commitTx(null, userMetadataMap) to openTx
+                } catch (e: Throwable) {
+                    openTx.close(); throw e
                 }
+
+            is TxResult.Aborted -> {
+                LOG.debug(result.error) { "aborted tx" }
+                // fresh tx for the abort row — the original openTx may hold partial writes
+                openTx.close()
+                commitStandaloneTx(txKey, result.error, userMetadataMap, countError = true)
             }
         }
     }
 
     private fun resolveTx(
         msgId: MessageId, record: Log.Record<SourceMessage>, msg: SourceMessage
-    ): ReplicaMessage.ResolvedTx {
+    ): Pair<ReplicaMessage.ResolvedTx, OpenTx> {
         if (skipTxs.isNotEmpty() && skipTxs.contains(msgId)) {
             LOG.warn("[$dbName] Skipping transaction id $msgId - within XTDB_SKIP_TXS")
 
@@ -622,6 +677,7 @@ class LeaderLogProcessor(
     override fun close() {
         extSource?.close()
         replicaProducer.close()
+        stagingIndex.close() // free any un-promoted staged slices before the allocator
         allocator.close() // last: Arrow won't close it while a child buffer is live
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -143,12 +143,24 @@ class LeaderLogProcessor(
             LOG.trace { "[$dbName] leader: message ${record.msgId} (${record.message::class.simpleName})" }
             handleSourceLogRecord(record)
         }
+
+        // Poll-boundary drain: flush any accumulated tail so the batch task returns with the resolver
+        // quiescent — nothing in flight when the poll loop re-enters poll() and Kafka may run a
+        // rebalance/transition under runBlocking (#5741).
+        drainStaging()
     }
 
     private suspend fun handleSourceLogRecord(record: Log.Record<SourceMessage>) {
         val msgId = record.msgId
+        val msg = record.message
 
-        when (val msg = record.message) {
+        // Data txs accumulate into the staging batch and are committed together at the next drain. Every
+        // other message is a boundary that must first drain the accumulated txs: a control message's
+        // replica-log append has to land after the appends of the txs that preceded it in source order,
+        // and a block cut needs those txs durable before the block is written.
+        if (msg !is SourceMessage.Tx && msg !is SourceMessage.LegacyTx) drainStaging()
+
+        when (msg) {
             is SourceMessage.Tx, is SourceMessage.LegacyTx -> {
                 val (resolvedTx, openTx) = resolveTx(msgId, record, msg)
                 openTx.use {
@@ -156,7 +168,6 @@ class LeaderLogProcessor(
                         it, resolvedTx.copy(srcMsgId = msgId), msgId, resolvedTx.txResult(it.txKey), null
                     )
                 }
-                drainStaging()
             }
 
             is SourceMessage.FlushBlock -> {

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -134,6 +134,28 @@ class LiveIndex private constructor(
         }
     }
 
+    // Promote a staged (now-durable) tx into the live tables from its owned relation slices — the
+    // leader's promote path. Distinct from `importTx(resolvedTx)`, which followers use to replay a
+    // serialized replica message; here the relations are already in hand, no IPC round-trip.
+    fun importStagedTx(stagedTx: StagedTx) {
+        val stamp = snapLock.writeLock()
+        try {
+            for (table in stagedTx.allTables) {
+                val liveTable =
+                    this@LiveIndex.tables.getOrPut(table.ref) {
+                        LiveTable(allocator, table.ref, blockIdx, rowCounter, liveTrieFactory)
+                    }
+                liveTable.importData(table.relation)
+            }
+
+            latestCompletedTx = stagedTx.txKey
+
+            refreshSnap0()
+        } finally {
+            snapLock.unlock(stamp)
+        }
+    }
+
     private inline fun <R> StampedLock.withReadLock(block: () -> R): R {
         val stamp = readLock()
         return try {
@@ -148,14 +170,14 @@ class LiveIndex private constructor(
             sharedSnap!!.also { it.retain() }
         }
 
-    fun openSnapshot(openTx: OpenTx): Snapshot =
+    fun openSnapshot(stagedTxs: List<StagedTx>, ownTx: OpenTx): Snapshot =
         snapLock.withReadLock {
             // Hold the snap read-lock for the whole capture: it blocks `nextBlock` (write-lock) so live
             // tables can't be cleared mid-iteration, and it brackets the trie-cat snapshot so we can't
             // end up with a stale (no-L0_N) trie-cat alongside a live-tables view that's already been
             // reset past N. `addTries` doesn't take the snap lock — it's allowed to land on either side
             // of our trie-cat capture without breaking correctness.
-            Snapshot.open(allocator, tableCatalog, trieCatalog, this, listOf(openTx))
+            Snapshot.open(allocator, tableCatalog, trieCatalog, this, stagedTxs, ownTx)
         }
 
     fun isFull() = rowCounter.blockRowCount >= rowsPerBlock

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -181,6 +181,7 @@ class OpenTx @JvmOverloads constructor(
      *
      * DML writes to forbidden schemas (`xt`, `information_schema`, `pg_catalog`) will throw.
      */
+    @JvmOverloads
     fun executeSql(sql: String, args: RelationReader? = null, opts: QueryOpts = QueryOpts(), user: String? = null) {
         val currentTime = opts.currentTime ?: txKey.systemTime
         val currentTimeMicros = currentTime.asMicros

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -52,7 +52,7 @@ private val LOG = OpenTx::class.logger
  * read-your-writes visibility into those staged writes. [TxIndexer] owns opening, committing and closing the
  * OpenTx — a writer is handed one, it never constructs its own.
  */
-class OpenTx(
+class OpenTx @JvmOverloads constructor(
     private val allocator: BufferAllocator,
     private val nodeBase: NodeBase,
     private val dbStorage: DatabaseStorage,
@@ -60,6 +60,9 @@ class OpenTx(
     val txKey: TransactionKey,
     val externalSourceToken: ExternalSourceToken?,
     private val tracer: Tracer? = null,
+    // In-flight staged predecessors this tx must read behind (read-your-writes across the batch),
+    // supplied by the resolver which owns the staging index. Empty for external / non-resolution txs.
+    private val stagedTxs: List<StagedTx> = emptyList(),
 ) : AutoCloseable {
 
     data class QueryOpts(
@@ -145,7 +148,7 @@ class OpenTx(
                 override val storage get() = dbStorage
                 override val queryState get() = dbState
                 override fun openSnapshot() =
-                    DatabaseSnapshot(listOf(liveIndex.openSnapshot(this@OpenTx)))
+                    DatabaseSnapshot(listOf(liveIndex.openSnapshot(stagedTxs, this@OpenTx)))
             }
 
             return object : IQuerySource.QueryCatalog {

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -79,11 +79,16 @@ class Snapshot(
             return tableInfo
         }
 
+        // Precedence, bottom→top (later layers win): durable live tables ⊕ in-flight staged txs
+        // (oldest→newest) ⊕ the resolving tx's own writes. External snapshots pass neither and see
+        // durable only (strict visibility); a resolving tx passes the in-flight staged txs it must read
+        // behind plus itself (read-your-writes across the batch).
         @JvmStatic
         fun open(
             al: BufferAllocator, tableCat: TableCatalog,
             trieCatalog: TrieCatalog, liveIndex: LiveIndex,
-            openTxs: List<OpenTx> = emptyList(),
+            stagedTxs: List<StagedTx> = emptyList(),
+            ownTx: OpenTx? = null,
         ): Snapshot = safelyOpening {
             val trieCatSnap = trieCatalog.snapshot()
 
@@ -99,17 +104,21 @@ class Snapshot(
                     .safeMap { TableSnapshot.open(al, it) }
             }
 
-            val openTxSnaps = openAll {
-                openTxs.flatMap { it.tables }
-                    .safeMap { TableSnapshot.openTx(al, it.value) }
+            val stagedSnaps = openAll {
+                stagedTxs.flatMap { it.allTables }
+                    .safeMap { it.openSnapshot(al) }
                     .filterNotNull()
             }
 
-            val byTable = liveIndexSnaps.plus(openTxSnaps).groupBy { it.table }
+            val ownSnaps = openAll {
+                ownTx?.tables?.safeMap { TableSnapshot.openTx(al, it.value) }?.filterNotNull() ?: emptyList()
+            }
+
+            val byTable = (liveIndexSnaps + stagedSnaps + ownSnaps).groupBy { it.table }
 
             val tableInfo = tableCat.buildTableInfo(byTable.mapValues { (_, snaps) -> snaps.mergeTypes() })
 
-            Snapshot(openTxs.lastOrNull()?.txKey ?: liveIndex.latestCompletedTx, trieCatSnap, byTable, tableInfo)
+            Snapshot(ownTx?.txKey ?: liveIndex.latestCompletedTx, trieCatSnap, byTable, tableInfo)
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -104,8 +104,10 @@ class Snapshot(
                     .safeMap { TableSnapshot.open(al, it) }
             }
 
+            val stagedTables = stagedTxs.flatMap { it.allTables }
+
             val stagedSnaps = openAll {
-                stagedTxs.flatMap { it.allTables }
+                stagedTables
                     .safeMap { it.openSnapshot(al) }
                     .filterNotNull()
             }
@@ -116,7 +118,15 @@ class Snapshot(
 
             val byTable = (liveIndexSnaps + stagedSnaps + ownSnaps).groupBy { it.table }
 
-            val tableInfo = tableCat.buildTableInfo(byTable.mapValues { (_, snaps) -> snaps.mergeTypes() })
+            // tableInfo drives base-table resolution — an unresolved table throws `Table not found`. It
+            // must carry every staged table's declared columns *including* 0-row ones (e.g. `CREATE TABLE`),
+            // which openSnapshot drops from `byTable` (empty relation), so a tx resolving behind a freshly
+            // created empty table in the same batch still sees it exists.
+            val colTypes = LinkedHashMap<TableRef, MutableMap<ColumnName, VectorType>>()
+            for ((table, snaps) in byTable) colTypes.getOrPut(table) { LinkedHashMap() }.putAll(snaps.mergeTypes())
+            for (t in stagedTables) colTypes.getOrPut(t.ref) { LinkedHashMap() }.putAll(t.columnTypes)
+
+            val tableInfo = tableCat.buildTableInfo(colTypes)
 
             Snapshot(ownTx?.txKey ?: liveIndex.latestCompletedTx, trieCatSnap, byTable, tableInfo)
         }

--- a/core/src/main/kotlin/xtdb/indexer/StagedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagedTx.kt
@@ -1,0 +1,86 @@
+package xtdb.indexer
+
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.TransactionKey
+import xtdb.api.TransactionResult
+import xtdb.api.log.MessageId
+import xtdb.arrow.Relation
+import xtdb.database.ExternalSourceToken
+import xtdb.indexer.LiveTable.Companion.logRelTypes
+import xtdb.segment.MemorySegment
+import xtdb.table.TableRef
+import xtdb.trie.MemoryHashTrie
+import xtdb.util.closeAll
+import xtdb.util.closeAllOnCatch
+import xtdb.util.safelyOpening
+
+/**
+ * A committed-but-not-yet-durable transaction, staged in memory between the resolver committing it and
+ * the replica-log producer confirming it durable. Distinct from [OpenTx] on purpose: once staged a tx
+ * is no longer *open* — it can't be written to or queried. It exists only to be (a) read by later txs
+ * resolving behind it (read-your-writes across the in-flight batch) and (b) imported into the durable
+ * live tables once its replica-log commit lands.
+ *
+ * It owns independent slices of the tx's relations, taken from the [OpenTx] at [stage] via
+ * `openDirectSlice` (which transfers the buffers into the staging allocator), and a trie sharing the
+ * tx's heap `rootNode` re-pointed at the slice. So a StagedTx outlives its OpenTx — the resolver closes
+ * the OpenTx right after staging — and its lifetime is its own (freed at [close], on promote/teardown).
+ *
+ * No durability handle: the single async replica-log commit is what confirms durability, and the per-tx
+ * replica-log positions for the apply cursor come back from that commit — not from here.
+ */
+class StagedTx private constructor(
+    val txKey: TransactionKey,
+    val notifyMsgId: MessageId,
+    val txResult: TransactionResult,
+    val externalSourceToken: ExternalSourceToken?,
+    private val tables: Map<TableRef, Table>,
+) : AutoCloseable {
+
+    /** One table's staged writes: an owned slice of the tx's relation plus its iid trie. */
+    class Table(val ref: TableRef, val relation: Relation, private val trie: MemoryHashTrie) : AutoCloseable {
+
+        /**
+         * A fresh, caller-owned [TableSnapshot] of these staged writes — re-sliced into [al] so it's
+         * freed with the enclosing [Snapshot], leaving this table's own slice intact until promote.
+         */
+        fun openSnapshot(al: BufferAllocator): TableSnapshot? {
+            if (relation.rowCount == 0) return null
+            return safelyOpening {
+                val wmRel = open { relation.openDirectSlice(al) }
+                val wmTrie = trie.withIidReader(wmRel["_iid"])
+                val seg = MemorySegment(wmTrie, wmRel)
+                TableSnapshot(ref, seg.rel.logRelTypes.orEmpty(), seg)
+            }
+        }
+
+        override fun close() = relation.close()
+    }
+
+    val allTables: Collection<Table> get() = tables.values
+
+    override fun close() = tables.values.closeAll()
+
+    companion object {
+        /**
+         * Stage a committed [openTx]: take independent slices of its non-empty table relations into
+         * [al] (the staging allocator) so they outlive the OpenTx. The caller closes the OpenTx after.
+         */
+        fun stage(
+            al: BufferAllocator, openTx: OpenTx, notifyMsgId: MessageId,
+            txResult: TransactionResult, externalSourceToken: ExternalSourceToken?,
+        ): StagedTx =
+            mutableListOf<Table>().closeAllOnCatch { staged ->
+                // Every table the tx touched, including 0-row ones: `CREATE TABLE` declares columns with no
+                // rows, and it must register in the durable index on promotion. This matches what
+                // `serializeTableData` / `importTx` carry (all `tableTxs`, 0-row included);
+                // `Table.openSnapshot` drops 0-row slices for reads, so resolution is unaffected.
+                for ((ref, tableTx) in openTx.tables) {
+                    val slice = tableTx.txRelation.openDirectSlice(al)
+                    staged.add(Table(ref, slice, tableTx.trie.withIidReader(slice["_iid"])))
+                }
+
+                StagedTx(openTx.txKey, notifyMsgId, txResult, externalSourceToken, staged.associateBy { it.ref })
+            }
+    }
+}

--- a/core/src/main/kotlin/xtdb/indexer/StagedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagedTx.kt
@@ -5,10 +5,12 @@ import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
 import xtdb.api.log.MessageId
 import xtdb.arrow.Relation
+import xtdb.arrow.VectorType
 import xtdb.database.ExternalSourceToken
 import xtdb.indexer.LiveTable.Companion.logRelTypes
 import xtdb.segment.MemorySegment
 import xtdb.table.TableRef
+import xtdb.trie.ColumnName
 import xtdb.trie.MemoryHashTrie
 import xtdb.util.closeAll
 import xtdb.util.closeAllOnCatch
@@ -54,6 +56,13 @@ class StagedTx private constructor(
             }
         }
 
+        /**
+         * The tx's declared columns for this table, present even at 0 rows (e.g. `CREATE TABLE`).
+         * Resolution needs these for table *existence*: [openSnapshot] drops the empty relation, so a
+         * freshly-created empty table can't be learned from the snapshot data alone.
+         */
+        val columnTypes: Map<ColumnName, VectorType> get() = relation.logRelTypes.orEmpty()
+
         override fun close() = relation.close()
     }
 
@@ -63,9 +72,10 @@ class StagedTx private constructor(
 
     companion object {
         /**
-         * Stage a committed [openTx]: take independent slices of its non-empty table relations into
-         * [al] (the staging allocator) so they outlive the OpenTx. The caller closes the OpenTx after.
+         * Stage a committed [openTx]: take independent slices of its table relations into [al] (the
+         * staging allocator) so they outlive the OpenTx. The caller closes the OpenTx after.
          */
+        @JvmStatic
         fun stage(
             al: BufferAllocator, openTx: OpenTx, notifyMsgId: MessageId,
             txResult: TransactionResult, externalSourceToken: ExternalSourceToken?,
@@ -73,8 +83,9 @@ class StagedTx private constructor(
             mutableListOf<Table>().closeAllOnCatch { staged ->
                 // Every table the tx touched, including 0-row ones: `CREATE TABLE` declares columns with no
                 // rows, and it must register in the durable index on promotion. This matches what
-                // `serializeTableData` / `importTx` carry (all `tableTxs`, 0-row included);
-                // `Table.openSnapshot` drops 0-row slices for reads, so resolution is unaffected.
+                // `serializeTableData` / `importTx` carry (all `tableTxs`, 0-row included). `Table.openSnapshot`
+                // drops the empty relation for row-reads, but the table's existence still reaches resolution
+                // via its `columnTypes` (see `Snapshot.open`).
                 for ((ref, tableTx) in openTx.tables) {
                     val slice = tableTx.txRelation.openDirectSlice(al)
                     staged.add(Table(ref, slice, tableTx.trie.withIidReader(slice["_iid"])))

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -1,0 +1,78 @@
+package xtdb.indexer
+
+import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.TransactionKey
+import xtdb.api.TransactionResult
+import xtdb.api.log.MessageId
+import xtdb.api.log.ReplicaMessage
+import xtdb.database.ExternalSourceToken
+import xtdb.util.closeAll
+
+/**
+ * The leader's staging area for resolved-but-not-yet-durable transactions. Standing state the
+ * [LeaderLogProcessor] owns from construction and frees in its two-phase close (after the resolver
+ * job is joined); the resolver is its sole accessor, so it needs no lock.
+ *
+ * As each tx resolves, the resolver holds its owned row slices ([StagedTx]) plus the replica
+ * [message][ReplicaMessage.ResolvedTx] to be appended at seal in the `accumulating` slot, and advances
+ * the [applied head][latestCompletedTx]. Nothing is appended to a producer transaction here — the append
+ * happens when the resolver seals the batch (a single fenced producer permits only one open transaction
+ * at a time, so appends are queued into one transaction and committed together).
+ *
+ * Two heads: this [latestCompletedTx] is the APPLIED head (drives resolution — next external-source
+ * tx-id and system-time smoothing), which leads [LiveIndex.latestCompletedTx] (the durable/query basis,
+ * advanced by promotion) by the txs staged but not yet promoted.
+ */
+class StagingIndex(
+    allocator: BufferAllocator,
+    latestCompletedTx: TransactionKey?,
+) : AutoCloseable {
+
+    private val allocator = allocator.newChildAllocator("staging-index", 0, Long.MAX_VALUE)
+
+    // Resolver-confined (its sole accessor), so a plain var — no cross-thread sharing to guard.
+    var latestCompletedTx: TransactionKey? = latestCompletedTx
+        private set
+
+    /** A resolved tx held for staging: its owned row slices plus the replica message to append at seal. */
+    class Pending(
+        val stagedTx: StagedTx,
+        val message: ReplicaMessage.ResolvedTx,
+    ) : AutoCloseable {
+        override fun close() = stagedTx.close()
+    }
+
+    private val accumulating = ArrayDeque<Pending>()
+
+    /** In-flight staged predecessors for resolution layering (read-your-writes), oldest→newest. */
+    val stagedTxs: List<StagedTx> get() = accumulating.map { it.stagedTx }
+
+    val isEmpty: Boolean get() = accumulating.isEmpty()
+
+    /**
+     * Stage a resolved [openTx] (whose replica [message] the resolver holds for seal-time append): take
+     * independent slices of its writes into the staging allocator, hold them + the message in the
+     * accumulating slot, and advance the applied head. The caller closes [openTx] afterwards.
+     */
+    fun stage(
+        openTx: OpenTx, message: ReplicaMessage.ResolvedTx,
+        notifyMsgId: MessageId, txResult: TransactionResult, externalSourceToken: ExternalSourceToken?,
+    ) {
+        // StagedTx.stage cleans up its own partial slices on throw; nothing else here can leak.
+        val stagedTx = StagedTx.stage(allocator, openTx, notifyMsgId, txResult, externalSourceToken)
+        accumulating.addLast(Pending(stagedTx, message))
+        latestCompletedTx = openTx.txKey
+    }
+
+    /** Take the accumulated slot as an ordered batch (send order) and clear the slot. */
+    fun drainAccumulated(): List<Pending> {
+        val batch = accumulating.toList()
+        accumulating.clear()
+        return batch
+    }
+
+    override fun close() {
+        accumulating.closeAll()
+        allocator.close()
+    }
+}

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -235,7 +235,7 @@ class ExternalSourceTest {
     fun `fault in the commit pipeline tips watchers into Failed`() = runTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
-            every { importTx(any()) } throws RuntimeException("commit pipeline fault")
+            every { importStagedTx(any()) } throws RuntimeException("commit pipeline fault")
         }
 
         val extSource = InMemoryExternalSource()
@@ -273,7 +273,7 @@ class ExternalSourceTest {
     fun `submit surfaces an unrecoverable failure to the caller on a later submit`() = runTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
-            every { importTx(any()) } throws RuntimeException("commit pipeline fault")
+            every { importStagedTx(any()) } throws RuntimeException("commit pipeline fault")
         }
 
         val caught = CompletableDeferred<Throwable>()

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -16,21 +16,61 @@
 -- A single LiveIndex sits outside the processor as shared state.
 -- Leader mode feeds it from source processing; follower mode feeds it from replica processing.
 --
--- Leader pipelining (see live-index.allium): on a leader, resolution runs ahead
--- of the replica-log write, modelled as two cooperating processes:
---   Resolver (proc 1)       — serialises source-log / external-source messages,
---                             resolves each, writes it to the staging accumulating
---                             slot (advancing the staging area's own
---                             latest_completed_tx, the applied head), and hands it
---                             downstream. No watcher notify here.
---   Replica-writer (proc 2) — sole owner of the replica-log producer. Seals the
---                             staged batch, writes it to the replica log; on durable
---                             confirmation, promotes staging → durable live tables,
---                             advances the durable LiveIndex.latest_completed_tx,
---                             refreshes the shared snapshot, and notifies watchers.
+-- Leader pipelining (see live-index.allium) — single-resolver model. NOTE:
+-- spec-ahead-of-code — the leader is currently a fully-synchronous single
+-- persister; the pipelined commit described here is not yet implemented.
+--
+-- On a leader, a SINGLE resolver coroutine drives the whole pipeline. Only the
+-- producer-transaction commit (the durability step) is offloaded to a secondary
+-- committer coroutine:
+--   Resolver           — OWNS the staging index outright (sole accessor, so staging
+--                        needs no lock) AND owns the replica-log producer's append
+--                        path. Serialises source-log / external-source messages,
+--                        resolves each (reading durable ⊕ its own staging for
+--                        read-your-writes), applies it to the accumulating slot
+--                        (advancing the staging index's own latest_completed_tx, the
+--                        applied head) AND holds the tx's pending replica message in
+--                        the slot in send order. It does NOT append to a producer
+--                        transaction at resolve time. At each tx boundary it decides
+--                        whether to seal the batch and whether to cut a block. SEALING
+--                        is where the appends happen: it opens a FRESH producer
+--                        transaction, appends the whole accumulating slot's held
+--                        messages in send order (the cheap step that fixes the txs'
+--                        order on the replica log and yields per-tx append handles),
+--                        and hands the OPEN-BUT-UNCOMMITTED producer transaction to
+--                        the committer. Once the committer confirms a batch durable it
+--                        PROMOTES the committing batch → durable live tables ONE TX AT
+--                        A TIME in send order, advancing the durable
+--                        LiveIndex.latest_completed_tx and the apply cursor per tx,
+--                        refreshing the shared snapshot, and notifying watchers
+--                        POST-DURABLE.
+--   Committer          — a secondary coroutine that does ONE thing: commit() the
+--                        already-appended sealed producer transaction (the slow Kafka
+--                        round-trip), off the resolver's dispatcher thread, and signal
+--                        the resolver when it lands. It does NOT append (the resolver
+--                        appended at seal), does NOT touch staging, and does NOT touch
+--                        the durable index. A Kafka transactional producer allows only
+--                        one open transaction at a time, and commit() commits
+--                        everything appended since the transaction opened (no prefix
+--                        commit, no second concurrent transaction — a second producer
+--                        would be fenced); so appending each tx at RESOLVE time is not
+--                        realizable (a tx resolving during a commit would have nowhere
+--                        to append), which is why appends move to SEAL time — a fresh
+--                        transaction per batch, committed once — no double-buffer of
+--                        producer transactions.
+-- SENDS are serial (one open producer transaction at a time) but ACCUMULATION
+-- continues during a send: while the committer commits the sealed batch, the resolver
+-- keeps resolving and accumulating the NEXT slot; it just cannot SEAL the next batch
+-- until the current commit completes and promotes. At-most-one-batch-in-flight is
+-- enforced by the resolver (the staging index's in_flight flag), matching the single
+-- open producer transaction.
+-- The block cut + uploadBlock and the per-tx watcher notify stay on the resolver,
+-- downstream of the commit (post-durable). The apply cursor advances per promoted tx
+-- to that tx's replica-log position (the append positions from the per-tx handles the
+-- resolver recorded at seal time). Errors propagate via job-tree cancellation.
 -- A query MUST NEVER see a tx that isn't yet durably on the replica log: external
 -- snapshots open at the durable LiveIndex.latest_completed_tx. The applied head is
--- the staging area's own latest_completed_tx — callers choose which to read.
+-- the staging index's own latest_completed_tx — callers choose which to read.
 -- Followers/transition have no staging — they import already-durable replica
 -- messages straight into the durable live index.
 -- A single Watchers instance tracks both txId and sourceMsgId for client correlation,
@@ -53,7 +93,8 @@ use "./compaction.allium" as compaction
 given {
     database: Database
     log_processor: LogProcessor
-    replica_writer: ReplicaWriter      -- leader-only (proc 2); absent in follower/transition modes
+    staging_index: StagingIndex?       -- leader-only (resolver-owned); absent in follower/transition modes
+    committer: Committer?              -- leader-only (secondary coroutine, commit only); absent in follower/transition modes
     live_index: LiveIndex              -- shared across leader/follower modes
     watchers: Watchers                 -- single instance: correlates source msg_ids and tx_ids with client futures
     block_catalog: BlockCatalog
@@ -101,8 +142,8 @@ entity LiveIndex {
     --   durable live tables. External snapshots open at this. On a leader it is
     --   advanced by promotion from staging; on a follower/transition by importTx.
     -- The APPLIED/resolution head (next external-source tx_id, system-time
-    --   smoothing) is NOT a field here: on a leader it lives in the staging area
-    --   (the staging area's own latest_completed_tx, see live-index.allium
+    --   smoothing) is NOT a field here: on a leader it lives in the staging index
+    --   (the staging index's own latest_completed_tx, see live-index.allium
     --   StagingIndex), which db.allium does not import and therefore cannot read
     --   directly. Resolution that needs the next tx key delegates id-assignment to
     --   the staging layer via beginStagedTx (below); external queries read the
@@ -193,38 +234,58 @@ variant Transition : LogProcessor {
     -- See: indexer/TransitionLogProcessor.kt
 }
 
-entity ReplicaWriter {
-    -- The leader's replica-writer (proc 2): sole owner of the replica-log
-    -- transactional producer and the staging area's write lifecycle. Exists only
-    -- on a leader (client-driven Leader or ExternalSourceLeader); followers and
-    -- the transition processor have no staging and no writer.
-    -- See: indexer/LeaderLogProcessor.kt (replica-write half), live-index.allium.
+entity StagingIndex {
+    -- The resolver-owned staging index for a leader term. Its full structure
+    -- (slots, staged tables, the applied head) lives in live-index.allium; here it
+    -- is an opaque handle so db.allium's rules can name the resolver's apply /
+    -- seal / promote operations. db.allium does not `use` live-index.allium, so it
+    -- cannot name StagingSlot directly. Exists only on a leader (Leader or
+    -- ExternalSourceLeader); absent on followers and the transition processor.
     --
-    -- A STATE STORE, not a state machine. It owns the staging area (whose
-    -- structure lives under LiveIndex in live-index.allium so the resolution
-    -- snapshots can see it) and the replica producer; it has no idle/committing
-    -- FSM. The "one batch in flight at a time" property comes from the
-    -- single-threaded proviso below, not from a modelled state.
+    -- Standing state the LeaderLogProcessor owns from construction and frees in
+    -- its two-phase close (see TransitionToFollower). NOT a field on LiveIndex —
+    -- the resolver is its sole accessor, so it needs no lock.
     --
-    -- SINGLE-THREADED (like the live-index single-writer thread): the writer
-    -- handles one event to completion before the next. So a batch is sealed,
-    -- durably written, awaited, and promoted within a single event-handling —
-    -- there is never a second batch in flight, and any txs the resolver stages
-    -- meanwhile simply coalesce into the next batch. This is the proviso that
-    -- replaces the FSM gate.
-    --
-    -- Both the client-driven leader and the external-source leader share this one
-    -- writer: the resolved txs in a batch carry their own external_source_token
-    -- (null for the client-driven leader, the LSN for an external source), so the
-    -- writer threads whatever the batch carries.
-    --
-    -- The in-flight batch and the staging slots are reached only via opaque
-    -- live_index calls — db.allium does not `use` live-index.allium, so it cannot
-    -- name StagingSlot directly.
+    -- APPLIED head: the staging index's own latest_completed_tx (next tx_id,
+    -- system-time smoothing). See live-index.allium StagingIndex.
+    latest_completed_tx: TransactionKey?
 
-    -- Highest replica-log message id this writer has durably written.
-    -- Monotonicity (advances, never decreases) is a runtime/temporal property,
-    -- not a single-point-in-time invariant — documented here, not asserted.
+    -- in_flight is true exactly while a sealed batch's producer transaction is open,
+    -- being committed and promoted (between seal — which opens the transaction,
+    -- appends, and hands off — and the last per-tx promote once the committer confirms
+    -- the batch durable). The resolver checks it to enforce at-most-one-batch in flight
+    -- — matching the single open producer transaction a Kafka transactional producer
+    -- permits. Accumulation of the next slot continues while in_flight is true; only
+    -- the next seal (the next send) is gated.
+    in_flight: Boolean
+}
+
+entity Committer {
+    -- The leader's committer: a secondary coroutine that does ONE thing — commit()
+    -- the sealed replica-log producer transaction (the slow Kafka round-trip), off
+    -- the resolver's dispatcher thread. Exists only on a leader (client-driven Leader
+    -- or ExternalSourceLeader); followers and the transition processor have none.
+    -- See: indexer/LeaderLogProcessor.kt (commit-offload half).
+    --
+    -- It does NOT append — the resolver appended each tx's message at SEAL time (openTx
+    -- once per batch, then appendMessage per held pending message, in send order),
+    -- before handing the OPEN-BUT-UNCOMMITTED transaction over. The committer receives
+    -- the sealed producer transaction, commits it durably, and signals the resolver
+    -- when the commit lands. It touches NEITHER the staging index NOR the durable live
+    -- index — promotion (and the block cut + uploadBlock) is the resolver's job, done
+    -- once the commit confirms durable.
+    --
+    -- A Kafka transactional producer allows only one open transaction at a time, and
+    -- commit() commits everything appended since it opened (no prefix commit); so there
+    -- is one open producer transaction per batch, opened fresh at seal and committed
+    -- once — no double-buffer. Both the client-driven leader and the external-source
+    -- leader share the one producer: each appended tx carries its own
+    -- external_source_token (null for the client-driven leader, the LSN for an external
+    -- source), threaded at seal/append time by the resolver.
+
+    -- Highest replica-log message id whose producer transaction has been durably
+    -- committed. Monotonicity (advances, never decreases) is a runtime/temporal
+    -- property, not a single-point-in-time invariant — documented here, not asserted.
     latest_replica_msg_id: MessageId
 }
 
@@ -626,10 +687,17 @@ rule TransitionToLeader {
         log_processor.mode = Leader
         log_processor.start(source_resume, after_replica_msg_id: replay_target)
 
-        -- Stand up the replica-writer (proc 2) for this leader term, owning the
-        -- transactional producer opened above. It is torn down on revocation
-        -- (TransitionToFollower drops staging).
-        ReplicaWriter.created(
+        -- Stand up the leader term's pipeline: the resolver-owned staging index
+        -- (applied head seeded from the durable head; see live-index BeginStagedTx)
+        -- and the secondary committer coroutine that commits the sealed producer
+        -- transactions (the resolver opens a fresh one and appends at each seal; this
+        -- producer handle is used per-seal). Both are torn down on revocation by the
+        -- two-phase close (TransitionToFollower).
+        StagingIndex.created(
+            latest_completed_tx: live_index.latest_completed_tx,
+            in_flight: false
+        )
+        Committer.created(
             latest_replica_msg_id: replay_target
         )
 
@@ -644,16 +712,21 @@ rule TransitionToFollower {
     requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
 
     ensures:
-        -- close() completes any in-flight commit, then stops.
-        -- Capture the leader's positions and pending block before switching.
+        -- Two-phase close (per commit ec0f3947e). Phase 1: cancelAndJoin the
+        -- leader's job tree (resolver + committer) so nothing live still touches
+        -- staging — close() completes any in-flight commit, joins both coroutines,
+        -- then stops the subscription.
         let leader = log_processor as Leader
         leader.close()
 
-        -- Drop the leader-term-scoped staging index wholesale: any staged-but-
-        -- not-yet-durable txs are discarded (they were never visible to external
-        -- queries) and will be re-read from the source log and re-resolved by the
-        -- next leader. The durable live index is untouched (live-index DropStaging).
-        live_index.dropStaging()
+        -- Phase 2: synchronously free the leader-term staging index (closing any
+        -- un-promoted slot buffers) BEFORE the allocator. Demotion IS this teardown
+        -- — there is no separate runtime drop. Any staged-but-not-yet-durable txs
+        -- are discarded (they were never visible to external queries) and will be
+        -- re-read from the source log and re-resolved by the next leader. The
+        -- durable live index is untouched (live-index CloseStagingIndex).
+        if staging_index != null:
+            CloseStagingIndex(staging_index)
 
         -- The leader's pending_block is passed to the new follower.
         -- If the leader was mid-block-flush when revoked (between BlockBoundary
@@ -702,15 +775,19 @@ rule ClientSubmitsTransactionToExternalSourceDb {
         )
 }
 
----- Rules: Leader Mode — Resolver (proc 1, source processing)
+---- Rules: Leader Mode — Resolver (source processing)
 
--- The leader subscribes to the source log. The RESOLVER resolves each message
--- and writes the result to the STAGING accumulating slot (live_index.applyToStaging),
--- advancing the staging area's own latest_completed_tx (the applied head). It does
--- NOT write to the replica log and does NOT notify watchers — those are the replica-writer's job
--- (proc 2). It then wakes the writer with StagedTxReady (a bare signal — the writer
--- seals whatever staging holds, not a specific tx). Resolution runs AHEAD of the
--- durable write: later txs resolve against staging.
+-- The leader subscribes to the source log. The RESOLVER, sole accessor of its
+-- staging index, resolves each message (reading durable ⊕ its own staging), applies
+-- the result to the STAGING accumulating slot (live_index.applyToStaging), advancing
+-- the staging index's own latest_completed_tx (the applied head), AND holds the tx's
+-- pending replica message in the slot in send order. It does NOT append to a producer
+-- transaction here — the append happens at seal time (MaybeSealBatch → sealStagingBatch)
+-- — and does NOT commit (the committer does that) and does NOT notify watchers — those
+-- follow from the durable commit and the resolver's own post-durable promotion. At each
+-- tx boundary it decides whether to seal a batch (MaybeSealBatch): only if no batch is
+-- in flight and work has accumulated. Resolution runs AHEAD of the durable commit:
+-- later txs resolve against staging while a sealed batch commits.
 -- At the start of each processRecords batch, the leader checks the block flush
 -- timeout via BlockFlusher.
 
@@ -721,15 +798,18 @@ rule LeaderProcessesTx {
     requires: msg.msg_id > log_processor.latest_source_msg_id
 
     ensures:
-        -- Resolve and apply to staging (advances latest_completed_tx).
+        -- Resolve and apply to the resolver-owned staging index (advances the applied
+        -- head latest_completed_tx). ApplyToStaging applies the tx to the accumulating
+        -- slot and holds its pending replica message in send order — it does NOT append
+        -- to a producer transaction; the append happens at seal time.
         let resolved = IndexTransaction(msg)
-        live_index.applyToStaging(resolved)
+        live_index.applyToStaging(staging_index, resolved)
         log_processor.latest_source_msg_id = msg.msg_id
 
-        -- Hand downstream to the replica-writer (proc 2). No replica-log write
+        -- Tx-boundary decision: seal the batch (open a fresh producer transaction,
+        -- append the held messages, hand it to the committer) if appropriate. No commit
         -- and no watcher notify here.
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        MaybeSealBatch(staging_index)
 }
 
 rule LeaderProcessesAttachDb {
@@ -740,11 +820,10 @@ rule LeaderProcessesAttachDb {
 
     ensures:
         let resolved = ResolveAttach(msg)
-        live_index.applyToStaging(resolved)
+        live_index.applyToStaging(staging_index, resolved)
         log_processor.latest_source_msg_id = msg.msg_id
 
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        MaybeSealBatch(staging_index)
 }
 
 rule LeaderProcessesDetachDb {
@@ -755,75 +834,124 @@ rule LeaderProcessesDetachDb {
 
     ensures:
         let resolved = ResolveDetach(msg)
-        live_index.applyToStaging(resolved)
+        live_index.applyToStaging(staging_index, resolved)
         log_processor.latest_source_msg_id = msg.msg_id
 
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        MaybeSealBatch(staging_index)
 }
 
----- Rules: Leader Mode — Replica-writer (proc 2, durable write + promotion)
+---- Rules: Leader Mode — Resolver seal and post-commit promotion
 
--- The REPLICA-WRITER (entity ReplicaWriter, proc 2) is the sole owner of the
--- replica-log transactional producer and the staging area's write lifecycle. It
--- is SINGLE-THREADED, not a state machine: each event is handled to completion
--- before the next, so a batch is sealed, durably written, awaited, and promoted
--- within one handling — there is never a second batch in flight, and txs the
--- resolver stages meanwhile coalesce into the next batch.
---
--- Both the client-driven leader and the external-source leader use this one
--- writer. The resolved txs in a batch carry their own external_source_token (null
--- for the client-driven leader, the LSN for an external source); the writer
--- threads whatever the batch carries — there is no separate external-source
--- variant of the writer.
---
--- Handoff: the resolver emits StagedTxReady as it stages txs; the writer coalesces
--- whatever has accumulated into one batch when it next handles the signal (the
--- coalescing policy — batch size / linger — is a pipelining concern below this
--- contract-level model). The spec asserts only the ordering and durability
--- invariants, not the batching mechanics.
+-- The resolver-side of the pipeline. The resolver, at a tx boundary, seals: it opens
+-- a fresh producer transaction, appends the accumulating slot's held messages in send
+-- order, moves the slot into the committing sequence (live-index SealStagingBatch),
+-- and hands the OPEN-BUT-UNCOMMITTED producer transaction to the secondary committer
+-- coroutine to COMMIT. At-most-one-batch-in-flight is enforced here by the staging
+-- index's in_flight flag — matching the single open producer transaction a Kafka
+-- transactional producer permits. When the committer signals the batch durable
+-- (BatchCommitted), the resolver PROMOTES the committing batch → durable ONE TX AT A
+-- TIME, advancing the durable basis and the apply cursor per tx, refreshing the shared
+-- snapshot and notifying watchers POST-DURABLE — and then may seal the next
+-- accumulated batch.
 
-rule WriteStagedBatch {
-    -- The writer's event handler. Single-threaded, so this runs start-to-finish
-    -- per batch: seal the staged batch, write its resolved txs durably to the
-    -- replica log, await durable confirmation INLINE (the transactional commit
-    -- ack — not a separate event), promote staging → durable, notify watchers
-    -- POST-DURABLE, and finish the block if the durable live index is now full.
-    --
-    -- The triggering StagedTxReady's per-tx payload is NOT read: the writer seals
-    -- whatever the staging accumulating slot holds (possibly several txs coalesced
-    -- since the last write). resolved_batch is the ordered list of resolved txs in
-    -- the sealed slot, each carrying its own external_source_token (null for the
-    -- client-driven leader). durable_tx is the highest tx key in the batch;
-    -- durable_token is the token as of its last tx.
-    when: StagedTxReady(database)
+rule MaybeSealBatch {
+    -- Tx-boundary decision: seal only when no batch is in flight and work has
+    -- accumulated. If a batch is already in flight, the newly-staged txs simply
+    -- coalesce into the accumulating slot (accumulating continues during a send) and
+    -- their held pending messages are appended when THIS slot is next sealed, once the
+    -- in-flight batch is promoted (see ResolverPromotesBatch).
+    when: MaybeSealBatch(staging_index)
+
+    requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
+    requires: not staging_index.in_flight
+
+    ensures:
+        -- Seal: open a fresh producer transaction, append the accumulating slot's held
+        -- pending messages in send order, move the slot into the committing sequence,
+        -- and return the batch's resolved txs in send order (live-index
+        -- SealStagingBatch). If the accumulating slot was empty, sealStagingBatch is a
+        -- no-op (see its requires) — nothing is appended and nothing is committed.
+        let resolved_batch = live_index.sealStagingBatch(staging_index)
+        staging_index.in_flight = true
+
+        -- Hand the OPEN-BUT-UNCOMMITTED producer transaction to the committer to commit
+        -- durably. The committer signals back when the commit lands. Each appended tx
+        -- carries its own external_source_token (null for the client-driven leader),
+        -- threaded at seal/append time; the batch carries a block cut only when the
+        -- resolver decided to cut one at this boundary.
+        CommitBatch(committer, resolved_batch)
+}
+
+rule CommitterCommitsBatch {
+    -- The secondary committer coroutine: commit() the already-appended sealed producer
+    -- transaction durably (the slow Kafka round-trip), then signal the resolver. It
+    -- does NOT append (the resolver appended at seal), and touches NEITHER the staging
+    -- index NOR the durable live index — promotion is the resolver's job.
+    when: CommitBatch(committer, resolved_batch)
 
     requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
 
     ensures:
-        -- Seal the accumulating slot into the committing slot (double-buffer) and
-        -- take the batch.
-        let resolved_batch = live_index.sealStagingBatch()
-        let durable_tx = resolved_batch.last.tx_key
-        let durable_token = resolved_batch.last.external_source_token
+        -- Commit the open producer transaction: everything appended at seal becomes
+        -- durable together (commit() commits the whole transaction, not a prefix). The
+        -- PER-TX replica-log positions (i-th ↔ i-th tx, send order) come from the
+        -- per-tx append handles the resolver obtained at seal (each appendMessage
+        -- returns a handle completing at commit with the position); commit does not
+        -- reassign them. resolved_batch carries them so the resolver can advance the
+        -- apply cursor tx-by-tx on promote. These are replica-LOG positions, distinct
+        -- from the tx-id (a source-log position).
+        CommitProducerTransaction(database, resolved_batch)
 
-        -- Write each resolved tx to the replica log via the transactional producer
-        -- and await durable confirmation inline. WriteResolvedToReplica builds the
-        -- per-tx ResolvedTxMessage (incl. the abort-error projection and the tx's
-        -- own external_source_token).
+        -- Signal the resolver that the batch is durable; promotion follows on the
+        -- resolver, not here.
+        BatchCommitted(staging_index, resolved_batch)
+}
+
+rule ResolverPromotesBatch {
+    -- The resolver handles the committer's durable signal: the committing batch is
+    -- durable. It promotes the batch → durable ONE TX AT A TIME, in send order (via
+    -- live-index PromoteNext, which imports the tx into the durable live tables,
+    -- advances the durable basis to that tx, and refreshes the shared snapshot). For
+    -- each promoted tx it advances the apply cursor (latest_replica_msg_id, the
+    -- follower's resume point) to that tx's replica-log position — the i-th promoted
+    -- tx takes the i-th seal-time append position — and notifies watchers POST-DURABLE.
+    -- Once the batch is drained no batch is in flight, so it finishes the block if the
+    -- durable live index is now full and seals the next accumulated batch if any.
+    --
+    -- Per-tx (not wholesale) promotion + per-tx cursor advance is what makes a partial
+    -- failure safe: if importTx faults mid-batch, the imported prefix is durable, the
+    -- cursor sits at the last tx that ACTUALLY imported, and the un-imported tail stays
+    -- parked in committing (freed by CloseStagingIndex on teardown). A follower
+    -- resuming from that cursor re-applies only the tail — never double-importing the
+    -- durable prefix.
+    --
+    -- The per-tx replica-log positions carried on resolved_batch are the append
+    -- positions from the per-tx handles the resolver obtained at SEAL time, i-th ↔ i-th
+    -- tx in send order. durable_token is the token as of the batch's last tx.
+    when: BatchCommitted(staging_index, resolved_batch)
+
+    requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
+
+    let durable_token = resolved_batch.last.external_source_token
+
+    ensures:
+        -- Promote each tx in send order. Each resolved tx carries its own replica-log
+        -- position (from the per-tx append handle the resolver obtained at seal, i-th ↔ i-th tx).
+        -- PromoteNext imports the tx into the durable live tables, advances the durable
+        -- basis to it, and refreshes the shared snapshot. Advance the apply cursor to
+        -- this tx's replica-log position, then notify watchers POST-DURABLE, threading
+        -- the tx's own external_source_token so restarts can resume the external source.
+        -- If PromoteNext faults partway, the cursor is left at the last tx that actually
+        -- imported (partial-failure safety).
         for resolved in resolved_batch:
-            WriteResolvedToReplica(database, resolved)
-
-        -- Durable: promote staging → durable, advancing the durable basis and
-        -- refreshing the external snapshot (live-index PromoteStaging).
-        live_index.promoteStaging(durable_tx)
-
-        -- Notify watchers POST-DURABLE, threading each tx's own external_source_token
-        -- so restarts can resume the external source.
-        for resolved in resolved_batch:
+            live_index.promoteNext(staging_index)
+            log_processor.latest_replica_msg_id = resolved.replica_msg_id
             watchers.notifyTx(resolved.result, resolved.tx_key.tx_id, resolved.external_source_token)
 
-        replica_writer.latest_replica_msg_id = durable_tx.tx_id
+        -- The committing sequence is now drained; no batch is in flight.
+        staging_index.in_flight = false
+
+        let durable_tx = resolved_batch.last.tx_key
 
         -- BlockBoundary closes the batch: finish the block once durable and full,
         -- by which point staging is drained (see live-index FinishBlock). An
@@ -835,12 +963,16 @@ rule WriteStagedBatch {
                 ExternalSourceFinishesBlock(durable_tx.tx_id, durable_token)
             else:
                 LeaderFinishesBlock(durable_tx.tx_id)
+
+        -- Now no batch is in flight; seal the next accumulated batch if any.
+        MaybeSealBatch(staging_index)
 }
 
 rule LeaderProcessesFlushBlock {
-    -- Source-log coordination message, handled on the resolver thread. Block
-    -- finishing itself is a replica-writer (proc 2) operation: it drains staging
-    -- first (see live-index FinishBlock).
+    -- Source-log coordination message, handled on the resolver thread. The block
+    -- cut itself is a resolver decision: it drains staging (awaits the in-flight
+    -- commit and promotes), then the block is finished with staging drained (see
+    -- live-index FinishBlock).
     when: msg: FlushBlockMessage consumed from database.source_log
     requires: log_processor.mode = Leader
 
@@ -860,8 +992,8 @@ rule LeaderProcessesFlushBlock {
 
 rule LeaderProcessesTriesAdded {
     -- L1+ from compactor. The leader needs these in its trie catalog
-    -- for correct partition info at block time, and forwards them to the replica
-    -- log (a replica-writer / proc-2 op, since it owns the producer).
+    -- for correct partition info at block time, and the resolver forwards them to
+    -- the replica log via the producer (the resolver owns the append path).
     when: msg: TriesAddedMessage consumed from database.source_log
     requires: log_processor.mode = Leader
 
@@ -901,18 +1033,18 @@ rule LeaderProcessesBlockUploaded {
 
 ---- Rules: Leader Block Finishing
 
--- The leader finishes blocks via BlockUploader, on the replica-writer (proc 2)
--- side: by the time we get here the in-flight batch has been promoted and
--- staging is drained, so the durable block never contains non-durable rows
--- (see live-index FinishBlock, which requires staging drained).
+-- The leader finishes blocks via BlockUploader: by the time we get here the
+-- resolver has drained staging (the in-flight batch promoted), so the durable
+-- block never contains non-durable rows (see live-index FinishBlock, which
+-- requires staging drained).
 -- The leader sets pending_block between writing BlockBoundary and BlockUploaded.
 -- If the leader is revoked during this window, the pending block gets passed
 -- to the follower (see TransitionToFollower).
 --
 -- Double-finish is not possible: LeaderFinishesBlock is fired by either
--- WriteStagedBatch (when live_index.is_full, post-promotion) or
+-- ResolverPromotesBatch (when live_index.is_full, post-promotion) or
 -- LeaderProcessesFlushBlock.
--- These are processed sequentially on the source log subscription thread.
+-- These are processed sequentially on the resolver thread.
 -- If a batch flush triggers a block finish, it calls
 -- nextBlock() — the live index is no longer full. If a FlushBlock message
 -- arrives later for the same block_index, its CAS (expected_block_idx ==
@@ -1013,32 +1145,37 @@ rule ExternalSourceIndexesTx {
     -- result, which is caller-side and below this spec's abstraction level.
     --
     -- Unlike the client-driven leader, tx_id here is assigned off the STAGING
-    -- head (the staging area's own latest_completed_tx), NOT a source-log
-    -- position and NOT the durable basis. db.allium does not import the staging
-    -- area, so it cannot read that head; id-assignment is delegated to the
+    -- head (the staging index's own latest_completed_tx), NOT a source-log
+    -- position and NOT the durable basis. id-assignment is delegated to the
     -- staging layer via live_index.beginStagedTx, which assigns the next tx_id
     -- (staging-head tx_id + 1), smooths system_time strictly greater than the
-    -- previous tx's, applies the resolved data to staging, and returns the
-    -- assigned TransactionKey. (See live-index.allium BeginStagedTx / deferred
-    -- below.)
+    -- previous tx's, applies the resolved data to the resolver's staging index, and
+    -- returns the assigned TransactionKey. (See live-index.allium BeginStagedTx /
+    -- deferred below.)
     --
     -- The resulting ResolvedTx carries the external_source_token all the way
     -- through watchers, so block boundaries and restarts can resume from it.
     --
-    -- This is the RESOLVER (proc 1): resolve and apply to staging, then hand
-    -- downstream. The durable replica-log write, promotion and watcher notify are
-    -- done by the replica-writer (proc 2): WriteStagedBatch.
+    -- This is the RESOLVER: resolve and apply to its staging index, holding the tx's
+    -- pending replica message in the slot (beginStagedTx does both — no append yet),
+    -- then decide at this tx boundary whether to seal (the append happens at seal). The
+    -- durable commit is the committer's job (CommitterCommitsBatch); the promotion and
+    -- post-durable watcher notify are the resolver's own, once the commit lands
+    -- (ResolverPromotesBatch).
     when: ExternalSourceIndexTx(external_source_token, system_time, writer)
     requires: log_processor.mode = ExternalSourceLeader
 
     ensures:
         -- Delegate id-assignment and the staging apply to the staging layer.
-        -- beginStagedTx assigns tx_id off the staging head, smooths system_time,
-        -- applies the writer's resolved data to staging, and returns the key.
-        let tx_key = live_index.beginStagedTx(system_time, external_source_token, writer)
+        -- beginStagedTx assigns tx_id off the staging head, smooths system_time, applies
+        -- the writer's resolved data to the resolver's staging index, holds the tx's
+        -- pending replica message (with the token) in the accumulating slot in send
+        -- order, and returns the key. It does NOT append to a producer transaction — the
+        -- append happens at seal.
+        let tx_key = live_index.beginStagedTx(staging_index, system_time, external_source_token, writer)
 
-        -- Wake the replica-writer; it seals whatever staging now holds.
-        StagedTxReady(database)
+        -- Tx-boundary decision: seal the batch if appropriate.
+        MaybeSealBatch(staging_index)
 }
 
 rule ExternalSourceProcessesFlushBlock {
@@ -1098,9 +1235,9 @@ rule ExternalSourceFinishesBlock {
     -- Mirror of LeaderFinishesBlock for the external-source leader. The
     -- BlockBoundary and the persisted Block both carry the
     -- external_source_token so that a restart can resume the external source
-    -- from the last durably persisted position. Driven by the replica-writer
-    -- (proc 2) after the in-flight batch is promoted, so staging is drained
-    -- before the block is written.
+    -- from the last durably persisted position. Driven by the resolver
+    -- (ResolverPromotesBatch) after the in-flight batch is promoted, so staging
+    -- is drained before the block is written.
     when: ExternalSourceFinishesBlock(latest_processed_msg_id, external_source_token)
 
     let block_index = (block_catalog.current_block_index ?? -1) + 1
@@ -1398,14 +1535,44 @@ surface QueryAccess {
 deferred IndexTransaction           -- transaction resolution (put/delete/erase logic)
 deferred ResolveAttach              -- attach database resolution
 deferred ResolveDetach              -- detach database resolution
-deferred WriteResolvedToReplica     -- builds the per-tx ResolvedTxMessage (incl. abort-error
-                                    -- projection and external_source_token) and appends it to
-                                    -- the replica log via the transactional producer
-deferred BeginStagedTx              -- live_index.beginStagedTx(system_time, token, writer): the
-                                    -- staging layer assigns the next external-source tx_id off the
+deferred CommitProducerTransaction  -- commits the open replica-log producer transaction (the
+                                    -- committer's durability step — the slow Kafka round-trip): the
+                                    -- batch's appends (made by the resolver at seal) become durable
+                                    -- together (commit() commits the whole transaction, not a prefix).
+                                    -- The per-tx replica-log positions come from the per-tx append
+                                    -- handles the resolver obtained at seal (i-th ↔ i-th tx, send order);
+                                    -- commit does not reassign them, and the resolver uses them to advance
+                                    -- the apply cursor on promote.
+deferred BeginStagedTx              -- live_index.beginStagedTx(staging_index, system_time, token, writer):
+                                    -- the staging layer assigns the next external-source tx_id off the
                                     -- staging head (head tx_id + 1), smooths system_time strictly
-                                    -- greater than the previous tx's, applies the writer's resolved
-                                    -- data to staging, and returns the assigned TransactionKey.
-                                    -- db.allium delegates here rather than reading the staging head
-                                    -- (which it cannot — it does not use live-index.allium).
+                                    -- greater than the previous tx's, applies the writer's resolved data
+                                    -- to the resolver's staging index, holds the tx's pending replica
+                                    -- message (with the token) in the accumulating slot in send order,
+                                    -- and returns the assigned TransactionKey. It does NOT append to a
+                                    -- producer transaction — the append happens at seal. db.allium
+                                    -- delegates here rather than reading the staging head (which it
+                                    -- cannot — it does not use live-index.allium).
                                     -- See: live-index.allium BeginStagedTx
+deferred ApplyToStaging             -- live_index.applyToStaging(staging_index, resolved): the resolver
+                                    -- applies the resolved tx into the accumulating slot, holds its
+                                    -- pending replica message in the slot in send order, and advances the
+                                    -- staging index's applied head. It does NOT append to a producer
+                                    -- transaction — the append happens at seal. See: live-index.allium
+                                    -- CommitTransaction
+deferred SealStagingBatch           -- live_index.sealStagingBatch(staging_index): opens a fresh producer
+                                    -- transaction, appends the accumulating slot's held pending messages
+                                    -- in send order (yielding the per-tx append handles), seals the slot
+                                    -- into the committing sequence (no-op if empty), and returns the
+                                    -- batch's resolved txs in send order. See: live-index.allium
+                                    -- SealStagingBatch
+deferred PromoteNext                -- live_index.promoteNext(staging_index): once the committer confirms
+                                    -- the batch durable, the resolver promotes the OLDEST staged tx in
+                                    -- the committing sequence — imports its rows into the durable live
+                                    -- tables, advances the durable basis to it, refreshes the shared
+                                    -- snapshot, then drops it. Called once per tx, in send order.
+                                    -- See: live-index.allium PromoteNext
+deferred CloseStagingIndex           -- live-index.allium CloseStagingIndex(staging_index): phase-2 of the
+                                    -- leader's two-phase close frees the staging index; demotion is
+                                    -- exactly this teardown (no separate runtime drop).
+                                    -- See: live-index.allium CloseStagingIndex

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -18,8 +18,8 @@
            [org.apache.arrow.memory BufferAllocator RootAllocator]
            [org.apache.arrow.vector FixedSizeBinaryVector]
            (xtdb.arrow Relation)
-           (xtdb.api IndexerConfig)
-           (xtdb.indexer LiveIndex)
+           (xtdb.api IndexerConfig TransactionResult$Committed)
+           (xtdb.indexer LiveIndex StagedTx)
            (xtdb.indexer LiveTable$FinishedBlock)
            (xtdb.trie ArrowHashTrie ArrowHashTrie$Leaf Bucketer MemoryHashTrie$Leaf)
            (xtdb.util RefCounter RowCounter)))
@@ -207,7 +207,7 @@
                 "External snapshot should not see table created in uncommitted tx"))
 
         ;; But the transaction's own snapshot SHOULD see its data (one TableSnapshot for the tx slot)
-        (with-open [tx-snap (.openSnapshot live-index live-tx)]
+        (with-open [tx-snap (.openSnapshot live-index [] live-tx)]
           (let [table-snaps (.table tx-snap table)]
             (t/is (= 1 (count table-snaps))
                   "Transaction snapshot should have one entry (just the uncommitted tx data)")
@@ -289,7 +289,7 @@
           (.endStruct doc-wtr)
           (.endPut table-tx-1))
 
-        (with-open [tx-snap (.openSnapshot live-index live-tx)]
+        (with-open [tx-snap (.openSnapshot live-index [] live-tx)]
           (let [table-snaps (.table tx-snap table)]
             (t/is (= 1 (count table-snaps)))
             (t/is (= 1 (.getRowCount (.getRelation (first table-snaps))))
@@ -356,7 +356,7 @@
           ;; `addTries` below, so it wouldn't see the L0.
           (with-open [observer-tx (tu/->open-tx allocator tu/*node* #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-01T00:00:01Z"})]
 
-            (with-open [snap (.openSnapshot live-index observer-tx)]
+            (with-open [snap (.openSnapshot live-index [] observer-tx)]
               (t/is (= 1 (count (.table snap table)))
                     "live-table is the only source for block 0 before finishBlock")
               (t/is (= -1 (.l0MaxBlockIdx (.getTrieCatSnap snap) table))
@@ -371,7 +371,7 @@
                                                     :trie-metadata (.getTrieMetadata fb)})]
                            (Instant/now))))
 
-            (with-open [snap (.openSnapshot live-index observer-tx)]
+            (with-open [snap (.openSnapshot live-index [] observer-tx)]
               (t/is (empty? (.table snap table))
                     "live-table must be filtered — its rows now live in L0_0")
               (t/is (= 0 (.l0MaxBlockIdx (.getTrieCatSnap snap) table))
@@ -438,7 +438,7 @@
 
         ;; Transaction snapshot should see BOTH committed (iid1) and own uncommitted (iid2),
         ;; now as two separate TableSnapshot entries: live (committed) + tx (uncommitted).
-        (with-open [tx-snap (.openSnapshot live-index live-tx2)]
+        (with-open [tx-snap (.openSnapshot live-index [] live-tx2)]
           (let [table-snaps (.table tx-snap table)
                 row-counts (mapv #(.getRowCount (.getRelation %)) table-snaps)]
             (t/is (= 2 (count table-snaps))
@@ -447,3 +447,20 @@
                   "Each entry should hold one row (1 committed + 1 uncommitted)")))
 
         ))))
+
+(t/deftest staged-empty-create-table-visible-across-a-batch-5507
+  ;; A tx that CREATEs a table (columns declared, 0 rows) is read behind by a later tx while still staged
+  ;; in the same batch. openSnapshot drops the empty relation, so tableInfo has to carry the freshly-created
+  ;; table's existence directly — else SQL base-table resolution throws "Table not found" for the later tx.
+  (let [live-index (.getLiveIndex (db/primary-db tu/*node*))
+        table #xt/table foo
+        tx-key #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"}]
+    (util/with-open [staging-alloc (util/->child-allocator (.getAllocator tu/*node*) "staging")]
+      (util/with-open [staged (with-open [create-tx (tu/->open-tx tx-key)]
+                                (.executeSql create-tx "CREATE TABLE foo (_id, bar)")
+                                (.commitTx create-tx)
+                                (StagedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil))
+                       observer-tx (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-01T00:00:01Z"})
+                       snap (.openSnapshot live-index [staged] observer-tx)]
+        (t/is (.containsKey (.getTableInfo snap) table)
+              "a table CREATEd in a still-staged tx is visible to a later tx resolving behind it")))))

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -614,3 +614,17 @@ INSERT INTO docs (_id, _valid_from, _valid_to)
                (xt/q node "SELECT *, _valid_from, _valid_to, _system_from, _system_to
                            FROM docs FOR ALL VALID_TIME FOR ALL SYSTEM_TIME
                            ORDER BY _system_from, _valid_from"))))))
+
+(t/deftest staged-txs-read-your-writes-across-a-batch
+  ;; Several dependent txs that land in one poll batch each resolve against the earlier ones while they
+  ;; are still staged (committed, not yet durable). Each increment must see its predecessor's write, or
+  ;; batched updates collapse to one. The batch isn't forced here — many rapid async submits make it very
+  ;; likely — so this catches a gross read-your-writes-across-staging break rather than proving its absence.
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO counter (_id, v) VALUES (1, 0)"]])
+
+  (let [n 50]
+    (dotimes [_ (dec n)]
+      (xt/submit-tx tu/*node* [[:sql "UPDATE counter SET v = v + 1 WHERE _id = 1"]]))
+    (xt/execute-tx tu/*node* [[:sql "UPDATE counter SET v = v + 1 WHERE _id = 1"]])
+
+    (t/is (= [{:v n}] (xt/q tu/*node* "SELECT c.v FROM counter c")))))


### PR DESCRIPTION
Part of #5507.

## Summary

Batches the leader's replica-log writes within a poll batch. The resolver stages each resolved transaction in a resolver-owned staging index, commits a whole poll batch's transactions to the replica log in a single producer transaction, and promotes them into the durable live index on the durability signal. This collapses the per-transaction replica-log commit — the dominant per-tx overhead for high-volume single-row ingest — into one commit per poll batch.

## Context

#5507 batches and pipelines the leader's replica-log writes. This PR is sub-steps 1–2: the resolver-owned staging index and the intra-poll-batch batching. Increment 1 (the resolver/replica-writer split) landed in #5754; the earlier #5756 is closed, superseded by this single-resolver / append-at-seal design.

Scope note: the batching win accrues to the source-log ingest path (regular `submit-tx`). External-source ingest still commits one transaction per tx; whether that matters is being benchmarked separately (FHIR ingest through Postgres / Kafka-connect sources), and the ext-source batching/pipelining is the immediate follow-up — see Out of scope.

## Changes

1. `docs(allium)` — the single-resolver, append-at-seal model.
2. `refactor(indexer)` — `StagedTx` + a resolver-owned `StagingIndex`; the leader resolves into staging and snapshot resolution reads durable ⊕ staged ⊕ own-writes. Behaviour-preserving (synchronous per-tx drain).
3. `perf(indexer)` — accumulate a poll batch's transactions and commit them together, promoting per-tx on the drain.
4. `fix(indexer)` — surface staged empty tables (`CREATE TABLE`) to resolution (see Implementation notes).

## Implementation notes

Strict visibility: external queries see durable-only (`LiveIndex.latestCompletedTx`); resolution sees durable ⊕ staged ⊕ own-writes. A mid-batch fault tears the term down; the next term replays forward from `latestReplicaMsgId` off the durable replica log — the apply cursor advances per-tx after import, so it never leads what has been imported.

The `fix(indexer)` commit closes a regression the batching introduced. A transaction resolving behind a `CREATE TABLE` still staged in the same batch couldn't see the (empty) table — it was dropped from the resolution snapshot's `tableInfo` — so a same-batch `INSERT INTO bar SELECT FROM foo` would throw `Table not found`. `Snapshot.open` now surfaces staged tables' declared columns (including zero-row) into `tableInfo`, mirroring how durable empty tables get their existence from the table catalogue.

## Out of scope (immediate follow-up)

- Ext-source batching / pipelining — the source-log path is batched here; external-source ingest (Kafka-connect `submitTx`, Postgres `executeTx`) is the next increment.
- `importStagedTx` / `importTx` share a promote critical section that is currently duplicated across the leader-promote and follower-replay paths; they should be factored into one helper so they can't drift.
- Visibility entry points — `Snapshot.open` / `OpenTx` thread the staged and own layers through defaulted parameters; distinct entry points (durable vs resolution) would make the wrong-visibility combination unrepresentable.
- Block-cut granularity — the block-fullness check moved from per-tx to per-batch, so a large backlog poll batch can overshoot `rowsPerBlock` before a block is cut. Block contents stay consistent; only sizing is now batch-dependent.

## Test plan

Full `./gradlew test` (1601 tests) green, no reflection or boxed-math warnings. New deterministic regression test `staged-empty-create-table-visible-across-a-batch-5507` (confirmed to fail with the fix disabled), alongside `staged-txs-read-your-writes-across-a-batch`. Integration tests run in CI.