### PR TITLE
perf(indexer): rebuild the live-index snapshot lazily instead of on every tx

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -17,9 +17,10 @@
 --     the live index, so the concurrency model below is the same regardless of
 --     which variant is in play.
 --   - Multiple concurrent readers: snapshots can be held and read concurrently
---   - Writes don't block reads: a shared, reference-counted snapshot is published
---     after each DURABLE confirmation; existing snapshots remain valid until their
---     last holder releases them
+--   - Writes don't block reads: a shared, reference-counted snapshot is a lazily-
+--     advanced cache, rebuilt on read only when a reader demands a basis it does
+--     not yet satisfy (gated by the reader's minimum basis); existing snapshots
+--     remain valid until their last holder releases them
 --
 -- Pipelining (leader only) — single-resolver model:
 --   On a leader, a SINGLE resolver coroutine drives the whole pipeline (see
@@ -61,14 +62,16 @@
 --   — opportunistically between the records of a source-log batch, or forced at drain
 --   points — by awaiting the per-tx positions and PROMOTING the batch
 --   into the durable live tables ONE TX AT A TIME, in send order: advancing the DURABLE
---   basis (LiveIndex.latest_completed_tx) and the apply cursor per tx, refreshing the
---   shared external snapshot, notifying watchers, cutting a block if the live index
---   filled, then freeing the batch and immediately sealing+launching the accumulated
---   tail if any. Because batch N+1's append is only launched after batch N settles, at
+--   basis (LiveIndex.latest_completed_tx) and the apply cursor per tx, notifying
+--   watchers, cutting a block if the live index filled, then freeing the batch and
+--   immediately sealing+launching the accumulated tail if any. It does NOT refresh the
+--   shared external snapshot here: the snapshot is a lazily-advanced cache, rebuilt on
+--   the next demanding read (see RefreshSharedSnapshot), so promotion leaves it stale.
+--   Because batch N+1's append is only launched after batch N settles, at
 --   most one producer transaction is ever open — the resolver's single `in_flight` slot
 --   makes this structural (same fencing rationale as before). Everything except the background
 --   serialize+append+commit — apply, promote/import, advance the durable head + apply
---   cursor, refresh, notify, finish blocks — stays on the resolver. Followers and the
+--   cursor, notify, finish blocks — stays on the resolver. Followers and the
 --   transition processor have no staging index: the messages they import are already
 --   durable, so they advance LiveIndex.latest_completed_tx directly.
 --
@@ -245,10 +248,12 @@ entity LiveIndex {
     -- Durable live tables: hold only promoted (durably-replicated) rows.
     tables: LiveTable with index = this
 
-    -- Current shared external snapshot. Refreshed on each durable confirmation
-    -- (promotion) and on NextBlock (see RefreshSharedSnapshot). External readers
-    -- retain this snapshot when calling OpenSnapshot(index); see
-    -- OpenExternalSnapshot. Its basis is latest_completed_tx (durable).
+    -- Current shared external snapshot: a lazily-advanced cache, NOT refreshed
+    -- eagerly. It is rebuilt (see RefreshSharedSnapshot) only when a reader
+    -- requests a basis this cache does not satisfy; promotion and NextBlock leave
+    -- it stale. External readers retain this snapshot when calling
+    -- OpenSnapshot(index, min_basis); see OpenExternalSnapshot. Its basis is
+    -- latest_completed_tx (durable) as of the last rebuild.
     shared_snap: Snapshot
 
     row_count: tables.sum(t => t.row_count)
@@ -499,8 +504,9 @@ entity LiveTableTx {
 --     observe later writes
 --   - Commits are atomic: all tx rows become visible together, or none
 --   - Multiple snapshots can be held concurrently without interference
---   - Writes don't block reads: a shared external snapshot is refreshed
---     after each commit, and existing snapshots remain valid until released
+--   - Writes don't block reads: a shared external snapshot is rebuilt lazily on
+--     read (only when a reader demands a basis it does not yet satisfy), and
+--     existing snapshots remain valid until released
 --
 -- Sharing and reference counting:
 --   - External snapshots are shared: the live index publishes a single
@@ -770,9 +776,11 @@ rule PromoteNext {
     -- the front of the in-flight batch, imports its rows into the durable live tables
     -- (advancing the durable basis to that tx and its apply cursor to that tx's replica-
     -- log position), THEN drops it from the batch — import-before-drop is what makes a
-    -- partial failure safe (see below). Refreshing the external shared snapshot and
-    -- notifying watchers happen per promoted tx, driven by the resolver in db.allium.
-    -- This is the point at which a committed tx becomes queryable. When the batch empties
+    -- partial failure safe (see below). Notifying watchers happens per promoted tx,
+    -- driven by the resolver in db.allium. This is the point at which a committed tx
+    -- becomes queryable — the durable-basis advance alone makes it so. The shared
+    -- external snapshot is NOT refreshed here: it is a lazily-advanced cache, rebuilt on
+    -- the next demanding read (see RefreshSharedSnapshot). When the batch empties
     -- the resolver frees it (removes the batch, so staging.in_flight becomes null) and
     -- immediately seals+launches the accumulated tail if any, so batches chain
     -- back-to-back (double-buffering: resolution of the next txs overlapped the
@@ -824,9 +832,10 @@ rule PromoteNext {
             live_table.rows.addAll(staged_table.rows)
 
         -- Advance the durable basis to this tx (the durable live index's own
-        -- latest_completed_tx) and refresh the external snapshot to reflect it.
+        -- latest_completed_tx). This alone makes the newly-durable tx queryable;
+        -- the shared external snapshot is rebuilt lazily on the next demanding
+        -- read (see RefreshSharedSnapshot), NOT refreshed here.
         index.latest_completed_tx = staged_tx.tx_key
-        RefreshSharedSnapshot(index)
 
         -- Collect an external-source tx's durability handle onto the resolver for settle-
         -- end completion (source-log txs carry none). NOT completed here — see
@@ -927,18 +936,26 @@ rule AbortTransaction {
 ------------------------------------------------------------
 
 rule OpenExternalSnapshot {
-    -- Called by queries outside any transaction.
+    -- Called by queries outside any transaction. min_basis is the caller's
+    -- minimum read basis (a system-time); it may be absent (null).
     --
-    -- The index publishes a single shared Snapshot whose basis is
-    -- latest_completed_tx (durable) and whose layers are the DURABLE live segments only
-    -- — no staging. It is refreshed on each durable confirmation (see
-    -- PromoteNext / RefreshSharedSnapshot). Each external opener retains
-    -- the current shared snapshot rather than building a fresh one, and
-    -- releases it on close. The underlying segments are freed when the last
-    -- holder releases.
-    when: OpenSnapshot(index)
+    -- The index holds a single shared Snapshot whose basis is latest_completed_tx
+    -- (durable) as of its last rebuild and whose layers are the DURABLE live
+    -- segments only — no staging. It is a lazily-advanced cache, NOT refreshed on
+    -- promotion or NextBlock. If the caller has no minimum basis, or the cached
+    -- snapshot's basis already satisfies it, the current cache is retained and
+    -- returned as-is; otherwise it is rebuilt to the current durable basis first
+    -- (see RefreshSharedSnapshot). The awaited/durable basis guarantees
+    -- latest_completed_tx >= min_basis by the time this runs, so a rebuild can
+    -- always reach a satisfying basis. Each external opener retains the shared
+    -- snapshot and releases it on close; the underlying segments are freed when
+    -- the last holder releases.
+    when: OpenSnapshot(index, min_basis?)
 
     ensures:
+        -- Rebuild only when the cache is too stale for the requested basis.
+        if min_basis != null and index.shared_snap.basis_tx.system_time < min_basis:
+            RefreshSharedSnapshot(index)
         let snap = index.shared_snap
         snap.ref_count = snap.ref_count + 1
         snap   -- returned to the caller; close() decrements ref_count
@@ -994,11 +1011,15 @@ rule OpenTransactionSnapshot {
 }
 
 rule RefreshSharedSnapshot {
-    -- Triggered on each durable confirmation (promotion) and on NextBlock (which
-    -- drops all live tables). The index atomically swaps its shared snapshot for
-    -- a freshly-built one reflecting the newly-durable state, and releases its
-    -- own retention on the previous shared snapshot. Readers already holding the
-    -- previous shared snapshot retain it independently.
+    -- The rebuild PRIMITIVE for the shared external snapshot. NOT triggered by
+    -- promotion or NextBlock (the cache is advanced lazily). It is invoked by
+    -- OpenExternalSnapshot when the cached snapshot is too stale for the
+    -- requested basis, and out-of-band by compaction (which mutates the
+    -- trie-catalog without advancing latest_completed_tx). The index atomically
+    -- swaps its shared snapshot for a freshly-built one reflecting the current
+    -- durable state, and releases its own retention on the previous shared
+    -- snapshot. Readers already holding the previous shared snapshot retain it
+    -- independently.
     when: RefreshSharedSnapshot(index)
 
     ensures:
@@ -1088,8 +1109,9 @@ rule NextBlock {
     -- Tables will be recreated on demand by future transactions
     ensures: index.tables = {}
 
-    -- The shared snapshot no longer reflects reality; refresh it so
-    -- subsequent external openers see an empty index.
-    ensures: RefreshSharedSnapshot(index)
+    -- The shared snapshot is NOT refreshed here. A subsequent reader whose basis
+    -- the (now stale) cache still satisfies may reuse it: its sliced segments are
+    -- independent of the cleared tables and remain valid. A reader demanding a
+    -- newer basis rebuilds the cache (see OpenExternalSnapshot).
 }
 

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -113,7 +113,7 @@
       bounds)))
 
 (defn tables-with-cols [^Snapshot$Source snap-src]
-  (with-open [snap (.openSnapshot snap-src)]
+  (with-open [snap (.openSnapshot snap-src nil)]
     (update-vals (.getTableInfo snap) set)))
 
 (defn- eid-select->eid [eid-select]

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -337,31 +337,36 @@
           parsed-query (if stmt (.getAst stmt) parsed-query)
           qtext (cond stmt (.getOriginalSql stmt)
                       (instance? Sql$DirectlyExecutableStatementContext parsed-query) (ast-source-text parsed-query))
+          ;; the connection's read basis at prepare time — so prepare-time schema (table-info) sees tables
+          ;; committed up to what this connection has awaited. nil for basis-less callers (they get "whatever").
+          prepare-min-basis (some-> (.getSnapshotToken ^PrepareOpts query-opts) basis/<-time-basis-str)
           {:keys [default-tz query-text] :as query-opts} (-> (->prepare-opts-map query-opts)
                                                               (update :default-tz (fnil identity expr/*default-tz*))
                                                               (cond-> qtext (assoc :query-text qtext))
                                                               (assoc :db-names (vec (sort (.getDatabaseNames db-cat)))))]
-      (letfn [(open-snaps []
+      ;; min-basis is {db-name [system-time per partition]} — the caller's already-awaited read basis, so the
+      ;; live index can hand back its cached snapshot when it's fresh enough. nil = "don't care" (schema/prepare).
+      (letfn [(open-snaps [min-basis]
                 ;; TODO this opens up a snapshot for *every* db in the catalog
                 ;; when people have 'proper' multi-tenancy, this will be a problem
                 ;; thankfully we can probably figure out what databases may be relevant to the query at parse-time
                 (util/with-close-on-catch [!snaps (HashMap.)]
                   (doseq [db-name (.getDatabaseNames db-cat)]
-                    (.put !snaps db-name (.openSnapshot (.databaseOrNull db-cat db-name))))
+                    (.put !snaps db-name (.openSnapshot (.databaseOrNull db-cat db-name) (get min-basis db-name))))
                   (into {} !snaps)))
 
-              (->table-info []
+              (->table-info [min-basis]
                 ;; TODO this, too, gets the schema for *every* db in the catalog
                 (->> (.getDatabaseNames db-cat)
                      (into {} (mapcat (fn [db-name]
-                                        (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat db-name))]
+                                        (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat db-name) (get min-basis db-name))]
                                           (->> (.tableInfo snap)
                                                (map (fn [[table-ref cols]] [[db-name table-ref] (set cols)])))))))))
 
               (plan-query* [table-info]
                 (-plan-query this parsed-query query-opts table-info))]
 
-        (let [!table-info (atom (->table-info))]
+        (let [!table-info (atom (->table-info prepare-min-basis))]
 
           (reify PreparedQuery
             (getParamCount [_] (:param-count (plan-query* @!table-info)))
@@ -371,7 +376,7 @@
 
             (getColumnFields [_ param-fields]
               (let [planned-query (plan-query* @!table-info)]
-                (util/with-open [snaps (open-snaps)]
+                (util/with-open [snaps (open-snaps prepare-min-basis)]
                   (let [emitted-query (emit-query planned-query scan-emitter db-cat snaps
                                                   (->> param-fields
                                                        (into {} (map (fn [^Field f]
@@ -388,16 +393,21 @@
             (getWarnings [_] (:warnings (plan-query* @!table-info)))
 
             (openQuery [_ args opts]
-              (let [default-tz (or (.getDefaultTz opts) default-tz)]
+              (let [default-tz (or (.getDefaultTz opts) default-tz)
+                    ;; the connection's resolved read basis — gates the cached snapshot and keeps the plan's
+                    ;; schema consistent with the data it'll read. This same token, decoded and (below) capped by
+                    ;; any SETTING/SNAPSHOT_TIME, is the effective read basis; capping only lowers the bound, so
+                    ;; gating on the resolved token stays safe.
+                    min-basis (some-> (.getSnapshotToken opts) basis/<-time-basis-str)]
               ;; we own the args from here: closed on any failure below, else handed to the cursor (which
               ;; closes them on close). the caller must not close them itself.
               (util/with-close-on-catch [^RelationReader args (or args vw/empty-args)
                                          ^BufferAllocator allocator (if allocator
                                                                       (util/->child-allocator allocator "BoundQuery/openCursor")
                                                                       (RootAllocator.))
-                                         snaps (open-snaps)]
+                                         snaps (open-snaps min-basis)]
                 (let [query-opts (-> query-opts (assoc :default-tz default-tz))
-                      table-info (reset! !table-info (->table-info))
+                      table-info (reset! !table-info (->table-info min-basis))
                       planned-query (plan-query* table-info)
 
                       {:keys [vec-types ->cursor] :as emitted-query} (emit-query planned-query scan-emitter db-cat snaps (->arg-types args) query-opts)
@@ -487,7 +497,7 @@
 
   (preparePatchDocsQuery [this table valid-from valid-to db-cat opts]
     (let [default-db (.getDefaultDb opts)
-          table-info (-> (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat default-db))]
+          table-info (-> (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat default-db) nil)]
                            (.tableInfo snap))
                          (sql/xform-table-info [default-db] default-db))
           plan (-> (sql/plan-patch {:table-info table-info}

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -361,9 +361,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                         // SHOW reads session/node state and must not await — only a real query/DML awaits its basis.
                         is ParsedStatement.Query, is ParsedStatement.Execute, is ParsedStatement.Dml -> {
                             dbCat.awaitAll(awaitToken, awaitTimeout)
+                            // gate prepare-time schema (table-info) reads on the awaited basis, so a table
+                            // committed on this connection is visible when planning the statement referencing it
                             qSrc.prepareQuery(
                                 parsedStatement, dbCat,
-                                PrepareOpts(defaultTz = defaultTz, defaultDb = targetDb)
+                                PrepareOpts(defaultTz = defaultTz, defaultDb = targetDb, snapshotToken = dbCat.snapshotToken())
                             )
                         }
 
@@ -820,13 +822,14 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // planner's own, so a frontend-pinned clock is authoritative.
         private fun queryOpts() = tx.let { t ->
             val b = t?.readBasis
-            QueryOpts(
-                b?.currentTime ?: clock.instant(),
-                t?.txDefaultTz ?: defaultTz,
-                b?.snapshotToken,
-                b?.snapshotTime,
-                tracer
-            )
+            // Resolve the read basis: a tx's pinned begin-time token, else (autocommit) latest-completed now —
+            // the statement's prepare() already awaited this connection's writes, so latest reflects them. Read
+            // directly (not via pinReadBasis) so we don't re-await / decode the AWAIT_TOKEN here. This token both
+            // gates the live snapshot (so a read sees this connection's writes) and is what SELECT SNAPSHOT_TOKEN
+            // reports.
+            val snapshotToken = b?.snapshotToken ?: dbCat.snapshotToken()
+            QueryOpts(b?.currentTime ?: clock.instant(), t?.txDefaultTz ?: defaultTz,
+                      snapshotToken, b?.snapshotTime, tracer)
         }
 
         // A SHOW answered from connection / catalog state as a zero-param [PreparedQuery]. [rows] is a thunk so

--- a/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
+++ b/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
@@ -46,7 +46,7 @@ object RoleMembership {
         val tableRef = TableRef("xt", "role_membership")
 
         val exists = primary.queryState.tableCatalog.getTypes(tableRef) != null ||
-                primary.openSnapshot().use { it.tableInfo().containsKey(tableRef) }
+                primary.openSnapshot(null).use { it.tableInfo().containsKey(tableRef) }
         if (!exists) return emptyList()
 
         val now = Instant.now()

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -51,6 +51,7 @@ import xtdb.util.safelyOpening
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import java.time.Duration
+import java.time.Instant
 import java.util.*
 import kotlin.concurrent.Volatile
 
@@ -80,9 +81,15 @@ class Database(
     val watchers: Watchers get() = partition0.watchers
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
 
-    override fun openSnapshot(): DatabaseSnapshot =
-        // List position = partition index, so basis-vector slot N matches `partitions[N]`.
-        DatabaseSnapshot(partitions.entries.sortedBy { it.key }.map { it.value.openSnapshot() })
+    override fun openSnapshot(minBasis: List<Instant?>?): DatabaseSnapshot =
+        // Index minBasis by sorted position, matching how `currentBasis`/`snapshotToken` pack it and how
+        // `txBasis`/`validate-basis-not-before` read it back — slot N is the Nth partition in key order.
+        DatabaseSnapshot(partitions.entries.sortedBy { it.key }
+            .mapIndexed { idx, e -> e.value.openSnapshot(minBasis?.getOrNull(idx)) })
+
+    /** This database's read basis right now — latest-completed system-time per partition, in partition-index order. */
+    fun currentBasis(): List<Instant?> =
+        partitions.entries.sortedBy { it.key }.map { it.value.liveIndex.latestCompletedTx?.systemTime }
 
     val blockCatalog: BlockCatalog get() = partition0.blockCatalog
     val tableCatalog: TableCatalog get() = partition0.tableCatalog
@@ -91,7 +98,8 @@ class Database(
         val historical = tableCatalog.getTypes(table)
         // TODO (#5557 unit 7) iterate the snapshot's partitions and merge per-partition live types;
         // for now single-partition is the only allowed shape, so pick the only Snapshot.
-        val live = openSnapshot().use { it.partitions.first().allColumnTypes[table] }
+        // gate on the current basis so a just-committed table's columns are visible (getTableSchema awaits first).
+        val live = openSnapshot(currentBasis()).use { it.partitions.first().allColumnTypes[table] }
         return if (historical == null && live == null) null
         else (historical ?: emptyMap()) + (live ?: emptyMap())
     }

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -8,6 +8,7 @@ import xtdb.indexer.LiveIndex
 import xtdb.indexer.LogProcessor
 import xtdb.indexer.Snapshot
 import xtdb.trie.TrieCatalog
+import java.time.Instant
 
 class DatabasePartition(
     val partition: Int,
@@ -25,7 +26,7 @@ class DatabasePartition(
     val compactor: Compactor.ForDatabase
         get() = compactorOrNull ?: error("compactor not initialised")
 
-    fun openSnapshot(): Snapshot = state.liveIndex.openSnapshot()
+    fun openSnapshot(minSystemTime: Instant?): Snapshot = state.liveIndex.openSnapshot(minSystemTime)
 
     override fun close() {
         logProcessor?.close()

--- a/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
@@ -4,6 +4,7 @@ import xtdb.api.TransactionKey
 import xtdb.table.TableRef
 import xtdb.trie.ColumnName
 import xtdb.util.closeAll
+import java.time.Instant
 
 /**
  * Database-level snapshot composed of one [Snapshot] per [xtdb.database.DatabasePartition].
@@ -18,7 +19,7 @@ import xtdb.util.closeAll
 class DatabaseSnapshot(val partitions: List<Snapshot>) : AutoCloseable {
 
     interface Source {
-        fun openSnapshot(): DatabaseSnapshot
+        fun openSnapshot(minBasis: List<Instant?>?): DatabaseSnapshot
     }
 
     init {

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -28,6 +28,7 @@ import xtdb.util.warn
 import java.io.ByteArrayInputStream
 import java.nio.channels.Channels
 import java.time.Duration
+import java.time.Instant
 import java.util.HashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.StampedLock
@@ -134,8 +135,6 @@ class LiveIndex private constructor(
             }
 
             latestCompletedTx = txKey
-
-            refreshSnap0()
         } finally {
             snapLock.unlock(stamp)
         }
@@ -150,10 +149,23 @@ class LiveIndex private constructor(
         }
     }
 
-    override fun openSnapshot() =
+    private fun Snapshot.freshEnough(minSystemTime: Instant?) =
+        minSystemTime == null || txBasis?.systemTime?.let { !it.isBefore(minSystemTime) } == true
+
+    override fun openSnapshot(minSystemTime: Instant?): Snapshot {
         snapLock.withReadLock {
-            sharedSnap!!.also { it.retain() }
+            sharedSnap!!.let { if (it.freshEnough(minSystemTime)) return it.also { s -> s.retain() } }
         }
+
+        // cache too stale for the caller's basis — rebuild under the write lock, double-checking first
+        val stamp = snapLock.writeLock()
+        try {
+            if (!sharedSnap!!.freshEnough(minSystemTime)) refreshSnap0()
+            return sharedSnap!!.also { it.retain() }
+        } finally {
+            snapLock.unlock(stamp)
+        }
+    }
 
     fun openSnapshot(resolvedTxs: List<ResolvedTx>, ownTx: OpenTx): Snapshot =
         snapLock.withReadLock {
@@ -183,8 +195,6 @@ class LiveIndex private constructor(
             this@LiveIndex.tables.clear()
 
             blockIdx += 1L
-
-            refreshSnap0()
         } finally {
             snapLock.unlock(stamp)
         }

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -140,7 +140,8 @@ class OpenTx @JvmOverloads constructor(
             val queryDb = object : IQuerySource.QueryDatabase {
                 override val storage get() = dbStorage
                 override val queryState get() = dbState
-                override fun openSnapshot() =
+                // a tx always builds a fresh read-your-writes snapshot; the read basis doesn't apply
+                override fun openSnapshot(minBasis: List<Instant?>?) =
                     DatabaseSnapshot(listOf(liveIndex.openSnapshot(resolvedTxs, this@OpenTx)))
             }
 

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -11,6 +11,7 @@ import xtdb.trie.TrieCatalog
 import xtdb.util.closeAll
 import xtdb.util.safeMap
 import xtdb.util.safelyOpening
+import java.time.Instant
 import java.util.HashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.collections.component1
@@ -26,7 +27,7 @@ class Snapshot(
     val tableInfo: Map<TableRef, Set<ColumnName>>,
 ) : AutoCloseable {
     interface Source {
-        fun openSnapshot(): Snapshot
+        fun openSnapshot(minSystemTime: Instant?): Snapshot
     }
 
     fun table(table: TableRef): List<TableSnapshot> = tableSnaps[table].orEmpty()

--- a/core/src/main/kotlin/xtdb/query/QueryOpts.kt
+++ b/core/src/main/kotlin/xtdb/query/QueryOpts.kt
@@ -9,6 +9,9 @@ import java.time.ZoneId
 data class QueryOpts @JvmOverloads constructor(
     val currentTime: Instant? = null,
     val defaultTz: ZoneId? = null,
+    // the connection's resolved read basis — a tx's pinned begin-time token, else (autocommit) latest-completed
+    // now. Gates the live snapshot so a read sees this connection's own writes, and is what SELECT SNAPSHOT_TOKEN
+    // reports. Null only for callers that resolve none (they read whatever's cached).
     val snapshotToken: String? = null,
     val snapshotTime: Instant? = null,
     val tracer: Tracer? = null,
@@ -28,4 +31,7 @@ data class PrepareOpts @JvmOverloads constructor(
     // explain a raw RA-plan prepare; for SQL the flag is read off the parse tree instead.
     val explain: Boolean = false,
     val explainAnalyze: Boolean = false,
+    // the connection's resolved read basis at prepare time — gates the snapshot that prepare-time schema
+    // (table-info) reads, so a freshly-committed table is visible when planning the statement that references it.
+    val snapshotToken: String? = null,
 )

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -4,6 +4,7 @@ import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -134,7 +135,7 @@ class LiveIndexTest {
             db.openTx(0, Instant.parse("2020-01-01T00:00:00Z")).use { tx ->
                 tx.put(table, UUID.randomUUID())
 
-                db.liveIndex.openSnapshot().use { snap ->
+                db.liveIndex.openSnapshot(null).use { snap ->
                     assertTrue(snap.table(table).isEmpty())
                 }
 
@@ -147,7 +148,7 @@ class LiveIndexTest {
                 db.commitTx(tx)
             }
 
-            db.liveIndex.openSnapshot().use { snap ->
+            db.liveIndex.openSnapshot(Instant.parse("2020-01-01T00:00:00Z")).use { snap ->
                 assertEquals(1, snap.table(table).single().relation.rowCount)
             }
         }
@@ -163,7 +164,7 @@ class LiveIndexTest {
                 db.commitTx(tx1)
             }
 
-            db.liveIndex.openSnapshot().use { snapBefore ->
+            db.liveIndex.openSnapshot(Instant.parse("2020-01-01T00:00:00Z")).use { snapBefore ->
                 val before = snapBefore.table(table).single()
                 assertEquals(1, before.relation.rowCount)
 
@@ -174,7 +175,7 @@ class LiveIndexTest {
 
                 assertEquals(1, before.relation.rowCount)
 
-                db.liveIndex.openSnapshot().use { snapAfter ->
+                db.liveIndex.openSnapshot(Instant.parse("2020-01-02T00:00:00Z")).use { snapAfter ->
                     assertEquals(2, snapAfter.table(table).single().relation.rowCount)
                 }
             }
@@ -216,7 +217,7 @@ class LiveIndexTest {
                 db.commitTx(tx)
             }
 
-            db.liveIndex.openSnapshot().use { snap ->
+            db.liveIndex.openSnapshot(Instant.parse("2020-01-01T00:00:00Z")).use { snap ->
                 assertEquals(3, snap.table(table).single().relation.rowCount)
             }
         }
@@ -254,7 +255,7 @@ class LiveIndexTest {
                 db.commitTx(tx)
             }
 
-            db.liveIndex.openSnapshot().use { snap ->
+            db.liveIndex.openSnapshot(Instant.parse("2000-01-01T00:00:00Z")).use { snap ->
                 val before = snap.table(table).single().relation.rowCount
                 db.liveIndex.finishBlock(db.bp, 0L)
                 assertEquals(before, snap.table(table).single().relation.rowCount)
@@ -299,6 +300,59 @@ class LiveIndexTest {
                     assertTrue(snap.table(table).isEmpty(), "live-table must be filtered — its rows now live in L0_0")
                     assertEquals(0L, snap.trieCatSnap.l0MaxBlockIdx(table), "L0_0 must be visible in the snap's trie-cat")
                 }
+            }
+        }
+    }
+
+    // the lazy gate: a commit no longer eagerly rebuilds the shared snapshot — only a read demanding a
+    // basis the cache doesn't yet satisfy does.
+    @Test
+    fun `snapshot not rebuilt until a newer basis is demanded`() {
+        TestDb().use { db ->
+            val table = TableRef("public", "test-table")
+
+            db.openTx(0, Instant.parse("2020-01-01T00:00:00Z")).use { tx ->
+                tx.put(table, UUID.randomUUID())
+                db.commitTx(tx)
+            }
+
+            db.liveIndex.openSnapshot(Instant.parse("2020-01-01T00:00:00Z")).use { snap0 ->
+                // a second commit, with no read in between — must not eagerly rebuild the cached snapshot
+                db.openTx(1, Instant.parse("2020-01-02T00:00:00Z")).use { tx ->
+                    tx.put(table, UUID.randomUUID())
+                    db.commitTx(tx)
+                }
+
+                db.liveIndex.openSnapshot(Instant.parse("2020-01-01T00:00:00Z")).use { reused ->
+                    assertSame(snap0, reused, "a basis the cache already satisfies reuses it — the commit did not rebuild the snapshot")
+                }
+
+                db.liveIndex.openSnapshot(Instant.parse("2020-01-02T00:00:00Z")).use { rebuilt ->
+                    assertNotSame(snap0, rebuilt, "a newer basis rebuilds the snapshot on demand")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `gated snapshot reflects its demanded basis`() {
+        TestDb().use { db ->
+            val table = TableRef("public", "test-table")
+
+            db.openTx(0, Instant.parse("2020-01-01T00:00:00Z")).use { tx ->
+                tx.put(table, UUID.randomUUID())
+                db.commitTx(tx)
+            }
+
+            db.liveIndex.openSnapshot(Instant.parse("2020-01-01T00:00:00Z")).use { snap ->
+                assertEquals(
+                    Instant.parse("2020-01-01T00:00:00Z"), snap.txBasis?.systemTime,
+                    "snapshot basis covers the demanded tx"
+                )
+                assertEquals(
+                    1, snap.table(table).single().relation.rowCount,
+                    "the row committed at the demanded basis is visible"
+                )
             }
         }
     }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -233,7 +233,7 @@ class LogProcessorSimTest : SimulationTestBase() {
             .toSet()
 
     private fun assertSnapshotHasNoAbortedRows(node: SimNode) {
-        node.liveIndex.openSnapshot().use { snap ->
+        node.liveIndex.openSnapshot(node.liveIndex.latestCompletedTx?.systemTime).use { snap ->
             assertEquals(
                 node.liveIndex.latestCompletedTx?.txId, snap.txBasis?.txId,
                 "snapshot basis should equal liveIndex.latestCompletedTx"

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2599,8 +2599,8 @@ ORDER BY 1,2;")
 
 (t/deftest select-snapshot-token
   (with-open [conn (jdbc-conn)]
-    (t/is (= [{:ts nil}] (jdbc/execute! conn ["SELECT SNAPSHOT_TOKEN ts"]))
-          "before any transactions")
+    (t/is (= [{:ts (basis/->time-basis-str {"xtdb" [nil]})}] (jdbc/execute! conn ["SELECT SNAPSHOT_TOKEN ts"]))
+          "before any transactions, the resolved token has null components")
 
     (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1, :x 3}]])
 
@@ -2643,8 +2643,9 @@ ORDER BY 1,2;")
 
 (t/deftest snapshot-time
   (with-open [conn (jdbc-conn)]
-    (t/is (= [{:ts nil}] (jdbc/execute! conn ["SETTING SNAPSHOT_TIME = TIMESTAMP '2019-01-01Z' SELECT SNAPSHOT_TOKEN ts"]))
-          "before any transactions")
+    (t/is (= [{:ts (basis/->time-basis-str {"xtdb" [nil]})}]
+             (jdbc/execute! conn ["SETTING SNAPSHOT_TIME = TIMESTAMP '2019-01-01Z' SELECT SNAPSHOT_TOKEN ts"]))
+          "before any transactions, the resolved token has null components")
 
     (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1, :x 3}]])
 

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -246,7 +246,13 @@
          query-opts (-> query-opts
                         (update :default-db (fnil identity "xtdb"))
                         (cond-> node (-> (update :await-token (fnil identity (await-token node)))
-                                         (doto (-> :await-token (as-> token (xt-log/await-node node token nil)))))))
+                                         (doto (-> :await-token (as-> token (xt-log/await-node node token nil))))
+                                         ;; this path calls prepareRa/openQuery directly, bypassing the Connection's
+                                         ;; own basis resolution; resolve the read basis here, post-await, so the
+                                         ;; lazily-rebuilt live-index snapshot is gated to the awaited data rather
+                                         ;; than served stale from the cache.
+                                         (update :snapshot-token
+                                                 (fnil identity (.snapshotToken ^Database$Catalog (or (db/<-node node) Database$Catalog/EMPTY)))))))
 
          [^IQuerySource q-src close-q-src?] (if node
                                               [(.getQuerySource (util/node-base node)) false]
@@ -257,7 +263,8 @@
      (try
        (let [^PreparedQuery pq (.prepareRa q-src query (or (db/<-node node) Database$Catalog/EMPTY)
                                            (PrepareOpts. (:default-tz query-opts) (:default-db query-opts) (:current-time query-opts) nil
-                                                         (boolean (:explain? query-opts)) (boolean (:explain-analyze? query-opts))))]
+                                                         (boolean (:explain? query-opts)) (boolean (:explain-analyze? query-opts))
+                                                         (:snapshot-token query-opts)))]
 
          (util/with-open [^RelationReader args-rel (if args
                                                      (vw/open-args allocator args)


### PR DESCRIPTION
Part of #5781.

## Summary

The live-index shared `Snapshot` was rebuilt eagerly on every transaction; this makes it lazy — rebuilt on read, gated by the caller's already-awaited basis — so a write no longer pays to refresh a snapshot nothing is reading.

## Context

`LiveIndex.refreshSnap0` rebuilt the entire cached `Snapshot` on every `commitTx` (leader, follower and transition paths) and every `nextBlock` — slicing each live table's relation and rebuilding the column-type maps. On the `ingest-tx-overhead` benchmark (#5781) this dominates small-batch ingest: under bulk load / high write throughput there are few or no concurrent readers, so the per-tx rebuild is pure waste on the indexing hot path.

## Approach

`openSnapshot` takes the caller's read basis (a per-partition system-time) and returns the cached `sharedSnap` when it's fresh enough — `txBasis.systemTime >= minSystemTime`, or `null` for a caller that doesn't care — rebuilding under the write lock only on a stale read (read-lock fast path, write-lock double-check). `commitTx`/`nextBlock` drop the refresh and only mutate; the write lock still brackets the relation slice against concurrent appends, and building a snapshot is a pure read, so no new locking primitive is needed. The number of snapshots built is bounded by demanding reads, never by writes — a read-free ingest builds none.

`sharedSnap` stays a shared cache (not per-reader). The compactor's out-of-band `refreshSnap()` in `compactAll` stays too: compaction advances the trie-cat but not system-time, so the gate wouldn't otherwise rebuild for the test-sync callers that read the compacted view.

The basis threads per-partition down the `openSnapshot` chain (`Snapshot.Source` → `DatabaseSnapshot.Source` → `Database`/`DatabasePartition`), packed and read by sorted partition position throughout. There's deliberately no zero-arg overload — every caller passes the basis, `null` only where it genuinely doesn't care (OpenTx-internal reads, which always build a fresh read-your-writes snapshot).

## The read basis is the snapshot-token

The eager rebuild had quietly been keeping the cache current for reads that carry no basis of their own. With it gone, the read basis is resolved from the connection (which has already awaited its own writes) and threaded through as a single `snapshotToken` on the query/prepare opts:

- one resolved token — a transaction's pinned begin-time token, else (autocommit) `dbCat.snapshotToken()` = latest-completed system-times now;
- it both **gates** the live snapshot (so a read sees this connection's writes) and is what **`SELECT SNAPSHOT_TOKEN` reports**; `query.clj` decodes it at the point it opens each snapshot;
- **execute** resolves the token in the connection's `queryOpts()`; **prepare** resolves it in `Connection.Statement.prepare()` (after its `awaitAll`), gating the prepare-time schema read so a `SELECT` prepared immediately after `CREATE TABLE` can still plan;
- **ADBC `getTableSchema`** awaits, then reads column types via `Database.getColumnTypes`, which gates its snapshot on `currentBasis()` (latest-completed);
- the low-level RA path used by tests (`query-ra`) bypasses the connection, so it resolves the token itself after awaiting — without this, a read of on-disk data over that path served a stale cached snapshot.

`null` remains only for genuinely basis-less internal reads — table-existence checks (`RoleMembership`), patch-docs schema, and OpenTx's own read-your-writes snapshot.

## Behaviour change

`SELECT SNAPSHOT_TOKEN` against a database with no completed transactions now returns the resolved token with null components rather than `nil` — it reports the connection's actual read basis, empty components and all. A null component means "no lower bound" throughout the basis machinery (`default-basis`, `validate-basis-not-before`, `cap-basis`), so nothing else reads a different result. The `select-snapshot-token` / `snapshot-time` pgwire tests are updated for the new value.

## Test plan

New white-box tests in `LiveIndexTest.kt`: `snapshot not rebuilt until a newer basis is demanded` (a commit with no interleaved read reuses the cached snapshot by identity; a newer basis rebuilds it on demand) and `gated snapshot reflects its demanded basis`. The existing "commit then read" live-index snapshot tests there now demand the committed system-time explicitly (a bare commit no longer refreshes the cache). The `test-on-disk-joining` integration test guards the `query-ra` basis-resolution path.

Rebased onto current `main` (the single-writer / staging-index and `public-api` refactors): the prepare-time resolution lives in `Connection.Statement.prepare()`, execute-time in `queryOpts()`, and the embedded node path delegates to the connection rather than resolving its own basis. `xtdb-core` Kotlin indexer/sim tests, `pgwire-test`, `api-test`, `indexer-test`, `live-index-test`, and `test-on-disk-joining` all re-run green post-rebase, no reflection/boxed-math warnings.
