### PR TITLE
refactor(indexer): cut the leader's commit-path serde round-trip

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -25,6 +25,7 @@ import xtdb.log.proto.TrieDetails
 import xtdb.storage.BufferPool
 import xtdb.table.TableRef
 import xtdb.util.StringUtil.asLexHex
+import xtdb.util.closeAll
 import xtdb.util.debug
 import xtdb.util.error
 import xtdb.util.logger
@@ -141,10 +142,16 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private suspend fun processRecord(record: Log.Record<ReplicaMessage>) {
         when (val msg = record.message) {
             is ReplicaMessage.ResolvedTx -> resolvedTxTimer.timed {
-                liveIndex.importTx(msg)
-
                 val systemTime = msg.systemTime
                 val txKey = TransactionKey(msg.txId, systemTime)
+
+                val tables = msg.loadTableData(allocator)
+                try {
+                    liveIndex.commitTx(txKey, tables)
+                } finally {
+                    tables.closeAll()
+                }
+
                 if (msg.committed) {
                     when (val dbOp = msg.dbOp) {
                         is DbOp.Attach -> if (dbCatalog != null) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -260,7 +260,7 @@ class LeaderLogProcessor(
 
             for ((pending, handle) in batch.zip(handles)) {
                 val stagedTx = pending.stagedTx
-                liveIndex.importStagedTx(stagedTx)
+                liveIndex.commitTx(stagedTx.txKey, stagedTx.allTables.associate { it.ref to it.relation })
                 latestReplicaMsgId = handle.await().msgId
                 watchers.notifyTx(stagedTx.txResult, stagedTx.notifyMsgId, stagedTx.externalSourceToken)
             }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -162,11 +162,9 @@ class LeaderLogProcessor(
 
         when (msg) {
             is SourceMessage.Tx, is SourceMessage.LegacyTx -> {
-                val (resolvedTx, openTx) = resolveTx(msgId, record, msg)
+                val (txResult, openTx) = resolveTx(msgId, record, msg)
                 openTx.use {
-                    stagingIndex.stage(
-                        it, resolvedTx.copy(srcMsgId = msgId), msgId, resolvedTx.txResult(it.txKey), null
-                    )
+                    stagingIndex.stage(it, msgId, txResult, dbOp = null)
                 }
             }
 
@@ -195,9 +193,9 @@ class LeaderLogProcessor(
 
                 openTx(txKey, null).use { openTx ->
                     openTx.writeTxRow(error, null)
-                    val resolvedTx = openTx.commitTx(error).copy(srcMsgId = msgId)
-                        .let { if (error == null) it.copy(dbOp = DbOp.Attach(msg.dbName, msg.config)) else it }
-                    stagingIndex.stage(openTx, resolvedTx, msgId, resolvedTx.txResult(txKey), null)
+                    val txResult = if (error == null) Committed(txKey) else Aborted(txKey, error)
+                    val dbOp = if (error == null) DbOp.Attach(msg.dbName, msg.config) else null
+                    stagingIndex.stage(openTx, msgId, txResult, dbOp)
                 }
                 drainStaging()
             }
@@ -216,9 +214,9 @@ class LeaderLogProcessor(
 
                 openTx(txKey, null).use { openTx ->
                     openTx.writeTxRow(error, null)
-                    val resolvedTx = openTx.commitTx(error).copy(srcMsgId = msgId)
-                        .let { if (error == null) it.copy(dbOp = DbOp.Detach(msg.dbName)) else it }
-                    stagingIndex.stage(openTx, resolvedTx, msgId, resolvedTx.txResult(txKey), null)
+                    val txResult = if (error == null) Committed(txKey) else Aborted(txKey, error)
+                    val dbOp = if (error == null) DbOp.Detach(msg.dbName) else null
+                    stagingIndex.stage(openTx, msgId, txResult, dbOp)
                 }
                 drainStaging()
             }
@@ -242,10 +240,9 @@ class LeaderLogProcessor(
         }
     }
 
-    private fun ReplicaMessage.ResolvedTx.txResult(txKey: TransactionKey): TransactionResult =
-        if (committed) Committed(txKey) else Aborted(txKey, error)
-
-    // Seal the accumulated batch, make it durable, and promote it into the durable live index.
+    // Seal the accumulated batch, make it durable, and promote it into the durable live index. Each tx
+    // serializes its own table data into a replica message here (ResolvedTx.toReplicaMessage) — at seal,
+    // off the resolver's resolve path — rather than eagerly when it was resolved.
     //
     // Seal + commit is synchronous for now (one producer transaction per batch, committed here on the
     // resolver); the committer-coroutine offload + cross-batch accumulation come with the pipeline step.
@@ -256,18 +253,18 @@ class LeaderLogProcessor(
 
         val batch = stagingIndex.drainAccumulated()
         try {
-            val handles = replicaProducer.withTx { tx -> batch.map { tx.appendMessage(it.message) } }
+            val messages = batch.map { it.toReplicaMessage() }
+            val handles = replicaProducer.withTx { tx -> messages.map { tx.appendMessage(it) } }
 
-            for ((pending, handle) in batch.zip(handles)) {
-                val stagedTx = pending.stagedTx
-                liveIndex.commitTx(stagedTx.txKey, stagedTx.allTables.associate { it.ref to it.relation })
+            for ((resolvedTx, handle) in batch.zip(handles)) {
+                liveIndex.commitTx(resolvedTx.txKey, resolvedTx.allTables.associate { it.ref to it.relation })
                 latestReplicaMsgId = handle.await().msgId
-                watchers.notifyTx(stagedTx.txResult, stagedTx.notifyMsgId, stagedTx.externalSourceToken)
+                watchers.notifyTx(resolvedTx.txResult, resolvedTx.srcMsgId, resolvedTx.externalSourceToken)
             }
 
             if (liveIndex.isFull()) {
-                val last = batch.last().stagedTx
-                finishBlock(last.notifyMsgId, last.externalSourceToken)
+                val last = batch.last()
+                finishBlock(last.srcMsgId, last.externalSourceToken)
             }
         } finally {
             batch.closeAll()
@@ -285,10 +282,10 @@ class LeaderLogProcessor(
         @Suppress("ConvertTryFinallyToUseCall") // because openTx is a var
         try {
             val writerResult = task.writer(openTx)
-            val resolvedTx = when (writerResult) {
+            val txResult: TransactionResult = when (writerResult) {
                 is TxResult.Committed -> {
                     openTx.writeTxRow(null, writerResult.userMetadata)
-                    openTx.commitTx(null)
+                    Committed(txKey)
                 }
 
                 is TxResult.Aborted -> {
@@ -297,7 +294,7 @@ class LeaderLogProcessor(
                     // fresh tx for the abort row — the original openTx may hold partial writes
                     openTx = openTx(txKey, task.externalSourceToken)
                     openTx.writeTxRow(writerResult.error, writerResult.userMetadata)
-                    openTx.commitTx(writerResult.error)
+                    Aborted(txKey, writerResult.error)
                 }
             }
 
@@ -307,10 +304,7 @@ class LeaderLogProcessor(
             // follower's `latestSourceMsgId` lags between block boundaries, and on promotion it resumes
             // the source log from a stale point and replays an already-covered block boundary.
             val effectiveSrcMsgId = watchers.latestSourceMsgId
-            stagingIndex.stage(
-                openTx, resolvedTx.copy(srcMsgId = effectiveSrcMsgId), effectiveSrcMsgId,
-                resolvedTx.txResult(txKey), resolvedTx.externalSourceToken
-            )
+            stagingIndex.stage(openTx, effectiveSrcMsgId, txResult, dbOp = null)
             drainStaging()
             task.result.complete(writerResult)
         } finally {
@@ -463,7 +457,7 @@ class LeaderLogProcessor(
     }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
-        OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer, stagingIndex.stagedTxs)
+        OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer, stagingIndex.resolvedTxs)
 
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
@@ -518,19 +512,19 @@ class LeaderLogProcessor(
     // leaks. `countError` mirrors the pre-staging behaviour: skipped txs don't count as errors.
     private fun commitStandaloneTx(
         txKey: TransactionKey, error: Throwable, userMetadata: Map<*, *>?, countError: Boolean,
-    ): Pair<ReplicaMessage.ResolvedTx, OpenTx> {
+    ): Pair<TransactionResult, OpenTx> {
         if (countError) txErrorCounter?.increment()
         val openTx = openTx(txKey, null)
         return try {
             openTx.writeTxRow(error, userMetadata)
-            openTx.commitTx(error) to openTx
+            Aborted(txKey, error) to openTx
         } catch (e: Throwable) {
             openTx.close(); throw e
         }
     }
 
-    // Resolves a source-log tx and returns its replica message alongside the LIVE OpenTx that produced it
-    // — the resolver stages that OpenTx (taking independent slices of its writes) and closes it afterwards.
+    // Resolves a source-log tx and returns its result alongside the LIVE OpenTx that produced it — the
+    // resolver stages that OpenTx (taking independent slices of its writes) and closes it afterwards.
     // Any OpenTx not returned (an aborted tx's partial-write attempt, or one whose commit throws) is closed
     // here.
     private fun indexSourceLogTx(
@@ -541,7 +535,7 @@ class LeaderLogProcessor(
         defaultTz: ZoneId?,
         user: String?,
         userMetadata: Any?,
-    ): Pair<ReplicaMessage.ResolvedTx, OpenTx> = tracer.withSpan(
+    ): Pair<TransactionResult, OpenTx> = tracer.withSpan(
         "xtdb.transaction",
         attributes = mapOf("operations.count" to (txOps?.valueCount ?: 0).toString()),
     ) {
@@ -599,7 +593,7 @@ class LeaderLogProcessor(
             is TxResult.Committed ->
                 try {
                     openTx.writeTxRow(null, userMetadataMap)
-                    openTx.commitTx(null) to openTx
+                    Committed(txKey) to openTx
                 } catch (e: Throwable) {
                     openTx.close(); throw e
                 }
@@ -615,7 +609,7 @@ class LeaderLogProcessor(
 
     private fun resolveTx(
         msgId: MessageId, record: Log.Record<SourceMessage>, msg: SourceMessage
-    ): Pair<ReplicaMessage.ResolvedTx, OpenTx> {
+    ): Pair<TransactionResult, OpenTx> {
         if (skipTxs.isNotEmpty() && skipTxs.contains(msgId)) {
             LOG.warn("[$dbName] Skipping transaction id $msgId - within XTDB_SKIP_TXS")
 

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -5,6 +5,7 @@ import xtdb.api.IndexerConfig
 import xtdb.api.TransactionKey
 import xtdb.api.log.ReplicaMessage
 import xtdb.arrow.Relation
+import xtdb.arrow.RelationReader
 import xtdb.arrow.VectorType
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
@@ -31,6 +32,22 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.StampedLock
 
 private val LOG = LiveIndex::class.logger
+
+// Deserialize a replica-log [ReplicaMessage.ResolvedTx]'s per-table IPC bytes back into owned
+// relations, for the follower/transition path which only has the serialized form. The leader skips
+// this entirely — it commits from the relations it already holds. The caller closes the result.
+internal fun ReplicaMessage.ResolvedTx.loadTableData(al: BufferAllocator): Map<TableRef, Relation> =
+    mutableMapOf<TableRef, Relation>().closeAllOnCatch { rels ->
+        for ((schemaAndTable, ipcBytes) in tableData) {
+            Relation.StreamLoader(al, Channels.newChannel(ByteArrayInputStream(ipcBytes))).use { loader ->
+                Relation(al, loader.schema).closeOnCatch { rel ->
+                    loader.loadNextPage(rel)
+                    rels[TableRef.parse(schemaAndTable)] = rel
+                }
+            }
+        }
+        rels
+    }
 
 class LiveIndex private constructor(
     private val allocator: BufferAllocator,
@@ -101,54 +118,21 @@ class LiveIndex private constructor(
     fun table(table: TableRef): LiveTable? = this@LiveIndex.tables[table]
     val tableRefs: Iterable<TableRef> get() = this@LiveIndex.tables.keys
 
-    fun importTx(resolvedTx: ReplicaMessage.ResolvedTx) {
-        val txKey = TransactionKey(resolvedTx.txId, resolvedTx.systemTime)
+    // Promote a committed tx into the live tables straight from its relations — no IPC round-trip.
+    // The leader passes its staged relation slices; a follower deserializes the replica message's
+    // table data first (see `loadTableData`). The caller owns [tables] and closes them afterwards.
+    fun commitTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>) {
         val stamp = snapLock.writeLock()
         try {
-            for ((schemaAndTable, ipcBytes) in resolvedTx.tableData) {
-                val tableRef = TableRef.parse(schemaAndTable)
+            for ((ref, rel) in tables) {
                 val liveTable =
-                    this@LiveIndex.tables.getOrPut(tableRef) {
-                        LiveTable(
-                            allocator,
-                            tableRef,
-                            blockIdx,
-                            rowCounter,
-                            liveTrieFactory
-                        )
+                    this@LiveIndex.tables.getOrPut(ref) {
+                        LiveTable(allocator, ref, blockIdx, rowCounter, liveTrieFactory)
                     }
-
-                Relation.StreamLoader(allocator, Channels.newChannel(ByteArrayInputStream(ipcBytes))).use { loader ->
-                    Relation(allocator, loader.schema).use { rel ->
-                        loader.loadNextPage(rel)
-                        liveTable.importData(rel)
-                    }
-                }
+                liveTable.importData(rel)
             }
 
             latestCompletedTx = txKey
-
-            refreshSnap0()
-        } finally {
-            snapLock.unlock(stamp)
-        }
-    }
-
-    // Promote a staged (now-durable) tx into the live tables from its owned relation slices — the
-    // leader's promote path. Distinct from `importTx(resolvedTx)`, which followers use to replay a
-    // serialized replica message; here the relations are already in hand, no IPC round-trip.
-    fun importStagedTx(stagedTx: StagedTx) {
-        val stamp = snapLock.writeLock()
-        try {
-            for (table in stagedTx.allTables) {
-                val liveTable =
-                    this@LiveIndex.tables.getOrPut(table.ref) {
-                        LiveTable(allocator, table.ref, blockIdx, rowCounter, liveTrieFactory)
-                    }
-                liveTable.importData(table.relation)
-            }
-
-            latestCompletedTx = stagedTx.txKey
 
             refreshSnap0()
         } finally {

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -154,14 +154,14 @@ class LiveIndex private constructor(
             sharedSnap!!.also { it.retain() }
         }
 
-    fun openSnapshot(stagedTxs: List<StagedTx>, ownTx: OpenTx): Snapshot =
+    fun openSnapshot(resolvedTxs: List<ResolvedTx>, ownTx: OpenTx): Snapshot =
         snapLock.withReadLock {
             // Hold the snap read-lock for the whole capture: it blocks `nextBlock` (write-lock) so live
             // tables can't be cleared mid-iteration, and it brackets the trie-cat snapshot so we can't
             // end up with a stale (no-L0_N) trie-cat alongside a live-tables view that's already been
             // reset past N. `addTries` doesn't take the snap lock — it's allowed to land on either side
             // of our trie-cat capture without breaking correctness.
-            Snapshot.open(allocator, tableCatalog, trieCatalog, this, stagedTxs, ownTx)
+            Snapshot.open(allocator, tableCatalog, trieCatalog, this, resolvedTxs, ownTx)
         }
 
     fun isFull() = rowCounter.blockRowCount >= rowsPerBlock

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -5,7 +5,6 @@ import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.ResultCursor
 import xtdb.api.TransactionKey
-import xtdb.api.log.ReplicaMessage
 import xtdb.arrow.*
 import xtdb.arrow.VectorType.Companion.BOOL
 import xtdb.arrow.VectorType.Companion.I64
@@ -60,9 +59,9 @@ class OpenTx @JvmOverloads constructor(
     val txKey: TransactionKey,
     val externalSourceToken: ExternalSourceToken?,
     private val tracer: Tracer? = null,
-    // In-flight staged predecessors this tx must read behind (read-your-writes across the batch),
+    // In-flight resolved predecessors this tx must read behind (read-your-writes across the batch),
     // supplied by the resolver which owns the staging index. Empty for external / non-resolution txs.
-    private val stagedTxs: List<StagedTx> = emptyList(),
+    private val resolvedTxs: List<ResolvedTx> = emptyList(),
 ) : AutoCloseable {
 
     data class QueryOpts(
@@ -122,18 +121,6 @@ class OpenTx @JvmOverloads constructor(
         liveTable.endPut()
     }
 
-    private fun serializeTableData(): Map<String, ByteArray> =
-        tableTxs.entries.associate { (tableRef, tableTx) -> tableRef.schemaAndTable to tableTx.serializeTxData() }
-
-    internal fun commitTx(error: Throwable? = null): ReplicaMessage.ResolvedTx =
-        ReplicaMessage.ResolvedTx(
-            txKey.txId, txKey.systemTime,
-            committed = error == null,
-            error = error,
-            tableData = serializeTableData(),
-            dbOp = null,
-            externalSourceToken = externalSourceToken,
-        )
 
     private val queryCatalog: IQuerySource.QueryCatalog
         get() {
@@ -143,7 +130,7 @@ class OpenTx @JvmOverloads constructor(
                 override val storage get() = dbStorage
                 override val queryState get() = dbState
                 override fun openSnapshot() =
-                    DatabaseSnapshot(listOf(liveIndex.openSnapshot(stagedTxs, this@OpenTx)))
+                    DatabaseSnapshot(listOf(liveIndex.openSnapshot(resolvedTxs, this@OpenTx)))
             }
 
             return object : IQuerySource.QueryCatalog {
@@ -665,8 +652,6 @@ class OpenTx @JvmOverloads constructor(
         @JvmOverloads
         fun patchDocs(docs: RelationReader, validFrom: Instant? = null, validTo: Instant? = null) =
             patchDocs(docs, validFrom?.asMicros ?: systemTimeMicros, validTo?.asMicros ?: MAX_LONG)
-
-        internal fun serializeTxData(): ByteArray = txRelation.asArrowStream
 
         override fun close() {
             txRelation.close()

--- a/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
@@ -3,7 +3,9 @@ package xtdb.indexer
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
+import xtdb.api.log.DbOp
 import xtdb.api.log.MessageId
+import xtdb.api.log.ReplicaMessage
 import xtdb.arrow.Relation
 import xtdb.arrow.VectorType
 import xtdb.database.ExternalSourceToken
@@ -17,25 +19,28 @@ import xtdb.util.closeAllOnCatch
 import xtdb.util.safelyOpening
 
 /**
- * A committed-but-not-yet-durable transaction, staged in memory between the resolver committing it and
- * the replica-log producer confirming it durable. Distinct from [OpenTx] on purpose: once staged a tx
- * is no longer *open* — it can't be written to or queried. It exists only to be (a) read by later txs
- * resolving behind it (read-your-writes across the in-flight batch) and (b) imported into the durable
- * live tables once its replica-log commit lands.
+ * A committed-but-not-yet-durable transaction, held in memory between the resolver committing it and the
+ * replica-log producer confirming it durable. Carries the salient facts of the [OpenTx] that produced it
+ * — its key, result, any db-op, source-log position and external-source token — plus independent slices
+ * of its relations. Distinct from [OpenTx] on purpose: a resolved tx is no longer *open* — it can't be
+ * written to or queried. It exists only to be (a) read by later txs resolving behind it (read-your-writes
+ * across the in-flight batch) and (b) imported into the durable live tables once its replica-log commit
+ * lands.
  *
- * It owns independent slices of the tx's relations, taken from the [OpenTx] at [stage] via
- * `openDirectSlice` (which transfers the buffers into the staging allocator), and a trie sharing the
- * tx's heap `rootNode` re-pointed at the slice. So a StagedTx outlives its OpenTx — the resolver closes
- * the OpenTx right after staging — and its lifetime is its own (freed at [close], on promote/teardown).
+ * The relation slices are taken from the [OpenTx] at [stage] via `openDirectSlice` (which transfers the
+ * buffers into the staging allocator), with a trie sharing the tx's heap `rootNode` re-pointed at the
+ * slice. So a ResolvedTx outlives its OpenTx — the resolver closes the OpenTx right after staging — and
+ * its lifetime is its own (freed at [close], on promote/teardown).
  *
  * No durability handle: the single async replica-log commit is what confirms durability, and the per-tx
  * replica-log positions for the apply cursor come back from that commit — not from here.
  */
-class StagedTx private constructor(
+class ResolvedTx private constructor(
     val txKey: TransactionKey,
-    val notifyMsgId: MessageId,
+    val srcMsgId: MessageId,
     val txResult: TransactionResult,
     val externalSourceToken: ExternalSourceToken?,
+    private val dbOp: DbOp?,
     private val tables: Map<TableRef, Table>,
 ) : AutoCloseable {
 
@@ -68,30 +73,53 @@ class StagedTx private constructor(
 
     val allTables: Collection<Table> get() = tables.values
 
+    /**
+     * Assemble this tx's replica-log message, serializing the table slices to Arrow IPC here — at seal,
+     * on the drain path — rather than eagerly at resolve, so the relation→bytes cost stays off the
+     * resolver's hot path. The leader imports from the slices directly ([LiveIndex.commitTx]); these
+     * bytes exist only for the replica log.
+     */
+    fun toReplicaMessage(): ReplicaMessage.ResolvedTx {
+        val (committed, error) = when (txResult) {
+            is TransactionResult.Committed -> true to null
+            is TransactionResult.Aborted -> false to txResult.error
+        }
+
+        return ReplicaMessage.ResolvedTx(
+            txKey.txId, txKey.systemTime, committed, error,
+            tableData = tables.entries.associate { (ref, table) -> ref.schemaAndTable to table.relation.asArrowStream },
+            dbOp = dbOp,
+            externalSourceToken = externalSourceToken,
+            srcMsgId = srcMsgId,
+        )
+    }
+
     override fun close() = tables.values.closeAll()
 
     companion object {
         /**
-         * Stage a committed [openTx]: take independent slices of its table relations into [al] (the
+         * Resolve a committed [openTx]: take independent slices of its table relations into [al] (the
          * staging allocator) so they outlive the OpenTx. The caller closes the OpenTx after.
          */
         @JvmStatic
         fun stage(
-            al: BufferAllocator, openTx: OpenTx, notifyMsgId: MessageId,
-            txResult: TransactionResult, externalSourceToken: ExternalSourceToken?,
-        ): StagedTx =
+            al: BufferAllocator, openTx: OpenTx, srcMsgId: MessageId,
+            txResult: TransactionResult, dbOp: DbOp?,
+        ): ResolvedTx =
             mutableListOf<Table>().closeAllOnCatch { staged ->
                 // Every table the tx touched, including 0-row ones: `CREATE TABLE` declares columns with no
-                // rows, and it must register in the durable index on promotion. This matches what
-                // `serializeTableData` carries (all `tableTxs`, 0-row included). `Table.openSnapshot`
-                // drops the empty relation for row-reads, but the table's existence still reaches resolution
-                // via its `columnTypes` (see `Snapshot.open`).
+                // rows, and it must register in the durable index on promotion. `Table.openSnapshot` drops
+                // the empty relation for row-reads, but the table's existence still reaches resolution via
+                // its `columnTypes` (see `Snapshot.open`), and `toReplicaMessage` serializes it for the replica.
                 for ((ref, tableTx) in openTx.tables) {
                     val slice = tableTx.txRelation.openDirectSlice(al)
                     staged.add(Table(ref, slice, tableTx.trie.withIidReader(slice["_iid"])))
                 }
 
-                StagedTx(openTx.txKey, notifyMsgId, txResult, externalSourceToken, staged.associateBy { it.ref })
+                ResolvedTx(
+                    openTx.txKey, srcMsgId, txResult, openTx.externalSourceToken, dbOp,
+                    staged.associateBy { it.ref }
+                )
             }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -87,7 +87,7 @@ class Snapshot(
         fun open(
             al: BufferAllocator, tableCat: TableCatalog,
             trieCatalog: TrieCatalog, liveIndex: LiveIndex,
-            stagedTxs: List<StagedTx> = emptyList(),
+            resolvedTxs: List<ResolvedTx> = emptyList(),
             ownTx: OpenTx? = null,
         ): Snapshot = safelyOpening {
             val trieCatSnap = trieCatalog.snapshot()
@@ -104,7 +104,7 @@ class Snapshot(
                     .safeMap { TableSnapshot.open(al, it) }
             }
 
-            val stagedTables = stagedTxs.flatMap { it.allTables }
+            val stagedTables = resolvedTxs.flatMap { it.allTables }
 
             val stagedSnaps = openAll {
                 stagedTables

--- a/core/src/main/kotlin/xtdb/indexer/StagedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagedTx.kt
@@ -83,7 +83,7 @@ class StagedTx private constructor(
             mutableListOf<Table>().closeAllOnCatch { staged ->
                 // Every table the tx touched, including 0-row ones: `CREATE TABLE` declares columns with no
                 // rows, and it must register in the durable index on promotion. This matches what
-                // `serializeTableData` / `importTx` carry (all `tableTxs`, 0-row included). `Table.openSnapshot`
+                // `serializeTableData` carries (all `tableTxs`, 0-row included). `Table.openSnapshot`
                 // drops the empty relation for row-reads, but the table's existence still reaches resolution
                 // via its `columnTypes` (see `Snapshot.open`).
                 for ((ref, tableTx) in openTx.tables) {

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -3,9 +3,8 @@ package xtdb.indexer
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
+import xtdb.api.log.DbOp
 import xtdb.api.log.MessageId
-import xtdb.api.log.ReplicaMessage
-import xtdb.database.ExternalSourceToken
 import xtdb.util.closeAll
 
 /**
@@ -13,11 +12,11 @@ import xtdb.util.closeAll
  * [LeaderLogProcessor] owns from construction and frees in its two-phase close (after the resolver
  * job is joined); the resolver is its sole accessor, so it needs no lock.
  *
- * As each tx resolves, the resolver holds its owned row slices ([StagedTx]) plus the replica
- * [message][ReplicaMessage.ResolvedTx] to be appended at seal in the `accumulating` slot, and advances
- * the [applied head][latestCompletedTx]. Nothing is appended to a producer transaction here — the append
- * happens when the resolver seals the batch (a single fenced producer permits only one open transaction
- * at a time, so appends are queued into one transaction and committed together).
+ * As each tx resolves, the resolver holds it ([ResolvedTx], owning its row slices) in the `accumulating`
+ * slot and advances the [applied head][latestCompletedTx]. Nothing is appended to a producer transaction
+ * here — the append happens when the resolver seals the batch (a single fenced producer permits only
+ * one open transaction at a time, so appends are queued into one transaction and committed together),
+ * where each resolved tx serializes itself into a replica message via [ResolvedTx.toReplicaMessage].
  *
  * Two heads: this [latestCompletedTx] is the APPLIED head (drives resolution — next external-source
  * tx-id and system-time smoothing), which leads [LiveIndex.latestCompletedTx] (the durable/query basis,
@@ -34,38 +33,25 @@ class StagingIndex(
     var latestCompletedTx: TransactionKey? = latestCompletedTx
         private set
 
-    /** A resolved tx held for staging: its owned row slices plus the replica message to append at seal. */
-    class Pending(
-        val stagedTx: StagedTx,
-        val message: ReplicaMessage.ResolvedTx,
-    ) : AutoCloseable {
-        override fun close() = stagedTx.close()
-    }
-
-    private val accumulating = ArrayDeque<Pending>()
+    private val accumulating = ArrayDeque<ResolvedTx>()
 
     /** In-flight staged predecessors for resolution layering (read-your-writes), oldest→newest. */
-    val stagedTxs: List<StagedTx> get() = accumulating.map { it.stagedTx }
+    val resolvedTxs: List<ResolvedTx> get() = accumulating.toList()
 
     val isEmpty: Boolean get() = accumulating.isEmpty()
 
     /**
-     * Stage a resolved [openTx] (whose replica [message] the resolver holds for seal-time append): take
-     * independent slices of its writes into the staging allocator, hold them + the message in the
-     * accumulating slot, and advance the applied head. The caller closes [openTx] afterwards.
+     * Stage a resolved [openTx]: take independent slices of its writes into the staging allocator, hold
+     * them in the accumulating slot, and advance the applied head. The caller closes [openTx] afterwards.
      */
-    fun stage(
-        openTx: OpenTx, message: ReplicaMessage.ResolvedTx,
-        notifyMsgId: MessageId, txResult: TransactionResult, externalSourceToken: ExternalSourceToken?,
-    ) {
-        // StagedTx.stage cleans up its own partial slices on throw; nothing else here can leak.
-        val stagedTx = StagedTx.stage(allocator, openTx, notifyMsgId, txResult, externalSourceToken)
-        accumulating.addLast(Pending(stagedTx, message))
+    fun stage(openTx: OpenTx, srcMsgId: MessageId, txResult: TransactionResult, dbOp: DbOp?) {
+        // ResolvedTx.stage cleans up its own partial slices on throw; nothing else here can leak.
+        accumulating.addLast(ResolvedTx.stage(allocator, openTx, srcMsgId, txResult, dbOp))
         latestCompletedTx = openTx.txKey
     }
 
     /** Take the accumulated slot as an ordered batch (send order) and clear the slot. */
-    fun drainAccumulated(): List<Pending> {
+    fun drainAccumulated(): List<ResolvedTx> {
         val batch = accumulating.toList()
         accumulating.clear()
         return batch

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -58,8 +58,15 @@ class TransitionLogProcessor(
         val msgId = record.msgId
         when (val msg = record.message) {
             is ReplicaMessage.ResolvedTx -> {
-                liveIndex.importTx(msg)
                 val txKey = TransactionKey(msg.txId, msg.systemTime)
+
+                val tables = msg.loadTableData(allocator)
+                try {
+                    liveIndex.commitTx(txKey, tables)
+                } finally {
+                    tables.closeAll()
+                }
+
                 if (msg.committed) {
                     when (val dbOp = msg.dbOp) {
                         is DbOp.Attach -> if (dbCatalog != null) {

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -235,7 +235,7 @@ class ExternalSourceTest {
     fun `fault in the commit pipeline tips watchers into Failed`() = runTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
-            every { importStagedTx(any()) } throws RuntimeException("commit pipeline fault")
+            every { commitTx(any(), any()) } throws RuntimeException("commit pipeline fault")
         }
 
         val extSource = InMemoryExternalSource()
@@ -273,7 +273,7 @@ class ExternalSourceTest {
     fun `submit surfaces an unrecoverable failure to the caller on a later submit`() = runTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
-            every { importStagedTx(any()) } throws RuntimeException("commit pipeline fault")
+            every { commitTx(any(), any()) } throws RuntimeException("commit pipeline fault")
         }
 
         val caught = CompletableDeferred<Throwable>()

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -113,9 +113,9 @@ class FollowerLogProcessorTest {
 
         proc.processRecords(listOf(record(0, tx40), record(1, tx42), record(2, tx43)))
 
-        verify(exactly = 0) { liveIndex.importTx(tx40) }
-        verify(exactly = 0) { liveIndex.importTx(tx42) }
-        verify { liveIndex.importTx(tx43) }
+        verify(exactly = 0) { liveIndex.commitTx(match { it.txId == tx40.txId }, any()) }
+        verify(exactly = 0) { liveIndex.commitTx(match { it.txId == tx42.txId }, any()) }
+        verify { liveIndex.commitTx(match { it.txId == tx43.txId }, any()) }
     }
 
     @Test
@@ -140,7 +140,7 @@ class FollowerLogProcessorTest {
 
         proc.processRecords(staleRecords)
 
-        verify(exactly = 0) { liveIndex.importTx(any()) }
+        verify(exactly = 0) { liveIndex.commitTx(any(), any()) }
         assert(watchers.latestSourceMsgId == 1000L) { "latestSourceMsgId should not have changed" }
     }
 
@@ -181,7 +181,7 @@ class FollowerLogProcessorTest {
             record(1, tx1001),
         ))
 
-        verify { liveIndex.importTx(tx1001) }
+        verify { liveIndex.commitTx(match { it.txId == tx1001.txId }, any()) }
         assert(watchers.latestSourceMsgId == 1001L)
     }
 
@@ -202,7 +202,7 @@ class FollowerLogProcessorTest {
             record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, -1, emptyList())),
         ))
 
-        verify { liveIndex.importTx(extTx) }
+        verify { liveIndex.commitTx(match { it.txId == extTx.txId }, any()) }
         assertEquals(-1L, watchers.latestSourceMsgId,
             "ext-source ResolvedTx must not bump latestSourceMsgId")
         assertEquals(0L, blockCatalog.currentBlockIndex)
@@ -218,9 +218,9 @@ class FollowerLogProcessorTest {
 
         proc.processRecords(listOf(record(0, ext0), record(1, src1), record(2, ext2)))
 
-        verify { liveIndex.importTx(ext0) }
-        verify { liveIndex.importTx(src1) }
-        verify { liveIndex.importTx(ext2) }
+        verify { liveIndex.commitTx(match { it.txId == ext0.txId }, any()) }
+        verify { liveIndex.commitTx(match { it.txId == src1.txId }, any()) }
+        verify { liveIndex.commitTx(match { it.txId == ext2.txId }, any()) }
         assertEquals(1L, watchers.latestSourceMsgId,
             "latestSourceMsgId reflects only the source-log tx; ext-source txs leave it alone")
     }

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -64,7 +64,7 @@ class LiveIndexTest {
 
         fun commitTx(openTx: OpenTx) {
             openTx.writeTxRow(null, null)
-            liveIndex.importTx(openTx.commitTx())
+            liveIndex.commitTx(openTx.txKey, openTx.tables.associate { (ref, t) -> ref to t.txRelation })
         }
 
         override fun close() {

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -137,7 +137,7 @@ class LogProcessorTest {
         // wait for the follower→leader transition to complete (runs on Dispatchers.Default)
         watchers.awaitTx(1)
 
-        verify { liveIndex.importTx(any()) }
+        verify { liveIndex.commitTx(any(), any()) }
 
         // Teardown: cancel+join the scope reaps the subscription and the live term, then free it.
         scope.coroutineContext.job.cancelAndJoin()
@@ -169,7 +169,7 @@ class LogProcessorTest {
 
         watchers.awaitTx(1)
 
-        verify { liveIndex.importTx(any()) }
+        verify { liveIndex.commitTx(any(), any()) }
 
         // Teardown: cancel+join the scope reaps the subscription and the live term, then free it.
         scope.coroutineContext.job.cancelAndJoin()

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -90,7 +90,7 @@ class TransitionLogProcessorTest {
             record(1, ReplicaMessage.BlockBoundary(0, -1)),
         ))
 
-        verify { liveIndex.importTx(extTx) }
+        verify { liveIndex.commitTx(match { it.txId == extTx.txId }, any()) }
         assertEquals(-1L, watchers.latestSourceMsgId,
             "ext-source ResolvedTx must not bump latestSourceMsgId")
 

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -14,7 +14,7 @@
            [org.apache.arrow.memory BufferAllocator]
            (xtdb.api TransactionResult$Committed)
            (xtdb.arrow Relation)
-           (xtdb.indexer StagedTx)
+           (xtdb.indexer ResolvedTx)
            (xtdb.trie ArrowHashTrie ArrowHashTrie$Leaf MemoryHashTrie$Leaf)))
 
 (t/use-fixtures :each tu/with-allocator
@@ -138,7 +138,7 @@
     (util/with-open [staging-alloc (util/->child-allocator (.getAllocator tu/*node*) "staging")]
       (util/with-open [staged (with-open [create-tx (tu/->open-tx tx-key)]
                                 (.executeSql create-tx "CREATE TABLE foo (_id, bar)")
-                                (StagedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil))
+                                (ResolvedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil))
                        observer-tx (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-01T00:00:01Z"})
                        snap (.openSnapshot live-index [staged] observer-tx)]
         (t/is (.containsKey (.getTableInfo snap) table)


### PR DESCRIPTION
Part of #5781.

## Summary

On the leader, committing a transaction serialized its table data to Arrow IPC and then — on the same node, moments later — deserialized those same bytes back into a relation to feed the live index. This cuts that round-trip: the leader imports from the relations it already holds, and the serialization it still owes the replica log moves off the resolve path onto the drain. Two behaviour-preserving refactors — same replica bytes, same imports.

## Context

The per-transaction overhead framing is in #5781. The earlier direct-append avenue (closed as #5784) concluded the one-row-transaction cost wasn't copier construction but "something else — the log/IPC round-trip". This is that round-trip.

Since the ingestion-pipelining work, the leader stages each tx's relation slices and promotes them into the live index directly. So the deserialize was already redundant — the leader had the relations in hand — and the serialized `ResolvedTx` it built at commit was only ever consumed once, at the replica-log append.

## What's here

Two commits, both behaviour-preserving:

1. **`unify LiveIndex import on commitTx(txKey, tables)`** — `LiveIndex` had two entry points: `importStagedTx` (leader, importing from in-memory relation slices) and `importTx` (follower, deserializing a replica message's per-table Arrow IPC bytes first). Same operation, different source of relations. Collapsed into one `commitTx(txKey, Map<TableRef, RelationReader>)` that imports from relations; the deserialization moves out to the follower/transition callers — the only ones holding just bytes — via a new `ReplicaMessage.ResolvedTx.loadTableData`. `LiveIndex` no longer touches `ReplicaMessage` on the import path.

2. **`serialize the replica message at seal, not at resolve`** — the leader built the serialized `ResolvedTx` eagerly at resolve time, inside `OpenTx.commitTx`, on the resolver's hot path. Nothing reads those bytes before the replica-log append, so `OpenTx`/`StagingIndex` now build no message at all: the resolved tx is modelled as `ResolvedTx` (carrying the salient `OpenTx` facts — key, result, any db-op, source-log position, external-source token — plus its owned relation slices) and assembles its replica message on demand at the drain via `toReplicaMessage`, serializing the slices there.

## This is half the win

It removes the redundant deserialize outright and relocates the serialize to the drain. The other half — taking that serialization off the indexing thread entirely, onto the replica-log-writing coroutine — is a follow-up, landing once that coroutine exists (a follow-on to the ingestion-pipelining commits). Until then, seal (and its serialize) is still synchronous on the resolver.

## Noted, out of scope

A code-review pass flagged a pre-existing error-path edge in `drainStaging`, unrelated to this diff: if `commitTx` throws after the batch's producer transaction has already committed, `latestReplicaMsgId` advances only through the last successfully imported tx. It's safe — a follower replays idempotently — but worth a future resilience pass. Left untouched here to keep these commits behaviour-preserving.

## Test plan

- Kotlin indexer + external-source unit tests (leader / follower / transition processors, `LiveIndex`).
- 1100 leader/follower simulation iterations (`NodeSimulationTest`, `LogProcessorSimTest`), which assert cross-node replica-log and block-file consistency — the check that would catch the serialized staged slice diverging from the original relation.
- Clojure indexer tests plus end-to-end transaction tests.
- No Arrow allocator leaks, no reflection or boxed-math warnings.