### PR TITLE
fix(postgres-source): recover unchanged TOASTed columns + troubleshooting guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -245,6 +245,7 @@ export default defineConfig({
                                     collapsed: true,
                                     items: [
                                         { label: 'Setup guide', link: '/ops/external-sources/postgres/setup' },
+                                        { label: 'Troubleshooting', link: '/ops/external-sources/postgres/troubleshooting' },
                                         { label: 'Reference', link: '/ops/external-sources/postgres/reference' },
                                     ],
                                 },

--- a/docs/src/content/docs/ops/external-sources/postgres/reference.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/reference.md
@@ -13,6 +13,9 @@ A [role](https://www.postgresql.org/docs/current/user-manag.html) with the follo
 
 A publication enumerating the tables to sync to XTDB, it's table set is the only filter on what gets synced.
 
+[`REPLICA IDENTITY FULL`](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY) on any table with a column that can hold a large ([TOASTable](https://www.postgresql.org/docs/current/storage-toast.html)) value — `text`, `bytea`, `jsonb`, and the like.
+Without it, an `UPDATE` that leaves such a column unchanged omits its value from the replication stream, and — since XTDB mirrors the whole row — the source can't reconstruct the row and halts (see [troubleshooting](/ops/external-sources/postgres/troubleshooting)).
+
 :::caution
 Adding non-empty tables to a publication after the initial snapshot is currently unsupported.
 Doing so will leave the table in an inconsistent state in XTDB.

--- a/docs/src/content/docs/ops/external-sources/postgres/setup.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/setup.md
@@ -100,3 +100,5 @@ Or from another database in XTDB by running:
 ```sql
 SELECT * FROM pg_test_db.public.test_table;
 ```
+
+If you have any problems, please see the [troubleshooting](/ops/external-sources/postgres/troubleshooting) guide.

--- a/docs/src/content/docs/ops/external-sources/postgres/troubleshooting.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/troubleshooting.md
@@ -1,0 +1,58 @@
+---
+title: Troubleshooting a Postgres external source
+---
+
+If a source's ingestion has stopped, you can make the database dormant — see [Skipping Databases](/ops/troubleshooting#skipping-databases-v22) in the general troubleshooting guide.
+
+## Recovering from a failed initial snapshot
+
+**Symptom:**
+Ingestion for the database has stopped with the error `Incomplete snapshot — database is inoperable` (`xtdb.postgres/incomplete-snapshot`).
+The initial snapshot was interrupted before it completed. The node lost leadership mid-snapshot, or was restarted.
+
+**Why a reset is needed:**
+Snapshotting must complete in a single run because a half-finished snapshot can't be resumed by a later leader.
+This should be rare: nodes tend to hold leadership for a long time, and snapshotting is a relatively short period.
+
+**Resolution:**
+
+1. Detach the database in XTDB:
+```sql
+DETACH DATABASE pg_test_db;
+```
+
+2. Delete the slot on Postgres:
+```sql
+SELECT pg_drop_replication_slot('xtdb');
+```
+
+3. Delete the publication on Postgres:
+```sql
+DROP PUBLICATION xtdb;
+```
+
+4. Clear the log:
+If using a [kafka log](/ops/config/log/kafka) you can clear the source & replica topics by either deleting and recreating them, or briefly setting the retention period to 1ms.
+
+5. Clear the object store:
+Delete everything under the location set in the `storage` block of the `ATTACH` — the `!Local` path, or the bucket and prefix of a remote object store.
+
+6. Re-run the [setup guide](/ops/external-sources/postgres/setup) from the beginning
+
+## Ingestion halted on an unchanged TOASTed column
+
+**Symptom:**
+Ingestion has stopped with an error like `Received unchanged TOASTed column '<column>' on <schema>.<table>`.
+
+**Cause:**
+The table isn't set to `REPLICA IDENTITY FULL`.
+When an `UPDATE` leaves a large ([TOASTed](https://www.postgresql.org/docs/current/storage-toast.html)) column unchanged, Postgres omits its value from the replication stream.
+XTDB mirrors the whole row, so without that value it can't reconstruct the row and halts.
+
+**Resolution:**
+Set [`REPLICA IDENTITY FULL`](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY) on the table, so the unchanged value is carried in the old tuple of each change:
+```sql
+ALTER TABLE "public"."my_table" REPLICA IDENTITY FULL;
+```
+This only affects changes written after it's set.
+A source that has already halted won't resume on its own — the change that stopped it was already written without the value — so reset it as in [Recovering from a failed initial snapshot](#recovering-from-a-failed-initial-snapshot) once `REPLICA IDENTITY FULL` is in place.

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -353,25 +353,28 @@ class PgWireDriver(
 
     private fun toRowOp(relation: PgOutputMessage.Relation, msg: PgOutputMessage): RowOp = when (msg) {
         is PgOutputMessage.Insert -> RowOp.Put(relation.schema, relation.table, toRowMap(relation, msg.values))
-        is PgOutputMessage.Update -> RowOp.Put(relation.schema, relation.table, toRowMap(relation, msg.newValues))
+        is PgOutputMessage.Update -> RowOp.Put(relation.schema, relation.table, toRowMap(relation, msg.newValues, msg.oldValues))
         is PgOutputMessage.Delete -> RowOp.Delete(relation.schema, relation.table, toRowMap(relation, msg.oldValues))
         else -> error("Unexpected op type: ${msg::class.simpleName}")
     }
 
-    private fun toRowMap(relation: PgOutputMessage.Relation, values: List<PgOutputMessage.ColumnValue>): Map<String, Any?> =
+    private fun toRowMap(relation: PgOutputMessage.Relation, values: List<PgOutputMessage.ColumnValue>, oldValues: List<PgOutputMessage.ColumnValue>? = null): Map<String, Any?> =
         relation.columns
             .mapIndexedNotNull { idx, col ->
                 values.getOrNull(idx)?.let { colValue ->
                     col.name to when (colValue) {
                         is PgOutputMessage.ColumnValue.Null -> null
                         is PgOutputMessage.ColumnValue.Unchanged ->
-                            throw Incorrect(
-                                buildString {
-                                    appendLine("Received unchanged TOASTed column '${col.name}' on ${relation.schema}.${relation.table}. ")
-                                    appendLine("Set REPLICA IDENTITY FULL on the source table: ")
-                                    appendLine("ALTER TABLE \"${relation.schema}\".\"${relation.table}\" REPLICA IDENTITY FULL")
-                                }
-                            )
+                            when (val old = oldValues?.getOrNull(idx)) {
+                                is PgOutputMessage.ColumnValue.Text -> coerceText(old.value, col.typeOid)
+                                else -> throw Incorrect(
+                                    buildString {
+                                        appendLine("Received unchanged TOASTed column '${col.name}' on ${relation.schema}.${relation.table}.")
+                                        appendLine("The value was omitted when this change was written, so it's unrecoverable and this source can't continue.")
+                                        appendLine("Set REPLICA IDENTITY FULL on the table to stop this recurring, then recreate the source.")
+                                    }
+                                )
+                            }
 
                         is PgOutputMessage.ColumnValue.Text -> coerceText(colValue.value, col.typeOid)
                     }

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceToastTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceToastTest.kt
@@ -1,0 +1,78 @@
+package xtdb.postgres
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import xtdb.XtdbInternal
+import xtdb.api.Xtdb
+import java.nio.file.Files
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("integration")
+class PostgresSourceToastTest : PostgresSourceTestBase() {
+
+    private fun cdcIngestionError(node: Xtdb) =
+        (node as XtdbInternal).dbCatalog["cdc"]?.ingestionError
+
+    // ~10KB of non-repeating text, forced out-of-line via EXTERNAL storage, so `blob` is reliably
+    // TOASTed and an UPDATE that doesn't touch it sends it as "unchanged" in the pgoutput message.
+    private val bigBlob = (0 until 10_000).joinToString("") { (('a' + (it * 7 + it / 3) % 26)).toString() }
+
+    private suspend fun updateLeavingToastUnchanged(replicaIdentityFull: Boolean, check: suspend (Xtdb, String) -> Unit) {
+        val table = unique("pg"); val pub = unique("pub"); val slot = unique("slot")
+        val dirs = List(4) { Files.createTempDirectory("pg-toast") }
+        pgExecute(
+            "CREATE TABLE $table (_id INT PRIMARY KEY, name TEXT, blob TEXT)",
+            "ALTER TABLE $table ALTER COLUMN blob SET STORAGE EXTERNAL",
+            *(if (replicaIdentityFull) arrayOf("ALTER TABLE $table REPLICA IDENTITY FULL") else emptyArray()),
+            "CREATE PUBLICATION $pub FOR TABLE $table",
+        )
+        val node = openNode(dirs[0], dirs[1])
+        try {
+            attachCdc(node, database = "cdc", cdcLog = dirs[2], cdcStorage = dirs[3], slot = slot, pub = pub)
+            awaitStreaming(node)
+            flushBlock(node)
+            commitTx("INSERT INTO $table (_id, name, blob) VALUES (1, 'before', ?)") { it.setString(1, bigBlob) }
+            commitTx("UPDATE $table SET name = 'after' WHERE _id = 1") { }
+            check(node, table)
+        } finally {
+            node.close()
+            runCatching { dropSlot(slot) }
+            dirs.forEach { it.toFile().deleteRecursively() }
+        }
+    }
+
+    @Test
+    fun `unchanged TOASTed column without REPLICA IDENTITY FULL halts the source`() = runTest(timeout = 5.minutes) {
+        updateLeavingToastUnchanged(replicaIdentityFull = false) { node, _ ->
+            val err = await(timeout = 30.seconds, done = { it != null }) { cdcIngestionError(node) }
+            assertNotNull(err, "expected ingestion to halt on the unchanged TOASTed column")
+            assertTrue(
+                err!!.message!!.contains("REPLICA IDENTITY FULL"),
+                "error should point at the REPLICA IDENTITY FULL remedy, got: ${err.message}",
+            )
+        }
+    }
+
+    @Test
+    fun `REPLICA IDENTITY FULL lets an unchanged TOASTed column stream`() = runTest(timeout = 5.minutes) {
+        updateLeavingToastUnchanged(replicaIdentityFull = true) { node, table ->
+            val rows = await(
+                timeout = 30.seconds,
+                done = { r -> r.any { (it["name"] as String?) == "after" } },
+            ) {
+                runCatching { xtQuery(node, "cdc", "SELECT _id, name, blob FROM public.$table ORDER BY _id") }
+                    .getOrDefault(emptyList())
+            }
+            assertNull(cdcIngestionError(node), "cdc ingestion should not have stopped with REPLICA IDENTITY FULL")
+            assertEquals(1, rows.size)
+            assertEquals("after", rows[0]["name"])
+            assertEquals(bigBlob, rows[0]["blob"])
+        }
+    }
+}


### PR DESCRIPTION
Resolves #5542.

**This PR is both a fix and its documentation:**

- **Fix** — an `UPDATE` that left a TOASTed column unchanged halted the Postgres external source, even with `REPLICA IDENTITY FULL` set (exactly what the error advised). Now handled.
- **Docs** — a new Postgres external-source troubleshooting guide, plus the `REPLICA IDENTITY FULL` prerequisite on the reference page.

## Root cause

pgoutput doesn't resend an unchanged out-of-line TOAST value; it marks the column "unchanged" in the new tuple. The `DirectMirror` indexer replaces the whole row, so `toRowMap` had no value to write for that column and threw.

`REPLICA IDENTITY FULL` didn't help because the update path only ever read the *new* tuple — the full old-row image that FULL provides was never consulted. So the error's "set `REPLICA IDENTITY FULL`" advice was ineffective: setting it changed nothing.

## Fix

For an `UPDATE`, an unchanged column now falls back to the old tuple, which `REPLICA IDENTITY FULL` includes (an unchanged value equals its old value by definition). Without FULL there's no old value to recover, so it still errors — but now that advice actually works. This is the same old-tuple-under-FULL path Debezium uses as its best case.

`REPLICA IDENTITY FULL` is therefore a requirement for tables with TOASTable columns, now documented on the reference page and in a new troubleshooting entry.

It only takes effect for changes written *after* it's set, so it doesn't clear a source that has **already** halted — that change was written to the WAL without the old value, and Postgres doesn't rewrite past WAL. Recovering an already-halted source is a reset (set `REPLICA IDENTITY FULL`, then reset), which the troubleshooting entry spells out.

## Changes

1. `docs: add a Postgres external source troubleshooting guide` — snapshot-recovery and the unchanged-TOAST resolution, wired into the sidebar. Ordered first so the reference page's link resolves.
2. `fix(postgres-source): recover unchanged TOASTed columns from the old tuple` — the fix, the reference-page requirement, and the test.

## Usage

Set `REPLICA IDENTITY FULL` on any replicated table with a large / TOASTable column (`text`, `bytea`, `jsonb`, …):

```sql
ALTER TABLE "public"."my_table" REPLICA IDENTITY FULL;
```

## Test plan

`PostgresSourceToastTest` (integration, against a real Postgres container):

- without `REPLICA IDENTITY FULL`: an update leaving a TOASTed column unchanged halts the source, with the (now-accurate) advice.
- with `REPLICA IDENTITY FULL`: the same update streams through with the column's value preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KPNAtL5yw7e3xzTpz81E1
