### PR TITLE
refactor(arrow): direct per-vector append, bypassing RowCopier (#5781)

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -359,7 +359,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 clearArgs()
                 args = Relation(allocator, root.schema).closeOnCatch { copy ->
                     Relation.fromRoot(allocator, root).use { src ->
-                        src.rowCopier(copy).copyRange(0, src.rowCount)
+                        copy.append(src)
                     }
                     copy
                 }
@@ -918,7 +918,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     this.docs?.close()
                     docs = Relation(allocator, root.schema).closeOnCatch { copy ->
                         Relation.fromRoot(allocator, root).use { src ->
-                            src.rowCopier(copy).copyRange(0, src.rowCount)
+                            copy.append(src)
                         }
                         copy
                     }

--- a/core/src/main/kotlin/xtdb/arrow/BitVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/BitVector.kt
@@ -7,6 +7,7 @@ import org.apache.arrow.vector.ipc.message.ArrowFieldNode
 import org.apache.arrow.vector.types.pojo.ArrowType
 import xtdb.api.query.IKeyFn
 import xtdb.arrow.VectorType.Companion.BOOL
+import xtdb.arrow.VectorIndirection.Companion.Slice
 import xtdb.arrow.metadata.MetadataFlavour
 import xtdb.util.Hasher
 import org.apache.arrow.vector.BitVector as ArrowBitVector
@@ -91,6 +92,15 @@ class BitVector private constructor(
             if (srcNullable && !nullable) nullable = true
             if (src.isNull(srcIdx)) writeNull() else writeBoolean(src.getBoolean(srcIdx))
         }
+    }
+
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is BitVector)
+        nullable = nullable || src.nullable
+
+        validityBuffer?.writeBits(src.validityBuffer, Slice(startIdx, len))
+        dataBuffer.writeBits(src.dataBuffer, Slice(startIdx, len))
+        valueCount += len
     }
 
     override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {

--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -193,6 +193,19 @@ class DenseUnionVector private constructor(
             return RowCopier { srcIdx -> writeValueThen(); innerCopier.copyRow(srcIdx) }
         }
 
+        // bulk analogue of rowCopierFrom: the whole [startIdx, startIdx+len) slice lands in this leg
+        fun appendRangeFrom(src: VectorReader, startIdx: Int, len: Int) {
+            if (!nested) {
+                val base = inner.valueCount
+                repeat(len) { i ->
+                    typeBuffer.writeByte(typeId)
+                    offsetBuffer.writeInt(base + i)
+                    this@DenseUnionVector.valueCount++
+                }
+            }
+            src.appendRangeTo(inner, startIdx, len)
+        }
+
         override fun clear() = inner.clear()
         override fun close() = reader.close()
     }
@@ -366,6 +379,68 @@ class DenseUnionVector private constructor(
 
             else -> src.rowCopier(legVectorFor(src.arrowType.toLeg(), src.arrowType, src.nullable))
         }
+
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        if (src !is DenseUnionVector) {
+            // mono source → the matching leg absorbs the whole slice
+            legVectorFor(src.arrowType.toLeg(), src.arrowType, src.nullable).appendRangeFrom(src, startIdx, len)
+            return
+        }
+
+        val pairs = src.legVectors.map { it to legVectorFor(it.name, it.arrowType, it.nullable) }
+        val destTypeIds = ByteArray(pairs.size) { pairs[it].second.typeId }
+
+        if (startIdx == 0 && len == src.valueCount) {
+            val destOffsets = IntArray(pairs.size) { pairs[it].second.inner.valueCount }
+
+            repeat(len) { srcIdx ->
+                val srcTypeId = src.typeBuffer.getByte(srcIdx).toInt()
+                if (srcTypeId < 0) {
+                    typeBuffer.writeByte(-1)
+                    offsetBuffer.writeInt(0)
+                } else {
+                    typeBuffer.writeByte(destTypeIds[srcTypeId])
+                    offsetBuffer.writeInt(src.offsetBuffer.getInt(srcIdx) + destOffsets[srcTypeId])
+                }
+            }
+
+            pairs.forEach { (srcLeg, destLeg) -> srcLeg.appendRangeTo(destLeg.inner, 0, srcLeg.valueCount) }
+
+            valueCount += len
+        } else {
+            // sub-range: source leg elements aren't contiguous per leg, so copy element-by-element
+            repeat(len) { i ->
+                val srcIdx = startIdx + i
+                val srcTypeId = src.getTypeId(srcIdx).toInt()
+                if (srcTypeId < 0) {
+                    typeBuffer.writeByte(-1)
+                    offsetBuffer.writeInt(0)
+                    valueCount++
+                } else {
+                    val (srcLeg, destLeg) = pairs[srcTypeId]
+                    destLeg.appendRangeFrom(srcLeg, src.getOffset(srcIdx), 1)
+                }
+            }
+        }
+    }
+
+    // as a source: the degenerate shapes below have special leg-collapsing behaviour in `rowCopier`
+    // (a 1-leg or nullable-mono DUV re-legs by type name), so mirror it exactly by delegating to the
+    // copier; every other shape (e.g. the 3-leg `op` vector) takes the bulk `appendRange0` path.
+    override fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
+        when {
+            legVectors.size == 1 || (legVectors.size == 2 && legVectors.count { it.arrowType == NULL_TYPE } == 1) ->
+                rowCopier(dest).copyRange(startIdx, len)
+
+            dest is DenseUnionVector -> dest.appendRange0(this, startIdx, len)
+
+            else -> {
+                check(dest is Vector) { "can only append to another Vector, got ${dest::class}" }
+                if (arrowType != dest.arrowType) throw InvalidCopySourceException(this, dest)
+                dest.appendRange0(this, startIdx, len)
+            }
+        }
+    }
 
     override fun rowCopier(dest: VectorWriter) =
         when {

--- a/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/DenseUnionVector.kt
@@ -426,20 +426,12 @@ class DenseUnionVector private constructor(
 
     // as a source: the degenerate shapes below have special leg-collapsing behaviour in `rowCopier`
     // (a 1-leg or nullable-mono DUV re-legs by type name), so mirror it exactly by delegating to the
-    // copier; every other shape (e.g. the 3-leg `op` vector) takes the bulk `appendRange0` path.
+    // copier; every other shape (e.g. the 3-leg `op` vector) takes the shared bulk dispatch.
     override fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
-        when {
-            legVectors.size == 1 || (legVectors.size == 2 && legVectors.count { it.arrowType == NULL_TYPE } == 1) ->
-                rowCopier(dest).copyRange(startIdx, len)
-
-            dest is DenseUnionVector -> dest.appendRange0(this, startIdx, len)
-
-            else -> {
-                check(dest is Vector) { "can only append to another Vector, got ${dest::class}" }
-                if (arrowType != dest.arrowType) throw InvalidCopySourceException(this, dest)
-                dest.appendRange0(this, startIdx, len)
-            }
-        }
+        if (legVectors.size == 1 || (legVectors.size == 2 && legVectors.count { it.arrowType == NULL_TYPE } == 1))
+            rowCopier(dest).copyRange(startIdx, len)
+        else
+            super.appendRangeTo(dest, startIdx, len)
     }
 
     override fun rowCopier(dest: VectorWriter) =

--- a/core/src/main/kotlin/xtdb/arrow/ExtensionVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/ExtensionVector.kt
@@ -65,6 +65,12 @@ abstract class ExtensionVector : MonoVector() {
         return inner.rowCopier0(src.inner)
     }
 
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is ExtensionVector)
+
+        inner.appendRange0(src.inner, startIdx, len)
+    }
+
     override fun valueReader(): ValueReader = inner.valueReader()
 
     override fun clear() = inner.clear()

--- a/core/src/main/kotlin/xtdb/arrow/FixedSizeListVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedSizeListVector.kt
@@ -8,6 +8,7 @@ import org.apache.arrow.vector.ipc.message.ArrowFieldNode
 import org.apache.arrow.vector.types.pojo.ArrowType
 import xtdb.api.query.IKeyFn
 import xtdb.arrow.VectorType.Listy
+import xtdb.arrow.VectorIndirection.Companion.Slice
 import xtdb.arrow.metadata.MetadataFlavour
 import xtdb.util.Hasher
 import xtdb.util.closeOnCatch
@@ -139,6 +140,23 @@ class FixedSizeListVector private constructor(
                 endList()
             }
         }
+    }
+
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is FixedSizeListVector)
+        check(src.listSize == listSize)
+        nullable = nullable || src.nullable
+
+        validityBuffer?.writeBits(src.validityBuffer, Slice(startIdx, len))
+
+        try {
+            src.elVector.appendRangeTo(elVector, startIdx * listSize, len * listSize)
+        } catch (_: InvalidCopySourceException) {
+            elVector = elVector.maybePromote(al, src.elVector.arrowType, src.elVector.nullable)
+            src.elVector.appendRangeTo(elVector, startIdx * listSize, len * listSize)
+        }
+
+        valueCount += len
     }
 
     override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {

--- a/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/FixedWidthVector.kt
@@ -214,6 +214,17 @@ sealed class FixedWidthVector : MonoVector() {
         }
     }
 
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is FixedWidthVector)
+        check(src.byteWidth == byteWidth)
+        nullable = nullable || src.nullable
+
+        dataBuffer.ensureWritable((len * byteWidth).toLong())
+        validityBuffer?.writeBits(src.validityBuffer, Slice(startIdx, len))
+        dataBuffer.unsafeWriteBytes(src.dataBuffer, (startIdx * byteWidth).toLong(), (len * byteWidth).toLong())
+        valueCount += len
+    }
+
     final override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {
         nodes.add(ArrowFieldNode(valueCount.toLong(), if (nullable) -1 else 0))
         if (nullable) validityBuffer?.unloadBuffer(buffers) else buffers.add(al.empty)

--- a/core/src/main/kotlin/xtdb/arrow/IndirectVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/IndirectVector.kt
@@ -74,6 +74,11 @@ class IndirectVector(private val inner: VectorReader, private val sel: VectorInd
         }
     }
 
+    // an indirect "range" is really a selection, so there's no buffer-level append — delegate to the copier
+    override fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
+        rowCopier(dest).copyRange(startIdx, len)
+    }
+
     override fun valueReader(): ValueReader {
         val inner = inner.valueReader()
         return object : ValueReader by inner {

--- a/core/src/main/kotlin/xtdb/arrow/ListVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/ListVector.kt
@@ -153,6 +153,33 @@ class ListVector private constructor(
         }
     }
 
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is ListVector)
+        nullable = nullable || src.nullable
+        if (len <= 0) return
+
+        val baseOffset = lastOffset
+        val srcElStart = src.getListStartIndex(startIdx)
+        val elCount = src.getListEndIndex(startIdx + len - 1) - srcElStart
+
+        try {
+            src.elVector.appendRangeTo(elVector, srcElStart, elCount)
+        } catch (_: InvalidCopySourceException) {
+            elVector = elVector.maybePromote(al, src.elVector.arrowType, src.elVector.nullable)
+            src.elVector.appendRangeTo(elVector, srcElStart, elCount)
+        }
+
+        repeat(len) { i ->
+            val srcIdx = startIdx + i
+            if (valueCount == 0) offsetBuffer.writeInt(0)
+            val destEnd = baseOffset + (src.getListEndIndex(srcIdx) - srcElStart)
+            offsetBuffer.writeInt(destEnd)
+            lastOffset = destEnd
+            validityBuffer?.writeBit(valueCount, if (src.isNull(srcIdx)) 0 else 1)
+            valueCount++
+        }
+    }
+
     override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {
         nodes.add(ArrowFieldNode(valueCount.toLong(), if (nullable) -1 else 0))
         if (nullable) validityBuffer?.unloadBuffer(buffers) else buffers.add(al.empty)

--- a/core/src/main/kotlin/xtdb/arrow/MapVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MapVector.kt
@@ -51,6 +51,11 @@ class MapVector(private val listVector: ListVector, private val keysSorted: Bool
         return listVector.rowCopier0(src.listVector)
     }
 
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is MapVector)
+        listVector.appendRange0(src.listVector, startIdx, len)
+    }
+
     override fun getObject0(idx: Int, keyFn: IKeyFn<*>): Any {
         val startIdx = listVector.getListStartIndex(idx)
         val entryCount = listVector.getListCount(idx)

--- a/core/src/main/kotlin/xtdb/arrow/NullVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/NullVector.kt
@@ -82,6 +82,17 @@ class NullVector(
 
     override fun rowCopier0(src: VectorReader) = RowCopier { writeNull() }
 
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        if (!nullable) nullable = true
+        valueCount += len
+    }
+
+    // as a source: write nulls into any dest (mirrors rowCopier above)
+    override fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
+        if (dest is DenseUnionVector) dest.appendRange0(this, startIdx, len)
+        else repeat(len) { dest.writeNull() }
+    }
+
     override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {
         nodes.add(ArrowFieldNode(valueCount.toLong(), valueCount.toLong()))
     }

--- a/core/src/main/kotlin/xtdb/arrow/RelationAsStructReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/RelationAsStructReader.kt
@@ -39,6 +39,12 @@ class RelationAsStructReader(
         }
     }
 
+    override fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
+        rel.vectors.forEach { it.appendRangeTo(dest.vectorFor(it.name, it.arrowType, it.nullable), startIdx, len) }
+        // children are already `len` ahead, so each endStruct just advances the struct's validity/count
+        repeat(len) { dest.endStruct() }
+    }
+
     override fun valueReader(): ValueReader {
         val rdrs = rel.vectors.associate { it.name to it.valueReader() }
 

--- a/core/src/main/kotlin/xtdb/arrow/SingletonListReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/SingletonListReader.kt
@@ -38,6 +38,11 @@ class SingletonListReader(override val name: String, private val elReader: Vecto
         }
     }
 
+    // a synthetic single-row list view — no buffer-level append, so delegate to the copier
+    override fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
+        rowCopier(dest).copyRange(startIdx, len)
+    }
+
     override fun hashCode(idx: Int, hasher: Hasher): Int {
         var hash = 0
         for (i in 0 until valueCount) {

--- a/core/src/main/kotlin/xtdb/arrow/StructVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/StructVector.kt
@@ -203,6 +203,20 @@ class StructVector private constructor(
         }
     }
 
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is StructVector)
+        nullable = nullable || src.nullable
+
+        validityBuffer?.writeBits(src.validityBuffer, Slice(startIdx, len))
+
+        for (colName in src.childWriters.keys + childWriters.keys) {
+            val srcChild = src.vectorForOrNull(colName) ?: NullVector(colName, true, src.valueCount)
+            srcChild.appendRangeTo(vectorFor(colName, srcChild.arrowType, srcChild.nullable), startIdx, len)
+        }
+
+        valueCount += len
+    }
+
     override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {
         nodes.add(ArrowFieldNode(valueCount.toLong(), if (nullable) -1 else 0))
         if (nullable) validityBuffer?.unloadBuffer(buffers) else buffers.add(allocator.empty)

--- a/core/src/main/kotlin/xtdb/arrow/VariableWidthVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VariableWidthVector.kt
@@ -162,6 +162,37 @@ abstract class VariableWidthVector : MonoVector() {
         }
     }
 
+    override fun appendRange0(src: VectorReader, startIdx: Int, len: Int) {
+        check(src is VariableWidthVector)
+        nullable = nullable || src.nullable
+        if (len <= 0) return
+
+        val srcValidity = src.validityBuffer
+        val srcOffset = src.offsetBuffer
+        val srcData = src.dataBuffer
+
+        val srcStartOffset = srcOffset.getInt(startIdx)
+        val srcEndOffset = srcOffset.getInt(startIdx + len)
+        val dataLen = srcEndOffset - srcStartOffset
+
+        validityBuffer?.ensureWritable(len)
+        offsetBuffer.ensureWritable(((len + 1) * Integer.BYTES).toLong())
+        dataBuffer.ensureWritable(dataLen.toLong())
+
+        validityBuffer?.writeBits(srcValidity, Slice(startIdx, len))
+
+        if (valueCount == 0) offsetBuffer.unsafeWriteInt(0)
+        val offsetDelta = lastOffset - srcStartOffset
+        repeat(len) {
+            offsetBuffer.unsafeWriteInt(srcOffset.getInt(startIdx + it + 1) + offsetDelta)
+        }
+
+        dataBuffer.unsafeWriteBytes(srcData, srcStartOffset.toLong(), dataLen.toLong())
+        lastOffset += dataLen
+
+        valueCount += len
+    }
+
     override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {
         nodes.add(ArrowFieldNode(valueCount.toLong(), if (nullable) -1 else 0))
         if (nullable) validityBuffer?.unloadBuffer(buffers) else buffers.add(al.empty)

--- a/core/src/main/kotlin/xtdb/arrow/Vector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Vector.kt
@@ -78,6 +78,13 @@ sealed class Vector : VectorReader, VectorWriter {
     internal abstract fun rowCopier0(src: VectorReader): RowCopier
 
     /**
+     * Appends the `[startIdx, startIdx + len)` slice of [src] directly into this vector, without
+     * constructing a [RowCopier]. [src] must already match this vector's shape (the caller promotes
+     * — see `VectorWriter.appendRange`); a [DenseUnionVector] absorbs a leg-typed source.
+     */
+    internal abstract fun appendRange0(src: VectorReader, startIdx: Int, len: Int)
+
+    /**
      * Divides this vector by [divisorVec] and writes the result into [outVec].
      * Returns null for any element where the divisor is zero (to avoid NaN).
      */

--- a/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
@@ -111,6 +111,24 @@ interface VectorReader : ILookup, AutoCloseable {
 
     fun rowCopier(dest: VectorWriter): RowCopier
 
+    /**
+     * Appends the `[startIdx, startIdx + len)` slice of this reader into [dest] without constructing
+     * a [RowCopier]. Source-dispatched, mirroring [rowCopier]: a [DenseUnionVector] dest absorbs a
+     * leg-typed source; otherwise the shallow arrow types must match (the caller promotes — see
+     * `VectorWriter.appendRange`), else [InvalidCopySourceException] is thrown for the caller to
+     * promote and retry.
+     */
+    fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
+        when {
+            dest is DenseUnionVector -> dest.appendRange0(this, startIdx, len)
+            dest is Vector -> {
+                if (arrowType != dest.arrowType) throw InvalidCopySourceException(this, dest)
+                dest.appendRange0(this, startIdx, len)
+            }
+            else -> error("can only append to another Vector, got ${dest::class}")
+        }
+    }
+
     companion object {
         fun toString(reader: VectorReader): String = reader.run {
             val content = when {

--- a/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VectorReader.kt
@@ -120,6 +120,7 @@ interface VectorReader : ILookup, AutoCloseable {
      */
     fun appendRangeTo(dest: VectorWriter, startIdx: Int, len: Int) {
         when {
+            dest is DenseUnionVector.LegVector -> dest.appendRangeFrom(this, startIdx, len)
             dest is DenseUnionVector -> dest.appendRange0(this, startIdx, len)
             dest is Vector -> {
                 if (arrowType != dest.arrowType) throw InvalidCopySourceException(this, dest)

--- a/core/src/main/kotlin/xtdb/arrow/VectorWriter.kt
+++ b/core/src/main/kotlin/xtdb/arrow/VectorWriter.kt
@@ -71,6 +71,5 @@ interface VectorWriter : VectorReader, AutoCloseable {
 
     fun appendRows(r: VectorReader, sel: IntArray) = r.rowCopier(this).copyRows(sel)
 
-    fun appendRange(r: VectorReader, startIdx: Int, length: Int) =
-        r.rowCopier(this).copyRange(startIdx, length)
+    fun appendRange(r: VectorReader, startIdx: Int, length: Int) = r.appendRangeTo(this, startIdx, length)
 }

--- a/core/src/test/kotlin/xtdb/arrow/AppendRangeTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/AppendRangeTest.kt
@@ -1,0 +1,173 @@
+package xtdb.arrow
+
+import io.kotest.matchers.shouldBe
+import org.apache.arrow.memory.BufferAllocator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import xtdb.test.AllocatorResolver
+
+/**
+ * `appendRangeTo` (the direct, copier-free append) must be behaviour-equivalent to
+ * `rowCopier(dest).copyRange(...)`. Each case copies the same source both ways and compares.
+ */
+@ExtendWith(AllocatorResolver::class)
+class AppendRangeTest {
+
+    /** Copies `src[offset, offset+len)` via the copier and via appendRangeTo into fresh dests, asserts equal. */
+    private fun assertAppendMatchesCopier(
+        al: BufferAllocator, src: VectorReader, offset: Int, len: Int, newDest: () -> Vector
+    ) {
+        newDest().use { viaCopier ->
+            newDest().use { viaAppend ->
+                src.rowCopier(viaCopier).copyRange(offset, len)
+                src.appendRangeTo(viaAppend, offset, len)
+
+                viaAppend.asList shouldBe viaCopier.asList
+                viaAppend.valueCount shouldBe viaCopier.valueCount
+            }
+        }
+    }
+
+    private fun ranges(n: Int) = listOf(0 to n, 0 to 0, 1 to (n - 1).coerceAtLeast(0), (n / 2) to (n - n / 2))
+
+    @Test
+    fun `fixed-width whole and sub-range`(al: BufferAllocator) {
+        IntVector.open(al, "src", true).use { src ->
+            listOf(1, 2, null, 4, 5).forEach { if (it == null) src.writeNull() else src.writeInt(it) }
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len) { IntVector.open(al, "d", true) }
+        }
+    }
+
+    @Test
+    fun `variable-width whole and sub-range`(al: BufferAllocator) {
+        Utf8Vector(al, "src", true).use { src ->
+            listOf("alpha", "b", null, "delta", "").forEach {
+                if (it == null) src.writeNull() else src.writeObject(it)
+            }
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len) { Utf8Vector(al, "d", true) }
+        }
+    }
+
+    @Test
+    fun `bit whole and sub-range`(al: BufferAllocator) {
+        BitVector(al, "src", true).use { src ->
+            listOf(true, false, null, true).forEach { if (it == null) src.writeNull() else src.writeBoolean(it) }
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len) { BitVector(al, "d", true) }
+        }
+    }
+
+    @Test
+    fun `struct whole and sub-range`(al: BufferAllocator) {
+        StructVector(al, "src", true).use { src ->
+            src.writeObject(mapOf("a" to 1L, "b" to "x"))
+            src.writeObject(mapOf("a" to 2L, "b" to "y"))
+            src.writeObject(mapOf("a" to 3L, "b" to "z"))
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len) { StructVector(al, "d", true) }
+        }
+    }
+
+    @Test
+    fun `struct with missing dest column back-fills nulls`(al: BufferAllocator) {
+        StructVector(al, "src", true).use { src ->
+            src.writeObject(mapOf("a" to 1L))
+            src.writeObject(mapOf("a" to 2L))
+
+            // dest already has a 'b' column; src has none, so appended rows should get null 'b'
+            StructVector(al, "viaCopier", true).use { viaCopier ->
+                StructVector(al, "viaAppend", true).use { viaAppend ->
+                    listOf(viaCopier, viaAppend).forEach {
+                        it.writeObject(mapOf("a" to 9L, "b" to "seed"))
+                    }
+                    src.rowCopier(viaCopier).copyRange(0, 2)
+                    src.appendRangeTo(viaAppend, 0, 2)
+
+                    viaAppend.asList shouldBe viaCopier.asList
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `dense union whole and sub-range`(al: BufferAllocator) {
+        DenseUnionVector(al, "src", listOf(LongVector(al, "i64", true), Utf8Vector(al, "utf8", true))).use { src ->
+            val i64 = src.vectorFor("i64"); val utf8 = src.vectorFor("utf8")
+            i64.writeLong(1); utf8.writeObject("two"); i64.writeLong(3); utf8.writeObject("four"); i64.writeLong(5)
+
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len) {
+                    DenseUnionVector(al, "d", listOf(LongVector(al, "i64", true), Utf8Vector(al, "utf8", true)))
+                }
+        }
+    }
+
+    @Test
+    fun `op-shape dense union with struct put leg`(al: BufferAllocator) {
+        // mirrors the log-relation `op` column: a DUV whose 'put' leg is a struct of doc columns
+        fun newOpVec() = DenseUnionVector(
+            al, "op",
+            listOf(StructVector(al, "put", false), NullVector("delete"))
+        )
+
+        newOpVec().use { src ->
+            val put = src.vectorFor("put")
+            put.writeObject(mapOf("_id" to 1L, "name" to "a"))
+            put.writeObject(mapOf("_id" to 2L, "name" to "b"))
+            src.vectorFor("delete").writeNull()
+            put.writeObject(mapOf("_id" to 3L, "name" to "c"))
+
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len, ::newOpVec)
+        }
+    }
+
+    @Test
+    fun `mono source absorbed into dense union leg`(al: BufferAllocator) {
+        LongVector(al, "src", true).use { src ->
+            listOf(1L, null, 3L).forEach { if (it == null) src.writeNull() else src.writeLong(it) }
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len) {
+                    DenseUnionVector(al, "d", listOf(LongVector(al, "i64", true)))
+                }
+        }
+    }
+
+    @Test
+    fun `list whole and sub-range`(al: BufferAllocator) {
+        ListVector(al, "src", true, IntVector.open(al, "\$data$", true)).use { src ->
+            src.writeObject(listOf(1, 2, 3))
+            src.writeObject(listOf<Int>())
+            src.writeObject(listOf(4))
+            src.writeObject(listOf(5, 6))
+            for ((off, len) in ranges(src.valueCount))
+                assertAppendMatchesCopier(al, src, off, len) {
+                    ListVector(al, "d", true, IntVector.open(al, "\$data$", true))
+                }
+        }
+    }
+
+    @Test
+    fun `RelationAsStructReader appended into struct`(al: BufferAllocator) {
+        IntVector.open(al, "a", false).use { a ->
+            Utf8Vector(al, "b", false).use { b ->
+                a.writeInt(1); a.writeInt(2); a.writeInt(3)
+                b.writeObject("x"); b.writeObject("y"); b.writeObject("z")
+                val rel = RelationReader.from(listOf(a, b), 3)
+                val src = RelationAsStructReader("docs", rel)
+
+                StructVector(al, "viaCopier", false).use { viaCopier ->
+                    StructVector(al, "viaAppend", false).use { viaAppend ->
+                        src.rowCopier(viaCopier).run { copyRow(0); copyRow(1); copyRow(2) }
+                        src.appendRangeTo(viaAppend, 0, 3)
+
+                        viaAppend.asList shouldBe viaCopier.asList
+                        viaAppend.valueCount shouldBe 3
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #5781 (the "faster append" avenue).

**Outcome: closing this unmerged — it didn't move the benchmark.** Opening it anyway to record the attempt and why the premise was wrong.

## What it does

Appending an Arrow vector routes through `RowCopier`: `VectorWriter.appendRange` built a fresh copier tree per call (`r.rowCopier(this).copyRange(...)`), used it to copy a contiguous slice, then threw it away. The hypothesis in #5781 was that this per-call *construction* — recursing the vector tree, allocating a closure per node, ~9 objects for a one-row `{_id}` put — was the per-transaction overhead dominating small-batch ingestion.

This adds a direct, copier-free path. `Vector.appendRange0` does the buffer-level copy per type (memcpy / `writeBits`, offset rebasing for the var-width and list types, a whole-vector fast path for dense unions), and `VectorReader.appendRangeTo` is the source-dispatched entry that mirrors `rowCopier` exactly — a `DenseUnionVector` dest absorbs a leg-typed source, a `LegVector` dest routes to `appendRangeFrom`, otherwise a shallow `arrowType` mismatch throws `InvalidCopySourceException` for the caller to promote and retry. `VectorWriter.appendRange` is then repointed onto it. `RowCopier` stays for the genuinely row-at-a-time callers (merge, sort, hash-distinct); `appendRows` (scatter) was left for a follow-up.

## Why it's closing

The `ingest-tx-overhead` benchmark showed no measurable change at any batch size.

The premise was wrong: the expensive part isn't *constructing* the copier, it's the copy work itself — walking the vector tree and moving the bytes. `appendRange0` does that same walk and the same byte-moves; it just does them from a method instead of from a closure the copier built. The work `RowCopier` was doing is relocated into `appendRange`, not removed, so the construction overhead we blamed turns out to be noise next to the copy itself — and, for one-row transactions, next to whatever else dominates the per-tx path outside the append.

No reason to carry a second copy path parallel to `RowCopier` for no gain.

## Salvageable independently

The first commit — `tidy: use RelationWriter.append for ADBC bind copies` — is a standalone equivalence cleanup unrelated to the perf question: it replaces a hand-rolled `rowCopier(...).copyRange(0, n)` with `append` at two `bind` sites. Worth keeping on its own, and can be cherry-picked to `main` separately.

## Test plan

Behaviour-preserving throughout. The direct path is verified equivalent to the copier by a new `AppendRangeTest` (each vector shape copied both ways and compared) and by the full unit suite (1599 tests green). The benchmark run was `ingest-tx-overhead` via `do-ingest-without-pgwire`.