### PR TITLE
feat(bench): benchmark the Kafka Connect source (local + cluster)

### DIFF
--- a/.github/workflows/nightly-benchmark-cleanup.yml
+++ b/.github/workflows/nightly-benchmark-cleanup.yml
@@ -1,6 +1,6 @@
 name: Nightly Benchmark Cleanup
 run-name: >-
-  Benchmark Cleanup: ${{ inputs.benchType == 'tpch' && 'TPC-H' || inputs.benchType == 'auctionmark' && 'AuctionMark' || inputs.benchType == 'readings' && 'Readings' || inputs.benchType == 'yakbench' && 'Yakbench' || inputs.benchType == 'clickbench' && 'ClickBench' || inputs.benchType == 'tsbs-iot' && 'TSBS IoT' || inputs.benchType == 'ingest-tx-overhead' && 'Ingest TX Overhead' || inputs.benchType == 'patch' && 'Patch' || inputs.benchType == 'products' && 'Products' || inputs.benchType == 'ts-devices' && 'TS Devices' || inputs.benchType == 'fusion' && 'Fusion' || inputs.benchType }}
+  Benchmark Cleanup: ${{ inputs.benchType == 'tpch' && 'TPC-H' || inputs.benchType == 'auctionmark' && 'AuctionMark' || inputs.benchType == 'readings' && 'Readings' || inputs.benchType == 'yakbench' && 'Yakbench' || inputs.benchType == 'clickbench' && 'ClickBench' || inputs.benchType == 'tsbs-iot' && 'TSBS IoT' || inputs.benchType == 'ingest-tx-overhead' && 'Ingest TX Overhead' || inputs.benchType == 'kafka-source' && 'Kafka Source' || inputs.benchType == 'patch' && 'Patch' || inputs.benchType == 'products' && 'Products' || inputs.benchType == 'ts-devices' && 'TS Devices' || inputs.benchType == 'fusion' && 'Fusion' || inputs.benchType }}
 
 on:
   workflow_dispatch:
@@ -17,6 +17,7 @@ on:
           - clickbench
           - tsbs-iot
           - ingest-tx-overhead
+          - kafka-source
           - patch
           - products
           - ts-devices
@@ -549,6 +550,7 @@ jobs:
             auctionmark) bench_friendly="AuctionMark" ;;
             readings) bench_friendly="Readings" ;;
             yakbench) bench_friendly="Yakbench" ;;
+            kafka-source) bench_friendly="Kafka Source" ;;
             patch) bench_friendly="Patch" ;;
             products) bench_friendly="Products" ;;
             ts-devices) bench_friendly="TS Devices" ;;

--- a/.github/workflows/nightly-benchmark-kafka-source.yml
+++ b/.github/workflows/nightly-benchmark-kafka-source.yml
@@ -1,0 +1,40 @@
+name: Nightly Benchmark Kafka Source
+run-name: "Kafka Source (Messages: ${{ inputs.message_count || '10000' }})"
+
+on:
+  workflow_dispatch:
+    inputs:
+      message_count:
+        description: 'Message Count'
+        required: false
+        default: '10000'
+        type: string
+      run_queue:
+        description: 'Part of nightly benchmark queue (set by suite workflow)'
+        required: false
+        default: 'false'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+  actions: write
+  packages: write
+
+concurrency:
+  group: nightly-benchmark-kafka-source
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'xtdb/xtdb' }}
+    uses: ./.github/workflows/run-nightly-benchmark.yml
+    with:
+      bench_type: kafka-source
+      job_display_name: Kafka Source
+      branch: ${{ github.ref_name }}
+      timeout_minutes: 90
+      benchmark_timeout: PT2H
+      kafka_source_message_count: ${{ inputs.message_count || '10000' }}
+      run_queue: ${{ inputs.run_queue || 'false' }}
+    secrets: inherit

--- a/.github/workflows/run-nightly-benchmark.yml
+++ b/.github/workflows/run-nightly-benchmark.yml
@@ -96,6 +96,11 @@ on:
         required: false
         default: ''
         type: string
+      kafka_source_message_count:
+        description: 'Message count for kafka-source benchmark'
+        required: false
+        default: ''
+        type: string
       ingest_tx_overhead_batch_sizes:
         description: 'Batch sizes for ingest-tx-overhead benchmark (comma-separated)'
         required: false
@@ -360,6 +365,7 @@ jobs:
           TSBS_BURN_IN: ${{ inputs.tsbs_burn_in }}
           INGEST_TX_OVERHEAD_DOC_COUNT: ${{ inputs.ingest_tx_overhead_doc_count }}
           INGEST_TX_OVERHEAD_BATCH_SIZES: ${{ inputs.ingest_tx_overhead_batch_sizes }}
+          KAFKA_SOURCE_MESSAGE_COUNT: ${{ inputs.kafka_source_message_count }}
           PATCH_DOC_COUNT: ${{ inputs.patch_doc_count }}
           PATCH_PATCH_COUNT: ${{ inputs.patch_patch_count }}
           PRODUCTS_LIMIT: ${{ inputs.products_limit }}
@@ -450,6 +456,9 @@ jobs:
             # Escape commas for Helm --set parsing
             ESCAPED_BATCH_SIZES="${INGEST_TX_OVERHEAD_BATCH_SIZES//,/\\,}"
             HELM_ARGS+=(--set "ingestTxOverhead.batchSizes=${ESCAPED_BATCH_SIZES}")
+          fi
+          if [ -n "$KAFKA_SOURCE_MESSAGE_COUNT" ]; then
+            HELM_ARGS+=(--set "kafkaSource.messageCount=${KAFKA_SOURCE_MESSAGE_COUNT}")
           fi
           if [ -n "$PATCH_DOC_COUNT" ]; then
             HELM_ARGS+=(--set "patch.docCount=${PATCH_DOC_COUNT}")
@@ -597,6 +606,7 @@ jobs:
           READING_COUNT: ${{ inputs.reading_count }}
           INGEST_TX_OVERHEAD_DOC_COUNT: ${{ inputs.ingest_tx_overhead_doc_count }}
           INGEST_TX_OVERHEAD_BATCH_SIZES: ${{ inputs.ingest_tx_overhead_batch_sizes }}
+          KAFKA_SOURCE_MESSAGE_COUNT: ${{ inputs.kafka_source_message_count }}
           PATCH_DOC_COUNT: ${{ inputs.patch_doc_count }}
           PATCH_PATCH_COUNT: ${{ inputs.patch_patch_count }}
           PRODUCTS_LIMIT: ${{ inputs.products_limit }}
@@ -636,6 +646,7 @@ jobs:
           [ -n "$READING_COUNT" ] && CONFIG_PARTS+=("Readings: ${READING_COUNT}")
           [ -n "$INGEST_TX_OVERHEAD_DOC_COUNT" ] && CONFIG_PARTS+=("Docs: ${INGEST_TX_OVERHEAD_DOC_COUNT}")
           [ -n "$INGEST_TX_OVERHEAD_BATCH_SIZES" ] && CONFIG_PARTS+=("Batch Sizes: ${INGEST_TX_OVERHEAD_BATCH_SIZES}")
+          [ -n "$KAFKA_SOURCE_MESSAGE_COUNT" ] && CONFIG_PARTS+=("Messages: ${KAFKA_SOURCE_MESSAGE_COUNT}")
           [ -n "$PATCH_DOC_COUNT" ] && CONFIG_PARTS+=("Docs: ${PATCH_DOC_COUNT}")
           [ -n "$PATCH_PATCH_COUNT" ] && CONFIG_PARTS+=("Patches: ${PATCH_PATCH_COUNT}")
           [ -n "$CLICKBENCH_SIZE" ] && CONFIG_PARTS+=("Size: ${CLICKBENCH_SIZE}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -759,7 +759,7 @@ createSltTask(
     extraArgs = listOf("--dirs")
 )
 
-fun createBench(benchName: String, properties: Map<String, String>) {
+fun createBench(benchName: String, properties: Map<String, String>, defaultArgs: Map<String, String> = emptyMap()) {
     tasks.register(benchName, JavaExec::class) {
         dependsOn(":modules:bench:assemble")
         classpath = sourceSets.dev.get().runtimeClasspath
@@ -786,6 +786,13 @@ fun createBench(benchName: String, properties: Map<String, String>) {
             if (project.hasProperty(k)) {
                 args.add(v)
                 args.add(project.properties[k] as String)
+            }
+        }
+
+        defaultArgs.forEach { (flag, value) ->
+            if (!args.contains(flag)) {
+                args.add(flag)
+                args.add(value)
             }
         }
 
@@ -851,6 +858,16 @@ createBench("patch", mapOf("docCount" to "--doc-count", "patchCount" to "--patch
 createBench("ingestTxOverhead", mapOf("docCount" to "--doc-count", "batchSizes" to "--batch-sizes"))
 
 createBench("clickbench", mapOf("limit" to "--limit", "size" to "--size"))
+
+createBench(
+    "kafka-source",
+    mapOf(
+        "messageCount" to "--message-count",
+        "bootstrapServers" to "--bootstrap-servers"
+    ),
+    // the source's `remote: kafka` needs a remote registered on the node, which only config files support
+    defaultArgs = mapOf("--config-file" to "modules/bench/config/kafka-source.yaml")
+)
 
 createBench("ts-devices", mapOf("size" to "--size"))
 

--- a/modules/bench/README.adoc
+++ b/modules/bench/README.adoc
@@ -23,7 +23,8 @@ Kafka Connect source::
 `docker-compose up -d kafka`, then `./gradlew kafka-source -PmessageCount=10000`
 +
 Pre-loads a Kafka topic with small JSON records, attaches a `!KafkaConnect` source database (source topic and replica log both on the docker-compose broker), and measures the drain rate into its `patient` table.
-The node config (registering the docker-compose broker as the `kafka` remote) defaults to `modules/bench/config/kafka-source.yaml` - override with `-PconfigFile=...`.
+The node config (registering the docker-compose broker as the `kafkaCluster` remote, matching the cloud bench node configs) defaults to `modules/bench/config/kafka-source.yaml` - override with `-PconfigFile=...`.
+On the benchmark cluster, run it via the 'Nightly Benchmark Kafka Source' workflow dispatch (or `./cloud/run-bench.sh azure kafka-source`).
 
 
 TSBS IoT::

--- a/modules/bench/README.adoc
+++ b/modules/bench/README.adoc
@@ -19,6 +19,12 @@ Products::
 IngestTsOverhead::
 `./gradlew ingest -PdocCount=100000 -PbatchSizes=10,100,1000`
 
+Kafka Connect source::
+`docker-compose up -d kafka`, then `./gradlew kafka-source -PmessageCount=10000`
++
+Pre-loads a Kafka topic with small JSON records, attaches a `!KafkaConnect` source database (source topic and replica log both on the docker-compose broker), and measures the drain rate into its `patient` table.
+The node config (registering the docker-compose broker as the `kafka` remote) defaults to `modules/bench/config/kafka-source.yaml` - override with `-PconfigFile=...`.
+
 
 TSBS IoT::
 `XTDB_LOGGING_LEVEL_BENCH_TSBS=debug ./gradlew :tsbs-iot -Pfile=/path/to/txs.transit.json`

--- a/modules/bench/cloud/helm/templates/benchmark-kafka-source.yaml
+++ b/modules/bench/cloud/helm/templates/benchmark-kafka-source.yaml
@@ -1,0 +1,157 @@
+{{- if eq .Values.benchType "kafka-source" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kafka-source
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: xtdb
+    app.kubernetes.io/component: benchmark
+  annotations:
+    {{- if .Values.git.sha }}
+    xtdb.com/git-sha: {{ .Values.git.sha | quote }}
+    {{- end }}
+    {{- if .Values.git.branch }}
+    xtdb.com/git-branch: {{ .Values.git.branch | quote }}
+    {{- end }}
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  {{- if .Values.job.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  {{- end }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished | default 0 }}
+  template:
+    metadata:
+      labels:
+        {{- $user := .Values.providerConfig.podLabels | default (dict) -}}
+        {{- $base := dict "app.kubernetes.io/name" "xtdb" "app.kubernetes.io/component" "benchmark" -}}
+        {{- $labels := merge (dict) $user $base -}}
+        {{- toYaml $labels | nindent 8 }}
+      annotations:
+        "helm.sh/hook": pre-install,pre-upgrade
+        "helm.sh/hook-delete-policy": before-hook-creation
+    spec:
+      shareProcessNamespace: true
+      nodeSelector:
+        {{- toYaml .Values.providerConfig.nodeSelector | nindent 8 }}
+      serviceAccountName: xtdb-service-account
+      restartPolicy: Never
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: xtdb-yaml-config
+          configMap:
+            name: xtdb-yaml-config
+        - name: local-disk-cache
+          emptyDir:
+            sizeLimit: {{ .Values.xtdbConfig.localDiskCache.sizeLimit }}
+        - name: dumps
+          emptyDir:
+            sizeLimit: {{ .Values.dumpUpload.volumeSizeLimit }}
+        - name: dump-upload-scripts
+          configMap:
+            name: dump-upload-scripts
+            defaultMode: 0755
+      initContainers:
+      - name: wait-for-kafka
+        image: busybox
+        command: ['sh', '-c', 'until nc -z -w 2 {{ include "xtdb.kafka.host" .Values.xtdbConfig.kafkaBootstrapServers }} {{ include "xtdb.kafka.port" .Values.xtdbConfig.kafkaBootstrapServers }}; do echo waiting for kafka; sleep 5; done;']
+        resources:
+          requests:
+            memory: "256Mi"
+          limits:
+            memory: "256Mi"
+      containers:
+        - name: xtdb-node
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - mountPath: /var/lib/xtdb-config/xtdbconfig.yaml
+              name: xtdb-yaml-config
+              subPath: xtdbconfig.yaml
+            - name: local-disk-cache
+              mountPath: /var/lib/xtdb/buffers/
+            - name: dumps
+              mountPath: /dumps
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: xtdb-env-config
+            {{- if .Values.providerConfig.existingSecret }}
+            - secretRef:
+                name: {{ .Values.providerConfig.existingSecret }}
+            {{- end }}
+          env:
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.git.sha }}
+            - name: GIT_SHA
+              value: {{ .Values.git.sha | quote }}
+            {{- end }}
+            {{- if .Values.git.branch }}
+            - name: GIT_BRANCH
+              value: {{ .Values.git.branch | quote }}
+            {{- end }}
+            - name: GITHUB_REPOSITORY
+              value: {{ .Values.git.repo | default "xtdb/xtdb" | quote }}
+            - name: GITHUB_RUN_ID
+              value: {{ .Values.git.runId | default "" | quote }}
+          args:
+            - kafka-source
+            - -f
+            - "/var/lib/xtdb-config/xtdbconfig.yaml"
+            - --message-count
+            - {{ .Values.kafkaSource.messageCount | quote }}
+            - --bootstrap-servers
+            - {{ .Values.xtdbConfig.kafkaBootstrapServers | quote }}
+            {{- if .Values.timeout }}
+            - --timeout
+            - {{ .Values.timeout | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+        - name: dump-uploader
+          image: mcr.microsoft.com/azure-cli:latest
+          command: ["/bin/bash", "/scripts/upload-dumps.sh"]
+          volumeMounts:
+            - name: dumps
+              mountPath: /dumps
+            - name: dump-upload-scripts
+              mountPath: /scripts
+          resources:
+            {{- toYaml .Values.dumpUpload.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: xtdb-env-config
+            {{- if .Values.providerConfig.existingSecret }}
+            - secretRef:
+                name: {{ .Values.providerConfig.existingSecret }}
+            {{- end }}
+          env:
+            - name: AZURE_STORAGE_ACCOUNT
+              value: {{ .Values.providerConfig.env.AZURE_STORAGE_ACCOUNT | default "" | quote }}
+            - name: AZURE_STORAGE_CONTAINER
+              value: {{ .Values.providerConfig.env.AZURE_STORAGE_CONTAINER | default "" | quote }}
+            - name: AZURE_DUMPS_CONTAINER
+              value: {{ .Values.providerConfig.env.AZURE_DUMPS_CONTAINER | default "" | quote }}
+            - name: XTDB_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.git.branch }}
+            - name: GIT_BRANCH
+              value: {{ .Values.git.branch | quote }}
+            {{- end }}
+            - name: GITHUB_REPOSITORY
+              value: {{ .Values.git.repo | default "xtdb/xtdb" | quote }}
+            - name: BENCH_TYPE
+              value: {{ .Values.benchType | quote }}
+{{- end }}

--- a/modules/bench/cloud/helm/values.yaml
+++ b/modules/bench/cloud/helm/values.yaml
@@ -49,6 +49,9 @@ ingestTxOverhead:
   docCount: 100000
   batchSizes: "1000,100,10,1"
 
+kafkaSource:
+  messageCount: 10000
+
 patch:
   docCount: 500000
   patchCount: 10

--- a/modules/bench/cloud/run-bench.sh
+++ b/modules/bench/cloud/run-bench.sh
@@ -26,7 +26,7 @@ usage() {
 
 validate_inputs() {
   [[ "$CLOUD" =~ ^(aws|azure|google-cloud)$ ]] || error "Invalid cloud: $CLOUD"
-  [[ "$BENCH_TYPE" =~ ^(tpch|readings|auctionmark|yakbench)$ ]] || error "Invalid bench type: $BENCH_TYPE"
+  [[ "$BENCH_TYPE" =~ ^(tpch|readings|auctionmark|yakbench|kafka-source)$ ]] || error "Invalid bench type: $BENCH_TYPE"
 }
 
 get_cloud_config() {

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/charts.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/charts.clj
@@ -114,6 +114,11 @@
                          :filter-param "doc-count"
                          :filter-value 100000
                          :filter-is-string false}
+   "kafka-source" {:benchmark-name "Kafka Connect source ingestion"
+                   :title "Kafka Source Benchmark Performance"
+                   :filter-param "message-count"
+                   :filter-value 10000
+                   :filter-is-string false}
    "patch"    {:benchmark-name "PATCH Performance Benchmark"
                :title "Patch Benchmark Performance"
                :filter-param "doc-count"

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/log_parsing.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/log_parsing.clj
@@ -173,6 +173,23 @@
      :benchmark-total-time-ms benchmark-total-time-ms
      :benchmark-summary benchmark-summary}))
 
+(defmethod parse-log "kafka-source" [_benchmark-type log-file-path]
+  (let [content (slurp log-file-path)
+        lines (str/split-lines content)
+        stage-lines (filter #(str/starts-with? % "{\"stage\":") lines)
+        stages (mapv (fn [line]
+                       (try
+                         (json/parse-string line true)
+                         (catch Exception e
+                           (throw (ex-info (str "Failed to parse JSON line: " line)
+                                           {:line line :error (.getMessage e)})))))
+                     stage-lines)
+        {:keys [benchmark-total-time-ms benchmark-summary]} (parse-benchmark-summary lines)]
+    {:all-stages stages
+     :ingest-stages (filterv #(contains? #{"create-topics" "produce" "attach" "drain" "verify"} (name (:stage %))) stages)
+     :benchmark-total-time-ms benchmark-total-time-ms
+     :benchmark-summary benchmark-summary}))
+
 (defmethod parse-log "patch" [_benchmark-type log-file-path]
   (let [content (slurp log-file-path)
         lines (str/split-lines content)

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/summary.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/summary.clj
@@ -259,6 +259,20 @@
     {:rows rows-with-percent
      :total-ms total-ms}))
 
+(defn kafka-source-drain-rate
+  "Headline rows/sec for the kafka-source drain stage, when derivable from the log."
+  [summary]
+  (let [message-count (get-in summary [:benchmark-summary :parameters :message-count])
+        drain-ms (->> (:ingest-stages summary)
+                      (filter #(= "drain" (name (:stage %))))
+                      first
+                      :time-taken-ms)]
+    (when (and message-count drain-ms (pos? drain-ms))
+      (format "Drain: %,d rows in %s (%.1f rows/sec)"
+              (long message-count)
+              (util/format-duration :millis drain-ms)
+              (/ (* 1000.0 message-count) drain-ms)))))
+
 (defn fusion-stage->row
   [idx {:keys [stage time-taken-ms]}]
   {:stage-order idx
@@ -334,6 +348,13 @@
 (defmethod summary->table "ingest-tx-overhead" [summary]
   (let [{:keys [rows total-ms]} (ingest-tx-overhead-summary->stage-rows summary)]
     (str (util/totals->string total-ms (:benchmark-total-time-ms summary) "ingest")
+         "\n\n"
+         (rows->string [:stage :time-taken-ms :duration :percent-of-total] rows))))
+
+(defmethod summary->table "kafka-source" [summary]
+  (let [{:keys [rows total-ms]} (clickbench-summary->stage-rows summary)]
+    (str (util/totals->string total-ms (:benchmark-total-time-ms summary) "ingest")
+         (some->> (kafka-source-drain-rate summary) (str "\n"))
          "\n\n"
          (rows->string [:stage :time-taken-ms :duration :percent-of-total] rows))))
 
@@ -433,6 +454,15 @@
   (let [{:keys [rows total-ms]} (ingest-tx-overhead-summary->stage-rows summary)]
     (str
      (util/totals->string total-ms (:benchmark-total-time-ms summary) "ingest")
+     "\n\n"
+     (util/wrap-slack-code
+      (rows->string [:stage :duration] rows)))))
+
+(defmethod summary->slack "kafka-source" [summary]
+  (let [{:keys [rows total-ms]} (clickbench-summary->stage-rows summary)]
+    (str
+     (util/totals->string total-ms (:benchmark-total-time-ms summary) "ingest")
+     (some->> (kafka-source-drain-rate summary) (str "\n"))
      "\n\n"
      (util/wrap-slack-code
       (rows->string [:stage :duration] rows)))))

--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/tasks.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/tasks.clj
@@ -48,6 +48,10 @@
                      (throw (ex-info "No ingest stages found in log file"
                                      {:benchmark-type "tsbs-iot"
                                       :log-file log-file-path})))
+        "kafka-source" (when (empty? (:ingest-stages parsed-summary))
+                         (throw (ex-info "No ingest stages found in log file"
+                                         {:benchmark-type "kafka-source"
+                                          :log-file log-file-path})))
         "ingest-tx-overhead" (when (empty? (:batch-stages parsed-summary))
                                (throw (ex-info "No batch stages found in log file"
                                                {:benchmark-type "ingest-tx-overhead"
@@ -168,7 +172,7 @@
   (println "  plot-benchmark-timeseries [options] <benchmark-type>")
   (println "      Plot a benchmark timeseries chart from Azure Log Analytics.")
   (println "      Options: --scale-factor SF, --repo owner/repo, --branch branch")
-  (println "      Supported: tpch, yakbench, auctionmark, readings, clickbench, tsbs-iot, ingest-tx-overhead, patch, products, ts-devices, fusion, scan-perf")
+  (println "      Supported: tpch, yakbench, auctionmark, readings, clickbench, tsbs-iot, ingest-tx-overhead, kafka-source, patch, products, ts-devices, fusion, scan-perf")
   (println)
   (println "Kubernetes Commands (output JSON):")
   (println "  inspect-deployment [--namespace NS]")

--- a/modules/bench/config/kafka-source.yaml
+++ b/modules/bench/config/kafka-source.yaml
@@ -1,8 +1,10 @@
 # Node config for the kafka-source bench (xtdb.bench.kafka-source).
 # Registers the docker-compose Kafka broker (`docker-compose up kafka`) as a remote,
-# so the attached source database can reference it via `remote: kafka` / `cluster: kafka`.
+# so the attached source database can reference it via `remote: kafkaCluster` / `cluster: kafkaCluster`.
+# The cluster name matches the cloud bench values (modules/bench/cloud/*/values.yaml), so the
+# same ATTACH yaml works locally and on the benchmark cluster.
 # The node's own log/storage are left as the in-memory defaults - the attached source
 # database is what the bench measures.
 logClusters:
-  kafka: !Kafka
+  kafkaCluster: !Kafka
     bootstrapServers: localhost:9092

--- a/modules/bench/config/kafka-source.yaml
+++ b/modules/bench/config/kafka-source.yaml
@@ -1,0 +1,8 @@
+# Node config for the kafka-source bench (xtdb.bench.kafka-source).
+# Registers the docker-compose Kafka broker (`docker-compose up kafka`) as a remote,
+# so the attached source database can reference it via `remote: kafka` / `cluster: kafka`.
+# The node's own log/storage are left as the in-memory defaults - the attached source
+# database is what the bench measures.
+logClusters:
+  kafka: !Kafka
+    bootstrapServers: localhost:9092

--- a/modules/bench/src/main/clojure/xtdb/bench/kafka_source.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/kafka_source.clj
@@ -1,0 +1,168 @@
+(ns xtdb.bench.kafka-source
+  "Benchmarks the !KafkaConnect external source: pre-loads a Kafka topic with
+   small patient-shaped JSON records, attaches a source database, and measures
+   how fast the source drains the topic into its `patient` table.
+
+   Needs a local Kafka broker (`docker-compose up kafka`) and a node config that
+   registers it as a remote - see modules/bench/config/kafka-source.yaml (the
+   Gradle task defaults to it).
+
+   Run: ./gradlew kafka-source -PmessageCount=10000 [-Pyourkit]"
+  (:require [clojure.data.json :as json]
+            [clojure.tools.logging :as log]
+            [next.jdbc :as jdbc]
+            [xtdb.api :as xt]
+            [xtdb.bench :as b]
+            [xtdb.util :as util])
+  (:import [io.micrometer.core.instrument Counter DistributionSummary Gauge Meter MeterRegistry]
+           [java.sql Connection Statement]
+           [java.time Instant]
+           [java.util Properties]
+           [org.apache.kafka.clients.admin AdminClient NewTopic]
+           [org.apache.kafka.clients.producer KafkaProducer ProducerRecord]
+           [org.apache.kafka.common.serialization ByteArraySerializer StringSerializer]))
+
+(defn- ->props ^Properties [m]
+  (doto (Properties.) (.putAll m)))
+
+(defn- create-topics! [{:keys [bootstrap-servers topics]}]
+  (with-open [admin (AdminClient/create (->props {"bootstrap.servers" bootstrap-servers}))]
+    (-> (.createTopics admin (for [^String topic topics]
+                               (NewTopic. topic (int 1) (short 1))))
+        (.all)
+        (.get))))
+
+(defn- produce! [{:keys [bootstrap-servers ^String source-topic message-count]}]
+  (let [start-ms (System/currentTimeMillis)]
+    (with-open [producer (KafkaProducer. (->props {"bootstrap.servers" bootstrap-servers
+                                                   "key.serializer" (.getName StringSerializer)
+                                                   "value.serializer" (.getName ByteArraySerializer)}))]
+      (dotimes [_ message-count]
+        (when (Thread/interrupted) (throw (InterruptedException.)))
+        (let [id (str (random-uuid))
+              ^String json (json/write-str {:_id id
+                                            :resource_type "patient"
+                                            :status "bench"
+                                            :last_updated (str (Instant/now))})]
+          (.send producer (ProducerRecord. source-topic id (.getBytes json)))))
+      (.flush producer))
+    (let [secs (/ (- (System/currentTimeMillis) start-ms) 1000.0)]
+      (log/infof "produced %,d messages in %.3fs (%.1f msgs/sec)"
+                 (long message-count) secs (/ message-count secs)))))
+
+(defn- attach-source-db! [node {:keys [db-name ^String source-topic]}]
+  (with-open [^Connection conn (jdbc/get-connection node)
+              ^Statement stmt (.createStatement conn)]
+    (.execute stmt
+              (format "ATTACH DATABASE %s WITH $$
+log: !Kafka
+  cluster: kafka
+  topic: %s-replica
+externalSource: !KafkaConnect
+  remote: kafka
+  topic: %s
+  connectConfig:
+    key.converter: org.apache.kafka.connect.storage.StringConverter
+    value.converter: org.apache.kafka.connect.json.JsonConverter
+    value.converter.schemas.enable: \"false\"
+  indexer: !Docs
+    table: patient
+$$"
+                      db-name source-topic source-topic))))
+
+(defn- drain! [node {:keys [db-name ^long message-count]}]
+  (let [query (format "SELECT COUNT(*) n FROM %s.public.patient" db-name)
+        ;; table only exists once the source has indexed its first record
+        row-count (fn [] (or (try
+                               (:n (first (xt/q node [query])))
+                               (catch Exception _ nil))
+                             0))
+        start-ms (System/currentTimeMillis)]
+    (loop [logged-ms start-ms, logged-n 0]
+      (let [n (long (row-count))
+            now-ms (System/currentTimeMillis)]
+        (if (>= n message-count)
+          (let [secs (/ (- now-ms start-ms) 1000.0)]
+            (log/infof "drain complete: %,d rows in %.3fs (%.1f rows/sec)" n secs (/ n secs)))
+          (if (>= (- now-ms logged-ms) 10000)
+            (do (log/infof "drained %,d/%,d rows (%.1f rows/sec)"
+                           n message-count (/ (- n logged-n) (/ (- now-ms logged-ms) 1000.0)))
+                (Thread/sleep 1000)
+                (recur now-ms n))
+            (do (Thread/sleep 1000)
+                (recur logged-ms logged-n))))))))
+
+(defn- meter-value [m]
+  (condp instance? m
+    Counter {:count (.count ^Counter m)}
+    Gauge {:value (.value ^Gauge m)}
+    DistributionSummary (let [^DistributionSummary m m]
+                          {:count (.count m), :total (.totalAmount m), :max (.max m)})
+    {:type (str (class m))}))
+
+(defn- log-source-metrics []
+  (when-let [^MeterRegistry reg b/*registry*]
+    (doseq [^Meter m (->> (.getMeters reg)
+                          (filter #(= "kafka-connect" (-> ^Meter % (.getId) (.getTag "source_type"))))
+                          (sort-by #(-> ^Meter % (.getId) (.getName))))]
+      (log/info "source meter:" (-> m (.getId) (.getName)) (meter-value m)))))
+
+(defmethod b/cli-flags :kafka-source [_]
+  [[nil "--message-count COUNT" "Number of messages to produce"
+    :id :message-count
+    :parse-fn parse-long
+    :default 10000]
+
+   [nil "--bootstrap-servers SERVERS" "Kafka bootstrap servers - must match the `kafka` remote in the node config"
+    :id :bootstrap-servers
+    :default "localhost:9092"]
+
+   ["-h" "--help"]])
+
+(defn benchmark [{:keys [message-count bootstrap-servers]
+                  :or {message-count 10000, bootstrap-servers "localhost:9092"}}]
+  (let [source-topic (str "bench-kafka-source-" (subs (str (random-uuid)) 0 8))
+        opts {:bootstrap-servers bootstrap-servers
+              :source-topic source-topic
+              :topics [source-topic (str source-topic "-replica")]
+              :message-count message-count
+              :db-name "bench_kafka_src"}]
+    {:title "Kafka Connect source ingestion"
+     :benchmark-type :kafka-source
+     :parameters {:message-count message-count}
+     :tasks [{:t :call, :stage :create-topics
+              :f (fn [_] (create-topics! opts))}
+
+             {:t :call, :stage :produce
+              :f (fn [_] (produce! opts))}
+
+             ;; produce happens before attach, so the drain stage is pure
+             ;; source-consumption + indexing - a clean profiling window
+             {:t :call, :stage :attach
+              :f (fn [{:keys [node]}] (attach-source-db! node opts))}
+
+             {:t :call, :stage :drain
+              :f (fn [{:keys [node]}]
+                   (drain! node opts)
+                   (log-source-metrics))}]}))
+
+(defmethod b/->benchmark :kafka-source [_ opts]
+  (benchmark opts))
+
+(comment
+  ;; REPL workflow (e.g. under `./gradlew :clojureRepl -Pyourkit` for live-attach
+  ;; profiling) - needs `docker-compose up kafka`:
+  (require '[xtdb.node :as xtn])
+  (import '[xtdb.api Xtdb]
+          '[xtdb.api.log KafkaCluster$ClusterFactory])
+
+  (def node
+    ;; the map config has no hook for remotes, so register the cluster on the Config
+    (-> (xtn/->config {})
+        (.logCluster "kafka" (KafkaCluster$ClusterFactory. "localhost:9092"))
+        (Xtdb/openNode)))
+
+  (let [f (b/compile-benchmark (benchmark {:message-count 1000}))]
+    (f node))
+
+  (util/close node))

--- a/modules/bench/src/main/clojure/xtdb/bench/kafka_source.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/kafka_source.clj
@@ -60,10 +60,10 @@
     (.execute stmt
               (format "ATTACH DATABASE %s WITH $$
 log: !Kafka
-  cluster: kafka
+  cluster: kafkaCluster
   topic: %s-replica
 externalSource: !KafkaConnect
-  remote: kafka
+  remote: kafkaCluster
   topic: %s
   connectConfig:
     key.converter: org.apache.kafka.connect.storage.StringConverter
@@ -131,7 +131,7 @@ $$"
     :parse-fn parse-long
     :default 10000]
 
-   [nil "--bootstrap-servers SERVERS" "Kafka bootstrap servers - must match the `kafka` remote in the node config"
+   [nil "--bootstrap-servers SERVERS" "Kafka bootstrap servers - must match the `kafkaCluster` remote in the node config"
     :id :bootstrap-servers
     :default "localhost:9092"]
 
@@ -183,7 +183,7 @@ $$"
   (def node
     ;; the map config has no hook for remotes, so register the cluster on the Config
     (-> (xtn/->config {})
-        (.logCluster "kafka" (KafkaCluster$ClusterFactory. "localhost:9092"))
+        (.logCluster "kafkaCluster" (KafkaCluster$ClusterFactory. "localhost:9092"))
         (Xtdb/openNode)))
 
   (let [f (b/compile-benchmark (benchmark {:message-count 1000}))]

--- a/modules/bench/src/main/clojure/xtdb/bench/kafka_source.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/kafka_source.clj
@@ -32,18 +32,22 @@
         (.all)
         (.get))))
 
-(defn- produce! [{:keys [bootstrap-servers ^String source-topic message-count]}]
-  (let [start-ms (System/currentTimeMillis)]
+(defn- produce! [{:keys [bootstrap-servers ^String source-topic ^long message-count sample]}]
+  (let [start-ms (System/currentTimeMillis)
+        sample-step (max 1 (quot message-count 10))]
     (with-open [producer (KafkaProducer. (->props {"bootstrap.servers" bootstrap-servers
                                                    "key.serializer" (.getName StringSerializer)
                                                    "value.serializer" (.getName ByteArraySerializer)}))]
-      (dotimes [_ message-count]
+      (dotimes [i message-count]
         (when (Thread/interrupted) (throw (InterruptedException.)))
         (let [id (str (random-uuid))
-              ^String json (json/write-str {:_id id
-                                            :resource_type "patient"
-                                            :status "bench"
-                                            :last_updated (str (Instant/now))})]
+              doc {:_id id
+                   :resource_type "patient"
+                   :status "bench"
+                   :last_updated (str (Instant/now))}
+              ^String json (json/write-str doc)]
+          (when (zero? (mod i sample-step))
+            (swap! sample conj doc))
           (.send producer (ProducerRecord. source-topic id (.getBytes json)))))
       (.flush producer))
     (let [secs (/ (- (System/currentTimeMillis) start-ms) 1000.0)]
@@ -92,6 +96,20 @@ $$"
             (do (Thread/sleep 1000)
                 (recur logged-ms logged-n))))))))
 
+(defn- verify! [node {:keys [db-name ^long message-count sample]}]
+  (let [n (:n (first (xt/q node [(format "SELECT COUNT(*) n FROM %s.public.patient" db-name)])))]
+    (when-not (= message-count n)
+      (throw (ex-info "row count mismatch" {:expected message-count, :actual n}))))
+  (doseq [{:keys [_id] :as doc} @sample]
+    (let [row (first (xt/q node [(format "SELECT * FROM %s.public.patient WHERE _id = ?" db-name) _id]))]
+      (when-not (= {:xt/id _id
+                    :resource-type (:resource_type doc)
+                    :status (:status doc)
+                    :last-updated (:last_updated doc)}
+                   row)
+        (throw (ex-info "sampled doc mismatch" {:produced doc, :actual row})))))
+  (log/infof "verified: %,d rows, %d sampled docs match" message-count (count @sample)))
+
 (defn- meter-value [m]
   (condp instance? m
     Counter {:count (.count ^Counter m)}
@@ -126,6 +144,7 @@ $$"
               :source-topic source-topic
               :topics [source-topic (str source-topic "-replica")]
               :message-count message-count
+              :sample (atom [])
               :db-name "bench_kafka_src"}]
     {:title "Kafka Connect source ingestion"
      :benchmark-type :kafka-source
@@ -144,7 +163,12 @@ $$"
              {:t :call, :stage :drain
               :f (fn [{:keys [node]}]
                    (drain! node opts)
-                   (log-source-metrics))}]}))
+                   (log-source-metrics))}
+
+             ;; drain only waits for COUNT(*) >= message-count: check the count is *exact*
+             ;; and spot-check sampled docs round-tripped intact
+             {:t :call, :stage :verify
+              :f (fn [{:keys [node]}] (verify! node opts))}]}))
 
 (defmethod b/->benchmark :kafka-source [_ opts]
   (benchmark opts))


### PR DESCRIPTION
The FHIR benchmarks showed the `!KafkaConnect` external source indexing a flat ~60–65 rows/sec — ~120x slower than CDC and ~55x slower than the direct tx path on identical ~100-byte patient rows — and we had no way to profile it or measure a fix.

This adds a `kafka-source` benchmark that runs both locally (under YourKit) and on the benchmark cluster.

**Local** (`docker-compose up -d kafka`, then `./gradlew kafka-source -PmessageCount=10000 [-Pyourkit]`):

- Pre-loads a fresh, uniquely-named topic with patient-shaped JSON records (same row shape as the cluster benches), *then* attaches the source database — so the drain stage is pure source-consumption + indexing, a clean profiling window.
- Drain progress logs rows/sec every 10s; a verify stage checks the final count is exact and spot-checks that sampled docs round-tripped intact.
- Profiled locally, the source drains at ~1,550–1,600 rows/sec steady state — ~25x the cluster's flat 60–65 — pointing at the per-tx replica-log round-trip (`appendToReplica(...).await()` behind the capacity-1 ext-source channel) multiplied by broker RTT as the dominant cluster cost.

**Cluster**: wired in following the ingest-tx-overhead pattern — a benchType-gated Job template, a 'Nightly Benchmark Kafka Source' dispatch workflow, and log-parse/summary methods so the cleanup workflow's Slack message carries the headline drain rows/sec.

Key decisions:

- The bench pod reuses the cluster's existing node config rather than shipping a bench-specific one: that config already registers the broker as the `kafkaCluster` log cluster, which doubles as the source's `remote:`.
  The local config names its cluster `kafkaCluster` to match, so the hardcoded ATTACH yaml works in both places without a cluster-name flag.
- No Kafka topic cleanup is needed on the cluster — the benchmark Kafka is part of the helm release, and `clear-bench.sh` deletes its PVCs between runs.
  Locally, the per-run topics accumulate on the docker-compose broker until `docker-compose down -v`.
- Dispatch-only for now — deliberately not added to the nightly suite queue.

Out of scope / natural follow-on: a batching `RecordIndexer` (one tx per poll batch instead of `!Docs`' tx-per-record) — a local experiment showed ~55x the per-record steady state, so it's the obvious next lever.

Generated with Claude Code