### PR TITLE
perf(indexer): double-buffer the replica-log append (#5507)

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -22,19 +22,16 @@
 --     last holder releases them
 --
 -- Pipelining (leader only) — single-resolver model:
---   NOTE: spec-ahead-of-code. The leader is currently a fully-synchronous single
---   persister; the pipelined commit described here is not yet implemented.
---
 --   On a leader, a SINGLE resolver coroutine drives the whole pipeline (see
 --   db.allium). It owns the STAGING INDEX outright (sole accessor, so staging needs
 --   no lock — single-threaded by construction) AND owns the replica-log producer's
 --   append path. As each tx resolves, the resolver applies it to the staging index's
 --   `accumulating` slot (so later txs in the same stream resolve against it —
 --   read-your-writes), advancing the staging index's own APPLIED head
---   (StagingIndex.latest_completed_tx), AND holds the tx's resolved replica message
---   (the ResolvedTx to be appended) in the slot in send order. It does NOT append to
---   any producer transaction at resolve time. The tx is NOT yet visible to external
---   queries: it is applied-to-staging but not yet on the replica log.
+--   (StagingIndex.latest_completed_tx). Nothing is serialized or appended to any
+--   producer transaction at resolve time — the accumulating slot holds only the txs'
+--   row slices. The tx is NOT yet visible to external queries: it is applied-to-staging
+--   but not yet on the replica log.
 --
 --   The APPENDS happen at SEAL time, not resolve time — a single Kafka transactional
 --   producer permits only ONE open transaction at a time, and commit() commits
@@ -42,25 +39,35 @@
 --   open a second transaction — a second producer would be fenced). So appending each
 --   tx as it resolves is not realizable: while a sealed batch's producer transaction
 --   is being committed, the next tx would have nowhere to append (neither the
---   committing transaction — it commits with the wrong batch — nor a new one —
---   fenced). Instead, when the resolver SEALS a batch (see SealStagingBatch) it opens
---   a FRESH producer transaction, appends the whole accumulating slot's held messages
---   in send order (the cheap, nigh-on-free step that fixes the txs' order on the
---   replica log), moves the slot into the `committing` sequence, and hands the
---   OPEN-BUT-UNCOMMITTED producer transaction to a secondary COMMITTER coroutine.
+--   in-flight transaction — it commits with the wrong batch — nor a new one —
+--   fenced). Instead, when the resolver SEALS a batch (see SealStagingBatch) it
+--   LAUNCHES the batch's whole replica-log append as a background coroutine (a
+--   supervisor child of the leader term). That background append does the durability
+--   work off the resolver: it serializes each tx's replica message (only now, at seal,
+--   on the background coroutine — nothing holds a serialized message in the
+--   accumulating slot), opens a FRESH producer transaction, appends the batch's
+--   messages in send order, commits, and yields, per tx, that tx paired with its
+--   replica-log position. `seal()` hands the accumulated txs out as an ordered batch,
+--   transferring OWNERSHIP — including freeing responsibility — from the staging index
+--   to the resolver: the staging index knows nothing of appends or the in-flight batch.
+--   From then on the resolver holds the sealed batch as its own single `in_flight` slot
+--   — the txs together with the Deferred handle of that append.
 --
---   ONLY the producer-transaction commit (the durability step — the slow Kafka
---   round-trip) is offloaded to that committer coroutine, so the resolver's
---   dispatcher thread is not held during it. The committer does ONLY commit() on the
---   already-appended transaction; it does not append and touches neither staging nor
---   the durable index. When the committer signals that a batch is durable, the
---   RESOLVER PROMOTES the `committing` batch into the durable live tables — ONE TX AT
---   A TIME, in send order — advancing the DURABLE basis (LiveIndex.latest_completed_tx),
---   refreshing the shared external snapshot, and notifying watchers. Everything but
---   the commit itself — apply, append-at-seal, import, advance the durable head +
---   apply cursor, refresh, notify, finish blocks — stays on the resolver. Followers
---   and the transition processor have no staging index: the messages they import are
---   already durable, so they advance LiveIndex.latest_completed_tx directly.
+--   The slow work (serialize + producer commit) is thus off the resolver, which keeps
+--   resolving while the append runs. When the append COMPLETES, the resolver SETTLES it
+--   — opportunistically between the records of a source-log batch, or forced at drain
+--   points — by awaiting the per-tx positions and PROMOTING the batch
+--   into the durable live tables ONE TX AT A TIME, in send order: advancing the DURABLE
+--   basis (LiveIndex.latest_completed_tx) and the apply cursor per tx, refreshing the
+--   shared external snapshot, notifying watchers, cutting a block if the live index
+--   filled, then freeing the batch and immediately sealing+launching the accumulated
+--   tail if any. Because batch N+1's append is only launched after batch N settles, at
+--   most one producer transaction is ever open — the resolver's single `in_flight` slot
+--   makes this structural (same fencing rationale as before). Everything except the background
+--   serialize+append+commit — apply, promote/import, advance the durable head + apply
+--   cursor, refresh, notify, finish blocks — stays on the resolver. Followers and the
+--   transition processor have no staging index: the messages they import are already
+--   durable, so they advance LiveIndex.latest_completed_tx directly.
 --
 --   Two heads, two homes — callers choose: the durable basis is
 --   LiveIndex.latest_completed_tx (query basis); the applied/resolution head is
@@ -72,10 +79,16 @@
 --   staging-agnostic. Promotion appends into the durable LiveIndex under its
 --   existing write lock.
 --
+--   Ownership split: the staging index owns only the OPEN `accumulating` slot; the
+--   resolver owns the SEALED in-flight batch (its single `in_flight` slot). On a
+--   settle fault — including a teardown cancellation thrown out of the append's await —
+--   the batch stays on the resolver's `in_flight` slot and is freed at the leader's
+--   close() AFTER the term join (see CloseStagingIndex), never by the staging index.
+--
 -- Critical invariant: External queries see only durably-replicated transactions
 --   (LiveIndex.latest_completed_tx). A query returned to a user must never
 --   include a tx that could vanish if the leader crashed before its replica-log
---   write landed. Resolution sees durable ⊕ committing ⊕ accumulating ⊕ the tx's
+--   write landed. Resolution sees durable ⊕ in-flight ⊕ accumulating ⊕ the tx's
 --   own writes.
 
 ------------------------------------------------------------
@@ -102,6 +115,17 @@ external entity MemorySegment
     -- its IID column. The slice is taken at snapshot creation and is
     -- unaffected by subsequent writes to the source relation.
     -- See: xtdb.segment.MemorySegment, memory-hash-trie.allium.
+
+-- The background replica-log append launched for a sealed batch (a supervisor
+-- child of the leader term). It serializes each tx's replica message, opens a
+-- fresh producer transaction, appends the batch's messages in send order,
+-- commits, and — when settled — yields, per tx, that tx paired with its
+-- replica-log position (the tx↔position correspondence is structural — each tx
+-- carries its own position — not a positionally-zipped list). Modelled as a
+-- Deferred handle in the implementation, held on the resolver's in-flight batch
+-- (InFlightBatch.append). The resolver observes its completion and settles it
+-- (see PromoteNext).
+external entity ReplicaAppend {}
 
 ------------------------------------------------------------
 -- Value Types
@@ -139,14 +163,6 @@ value Put {
 
 value Delete { }   -- null marker in the "delete" leg
 value Erase { }    -- null marker in the "erase" leg
-
-value ResolvedTx {
-    -- A resolved tx's PENDING REPLICA MESSAGE: the message the resolver will append
-    -- onto the open producer transaction at SEAL time (not at resolve time). Held in
-    -- the accumulating slot in send order (StagingSlot.pending_messages) alongside the
-    -- StagedTx that carries the tx's row slices. See db.allium ResolvedTxMessage.
-    tx_key: TransactionKey
-}
 
 ------------------------------------------------------------
 -- Entities
@@ -190,30 +206,28 @@ entity StagingIndex {
     -- two-phase close (see CloseStagingIndex); absent on followers and the
     -- transition processor, which only import already-durable messages.
     --
-    -- Double-buffered: an open accumulating slot, plus a sealed committing batch.
-    -- At most one batch is ever in flight (a Kafka transactional producer allows
-    -- only one open producer transaction at a time) — the resolver enforces this via
-    -- in_flight — so this is optimal:
-    --   - accumulating: open, taking newly-resolved committed txs. Each accumulated
-    --                   tx also HOLDS its pending replica message (the ResolvedTx to
-    --                   append), in send order; nothing is appended to a producer
-    --                   transaction yet — the appends happen at seal time.
-    --   - committing:   the sealed batch whose producer transaction — opened fresh and
-    --                   appended-to at seal time — is currently being COMMITTED by the
-    --                   secondary committer coroutine, held as an ORDERED SEQUENCE of
-    --                   staged txs (oldest→newest, i.e. send order) so the resolver can
-    --                   promote it ONE TX AT A TIME once the commit lands (see
-    --                   PromoteNext); empty when no batch is in flight.
-    -- SENDS are serial but ACCUMULATION continues during a send: while the committer
-    -- commits the sealed batch's producer transaction, the resolver keeps resolving and
-    -- accumulating the NEXT slot. It cannot SEAL (and so cannot send) the next batch
-    -- until the current commit completes and the batch promotes — in_flight gates this,
-    -- matching the single open producer transaction. Run-ahead is in the accumulating
-    -- slot, not in a second producer transaction.
+    -- The staging index holds only the OPEN accumulating slot. It knows nothing of
+    -- appends or the sealed in-flight batch: seal() (see SealStagingBatch) hands the
+    -- accumulated txs out as an ordered batch, transferring ownership — including
+    -- freeing responsibility — to the RESOLVER, which holds the sealed batch as its
+    -- own single in-flight slot (see the header "Ownership split", InFlightBatch and
+    -- SealStagingBatch/PromoteNext).
+    --   - accumulating: open, taking newly-resolved committed txs. Holds only the txs'
+    --                   row slices, in send order; nothing is serialized or appended to
+    --                   a producer transaction yet — that happens on the background
+    --                   append the resolver launches at seal time.
+    -- Double-buffering — an open accumulating slot here plus AT MOST ONE sealed
+    -- in-flight batch on the resolver — matches the single open producer transaction a
+    -- Kafka transactional producer permits. ACCUMULATION continues while a batch is in
+    -- flight: the resolver keeps resolving and accumulating this slot while the
+    -- resolver's in-flight batch's append runs in the background. The resolver cannot
+    -- SEAL (and so cannot launch) the next batch until the current one settles and is
+    -- promoted; run-ahead is in this accumulating slot, not in a second producer
+    -- transaction.
     -- The accumulating slot mirrors the live tables (per-table relation + trie) so it
     -- composes with the snapshot/segment layering as an extra segment layer; it also
-    -- records its txs' send order plus each tx's pending replica message (accumulated_txs)
-    -- so a seal appends them in order and produces the ordered committing batch.
+    -- records its txs' send order (accumulated_txs) so a seal appends their serialized
+    -- messages in order and produces the ordered in-flight batch.
     --
     -- The durable LiveIndex this staging index pipelines into. The link is one-way:
     -- the staging index references the index, but the index does not reference the
@@ -229,44 +243,67 @@ entity StagingIndex {
 
     accumulating: StagingSlot
 
-    -- The sealed batch whose producer transaction is being committed: an ordered
-    -- sequence of staged txs, oldest→newest (send order). Empty when no batch is in
-    -- flight. Promoted one tx at a time from the front (see PromoteNext).
-    committing: List<StagedTx>
+    -- The resolver's single sealed in-flight batch, or null when none is in flight.
+    -- NOT a slot on the staging index — this is the RESOLVER's state, modelled here as
+    -- a navigable back-reference from the batch (InFlightBatch.staging = this) so the
+    -- rules (SealStagingBatch, PromoteNext, FinishBlock) can reach it from the staging
+    -- index they carry. The staging index neither reads nor frees it; the resolver
+    -- launches its append at seal, promotes it one tx at a time when it settles, frees
+    -- it as the batch empties, and — on a settle fault — frees it at the leader's
+    -- close(). At most one at a time (see the derived in_flight).
+    in_flight: InFlightBatch with staging = this
 
-    -- in_flight is true exactly while a batch's producer transaction is open and
-    -- committing (between SealStagingBatch, which opens+appends+hands off, and the last
-    -- PromoteNext). The resolver checks it to enforce at-most-one-batch in flight —
-    -- matching the single open producer transaction a Kafka transactional producer
-    -- permits. Accumulation of the next slot continues while in_flight is true; only
-    -- sealing (the next send) is gated.
-    in_flight: committing.count > 0
+    -- in_flight_present is true exactly while the resolver's in-flight batch's
+    -- background append is outstanding (between SealStagingBatch, which launches it, and
+    -- the last PromoteNext, which frees the batch). The resolver checks it to enforce
+    -- at-most-one-batch in flight — matching the single open producer transaction a
+    -- Kafka transactional producer permits. Accumulation of the next slot continues
+    -- while it is true; only sealing (the next append launch) is gated.
+    in_flight_present: in_flight != null
 
-    -- Derived: staging is drained when nothing is accumulated and nothing is
-    -- in flight. FinishBlock requires this so a durable block never contains
-    -- non-durable rows.
-    is_drained: accumulating.is_empty and committing.count = 0
+    -- Derived: staging is drained when nothing is accumulated and no batch is in
+    -- flight on the resolver. FinishBlock requires this so a durable block never
+    -- contains non-durable rows.
+    is_drained: accumulating.is_empty and in_flight = null
+}
+
+entity InFlightBatch {
+    -- One sealed batch: the txs bound for a single replica-log producer transaction,
+    -- in send order (oldest→newest), together with the background append that carries
+    -- them. This is the RESOLVER's single in-flight slot — at most one at a time; the
+    -- staging index does not hold or free it. Kept as one value on purpose: the txs and
+    -- the append that serializes+commits them cannot drift apart. Promoted one tx at a
+    -- time, from the front, when the append settles.
+    --
+    -- staging is a back-reference to the staging index the resolver sealed this batch
+    -- out of, so the rules can navigate to the in-flight batch via the staging index
+    -- they carry (StagingIndex.in_flight). Ownership is the resolver's, not staging's.
+    staging: StagingIndex
+
+    -- The batch's staged txs, oldest→newest (send order), retaining their per-table
+    -- rows so PromoteNext can import each into the durable live tables.
+    txs: List<StagedTx>
+
+    -- The background append: launched at seal, it serializes each tx's replica message,
+    -- opens a fresh producer transaction, appends the messages in send order, commits,
+    -- and — when settled — yields, per tx, that tx paired with its replica-log position
+    -- (the follower resume cursor, advanced per promoted tx). The tx↔position pairing is
+    -- structural, not index-based. See ReplicaAppend.
+    append: ReplicaAppend
 }
 
 entity StagingSlot {
     -- The open accumulating slot. Mirrors the live tables structurally (per-table
     -- relation + trie, for the read-your-writes segment layering) and additionally
-    -- records the send order of the txs applied to it, plus each tx's PENDING REPLICA
-    -- MESSAGE, so a seal appends the messages in order and produces the ordered
-    -- committing batch.
+    -- records the send order of the txs applied to it, so a seal serializes+appends
+    -- their messages in order and produces the ordered in-flight batch. Nothing is
+    -- serialized at resolve time; the slot holds only the txs' row slices.
     staging: StagingIndex
     tables: StagingTable with slot = this
 
     -- The txs applied to this slot, in send order (oldest→newest). SealStagingBatch
-    -- moves these into the committing sequence.
+    -- moves these into the in-flight batch.
     accumulated_txs: List<StagedTx>
-
-    -- Each accumulated tx's pending replica message, in the SAME send order as
-    -- accumulated_txs (i-th ↔ i-th). Nothing is appended to a producer transaction at
-    -- resolve time; SealStagingBatch opens a fresh producer transaction and appends
-    -- these in order, then discards them. Held here (a parallel ordered list), not on
-    -- StagedTx, which stays durability-handle-free.
-    pending_messages: List<ResolvedTx>
 
     row_count: tables.sum(t => t.row_count)
     is_empty: accumulated_txs.count = 0
@@ -285,16 +322,14 @@ entity StagingTable {
 entity StagedTx {
     -- One resolved, committed tx held in the staging area, retaining its per-table
     -- rows so PromoteNext can import it into the durable live tables on its own. Once
-    -- sealed into the committing sequence it is promoted (and dropped) one at a time,
-    -- in send order.
+    -- sealed into the in-flight batch it is promoted (and dropped) one at a time, in
+    -- send order.
     --
     -- StagedTx stays DURABILITY-HANDLE-FREE: it holds only the row slices (for
-    -- read-your-writes + promote). The tx's pending replica message (the ResolvedTx to
-    -- append at seal) and — in the implementation — the append handle returned by
-    -- appendMessage (which completes at commit with the tx's replica-log position) are
-    -- held ALONGSIDE it by the resolver: the pending message in the accumulating slot's
-    -- pending_messages, the handle in the sealed batch the resolver hands the committer
-    -- (see db.allium). They are not fields on StagedTx.
+    -- read-your-writes + promote). Serialization into a replica message happens at seal
+    -- time, on the batch's background append (StagedTx carries no serialized message);
+    -- the per-tx replica-log position that append yields is read from InFlightBatch.append
+    -- at settle. Neither is a field on StagedTx.
     staging: StagingIndex
     tx_key: TransactionKey
     tables: StagedTxTable with staged_tx = this
@@ -323,7 +358,7 @@ entity OpenTx {
     index: LiveIndex
 
     -- The resolver-owned staging index this tx resolves against. A resolving tx
-    -- reads durable ⊕ committing ⊕ accumulating ⊕ its own writes, so it carries
+    -- reads durable ⊕ in-flight ⊕ accumulating ⊕ its own writes, so it carries
     -- the staging index (which the resolver, its sole accessor, hands it). Always
     -- present: open transactions exist only on a leader, where staging exists.
     staging: StagingIndex
@@ -401,8 +436,8 @@ entity TableSnapshot {
     live_segment: MemorySegment?
 
     -- Staging segments: slices of this table's staged rows, layered on top of
-    -- live_segment (committing below accumulating). Two sources, oldest→newest:
-    -- first, from the committing batch, each StagedTx's matching StagedTxTable in
+    -- live_segment (in-flight below accumulating). Two sources, oldest→newest:
+    -- first, from the in-flight batch, each StagedTx's matching StagedTxTable in
     -- send order (a just-sealed batch's rows live ONLY here until promoted);
     -- then, on top, the accumulating slot's StagingTable for this table. Empty on
     -- external snapshots (which see durable data only); populated only on
@@ -514,14 +549,14 @@ rule LogErase {
 rule CommitTransaction {
     -- The resolver imports a committed tx into the STAGING accumulating slot and
     -- advances the staging index's APPLIED head (StagingIndex.latest_completed_tx).
-    -- It does NOT append to any producer transaction here: it HOLDS the tx's pending
-    -- replica message in the accumulating slot (pending_messages, in send order); the
-    -- append happens later, at seal time (see SealStagingBatch). The applied-but-not-
-    -- appended tx is held out of the durable index here in staging.
+    -- It does NOT serialize or append the tx to any producer transaction here: the
+    -- accumulating slot holds only the tx's row slices, in send order. Serialization
+    -- and the append happen later, on the background append launched at seal time (see
+    -- SealStagingBatch). The applied-but-not-appended tx is held out of the durable
+    -- index here in staging.
     -- It does NOT advance the DURABLE basis (LiveIndex.latest_completed_tx) and
     -- does NOT refresh the external shared snapshot — those happen only when the
-    -- resolver promotes after the committer confirms the batch durable (see
-    -- PromoteNext).
+    -- resolver promotes the batch once its background append settles (see PromoteNext).
     -- Later txs in the same stream resolve against staging (read-your-writes),
     -- but external queries cannot yet see it.
     when: CommitTransaction(tx)
@@ -552,10 +587,8 @@ rule CommitTransaction {
         staging_table.rows.addAll(table_tx.rows)
 
     -- Record the tx in send order, retaining its per-table rows, so SealStagingBatch
-    -- can produce an ordered committing batch that PromoteNext walks one tx at a time.
-    -- Also HOLD the tx's pending replica message in the slot (same send order), to be
-    -- appended when the batch is sealed — nothing is appended to a producer
-    -- transaction yet.
+    -- can produce an ordered in-flight batch that PromoteNext walks one tx at a time.
+    -- Nothing is serialized yet — the background append serializes each tx at seal.
     ensures:
         let staged_tx = StagedTx.created(
             staging: staging,
@@ -568,74 +601,88 @@ rule CommitTransaction {
                 rows: table_tx.rows
             )
         staging.accumulating.accumulated_txs.add(staged_tx)
-        staging.accumulating.pending_messages.add(ResolvedTx{ tx_key: tx.tx_key })
 }
 
 rule SealStagingBatch {
     -- At a tx boundary the RESOLVER decides to close the batch. This is where the
-    -- APPENDS happen (not at resolve time): the resolver opens a FRESH producer
-    -- transaction, appends the whole accumulating slot's held pending messages in send
-    -- order (the cheap, nigh-on-free step that fixes the txs' order on the replica log
-    -- and yields the per-tx append handles used later for the follower resume cursor),
-    -- seals the slot's txs into the committing sequence (same send order), swaps in a
-    -- fresh empty slot to take over accumulation, and hands the OPEN-BUT-UNCOMMITTED
-    -- producer transaction to the secondary committer coroutine to COMMIT (the
-    -- durability step). Double-buffering means there is only ever the open slot plus
-    -- the one committing batch; the resolver only seals when no batch is already in
-    -- flight (committing empty) and work has accumulated, so at most one batch is in
-    -- flight at a time — matching the single open producer transaction a Kafka
-    -- transactional producer permits. Accumulation of the next slot continues while
-    -- that batch commits; only the next SEAL is gated (on committing being empty
-    -- again).
+    -- background append is LAUNCHED (nothing was serialized or appended at resolve
+    -- time): the resolver takes the accumulating slot's txs out of the staging index via
+    -- seal() (transferring ownership to the resolver), holds them as its own single
+    -- in-flight batch (same send order), and LAUNCHES that batch's whole replica-log
+    -- append as a background coroutine (a supervisor child of the leader term). The
+    -- background append serializes each tx's replica message, opens a FRESH producer
+    -- transaction, appends the messages in send order, commits, and yields per tx that
+    -- tx paired with its replica-log position (the follower resume cursor, read at
+    -- settle). The staging index then swaps in a fresh empty slot to take over
+    -- accumulation and the resolver returns immediately — the serialize + producer
+    -- commit run off the resolver.
+    -- Double-buffering means there is only ever the open slot plus the one resolver-held
+    -- in-flight batch; the resolver only seals when no batch is already in flight and
+    -- work has accumulated, so at most one background append (hence one open producer
+    -- transaction) is ever outstanding — matching what a Kafka transactional producer
+    -- permits. Accumulation of the next slot continues while that append runs; only the
+    -- next SEAL is gated (on in_flight becoming empty again, at settle).
     when: SealStagingBatch(staging)
 
-    requires: staging.committing.count = 0
+    requires: not staging.in_flight_present
     requires: not staging.accumulating.is_empty
 
     ensures:
-        -- Open a fresh producer transaction and append the slot's pending messages in
-        -- send order. appendMessage returns, per tx, a handle that completes at commit
-        -- with that tx's replica-log position (the follower resume cursor); the
-        -- resolver holds those handles on the sealed batch it hands the committer.
-        let producer_tx = OpenProducerTransaction(staging)
-        for pending in staging.accumulating.pending_messages:
-            AppendMessage(producer_tx, pending)
-
-        -- Seal the accumulated txs into the committing sequence, preserving send
-        -- order so PromoteNext walks them oldest→newest.
-        staging.committing = staging.accumulating.accumulated_txs
+        -- Seal the accumulated txs into the resolver's in-flight batch, preserving send
+        -- order so PromoteNext walks them oldest→newest, and launch the background append
+        -- that serializes + appends + commits them. The batch's staging back-reference
+        -- makes it navigable as staging.in_flight; the resolver owns and frees it.
+        -- LaunchReplicaAppend returns the append handle whose completion the resolver
+        -- settles (see PromoteNext).
+        InFlightBatch.created(
+            staging: staging,
+            txs: staging.accumulating.accumulated_txs,
+            append: LaunchReplicaAppend(staging, staging.accumulating.accumulated_txs)
+        )
         staging.accumulating = StagingSlot.created(
             staging: staging,
             tables: {},
-            accumulated_txs: [],
-            pending_messages: []
+            accumulated_txs: []
         )
 }
 
 rule PromoteNext {
-    -- The RESOLVER promotes once the committer confirms the batch durable, ONE TX AT A
-    -- TIME in send order. It peeks the oldest staged tx in the committing sequence,
-    -- imports its rows into the durable live tables (advancing the durable basis to
-    -- that tx), THEN drops it from committing and closes its OpenTx — import-before-drop
-    -- is what makes a partial failure safe (see below). Refreshing the external shared
-    -- snapshot and notifying watchers happen per promoted tx, driven by the resolver in
-    -- db.allium. This is the point at which a committed tx becomes queryable.
+    -- SETTLE: once the in-flight batch's background append COMPLETES — observed
+    -- opportunistically between the records of a source-log batch, or forced at a drain
+    -- point — the RESOLVER promotes the batch ONE TX AT A TIME in send order. It awaits
+    -- the append's per-tx replica-log positions, then for each tx (oldest→newest) peeks
+    -- the front of the in-flight batch, imports its rows into the durable live tables
+    -- (advancing the durable basis to that tx and its apply cursor to that tx's replica-
+    -- log position), THEN drops it from the batch — import-before-drop is what makes a
+    -- partial failure safe (see below). Refreshing the external shared snapshot and
+    -- notifying watchers happen per promoted tx, driven by the resolver in db.allium.
+    -- This is the point at which a committed tx becomes queryable. When the batch empties
+    -- the resolver frees it (removes the batch, so staging.in_flight becomes null) and
+    -- immediately seals+launches the accumulated tail if any, so batches chain
+    -- back-to-back (double-buffering: resolution of the next txs overlapped the
+    -- just-settled append).
     --
     -- Partial-failure safety — the WHY for per-tx: if importing a tx faults partway
     -- through the batch (e.g. OOM), the txs already promoted are durable in the live
     -- tables and the durable basis sits at the last tx that ACTUALLY imported; the
-    -- un-imported tail stays parked in committing (freed by CloseStagingIndex, never
-    -- double-closed). A follower resuming from the apply cursor — which db.allium
-    -- advances per promoted tx to that tx's replica-log position — re-applies only the
-    -- un-imported tail and never double-imports the durable prefix. Promoting the whole
-    -- batch atomically would leave the cursor un-advanced after a mid-batch fault, so a
-    -- follower would re-import the durable prefix → duplicate rows / corrupt block.
+    -- un-imported tail stays parked on the resolver's in-flight batch (freed at the
+    -- leader's close, see CloseStagingIndex, never double-closed). A follower resuming
+    -- from the apply cursor — which db.allium advances per promoted tx to that tx's
+    -- replica-log position — re-applies only the un-imported tail and never
+    -- double-imports the durable prefix. Promoting the whole batch atomically would
+    -- leave the cursor un-advanced after a mid-batch fault, so a follower would
+    -- re-import the durable prefix → duplicate rows / corrupt block.
     when: PromoteNext(staging)
 
-    requires: staging.committing.count > 0
+    -- Only once the background append has settled: its per-tx replica-log positions
+    -- must be available before a tx is promoted (its apply cursor advances to that
+    -- position).
+    requires: staging.in_flight != null
+    requires: AppendSettled(staging.in_flight.append)
 
     let index = staging.index
-    let staged_tx = staging.committing.first
+    let batch = staging.in_flight
+    let staged_tx = batch.txs.first
 
     ensures:
         -- Import this tx's rows into the (possibly new) durable live tables.
@@ -657,11 +704,14 @@ rule PromoteNext {
         index.latest_completed_tx = staged_tx.tx_key
         RefreshSharedSnapshot(index)
 
-        -- Drop this tx from the committing sequence — AFTER importing it — and
-        -- discard the staged record. When the sequence empties the derived in_flight
-        -- becomes false and the resolver may seal the next batch.
-        staging.committing = staging.committing.drop(1)
+        -- Drop this tx from the resolver's in-flight batch — AFTER importing it — and
+        -- discard the staged record. When the batch empties, the resolver frees it
+        -- (removes it), so the derived in_flight_present becomes false and the resolver
+        -- may seal the next batch.
+        batch.txs = batch.txs.drop(1)
         not exists staged_tx
+        if batch.txs.count = 0:
+            not exists batch
 }
 
 rule AbortTransaction {
@@ -712,7 +762,7 @@ rule OpenTransactionSnapshot {
     --
     -- A resolving tx must read all prior txs whether DURABLE or merely STAGED,
     -- plus its own uncommitted writes. So each TableSnapshot layers, bottom to
-    -- top: the durable live segment ⊕ the staging segments (the committing
+    -- top: the durable live segment ⊕ the staging segments (the in-flight
     -- batch's StagedTxTables, oldest→newest, if a batch is in flight, then the
     -- accumulating slot's StagingTable) ⊕ the tx's own segment.
     when: OpenSnapshot(tx)
@@ -725,7 +775,7 @@ rule OpenTransactionSnapshot {
 
         -- One TableSnapshot per table touched by the tx: durable live segment
         -- from the existing LiveTable (if any), the staging segments for the
-        -- table (committing StagedTxTables oldest→newest, below the accumulating
+        -- table (in-flight StagedTxTables oldest→newest, below the accumulating
         -- slot's StagingTable), and the tx segment from this OpenTx.
         for table_tx in tx.table_txs:
             let live_seg = if table_tx.live_table != null: MemorySegment.for(table_tx.live_table) else: null
@@ -794,13 +844,13 @@ rule FinishBlock {
     -- messages).
     when: FinishBlock(index, staging, block_idx)
 
-    -- Staging MUST be drained before the block is written: all in-flight
-    -- commits promoted, nothing accumulated or committing. Otherwise a durable
+    -- Staging MUST be drained before the block is written: the in-flight batch
+    -- settled and promoted, nothing accumulated or in flight. Otherwise a durable
     -- L0 block could contain non-durable rows. On a leader, the resolver cuts a
-    -- block at a tx boundary by first draining (awaiting the in-flight persist
-    -- and promoting), then sending a boundary-batch, so staging is drained by the
-    -- time the block is written. On followers/transition staging is null, so this
-    -- is trivially satisfied.
+    -- block at a tx boundary by first draining (settling the in-flight append and
+    -- promoting, then sealing+settling any accumulated tail), then sending a
+    -- boundary-batch, so staging is drained by the time the block is written. On
+    -- followers/transition staging is null, so this is trivially satisfied.
     requires: staging = null or staging.is_drained
 
     -- Writes current (durable) live table contents to block storage.
@@ -810,16 +860,26 @@ rule FinishBlock {
 
 rule CloseStagingIndex {
     -- Leader → follower demotion is exactly the leader's two-phase close — there
-    -- is NO separate runtime drop. Phase 1 (cancelAndJoin the resolver + committer
-    -- job tree) ensures nothing live still touches staging; phase 2 (this) frees
-    -- the staging index synchronously, closing any un-promoted slot buffers, before
-    -- the allocator is closed. Any staged-but-not-yet-durable txs are discarded
-    -- (they were never visible to external queries) and will be re-read from the
-    -- source log and re-resolved by the next leader. The durable LiveIndex is
+    -- is NO separate runtime drop. Phase 1 (cancelAndJoin the resolver + background-
+    -- append job tree) ensures nothing live still touches staging or the in-flight
+    -- batch; phase 2 (this) frees them synchronously, before the allocator is closed.
+    -- The leader frees, in order: FIRST the resolver's in-flight batch if one is still
+    -- parked there (a batch whose settle never completed — a fault, or a teardown
+    -- cancellation thrown out of the append's await; it stays on the resolver's
+    -- in_flight slot precisely so it is freed here, after the term join, never by the
+    -- staging index and never double-closed), THEN the staging index (closing any
+    -- un-promoted accumulating-slot buffers). Any staged-but-not-yet-durable txs are
+    -- discarded (they were never visible to external queries) and will be re-read from
+    -- the source log and re-resolved by the next leader. The durable LiveIndex is
     -- untouched. See db.allium TransitionToFollower; commit ec0f3947e.
     when: CloseStagingIndex(staging)
 
-    ensures: not exists staging
+    ensures:
+        -- Free a faulted/teardown-parked in-flight batch first — the leader's
+        -- responsibility, after the term join — then the staging index itself.
+        if staging.in_flight != null:
+            not exists staging.in_flight
+        not exists staging
 }
 
 rule NextBlock {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -97,6 +97,97 @@ class LeaderLogProcessor(
     // joined so nothing live still touches it; see StagingIndex.
     private val stagingIndex = StagingIndex(allocator, liveIndex.latestCompletedTx)
 
+    /**
+     * A sealed batch: the txs bound for one replica-log producer transaction, in send order, together
+     * with [append] — that producer transaction's background commit, yielding the per-tx replica-log
+     * positions. One value on purpose: the txs and the append that carries them can't drift apart.
+     */
+    private inner class InFlightBatch(
+        val txs: List<ResolvedTx>, private val append: Deferred<List<Pair<ResolvedTx, Log.MessageMetadata>>>
+    ) : AutoCloseable {
+
+        val isCompleted: Boolean get() = append.isCompleted
+
+        suspend fun settle() {
+            val metadatas = append.await()
+
+            for ((resolvedTx, metadata) in metadatas) {
+                liveIndex.commitTx(resolvedTx.txKey, resolvedTx.allTables.associate { it.ref to it.relation })
+                latestReplicaMsgId = metadata.msgId
+                watchers.notifyTx(resolvedTx.txResult, resolvedTx.srcMsgId, resolvedTx.externalSourceToken)
+            }
+
+            if (liveIndex.isFull()) {
+                val last = txs.last()
+                finishBlock(last.srcMsgId, last.externalSourceToken)
+            }
+        }
+
+        override fun close() {
+            txs.closeAll()
+        }
+    }
+
+    /**
+     * The sealed-but-not-yet-promoted batch. At most one — the single fenced producer permits only one
+     * open transaction at a time, and holding it as a nullable field makes that invariant structural
+     * rather than checked at every append site.
+     */
+    private var inFlight: InFlightBatch? = null
+
+    private val resolvedTxs get() = inFlight?.txs.orEmpty() + stagingIndex.resolvedTxs
+
+    // Seal whatever has accumulated and launch its replica-log append — each tx serializing itself into
+    // a replica message (ResolvedTx.toReplicaMessage), all appended in one fenced producer transaction —
+    // in the background, so the resolver keeps resolving while the serialize + producer commit run.
+    // At most one append is in flight, held on `inFlight`; the persister settles it (settleAppend) once
+    // it completes. No-op if a batch is already in flight (the accumulating tail rides the next kick,
+    // at settle) or there's nothing staged.
+    private fun kickAppend(): InFlightBatch? =
+        if (inFlight != null) null
+        else stagingIndex.seal()?.closeAllOnCatch { txs ->
+            InFlightBatch(
+                txs,
+                appendScope.async {
+                    replicaProducer
+                        .withTx { tx ->
+                            txs.map { it to tx.appendMessage(it.toReplicaMessage()) }
+                        }
+                        .map { it.first to it.second.await() }
+                }
+            ).also { this.inFlight = it }
+        }
+
+    // The batch is freed here only once settle returns; on a settle fault — including a teardown
+    // cancellation thrown out of its await while the append coroutine may still be serializing the
+    // slices — it stays on `inFlight`, and close() frees it after cancelAndJoin has joined the append.
+    private suspend fun settleAppend() {
+        val batch = inFlight ?: return
+        batch.settle()
+        inFlight = null
+        batch.close()
+        kickAppend()
+    }
+
+    // Opportunistically settle a *completed* append between records — promoting it and kicking
+    // the accumulated tail mid-batch — without ever suspending on one that's still going.
+    private suspend fun trySettleAppend() {
+        if (inFlight?.isCompleted == true) settleAppend()
+    }
+
+    // Fully drain: kick anything staged and settle appends until nothing is staged or in flight. The
+    // boundary callers — control messages, attach/detach, ext-source txs, GC's direct appends, the
+    // poll-boundary drain — rely on this post-condition: the replica log carries everything that
+    // preceded them in resolution order, and the fenced producer is idle for their own append.
+    private suspend fun drainStaging() {
+        while (true) {
+            kickAppend()
+            if (inFlight == null) return
+            settleAppend()
+        }
+    }
+
+
     private sealed interface PersisterTask {
         val onComplete: CompletableDeferred<Unit>
     }
@@ -136,6 +227,7 @@ class LeaderLogProcessor(
     // current one (bounding lookahead to ~2). `executeTx` still blocks on the result regardless of capacity.
     private val extSourceCh =
         Channel<ExtSourceTask>(capacity = 1, onUndeliveredElement = { it.onComplete.cancel() })
+
     private val gcCh =
         Channel<GcTask>(onUndeliveredElement = { it.onComplete.cancel() })
 
@@ -143,6 +235,8 @@ class LeaderLogProcessor(
         for (record in records) {
             LOG.trace { "[$dbName] leader: message ${record.msgId} (${record.message::class.simpleName})" }
             handleSourceLogRecord(record)
+
+            trySettleAppend()
         }
 
         // Poll-boundary drain: flush any accumulated tail so the batch task returns with the resolver
@@ -167,6 +261,7 @@ class LeaderLogProcessor(
                 openTx.use {
                     stagingIndex.stage(it, msgId, txResult, dbOp = null)
                 }
+                kickAppend()
             }
 
             is SourceMessage.FlushBlock -> {
@@ -241,37 +336,6 @@ class LeaderLogProcessor(
         }
     }
 
-    // Seal the accumulated batch, make it durable, and promote it into the durable live index. Each tx
-    // serializes its own table data into a replica message here (ResolvedTx.toReplicaMessage) — at seal,
-    // off the resolver's resolve path — rather than eagerly when it was resolved.
-    //
-    // Seal + commit is synchronous for now (one producer transaction per batch, committed here on the
-    // resolver); the committer-coroutine offload + cross-batch accumulation come with the pipeline step.
-    // Promotion is per-tx in send order, post-durable: a mid-batch import fault leaves the cursor at the
-    // last tx that actually imported (partial-failure safety), with the un-imported tail freed below.
-    private suspend fun drainStaging() {
-        if (stagingIndex.isEmpty) return
-
-        val batch = stagingIndex.drainAccumulated()
-        try {
-            val messages = batch.map { it.toReplicaMessage() }
-            val handles = replicaProducer.withTx { tx -> messages.map { tx.appendMessage(it) } }
-
-            for ((resolvedTx, handle) in batch.zip(handles)) {
-                liveIndex.commitTx(resolvedTx.txKey, resolvedTx.allTables.associate { it.ref to it.relation })
-                latestReplicaMsgId = handle.await().msgId
-                watchers.notifyTx(resolvedTx.txResult, resolvedTx.srcMsgId, resolvedTx.externalSourceToken)
-            }
-
-            if (liveIndex.isFull()) {
-                val last = batch.last()
-                finishBlock(last.srcMsgId, last.externalSourceToken)
-            }
-        } finally {
-            batch.closeAll()
-        }
-    }
-
     private suspend fun handleIndexTx(task: ExtSourceTask.IndexTx) {
         val txKey = TransactionKey(
             (stagingIndex.latestCompletedTx?.txId ?: -1) + 1,
@@ -314,6 +378,9 @@ class LeaderLogProcessor(
     }
 
     private suspend fun handleTriesDeleted(task: GcTask.TriesDeleted) {
+        // Drain first: this appends TriesDeleted directly, and replica appends must stay in
+        // resolver-processing order — appending ahead of earlier-staged txs would invert the log.
+        drainStaging()
         appendToReplica(ReplicaMessage.TriesDeleted(task.tableName.schemaAndTable, task.trieKeys))
         trieCatalog.deleteTries(task.tableName, task.trieKeys)
     }
@@ -341,6 +408,13 @@ class LeaderLogProcessor(
     // The GCs run under a SupervisorJob child of `termJob`, so one GC's failure cancels neither its
     // sibling nor the persister; cancelling `termJob` reaps them all.
     private val gcScope = scope + SupervisorJob(termJob)
+
+    // The in-flight replica-log append runs under its own SupervisorJob child of `termJob` for the same
+    // isolation: a failed append must NOT cancel the persister out from under settleAppend — the failure
+    // is held on the batch's Deferred and rethrown at settle, inside the task-handling try, so it
+    // surfaces through notifyError — while `cancelAndJoin` on the term still reaps an append mid-flight
+    // (the fenced producer transaction aborts, so nothing partial reaches the replica log).
+    private val appendScope = scope + SupervisorJob(termJob)
 
     internal val blockGc = nodeBase.config.garbageCollector.let { cfg ->
         BlockGarbageCollector(
@@ -458,7 +532,7 @@ class LeaderLogProcessor(
     }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
-        OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer, stagingIndex.resolvedTxs)
+        OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer, resolvedTxs)
 
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
@@ -690,6 +764,7 @@ class LeaderLogProcessor(
     override fun close() {
         extSource?.close()
         replicaProducer.close()
+        inFlight?.close() // free a batch whose settle never completed (fault / teardown)
         stagingIndex.close() // free any un-promoted staged slices before the allocator
         allocator.close() // last: Arrow won't close it while a child buffer is live
     }

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -14,9 +14,10 @@ import xtdb.util.closeAll
  *
  * As each tx resolves, the resolver holds it ([ResolvedTx], owning its row slices) in the `accumulating`
  * slot and advances the [applied head][latestCompletedTx]. Nothing is appended to a producer transaction
- * here — the append happens when the resolver seals the batch (a single fenced producer permits only
- * one open transaction at a time, so appends are queued into one transaction and committed together),
- * where each resolved tx serializes itself into a replica message via [ResolvedTx.toReplicaMessage].
+ * here — the resolver [seal]s the accumulated txs into a batch (a single fenced producer permits only
+ * one open transaction at a time, so appends are queued into one transaction and committed together)
+ * and from then on owns them itself: the batch rides the leader's in-flight slot until its background
+ * append settles and it is promoted into the durable index.
  *
  * Two heads: this [latestCompletedTx] is the APPLIED head (drives resolution — next external-source
  * tx-id and system-time smoothing), which leads [LiveIndex.latestCompletedTx] (the durable/query basis,
@@ -35,10 +36,8 @@ class StagingIndex(
 
     private val accumulating = ArrayDeque<ResolvedTx>()
 
-    /** In-flight staged predecessors for resolution layering (read-your-writes), oldest→newest. */
+    /** Staged predecessors for resolution layering (read-your-writes), oldest→newest. */
     val resolvedTxs: List<ResolvedTx> get() = accumulating.toList()
-
-    val isEmpty: Boolean get() = accumulating.isEmpty()
 
     /**
      * Stage a resolved [openTx]: take independent slices of its writes into the staging allocator, hold
@@ -50,12 +49,12 @@ class StagingIndex(
         latestCompletedTx = openTx.txKey
     }
 
-    /** Take the accumulated slot as an ordered batch (send order) and clear the slot. */
-    fun drainAccumulated(): List<ResolvedTx> {
-        val batch = accumulating.toList()
-        accumulating.clear()
-        return batch
-    }
+    /**
+     * Take the accumulated txs as an ordered batch (send order), or null if nothing is staged, clearing
+     * the slot — ownership of the txs (and freeing them) passes to the caller.
+     */
+    fun seal(): List<ResolvedTx>? =
+        accumulating.toList().takeIf { it.isNotEmpty() }.also { this.accumulating.clear() }
 
     override fun close() {
         accumulating.closeAll()

--- a/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/database/ExternalSourceTest.kt
@@ -103,13 +103,14 @@ class ExternalSourceTest {
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         extSource: ExternalSource = InMemoryExternalSource(),
         afterToken: ExternalSourceToken? = null,
+        wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
     ): LeaderLogProcessor {
         val blockCatalog = BlockCatalog("test", null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader")
+        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader"))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null)
 
@@ -305,6 +306,81 @@ class ExternalSourceTest {
             "the fire-and-forget caller sees the original failure cause"
         )
         assertNotNull(watchers.exception, "watchers should also be in failed state")
+    }
+
+    @Test
+    fun `executeTx throws when the drain faults, rather than hanging`() = runTest {
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { commitTx(any(), any()) } throws RuntimeException("commit pipeline fault")
+        }
+
+        val thrown = CompletableDeferred<Throwable>()
+        val extSource = object : ExternalSource {
+            override suspend fun onPartitionAssigned(
+                partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer
+            ) {
+                try {
+                    txIndexer.executeTx(null) { TxResult.Committed() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    thrown.complete(e)
+                }
+            }
+
+            override fun close() {}
+        }
+
+        leaderProc(liveIndex = liveIndex, extSource = extSource)
+
+        val e = thrown.await()
+        assertEquals(
+            "commit pipeline fault", e.message,
+            "executeTx surfaces the drain fault instead of hanging"
+        )
+    }
+
+    @Test
+    fun `a replica-log commit fault in the background append surfaces through executeTx`() = runTest {
+        val failingProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
+            object : Log.AtomicProducer<ReplicaMessage> {
+                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
+                    val tx = inner.openTx()
+                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
+                        override fun commit() = throw RuntimeException("replica-log commit fault")
+                    }
+                }
+
+                override fun close() = inner.close()
+            }
+        }
+
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+        val thrown = CompletableDeferred<Throwable>()
+        val extSource = object : ExternalSource {
+            override suspend fun onPartitionAssigned(
+                partition: Int, afterToken: ExternalSourceToken?, txIndexer: TxIndexer
+            ) {
+                try {
+                    txIndexer.executeTx(null) { TxResult.Committed() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    thrown.complete(e)
+                }
+            }
+
+            override fun close() {}
+        }
+
+        leaderProc(watchers = watchers, extSource = extSource, wrapProducer = failingProducer)
+
+        val e = thrown.await()
+        assertEquals(
+            "replica-log commit fault", e.message,
+            "executeTx surfaces the background append's fault via its durability handle"
+        )
+        assertNotNull(watchers.exception, "the fault reaches watchers: the term is failed, not silently wedged")
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -3,6 +3,7 @@ package xtdb.indexer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test
 import xtdb.NodeBase
 import xtdb.api.log.InMemoryLog
 import xtdb.api.log.Log
+import xtdb.api.log.MessageId
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
 import xtdb.api.log.Watchers
@@ -36,6 +38,8 @@ import xtdb.trie.TrieCatalog
 import xtdb.util.closeAll
 import java.time.Instant
 import java.time.InstantSource
+import java.time.ZoneId
+import kotlin.time.Duration.Companion.seconds
 
 class LeaderLogProcessorTest {
 
@@ -69,18 +73,20 @@ class LeaderLogProcessorTest {
         trieCatalog: TrieCatalog = mockk(relaxed = true),
         compactor: Compactor.ForDatabase = mockk(relaxed = true),
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
+        skipTxs: Set<MessageId> = emptySet(),
+        wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader")
+        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader"))
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, uploadDispatcher)
 
         return LeaderLogProcessor(
             allocator, nodeBase, dbStorage, mockk(relaxed = true),
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
-            skipTxs = emptySet(), dbCatalog = null,
+            skipTxs = skipTxs, dbCatalog = null,
             partition = 0, afterReplicaMsgId = -1,
             scope = backgroundScope,
         ).also(leadersToClose::add)
@@ -113,7 +119,7 @@ class LeaderLogProcessorTest {
     }
 
     @Test
-    fun `FlushBlock triggers block finish when CAS matches`() = runTest {
+    fun `FlushBlock triggers block finish when CAS matches`() = runTest(timeout = 5.seconds) {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
             every { finishBlock(any(), any()) } returns emptyMap()
@@ -238,5 +244,70 @@ class LeaderLogProcessorTest {
         val uploaded = replicaMessages[1] as ReplicaMessage.BlockUploaded
         assertEquals(0, uploaded.blockIndex)
         assertTrue(uploaded.tries.isNotEmpty(), "BlockUploaded should contain trie details")
+    }
+
+    @Test
+    fun `a slow append double-buffers the rest of the poll batch`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+        val producerBatchSizes = mutableListOf<Int>()
+
+        // Counts each producer transaction's size, and gates every append handle so the first batch's
+        // settle stalls on the gate (a slow commit-ack) without blocking any thread.
+        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
+            object : Log.AtomicProducer<ReplicaMessage> {
+                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
+                    val tx = inner.openTx()
+                    var count = 0
+                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
+                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
+                            count++
+                            val real = tx.appendMessage(message)
+                            appendStarted.complete(Unit)
+                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
+                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
+                            }
+                        }
+
+                        override fun commit() {
+                            tx.commit()
+                            producerBatchSizes += count
+                        }
+                    }
+                }
+
+                override fun close() = inner.close()
+            }
+        }
+
+        // Skipped txs each stage a real (aborted) row without needing a valid tx-ops payload.
+        val n = 5L
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
+            skipTxs = (0 until n).toSet(), wrapProducer = wrapProducer,
+        )
+
+        val now = Instant.now()
+        val records = (0 until n).map {
+            Log.Record(0, it, now.plusMillis(it), SourceMessage.Tx(ByteArray(0), null, ZoneId.of("UTC"), null, null))
+        }
+
+        val batchJob = launch { lp.processRecords(records) }
+
+        appendStarted.await()
+        gate.complete(Unit)
+        batchJob.join()
+
+        assertEquals(
+            listOf(1, 4), producerBatchSizes,
+            "record 0 kicked its append alone; 1-4 resolved behind it and rode the next producer transaction"
+        )
+
+        val resolvedTxs = replicaLog.readRecords(0, replicaLog.latestSubmittedMsgId + 1)
+            .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
+        assertEquals((0 until n).toList(), resolvedTxs.map { it.txId }, "all $n txs land, in send order")
     }
 }


### PR DESCRIPTION
Part of #5507; delivers the "other half of the win" deferred by #5786 (refs #5781).

## Summary

The leader's replica-log commit was synchronous on the resolver: seal the staged batch, serialize each tx to Arrow IPC, append, and wait out the fenced producer's commit round-trip before resolving anything else. This PR double-buffers it: sealing launches the whole append — serialization included — as a background coroutine, and the resolver keeps resolving behind it. Within a source-log poll batch the first tx kicks its append immediately and the rest resolve while it flies, riding the next producer transaction together — batches size themselves to the append latency.

## Context

#5786 cut the leader's serde round-trip and moved serialization to the drain, but left it on the resolver, explicitly deferring the offload until the coroutine carrying it existed. This is that coroutine.

An earlier cut of this work stacked on #5783 (ext-source accumulation + per-tx durability handles) so that CDC transactions could also coalesce behind an in-flight append. That machinery turned out not to be needed for the win that matters now — the source-log ingest path — so this PR deliberately excludes it: ext-source transactions keep their synchronous per-tx drain and `executeTx`'s semantics are untouched. See "Out of scope" for how the ext-source pieces return if wanted.

## Implementation notes

**One nullable value, owned by the resolver.** `StagingIndex` stays a pure accumulating slot; `seal()` hands the batch out and ownership transfers with it. The resolver holds the sealed batch as its single nullable in-flight slot — an `InFlightBatch` owning the txs together with the `Deferred` of their background append. At most one producer transaction is ever open (batch N+1 only launches after batch N settles — the fenced producer permits exactly one), and the append yields per-tx `(tx, replica-position)` pairs, so the tx↔position correspondence is structural rather than a positional zip.

**Kick and settle, all on the persister.** Anything staged with nothing in flight kicks an append; settling — a non-suspending completion check between the records of a source-log batch, or forced at drain points — awaits the per-tx positions, promotes one tx at a time in send order (apply-cursor semantics unchanged from #5507's batching increment), cuts blocks post-promote, then immediately kicks the accumulated tail. Only the serialize + producer commit leave the resolver; imports and all live-index mutation stay on it. Resolution's read-your-writes layering covers durable ⊕ in-flight ⊕ accumulating ⊕ own writes.

**Every task handler ends fully drained**, so a task always finds the producer idle: ext-source txs and GC appends never overlap an in-flight batch, `processRecords` still returns with the persister quiescent (the #5741 lock-step holds), and nothing is ever in flight at the persister's select — which is why there is no select arm, no durability handles, and no idle-flush machinery in this cut. `handleTriesDeleted` gains an explicit drain-first so the replica-ordering constraint is stated in code rather than implied by that invariant.

**Fault propagation shaped the coroutine scoping and the ownership.** The append rides a `SupervisorJob` child of the term: a failed append doesn't cancel the persister — the failure stays on the batch's `Deferred` and is rethrown at the next settle, inside the task-handling try, so it surfaces through `notifyError` like any other persister fault. Ownership follows the same line: a batch is freed once its settle completes, and a batch whose settle faulted — including a teardown cancellation thrown out of its await while the append coroutine may still be serializing the slices — stays parked on the in-flight slot until `close()`, which runs only after `cancelAndJoin` has joined the append. Term teardown aborts the producer transaction, so nothing partial reaches the replica log.

`allium/live-index.allium` is updated from its spec-ahead-of-code committer-coroutine sketch to the implemented shape (the staging index keeps only the accumulating slot; the in-flight batch is resolver-held; serialization happens at seal-time on the background append; settling is observed between records or at drain points).

## Out of scope

- **Ext-source coalescing** — letting CDC txs accumulate behind an in-flight append needs per-tx durability handles (an `executeTx` can no longer infer durability from its task completing), teardown-failure coverage for those handles, and a select arm for the persister to settle on. Those pieces are one coherent increment (the #5783 shape) and return together if the CDC benchmark justifies them; the settle machinery here is shaped so they drop in without restructuring.
- **Running ahead across polls** — gated on moving the leader/follower transition off Kafka's synchronous rebalance callback (#5741 names the follow-up), which #5773 only partially delivered (promotion moved; demotion didn't).
- **Demote replay window** — a committed-but-unsettled batch at demote means the follower replays up to one batch from the replica log (previously at most one tx): `latestReplicaMsgId` is deliberately the apply cursor, not the append position, and replay-from-cursor is the transition-safety mechanism #5507's staging increment introduced for exactly this.

## Test plan

- New deterministic test (`LeaderLogProcessorTest`): a counting, gated producer proves record 0 kicks its append alone and records 1–4 resolve behind it, riding the next producer transaction (`[1, 4]`), with all five landing in send order.
- Fault propagation (`ExternalSourceTest`): a drain fault surfaces through `executeTx` rather than hanging, and a producer-commit fault inside the background append surfaces through `executeTx` and fails the term via watchers.
- `LogProcessorSimTest` (3 × 300 = 900 invocations) and `NodeSimulationTest` (8 × 300 = 2,400 invocations) via `./gradlew property-test -PsimulationIterations=300` — cross-node replica-log/block-file consistency under randomized scheduling.
- Full `./gradlew test`; no Arrow allocator leaks, no reflection/boxed-math warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
