### PR TITLE
feat(indexer): accumulate external-source transactions (#5507)

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -112,12 +112,22 @@ class LeaderLogProcessor(
     }
 
     private sealed interface ExtSourceTask : PersisterTask {
+        // Completed when the tx is promoted (durable) in drainStaging. submitTx returns this handle;
+        // executeTx awaits it. It must be completed on *every* terminal path a task can take — drained,
+        // faulted, thrown pre-staging, left un-drained at term exit, or dropped undelivered by the channel
+        // — or an awaiting executeTx hangs. onComplete no longer implies durability for ext-source txs.
+        val durable: CompletableDeferred<Unit>
+
         class IndexTx(
             val externalSourceToken: ExternalSourceToken?,
             val systemTime: Instant?,
             val writer: suspend (OpenTx) -> TxResult,
         ) : ExtSourceTask {
+            // Completed at staging, once the writer has run and the outcome is known; executeTx reads it
+            // after `durable`. Distinct from durability — the tx is resolved but not yet on the replica log.
             val result = CompletableDeferred<TxResult>()
+
+            override val durable = CompletableDeferred<Unit>()
 
             override val onComplete = CompletableDeferred<Unit>()
         }
@@ -137,7 +147,12 @@ class LeaderLogProcessor(
     // capacity 1 so a fire-and-forget `submitTx` caller can queue one tx ahead while the persister works the
     // current one (bounding lookahead to ~2). `executeTx` still blocks on the result regardless of capacity.
     private val extSourceCh =
-        Channel<ExtSourceTask>(capacity = 1, onUndeliveredElement = { it.onComplete.cancel() })
+        Channel<ExtSourceTask>(capacity = 1, onUndeliveredElement = {
+            // Dropped before the persister received it (channel closed on term exit): fail the durability
+            // handle too, not just onComplete, so an executeTx caller awaiting `durable` doesn't hang.
+            it.onComplete.cancel()
+            it.durable.cancel()
+        })
     private val gcCh =
         Channel<GcTask>(onUndeliveredElement = { it.onComplete.cancel() })
 
@@ -167,7 +182,7 @@ class LeaderLogProcessor(
             is SourceMessage.Tx, is SourceMessage.LegacyTx -> {
                 val (txResult, openTx) = resolveTx(msgId, record, msg)
                 openTx.use {
-                    stagingIndex.stage(it, msgId, txResult, dbOp = null)
+                    stagingIndex.stage(it, msgId, txResult, dbOp = null, durable = null)
                 }
             }
 
@@ -198,7 +213,7 @@ class LeaderLogProcessor(
                     openTx.writeTxRow(error, null)
                     val txResult = if (error == null) Committed(txKey) else Aborted(txKey, error)
                     val dbOp = if (error == null) DbOp.Attach(msg.dbName, msg.config) else null
-                    stagingIndex.stage(openTx, msgId, txResult, dbOp)
+                    stagingIndex.stage(openTx, msgId, txResult, dbOp, durable = null)
                 }
                 drainStaging()
             }
@@ -219,7 +234,7 @@ class LeaderLogProcessor(
                     openTx.writeTxRow(error, null)
                     val txResult = if (error == null) Committed(txKey) else Aborted(txKey, error)
                     val dbOp = if (error == null) DbOp.Detach(msg.dbName) else null
-                    stagingIndex.stage(openTx, msgId, txResult, dbOp)
+                    stagingIndex.stage(openTx, msgId, txResult, dbOp, durable = null)
                 }
                 drainStaging()
             }
@@ -269,6 +284,20 @@ class LeaderLogProcessor(
                 val last = batch.last()
                 finishBlock(last.srcMsgId, last.externalSourceToken)
             }
+
+            // Signal durability only once the whole drain is done — including any block cut. A caller
+            // (executeTx) that returns here has the guarantee the pre-batching per-tx drain gave: the tx
+            // is on the replica log, promoted, and any block it triggered is uploaded. Signalling earlier
+            // (mid-loop) lets the caller race ahead of an in-flight finishBlock, which a term teardown can
+            // then cancel mid-way, leaving a BlockBoundary with no matching BlockUploaded.
+            batch.forEach { it.markDurable() }
+        } catch (e: Throwable) {
+            // Faulted before durability was signalled (append/commit, import, or block cut) — fail the
+            // handles so an awaiting executeTx throws rather than hangs. This fails the *whole* batch,
+            // including txs already promoted earlier in the loop; harmless while executeTx callers are
+            // serial (batch-of-one). Per-tx granularity is a follow-up for pipelined callers.
+            batch.forEach { it.failDurable(e) }
+            throw e
         } finally {
             batch.closeAll()
         }
@@ -307,15 +336,26 @@ class LeaderLogProcessor(
             // follower's `latestSourceMsgId` lags between block boundaries, and on promotion it resumes
             // the source log from a stale point and replays an already-covered block boundary.
             val effectiveSrcMsgId = watchers.latestSourceMsgId
-            stagingIndex.stage(openTx, effectiveSrcMsgId, txResult, dbOp = null)
-            drainStaging()
+            stagingIndex.stage(openTx, effectiveSrcMsgId, txResult, dbOp = null, durable = task.durable)
+            // No drain here: the tx accumulates and is committed at the next drain (idle, boundary, or
+            // block cut). The caller observes durability via `task.durable`, completed on promotion.
             task.result.complete(writerResult)
+        } catch (e: Throwable) {
+            // Threw before staging (writer, commit, or stage itself) — the tx never reached a batch, so no
+            // drain will complete its handles. Fail them so an awaiting executeTx throws rather than hangs.
+            // Once staged, durability is the drain's responsibility (drainStaging marks or fails it).
+            task.durable.completeExceptionally(e)
+            task.result.completeExceptionally(e)
+            throw e
         } finally {
             openTx.close()
         }
     }
 
     private suspend fun handleTriesDeleted(task: GcTask.TriesDeleted) {
+        // Drain first: this appends TriesDeleted directly, and replica appends must stay in
+        // resolver-processing order — appending ahead of earlier-staged txs would invert the log.
+        drainStaging()
         appendToReplica(ReplicaMessage.TriesDeleted(task.tableName.schemaAndTable, task.trieKeys))
         trieCatalog.deleteTries(task.tableName, task.trieKeys)
     }
@@ -404,39 +444,36 @@ class LeaderLogProcessor(
                             extSourceCh.onReceive { it }
                             gcCh.onReceive { it }
 
-                            // Idle: no task ready and a batch is waiting → drain it. The arm is registered
-                            // only when staging is non-empty, so an idle resolver still blocks in select
-                            // (no busy-spin); a ready onReceive wins the select over the zero timeout.
+                            // Idle: no task ready and a batch is waiting → drain it. Registered only when
+                            // staging is non-empty, so an idle resolver still blocks in select (no busy-spin).
+                            // A synchronously-ready onReceive is selected before the zero-delay timeout can
+                            // dispatch, so this fires only when all channels are momentarily empty.
                             if (!stagingIndex.isEmpty) {
                                 @OptIn(ExperimentalCoroutinesApi::class)
                                 onTimeout(0.milliseconds) { null }
                             }
                         }
 
-                        if (task == null) {
-                            drainStaging()
-                            continue
-                        }
-
                         try {
                             when (task) {
+                                null -> drainStaging()   // idle: flush the accumulated batch
                                 is SourceLogTask.Batch -> handleSourceLogBatch(task.records)
                                 is ExtSourceTask.IndexTx -> handleIndexTx(task)
                                 is GcTask.TriesDeleted -> handleTriesDeleted(task)
                             }
-                            task.onComplete.complete(Unit)
+                            task?.onComplete?.complete(Unit)
                         } catch (e: CancellationException) {
-                            task.onComplete.cancel(e)
+                            task?.onComplete?.cancel(e)
                             throw e
                         } catch (e: InterruptedException) {
-                            task.onComplete.completeExceptionally(e)
+                            task?.onComplete?.completeExceptionally(e)
                             throw e
                         } catch (e: Interrupted) {
-                            task.onComplete.completeExceptionally(e)
+                            task?.onComplete?.completeExceptionally(e)
                             throw e
                         } catch (e: Throwable) {
                             watchers.notifyError(e)
-                            task.onComplete.completeExceptionally(e)
+                            task?.onComplete?.completeExceptionally(e)
                             throw e
                         }
                     }
@@ -445,6 +482,10 @@ class LeaderLogProcessor(
                 } catch (t: Throwable) {
                     cause = t
                 } finally {
+                    // Fail the handles of any txs left accumulated (never drained): the resolver swallows
+                    // the fault into `cause` and is a supervisor child, so its exit won't cancel a caller
+                    // awaiting a staged tx's `durable` — without this they'd hang.
+                    stagingIndex.failPending(cause)
                     sourceLogCh.close(cause)
                     extSourceCh.close(cause)
                     gcCh.close(cause)
@@ -476,23 +517,30 @@ class LeaderLogProcessor(
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
         OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer, stagingIndex.resolvedTxs)
 
+    private suspend fun indexExtTx(
+        externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
+        writer: suspend (OpenTx) -> TxResult,
+    ): ExtSourceTask.IndexTx =
+        ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer).also { enqueue(it) }
+
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
         writer: suspend (OpenTx) -> TxResult,
-    ): TxResult =
-        ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer)
-            .also { enqueue(it).await() }
-            .result.await()
+    ): TxResult {
+        val task = indexExtTx(externalSourceToken, systemTime, writer)
+        task.durable.await()          // suspend until the tx is durable (promoted at the next drain)
+        return task.result.await()    // completed at staging, so already available once durable
+    }
 
     override suspend fun submitTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
         writer: suspend (OpenTx) -> TxResult,
-    ) {
-        // Fire-and-forget: enqueue and return without awaiting the completion handle. The task's
-        // `result`/`onComplete` are completed by the persister but go unawaited here — an unrecoverable
-        // failure closes the channel with its cause, so the next `enqueue` (this or `executeTx`) throws it.
-        enqueue(ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer))
-    }
+    ): Deferred<Unit> =
+        // Fire-and-forget: enqueue and hand back the durability handle without awaiting it. A caller that
+        // needs durability awaits it (that's `executeTx`); a high-volume source drops it. An unrecoverable
+        // ingestion failure closes the channel with its cause, so the next enqueue (this or `executeTx`)
+        // throws it — and the handle itself is failed if the drain faults before this tx is durable.
+        indexExtTx(externalSourceToken, systemTime, writer).durable
 
     private suspend fun maybeFlushBlock() {
         if (blockFlusher.checkBlockTimeout(blockCatalog, liveIndex)) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -3,6 +3,7 @@ package xtdb.indexer
 import io.micrometer.core.instrument.Counter
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.selectUnbiased
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.Metrics.withSpan
@@ -38,6 +39,7 @@ import xtdb.util.StringUtil.asLexDec
 import xtdb.util.StringUtil.asLexHex
 import java.nio.ByteBuffer
 import java.time.*
+import kotlin.time.Duration.Companion.milliseconds
 
 private val SKIPPED_EXN: Throwable = Fault("Transaction was skipped", "xtdb/skipped-tx")
 
@@ -397,11 +399,25 @@ class LeaderLogProcessor(
                 var cause: Throwable? = null
                 try {
                     while (true) {
-                        val task: PersisterTask = selectUnbiased {
+                        val task: PersisterTask? = selectUnbiased {
                             sourceLogCh.onReceive { it }
                             extSourceCh.onReceive { it }
                             gcCh.onReceive { it }
+
+                            // Idle: no task ready and a batch is waiting → drain it. The arm is registered
+                            // only when staging is non-empty, so an idle resolver still blocks in select
+                            // (no busy-spin); a ready onReceive wins the select over the zero timeout.
+                            if (!stagingIndex.isEmpty) {
+                                @OptIn(ExperimentalCoroutinesApi::class)
+                                onTimeout(0.milliseconds) { null }
+                            }
                         }
+
+                        if (task == null) {
+                            drainStaging()
+                            continue
+                        }
+
                         try {
                             when (task) {
                                 is SourceLogTask.Batch -> handleSourceLogBatch(task.records)

--- a/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CompletableDeferred
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
@@ -32,8 +33,10 @@ import xtdb.util.safelyOpening
  * slice. So a ResolvedTx outlives its OpenTx — the resolver closes the OpenTx right after staging — and
  * its lifetime is its own (freed at [close], on promote/teardown).
  *
- * No durability handle: the single async replica-log commit is what confirms durability, and the per-tx
- * replica-log positions for the apply cursor come back from that commit — not from here.
+ * The per-tx replica-log positions for the apply cursor come back from the replica-log commit — not from
+ * here. [durable] is the awaiting *caller's* signal (an ext-source `executeTx`/`submitTx`), completed at
+ * promote; null for source-log and attach/detach txs, whose durability is observed through the batch's
+ * completion instead.
  */
 class ResolvedTx private constructor(
     val txKey: TransactionKey,
@@ -41,8 +44,15 @@ class ResolvedTx private constructor(
     val txResult: TransactionResult,
     val externalSourceToken: ExternalSourceToken?,
     private val dbOp: DbOp?,
+    private val durable: CompletableDeferred<Unit>?,
     private val tables: Map<TableRef, Table>,
 ) : AutoCloseable {
+
+    /** Signal the awaiting caller that this tx is now durable (promoted into the live index). */
+    fun markDurable() { durable?.complete(Unit) }
+
+    /** Fail the awaiting caller when the drain faults before this tx is durable, so it throws rather than hangs. */
+    fun failDurable(cause: Throwable) { durable?.completeExceptionally(cause) }
 
     /** One table's staged writes: an owned slice of the tx's relation plus its iid trie. */
     class Table(val ref: TableRef, val relation: Relation, private val trie: MemoryHashTrie) : AutoCloseable {
@@ -104,7 +114,7 @@ class ResolvedTx private constructor(
         @JvmStatic
         fun stage(
             al: BufferAllocator, openTx: OpenTx, srcMsgId: MessageId,
-            txResult: TransactionResult, dbOp: DbOp?,
+            txResult: TransactionResult, dbOp: DbOp?, durable: CompletableDeferred<Unit>?,
         ): ResolvedTx =
             mutableListOf<Table>().closeAllOnCatch { staged ->
                 // Every table the tx touched, including 0-row ones: `CREATE TABLE` declares columns with no
@@ -117,7 +127,7 @@ class ResolvedTx private constructor(
                 }
 
                 ResolvedTx(
-                    openTx.txKey, srcMsgId, txResult, openTx.externalSourceToken, dbOp,
+                    openTx.txKey, srcMsgId, txResult, openTx.externalSourceToken, dbOp, durable,
                     staged.associateBy { it.ref }
                 )
             }

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -1,5 +1,7 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
@@ -44,10 +46,24 @@ class StagingIndex(
      * Stage a resolved [openTx]: take independent slices of its writes into the staging allocator, hold
      * them in the accumulating slot, and advance the applied head. The caller closes [openTx] afterwards.
      */
-    fun stage(openTx: OpenTx, srcMsgId: MessageId, txResult: TransactionResult, dbOp: DbOp?) {
+    fun stage(
+        openTx: OpenTx, srcMsgId: MessageId, txResult: TransactionResult, dbOp: DbOp?,
+        durable: CompletableDeferred<Unit>?,
+    ) {
         // ResolvedTx.stage cleans up its own partial slices on throw; nothing else here can leak.
-        accumulating.addLast(ResolvedTx.stage(allocator, openTx, srcMsgId, txResult, dbOp))
+        accumulating.addLast(ResolvedTx.stage(allocator, openTx, srcMsgId, txResult, dbOp, durable))
         latestCompletedTx = openTx.txKey
+    }
+
+    /**
+     * Fail the durability handles of all still-accumulated (never-drained) txs — the terminal path when
+     * the resolver exits without draining them (term teardown, or an unrecoverable fault on an unrelated
+     * task). Without this an executeTx caller awaiting a staged tx's handle would hang: the resolver
+     * swallows faults and is a supervisor child, so its exit doesn't cancel the caller on its own.
+     */
+    fun failPending(cause: Throwable?) {
+        val ex = cause ?: CancellationException("leader term ended before the tx was made durable")
+        accumulating.forEach { it.failDurable(ex) }
     }
 
     /** Take the accumulated slot as an ordered batch (send order) and clear the slot. */

--- a/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.Deferred
 import xtdb.database.ExternalSourceToken
 import java.time.Instant
 
@@ -37,12 +38,16 @@ interface TxIndexer {
     ): TxResult
 
     /**
-     * Like [executeTx], but hands the transaction off and returns without waiting for its [TxResult] — for a
-     * high-volume source that only needs ingestion to stay healthy, not each individual result, so it can keep
-     * submitting while the indexer works through the backlog.
+     * Like [executeTx], but hands the transaction off and returns as soon as it is queued — for a high-volume
+     * source that only needs ingestion to stay healthy, not each individual result, so it can keep submitting
+     * while the indexer works through the backlog. Ordering is preserved by the hand-off queue, so a caller can
+     * submit ahead without its transactions being reordered.
+     *
+     * Returns a durability handle that completes once the transaction is durable; [executeTx] is exactly this
+     * followed by awaiting the handle. A fire-and-forget caller ignores it.
      *
      * The hand-off buffer is bounded, so [submitTx] still suspends under backpressure; it just doesn't block on
-     * the result. An unrecoverable ingestion failure surfaces on a subsequent [submitTx] or [executeTx] — the call
+     * durability. An unrecoverable ingestion failure surfaces on a subsequent [submitTx] or [executeTx] — the call
      * throws the failure cause — so a caller can't keep submitting into a dead indexer and have its transactions
      * silently vanish.
      */
@@ -50,5 +55,5 @@ interface TxIndexer {
         externalSourceToken: ExternalSourceToken?,
         systemTime: Instant? = null,
         writer: suspend (OpenTx) -> TxResult,
-    )
+    ): Deferred<Unit>
 }

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -305,6 +306,108 @@ class ExternalSourceTest {
             "the fire-and-forget caller sees the original failure cause"
         )
         assertNotNull(watchers.exception, "watchers should also be in failed state")
+    }
+
+    @Test
+    fun `executeTx throws when the drain faults, rather than hanging`() = runTest {
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { commitTx(any(), any()) } throws RuntimeException("commit pipeline fault")
+        }
+
+        val thrown = CompletableDeferred<Throwable>()
+        val extSource = object : ExternalSource {
+            override suspend fun onPartitionAssigned(
+                partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer
+            ) {
+                try {
+                    txIndexer.executeTx(null) { TxResult.Committed() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    thrown.complete(e)
+                }
+            }
+
+            override fun close() {}
+        }
+
+        leaderProc(liveIndex = liveIndex, extSource = extSource)
+
+        val e = thrown.await()
+        assertEquals(
+            "commit pipeline fault", e.message,
+            "executeTx surfaces the drain fault via its durability handle instead of hanging"
+        )
+    }
+
+    @Test
+    fun `submitTx's durability handle fails when the drain faults`() = runTest {
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { commitTx(any(), any()) } throws RuntimeException("commit pipeline fault")
+        }
+
+        val thrown = CompletableDeferred<Throwable>()
+        val extSource = object : ExternalSource {
+            override suspend fun onPartitionAssigned(
+                partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer
+            ) {
+                val handle = txIndexer.submitTx(null) { TxResult.Committed() }
+                try {
+                    handle.await()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    thrown.complete(e)
+                }
+            }
+
+            override fun close() {}
+        }
+
+        leaderProc(liveIndex = liveIndex, extSource = extSource)
+
+        val e = thrown.await()
+        assertEquals(
+            "commit pipeline fault", e.message,
+            "the handle submitTx returns surfaces the drain fault"
+        )
+    }
+
+    @Test
+    fun `a burst of submitTx accumulates and all commit in send order`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val n = 8
+        val allDurable = CompletableDeferred<Unit>()
+
+        // Fires the whole burst back-to-back (each submitTx returns as soon as it's queued), collecting the
+        // durability handles, then awaits them all — a concrete 'all durable' signal, no blind delay. The
+        // txs accumulate and drain together; this asserts accumulation preserves send order and loses none.
+        val extSource = object : ExternalSource {
+            override suspend fun onPartitionAssigned(
+                partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer
+            ) {
+                val handles = (0 until n).map { txIndexer.submitTx(null) { TxResult.Committed() } }
+                handles.awaitAll()
+                allDurable.complete(Unit)
+            }
+
+            override fun close() {}
+        }
+
+        leaderProc(replicaLog = replicaLog, extSource = extSource)
+
+        allDurable.await()
+
+        val resolvedTxs = mutableListOf<ReplicaMessage.ResolvedTx>()
+        backgroundScope.launch {
+            replicaLog.tailAll(-1) { records ->
+                records.forEach { (it.message as? ReplicaMessage.ResolvedTx)?.let(resolvedTxs::add) }
+            }
+        }
+        delay(200.milliseconds)
+
+        assertEquals((0L until n).toList(), resolvedTxs.map { it.txId }, "all $n txs land, in send order")
+        assertTrue(resolvedTxs.all { it.committed }, "all $n txs committed")
     }
 
     @Test

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -138,7 +138,7 @@
     (util/with-open [staging-alloc (util/->child-allocator (.getAllocator tu/*node*) "staging")]
       (util/with-open [staged (with-open [create-tx (tu/->open-tx tx-key)]
                                 (.executeSql create-tx "CREATE TABLE foo (_id, bar)")
-                                (ResolvedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil))
+                                (ResolvedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil nil))
                        observer-tx (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-01T00:00:01Z"})
                        snap (.openSnapshot live-index [staged] observer-tx)]
         (t/is (.containsKey (.getTableInfo snap) table)


### PR DESCRIPTION
Part of #5507.

## Summary

The leader's external-source ingest (Postgres mirror, Kafka connect sink) committed one replica-log transaction per CDC tx. This lets ext-source txs accumulate into a shared staging batch and commit together when the resolver goes idle — the same treatment the source-log poll batch already gets (#5782).

## Context

#5507 batches and pipelines the leader's replica-log writes; #5782 landed the source-log side (accumulate a poll batch, one fenced commit). This is the external-source follow-up: the benchmark-agnostic foundation both CDC drivers need before any driver-specific tuning. A colleague is benchmarking FHIR ingest through multiple sources offline, and this is what lets the ext-source path benefit from batching at all.

Postgres-driver pipelining (decoupling the WAL slot-ack from `nextTransaction`) and cross-batch overlap (a committer coroutine resolving ahead of an in-flight commit) are explicitly out of scope. This keeps `drainStaging` synchronous, so the resolver never runs ahead of an in-flight commit — it's unaffected by the demote-off-thread question.

## Changes

1. `refactor(indexer)` — add a dormant idle-drain arm to the resolver's select loop. Behaviour-preserving: the arm never fires while the per-tx drain still stands, so it lands as a pure no-op.

2. `feat(indexer)` — remove the per-tx drain so ext-source txs accumulate; `submitTx` returns a durability handle; `executeTx` = submit + await; the GC drain-before-append barrier.

## Implementation notes

**Drain when idle.** A zero-delay `onTimeout` arm on the resolver's `selectUnbiased`, registered only while staging is non-empty (no busy-spin). A synchronously-ready `onReceive` is selected before the zero timeout dispatches, so it fires only when all channels are momentarily empty. There's no cap or timer — a new commit can't start before the previous one finishes (single fenced producer), and the synchronous drain already waits for that, so the batching window is free.

**Durability handle.** `submitTx` returns as soon as the tx is queued — ordering is guaranteed by the hand-off FIFO and the single resolver, not by staging — and hands back a `Deferred<Unit>` that completes on durability. `executeTx` is exactly `submitTx` plus awaiting it. A fire-and-forget source (the Kafka connect sink) drops the handle; the Postgres mirror awaits it. The handle is signalled after the *whole* drain, including any block cut: signalling mid-loop let a caller race ahead of an in-flight `finishBlock`, which a term teardown could then cancel between the `BlockBoundary` and its `BlockUploaded`, leaving an orphan boundary on the replica log.

The handle must be completed on *every* terminal path a staged tx can take, or an awaiting `executeTx` hangs. The resolver swallows faults and is a supervisor child, so its death doesn't cancel the caller — so the channel's `onUndeliveredElement` and the resolver's teardown (`StagingIndex.failPending`) close the two gaps the old `onComplete`-await path covered but the narrower `durable` handle didn't.

**GC ordering.** A GC `TriesDeleted` appends to the replica log directly, so it now drains first — like the existing control-message barrier — because appending ahead of earlier-staged txs would invert the log order once txs accumulate.

## Out of scope / follow-ups

On a mid-batch drain fault the whole batch's durability handles are failed, including txs already promoted. This is harmless while `executeTx` callers are serial (batch-of-one, as Postgres is today); per-tx granularity is a follow-up for pipelined callers.

Coalescing is emergent — how much a burst batches depends on how much accumulates before the resolver idles, which the capacity-1 hand-off channel bounds. That capacity is the throughput knob the FHIR benchmark will size; it's deliberately left at 1 here.

## Test plan

`ExternalSourceTest` (real `LeaderLogProcessor` + in-memory replica log) covers a lone `executeTx` becoming durable off the idle drain, a burst of `submitTx` accumulating and all committing in send order (awaiting the real durability handles, no blind delay), and `executeTx`/`submitTx` handles throwing on a drain fault rather than hanging. `LogProcessorSimTest` (300 property iterations) and `LeaderLogProcessorTest` guard block-boundary/upload consistency and source-log behaviour. Full `./gradlew test` is green, with no new reflection/boxed-math warnings.

Generated with Claude Code