### PR TITLE
feat(indexer): pipeline ext-source txs behind the in-flight replica append

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -85,6 +85,49 @@
 --   the batch stays on the resolver's `in_flight` slot and is freed at the leader's
 --   close() AFTER the term join (see CloseStagingIndex), never by the staging index.
 --
+--   Kicked, not drained — the resolver's select loop (see db.allium):
+--   An external-source tx (CDC / executeTx / submitTx) does NOT drain staging
+--   synchronously. The resolver stages the tx, KICKS an append if none is in flight
+--   (SealStagingBatch), and returns to its select loop; it does NOT seal-append-commit-
+--   promote inline before handling the next task. The tx COALESCES behind the (at most
+--   one) in-flight append and settles when that append completes. Because a source-log
+--   record and an external-source tx can accumulate into the same slot before it is
+--   sealed, a sealed batch may be MIXED (source-log txs and external-source txs sealed
+--   together) — no longer one external-source tx per batch.
+--
+--   The resolver's select therefore has an arm on the in-flight batch's append join:
+--   when that background append completes (success OR failure) the resolver SETTLES it
+--   (promote each tx in send order, cut a block if the live index is full, re-kick the
+--   accumulated tail). Nothing is idle-drained: the progress property (checked before
+--   each select) is "staging non-empty ⟹ an append is in flight", holding because every
+--   stage is followed by a kick and every settle re-kicks the tail. This is a select-loop
+--   ordering property, not a single-point-in-time state assertion (staging is transiently
+--   non-empty between staging a tx and kicking its append), so it lives here as prose, not
+--   an expression-bearing invariant. There is no idle-drain arm; an empty staging with no
+--   in-flight append is a quiescent resolver, which is correct.
+--
+--   Per-tx durability handles: each staged EXTERNAL-SOURCE tx carries a nullable
+--   durability handle (StagedTx.durability, a deferred completed with the tx's result);
+--   source-log txs carry none. The handle is completed as the LAST step of SETTLE —
+--   after the whole promote loop AND any block cut — never per-tx mid-loop (completing
+--   mid-loop let a caller race ahead of the block cut and orphan a BlockBoundary under
+--   hard cancel). executeTx = submit + await the handle; submitTx = fire-and-forget.
+--   Failure paths MUST fail the handle so no caller waits forever:
+--     (a) a writer/stage throw BEFORE the tx is staged fails it at the throw site;
+--     (b) staged or in-flight txs that will never settle are failed when the RESOLVER
+--         EXITS (fault or cancellation) — the fail-pending leg — before the channels
+--         close (phase 1 of teardown, not at the phase-2 free in CloseStagingIndex);
+--     (c) an undelivered task's handle is cancelled by the channel's undelivered-element
+--         hook;
+--     (d) a submit posted AFTER resolver death throws the close cause.
+--
+--   Staging row cap: after staging an external-source tx, if the accumulating slot holds
+--   more than a block's worth of rows (rows_per_block — the same dimension the block-sizing
+--   machinery already manages via is_full), the resolver falls back to a full SYNCHRONOUS
+--   drain (seal, await, promote) rather than kicking and returning to select. This is a
+--   safety bound against a bursty source growing staging without limit behind one slow
+--   commit; the drain it triggers is ordinary backpressure, not a failure.
+--
 -- Critical invariant: External queries see only durably-replicated transactions
 --   (LiveIndex.latest_completed_tx). A query returned to a user must never
 --   include a tx that could vanish if the leader crashed before its replica-log
@@ -126,6 +169,17 @@ external entity MemorySegment
 -- (InFlightBatch.append). The resolver observes its completion and settles it
 -- (see PromoteNext).
 external entity ReplicaAppend {}
+
+-- A per-tx durability handle: a deferred completed with the tx's result once the tx
+-- has settled (been promoted into the durable live tables and its batch's block cut,
+-- if any). Carried by external-source txs only (StagedTx.durability); source-log txs
+-- carry none. executeTx awaits this handle before returning; submitTx does not (fire-
+-- and-forget). The resolver completes it as the LAST step of settle, or FAILS it on any
+-- path where the tx will never settle (a stage-time throw, resolver exit with the tx
+-- still staged/in-flight, an undelivered task, or a submit after resolver death) — see
+-- the header "Per-tx durability handles". Modelled as a Deferred<TransactionKey> in the
+-- implementation.
+external entity DurabilityHandle {}
 
 ------------------------------------------------------------
 -- Value Types
@@ -261,9 +315,40 @@ entity StagingIndex {
     -- while it is true; only sealing (the next append launch) is gated.
     in_flight_present: in_flight != null
 
+    -- Durability handles collected during the CURRENT batch's settle, oldest→newest.
+    -- PromoteNext moves each promoted external-source tx's handle here (source-log txs
+    -- contribute none) instead of completing it mid-loop; the resolver completes the whole
+    -- collection as the LAST step of settle, AFTER the promote loop AND any block cut, then
+    -- clears the list (see CompleteSettledHandles). Held on the resolver (here), not on the
+    -- InFlightBatch, so the handles outlive the batch free at end-of-promote: the batch is
+    -- gone (in_flight = null) before FinishBlock runs, but the handles must not complete
+    -- until after it. Completing mid-loop let a caller race ahead of the block cut and
+    -- orphan a BlockBoundary under hard cancel.
+    --
+    -- MODELLING ARTIFACT — no such field exists in the implementation. This spec's
+    -- PromoteNext drops each StagedTx as it promotes (freeing the batch before the cut),
+    -- so the handles need a carrier that survives to settle-end; the implementation
+    -- instead keeps them on the batch's ResolvedTxs, which live until the batch is freed
+    -- AFTER settle returns (LeaderLogProcessor.InFlightBatch.settle completes them as its
+    -- last statement). Same population, same completion point — different carrier.
+    pending_handles: List<DurabilityHandle>
+
+    -- Rows across the accumulating slot's staged txs. Derived from the staged relations,
+    -- not tracked separately, so it can't drift.
+    row_count: accumulating.accumulated_txs.sum(tables.rows.count)
+
+    -- Derived: staging has grown past a block's worth of rows (see the header "Staging row
+    -- cap"). Checked after staging an external-source tx (see ExternalSourceIndexesTx in
+    -- db.allium): when true the resolver falls back to a full SYNCHRONOUS drain instead of
+    -- kicking the append and returning to select, so a bursty source cannot grow staging
+    -- without limit behind one slow commit.
+    over_row_cap: row_count > config.rows_per_block
+
     -- Derived: staging is drained when nothing is accumulated and no batch is in
     -- flight on the resolver. FinishBlock requires this so a durable block never
-    -- contains non-durable rows.
+    -- contains non-durable rows. pending_handles is deliberately NOT part of drained —
+    -- an emptied-but-not-yet-completed handle set is a settle in progress, and the block
+    -- cut runs between the batch free and the handle completion.
     is_drained: accumulating.is_empty and in_flight = null
 }
 
@@ -325,13 +410,22 @@ entity StagedTx {
     -- sealed into the in-flight batch it is promoted (and dropped) one at a time, in
     -- send order.
     --
-    -- StagedTx stays DURABILITY-HANDLE-FREE: it holds only the row slices (for
-    -- read-your-writes + promote). Serialization into a replica message happens at seal
-    -- time, on the batch's background append (StagedTx carries no serialized message);
-    -- the per-tx replica-log position that append yields is read from InFlightBatch.append
-    -- at settle. Neither is a field on StagedTx.
+    -- StagedTx carries no SERIALIZED message and no replica-log position: serialization
+    -- into a replica message happens at seal time, on the batch's background append; the
+    -- per-tx replica-log position that append yields is read from InFlightBatch.append at
+    -- settle. It holds only the row slices (for read-your-writes + promote) plus, for an
+    -- external-source tx, the caller's durability handle.
+    --
+    -- durability: the caller's per-tx durability handle, or null. Non-null for external-
+    -- source txs (executeTx/submitTx), null for source-log txs (the source log is the
+    -- durability record for those). The resolver completes it as the LAST step of settle
+    -- — after the whole promote loop AND any block cut — or fails it on a path where the
+    -- tx will never settle (see the header "Per-tx durability handles" and PromoteNext /
+    -- CloseStagingIndex). Kept off the append (InFlightBatch.append is one handle for the
+    -- whole batch's durability; this is one per tx for the caller) and off the row slices.
     staging: StagingIndex
     tx_key: TransactionKey
+    durability: DurabilityHandle?
     tables: StagedTxTable with staged_tx = this
 }
 
@@ -453,6 +547,19 @@ entity TableSnapshot {
 }
 
 ------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    -- The block-sizing bound (IndexerConfig.rowsPerBlock), which the staging row cap
+    -- reuses: staging never accumulates more than a block's worth of rows — see
+    -- StagingIndex.over_row_cap and the header "Staging row cap". A safety bound against
+    -- a bursty source growing staging without limit behind one slow commit, NOT a tuning
+    -- knob of its own.
+    rows_per_block: Integer = 102_400
+}
+
+------------------------------------------------------------
 -- Defaults
 ------------------------------------------------------------
 
@@ -559,7 +666,12 @@ rule CommitTransaction {
     -- resolver promotes the batch once its background append settles (see PromoteNext).
     -- Later txs in the same stream resolve against staging (read-your-writes),
     -- but external queries cannot yet see it.
-    when: CommitTransaction(tx)
+    --
+    -- durability is the caller's per-tx durability handle for an EXTERNAL-SOURCE tx
+    -- (executeTx/submitTx), or omitted (null) for a source-log tx. It is stored on the
+    -- StagedTx and completed as the last step of settle (see PromoteNext), or failed on a
+    -- non-settling path (see the header "Per-tx durability handles").
+    when: CommitTransaction(tx, durability?)
 
     requires: tx.status = active
 
@@ -592,7 +704,8 @@ rule CommitTransaction {
     ensures:
         let staged_tx = StagedTx.created(
             staging: staging,
-            tx_key: tx.tx_key
+            tx_key: tx.tx_key,
+            durability: durability
         )
         for table_tx in tx.table_txs where table_tx.rows.count > 0:
             StagedTxTable.created(
@@ -662,6 +775,14 @@ rule PromoteNext {
     -- back-to-back (double-buffering: resolution of the next txs overlapped the
     -- just-settled append).
     --
+    -- Durability handles are NOT completed per tx here — a mid-loop completion let a
+    -- caller race ahead of the block cut and orphan a BlockBoundary under hard cancel.
+    -- Instead each promoted external-source tx's handle is COLLECTED into
+    -- staging.pending_handles (source-log txs contribute none); the resolver completes the
+    -- whole collection as the LAST step of settle — after the promote loop AND any block
+    -- cut (FinishBlock, which the resolver runs before this completion when the live
+    -- index filled). See the header "Per-tx durability handles" and CompleteSettledHandles.
+    --
     -- Partial-failure safety — the WHY for per-tx: if importing a tx faults partway
     -- through the batch (e.g. OOM), the txs already promoted are durable in the live
     -- tables and the durable basis sits at the last tx that ACTUALLY imported; the
@@ -704,14 +825,80 @@ rule PromoteNext {
         index.latest_completed_tx = staged_tx.tx_key
         RefreshSharedSnapshot(index)
 
+        -- Collect an external-source tx's durability handle onto the resolver for settle-
+        -- end completion (source-log txs carry none). NOT completed here — see
+        -- CompleteSettledHandles. Held on staging, not the batch, so it outlives the batch
+        -- free below.
+        if staged_tx.durability != null:
+            staging.pending_handles.add(staged_tx.durability)
+
         -- Drop this tx from the resolver's in-flight batch — AFTER importing it — and
         -- discard the staged record. When the batch empties, the resolver frees it
-        -- (removes it), so the derived in_flight_present becomes false and the resolver
-        -- may seal the next batch.
+        -- (removes the batch, so staging.in_flight becomes null), then cuts a block if the
+        -- live index filled and completes the collected handles (CompleteSettledHandles),
+        -- then may seal the next batch.
         batch.txs = batch.txs.drop(1)
         not exists staged_tx
         if batch.txs.count = 0:
             not exists batch
+}
+
+rule CompleteSettledHandles {
+    -- The LAST step of settle. After the promote loop has drained the in-flight batch
+    -- (freed it, so in_flight = null) AND the resolver has cut a block if the live index
+    -- filled (FinishBlock, which needs staging drained — hence it runs before this, once
+    -- the batch is freed), the resolver completes each collected durability handle with
+    -- its tx's result and clears the collection. This is where an external-source
+    -- executeTx caller finally unblocks — after, not before, the block cut, so a caller
+    -- cannot race ahead and observe a state whose BlockBoundary the resolver has not yet
+    -- written (which under hard cancel would orphan it). submitTx callers never awaited,
+    -- so completion is a no-op for them beyond releasing the deferred.
+    --
+    -- Fires only when a settle has finished: the batch is gone and handles are waiting.
+    -- The non-settling failure paths (resolver exit, undelivered task, submit after
+    -- death) FAIL these handles instead — see the header "Per-tx durability handles" and
+    -- CloseStagingIndex; they are not this rule's success path.
+    --
+    -- In the implementation this is not a separate step: InFlightBatch.settle completes
+    -- the handles inline as its last statement, after the promote loop and any block cut
+    -- (see the pending_handles MODELLING ARTIFACT note on StagingIndex).
+    when: CompleteSettledHandles(staging)
+
+    requires: staging.in_flight = null
+    requires: staging.pending_handles.count > 0
+
+    ensures:
+        for handle in staging.pending_handles:
+            HandleCompleted(handle)
+        staging.pending_handles = []
+}
+
+rule FailPendingHandles {
+    -- The FAIL-PENDING leg (header legs b/c). When the RESOLVER EXITS — a fault, or a
+    -- teardown cancellation — every durability handle whose tx will NEVER settle is
+    -- FAILED with the exit cause, so no executeTx caller waits forever. This runs at
+    -- resolver exit, in PHASE 1 of the leader's two-phase close, BEFORE the channels
+    -- close and before the phase-2 buffer free (CloseStagingIndex). Three populations
+    -- carry handles that will never settle:
+    --   - collected-but-not-yet-completed: staging.pending_handles (a settle that had
+    --     drained the batch but not reached CompleteSettledHandles);
+    --   - in-flight: the sealed batch's external-source txs (its append never settled);
+    --   - staged: the accumulating slot's external-source txs (never sealed).
+    -- Source-log txs carry no handle, so they contribute nothing. An undelivered task's
+    -- handle (leg c) is failed by the channel's undelivered-element hook rather than
+    -- here; a submit after resolver death (leg d) throws the close cause at the submit
+    -- site. See the header "Per-tx durability handles".
+    when: ResolverExited(staging, cause)
+
+    ensures:
+        for handle in staging.pending_handles:
+            HandleFailed(handle, cause)
+        if staging.in_flight != null:
+            for staged_tx in staging.in_flight.txs where staged_tx.durability != null:
+                HandleFailed(staged_tx.durability, cause)
+        for staged_tx in staging.accumulating.accumulated_txs where staged_tx.durability != null:
+            HandleFailed(staged_tx.durability, cause)
+        staging.pending_handles = []
 }
 
 rule AbortTransaction {
@@ -872,11 +1059,20 @@ rule CloseStagingIndex {
     -- discarded (they were never visible to external queries) and will be re-read from
     -- the source log and re-resolved by the next leader. The durable LiveIndex is
     -- untouched. See db.allium TransitionToFollower; commit ec0f3947e.
+    --
+    -- The FAIL-PENDING leg does NOT happen here. Any per-tx durability handles of txs
+    -- that will never settle — staged, in-flight, or collected-but-not-yet-completed —
+    -- are FAILED when the RESOLVER EXITS (fault or cancellation), in PHASE 1, before the
+    -- channels close, so no executeTx caller waits forever. By the time this phase-2 free
+    -- runs the handles are already failed; this rule only reclaims the buffers. See the
+    -- header "Per-tx durability handles" (legs b, c, d).
     when: CloseStagingIndex(staging)
 
     ensures:
         -- Free a faulted/teardown-parked in-flight batch first — the leader's
-        -- responsibility, after the term join — then the staging index itself.
+        -- responsibility, after the term join — then the staging index itself. The
+        -- pending handles were already failed at resolver exit (phase 1); nothing to
+        -- complete or fail here.
         if staging.in_flight != null:
             not exists staging.in_flight
         not exists staging

--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -30,8 +30,11 @@
 --   read-your-writes), advancing the staging index's own APPLIED head
 --   (StagingIndex.latest_completed_tx). Nothing is serialized or appended to any
 --   producer transaction at resolve time — the accumulating slot holds only the txs'
---   row slices. The tx is NOT yet visible to external queries: it is applied-to-staging
---   but not yet on the replica log.
+--   row data: the tx's OWN relations (plus iid tries, already pointing at them),
+--   ownership transferred out of the OpenTx at commit — a reference move, not a
+--   per-vector slice, which cost real time per tx on the resolver's hot path. The tx
+--   is NOT yet visible to external queries: it is applied-to-staging but not yet on
+--   the replica log.
 --
 --   The APPENDS happen at SEAL time, not resolve time — a single Kafka transactional
 --   producer permits only ONE open transaction at a time, and commit() commits
@@ -267,7 +270,7 @@ entity StagingIndex {
     -- own single in-flight slot (see the header "Ownership split", InFlightBatch and
     -- SealStagingBatch/PromoteNext).
     --   - accumulating: open, taking newly-resolved committed txs. Holds only the txs'
-    --                   row slices, in send order; nothing is serialized or appended to
+    --                   row data, in send order; nothing is serialized or appended to
     --                   a producer transaction yet — that happens on the background
     --                   append the resolver launches at seal time.
     -- Double-buffering — an open accumulating slot here plus AT MOST ONE sealed
@@ -382,7 +385,7 @@ entity StagingSlot {
     -- relation + trie, for the read-your-writes segment layering) and additionally
     -- records the send order of the txs applied to it, so a seal serializes+appends
     -- their messages in order and produces the ordered in-flight batch. Nothing is
-    -- serialized at resolve time; the slot holds only the txs' row slices.
+    -- serialized at resolve time; the slot holds only the txs' row data.
     staging: StagingIndex
     tables: StagingTable with slot = this
 
@@ -413,7 +416,7 @@ entity StagedTx {
     -- StagedTx carries no SERIALIZED message and no replica-log position: serialization
     -- into a replica message happens at seal time, on the batch's background append; the
     -- per-tx replica-log position that append yields is read from InFlightBatch.append at
-    -- settle. It holds only the row slices (for read-your-writes + promote) plus, for an
+    -- settle. It holds only the row data (for read-your-writes + promote) plus, for an
     -- external-source tx, the caller's durability handle.
     --
     -- durability: the caller's per-tx durability handle, or null. Non-null for external-
@@ -422,7 +425,7 @@ entity StagedTx {
     -- — after the whole promote loop AND any block cut — or fails it on a path where the
     -- tx will never settle (see the header "Per-tx durability handles" and PromoteNext /
     -- CloseStagingIndex). Kept off the append (InFlightBatch.append is one handle for the
-    -- whole batch's durability; this is one per tx for the caller) and off the row slices.
+    -- whole batch's durability; this is one per tx for the caller) and off the row data.
     staging: StagingIndex
     tx_key: TransactionKey
     durability: DurabilityHandle?
@@ -657,7 +660,7 @@ rule CommitTransaction {
     -- The resolver imports a committed tx into the STAGING accumulating slot and
     -- advances the staging index's APPLIED head (StagingIndex.latest_completed_tx).
     -- It does NOT serialize or append the tx to any producer transaction here: the
-    -- accumulating slot holds only the tx's row slices, in send order. Serialization
+    -- accumulating slot holds only the tx's row data, in send order. Serialization
     -- and the append happen later, on the background append launched at seal time (see
     -- SealStagingBatch). The applied-but-not-appended tx is held out of the durable
     -- index here in staging.

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -123,7 +123,14 @@ class LeaderLogProcessor(
             // be a source-log tx whose null token would drop the CDC resume point from the boundary.
             // Matches the FlushBlock path, which already cuts blocks from the watchers' view.
             if (liveIndex.isFull()) finishBlock(watchers.latestSourceMsgId, watchers.externalSourceToken)
+
+            // Complete after the whole settle (promote loop + any block cut): signalling per-tx mid-loop
+            // lets a caller race ahead of finishBlock, and a hard cancel then can orphan a BlockBoundary
+            // with no BlockUploaded (the #5783 sim regression caught at 15/300).
+            txs.forEach { it.pending?.complete(it.txResult) }
         }
+
+        fun failPending(cause: Throwable) = txs.forEach { it.pending?.completeExceptionally(cause) }
 
         override fun close() {
             txs.closeAll()
@@ -208,7 +215,7 @@ class LeaderLogProcessor(
             val systemTime: Instant?,
             val writer: suspend (OpenTx) -> TxResult,
         ) : ExtSourceTask {
-            val result = CompletableDeferred<TxResult>()
+            val result = CompletableDeferred<TransactionResult>()
 
             override val onComplete = CompletableDeferred<Unit>()
         }
@@ -228,7 +235,12 @@ class LeaderLogProcessor(
     // capacity 1 so a fire-and-forget `submitTx` caller can queue one tx ahead while the persister works the
     // current one (bounding lookahead to ~2). `executeTx` still blocks on the result regardless of capacity.
     private val extSourceCh =
-        Channel<ExtSourceTask>(capacity = 1, onUndeliveredElement = { it.onComplete.cancel() })
+        Channel<ExtSourceTask>(capacity = 1, onUndeliveredElement = { task ->
+            task.onComplete.cancel()
+            // Also cancel the per-tx durability handle: the task was never delivered to the persister,
+            // so settle() will never complete it — this is the only path that can.
+            if (task is ExtSourceTask.IndexTx) task.result.cancel()
+        })
 
     private val gcCh =
         Channel<GcTask>(onUndeliveredElement = { it.onComplete.cancel() })
@@ -261,7 +273,7 @@ class LeaderLogProcessor(
             is SourceMessage.Tx, is SourceMessage.LegacyTx -> {
                 val (txResult, openTx) = resolveTx(msgId, record, msg)
                 openTx.use {
-                    stagingIndex.stage(it, msgId, txResult, dbOp = null)
+                    stagingIndex.stage(it, msgId, txResult, dbOp = null, pending = null)
                 }
                 kickAppend()
             }
@@ -293,7 +305,7 @@ class LeaderLogProcessor(
                     openTx.writeTxRow(error, null)
                     val txResult = if (error == null) Committed(txKey) else Aborted(txKey, error)
                     val dbOp = if (error == null) DbOp.Attach(msg.dbName, msg.config) else null
-                    stagingIndex.stage(openTx, msgId, txResult, dbOp)
+                    stagingIndex.stage(openTx, msgId, txResult, dbOp, pending = null)
                 }
                 drainStaging()
             }
@@ -314,7 +326,7 @@ class LeaderLogProcessor(
                     openTx.writeTxRow(error, null)
                     val txResult = if (error == null) Committed(txKey) else Aborted(txKey, error)
                     val dbOp = if (error == null) DbOp.Detach(msg.dbName) else null
-                    stagingIndex.stage(openTx, msgId, txResult, dbOp)
+                    stagingIndex.stage(openTx, msgId, txResult, dbOp, pending = null)
                 }
                 drainStaging()
             }
@@ -348,32 +360,39 @@ class LeaderLogProcessor(
 
         @Suppress("ConvertTryFinallyToUseCall") // because openTx is a var
         try {
-            val writerResult = task.writer(openTx)
-            val txResult: TransactionResult = when (writerResult) {
-                is TxResult.Committed -> {
-                    openTx.writeTxRow(null, writerResult.userMetadata)
-                    Committed(txKey)
+            try {
+                val writerResult = task.writer(openTx)
+                val txResult: TransactionResult = when (writerResult) {
+                    is TxResult.Committed -> {
+                        openTx.writeTxRow(null, writerResult.userMetadata)
+                        Committed(txKey)
+                    }
+
+                    is TxResult.Aborted -> {
+                        txErrorCounter?.increment()
+                        openTx.close()
+                        // fresh tx for the abort row — the original openTx may hold partial writes
+                        openTx = openTx(txKey, task.externalSourceToken)
+                        openTx.writeTxRow(writerResult.error, writerResult.userMetadata)
+                        Aborted(txKey, writerResult.error)
+                    }
                 }
 
-                is TxResult.Aborted -> {
-                    txErrorCounter?.increment()
-                    openTx.close()
-                    // fresh tx for the abort row — the original openTx may hold partial writes
-                    openTx = openTx(txKey, task.externalSourceToken)
-                    openTx.writeTxRow(writerResult.error, writerResult.userMetadata)
-                    Aborted(txKey, writerResult.error)
-                }
+                // Ext-source txs carry no source-log position of their own and track progress via
+                // `externalSourceToken`, so they don't advance `latestSourceMsgId` (driven by the source log).
+                // We do stamp the current source-log watermark onto the replicated record: without it a
+                // follower's `latestSourceMsgId` lags between block boundaries, and on promotion it resumes
+                // the source log from a stale point and replays an already-covered block boundary.
+                val effectiveSrcMsgId = watchers.latestSourceMsgId
+                stagingIndex.stage(openTx, effectiveSrcMsgId, txResult, dbOp = null, pending = task.result)
+            } catch (e: Throwable) {
+                // Writer, writeTxRow, or stage threw before the tx was handed to the in-flight batch.
+                // The persister finally won't see a staged entry for this tx, so complete the handle here —
+                // the caller awaiting task.result would otherwise hang until the term closes.
+                task.result.completeExceptionally(e)
+                throw e
             }
-
-            // Ext-source txs carry no source-log position of their own and track progress via
-            // `externalSourceToken`, so they don't advance `latestSourceMsgId` (driven by the source log).
-            // We do stamp the current source-log watermark onto the replicated record: without it a
-            // follower's `latestSourceMsgId` lags between block boundaries, and on promotion it resumes
-            // the source log from a stale point and replays an already-covered block boundary.
-            val effectiveSrcMsgId = watchers.latestSourceMsgId
-            stagingIndex.stage(openTx, effectiveSrcMsgId, txResult, dbOp = null)
             drainStaging()
-            task.result.complete(writerResult)
         } finally {
             openTx.close()
         }
@@ -505,6 +524,22 @@ class LeaderLogProcessor(
                 } catch (t: Throwable) {
                     cause = t
                 } finally {
+                    // Fail any ext-source tx that was staged or in-flight but will never settle:
+                    // the persister is exiting and settle() will never run for them.
+                    val pendingCause = cause ?: CancellationException("leader term closed")
+                    inFlight?.failPending(pendingCause)
+                    stagingIndex.failPending(pendingCause)
+
+                    // A buffered-but-never-received task is invisible to both failPending (it was
+                    // never staged) and onUndeliveredElement (close() doesn't visit buffered
+                    // elements — only cancel() does), so a caller outside the term scope would
+                    // await it forever.
+                    while (true) {
+                        val task = extSourceCh.tryReceive().getOrNull() ?: break
+                        task.onComplete.completeExceptionally(pendingCause)
+                        if (task is ExtSourceTask.IndexTx) task.result.completeExceptionally(pendingCause)
+                    }
+
                     sourceLogCh.close(cause)
                     extSourceCh.close(cause)
                     gcCh.close(cause)
@@ -539,10 +574,13 @@ class LeaderLogProcessor(
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
         writer: suspend (OpenTx) -> TxResult,
-    ): TxResult =
-        ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer)
-            .also { enqueue(it).await() }
-            .result.await()
+    ): TransactionResult {
+        val task = ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer)
+        // enqueue's send throws if the channel is closed (dead indexer) — that's the early-exit signal.
+        // We no longer await onComplete: durability is signalled via task.result, completed at settle.
+        enqueue(task)
+        return task.result.await()
+    }
 
     override suspend fun submitTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -92,6 +92,8 @@ class LeaderLogProcessor(
 
     private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
 
+    private val maxStagedRows = nodeBase.config.indexer.rowsPerBlock
+
     // Resolver-owned staging area: resolved-but-not-yet-durable txs, seeded at the durable head. The
     // resolver is its sole accessor (no lock). Freed in close() (phase 2), once the resolver job is
     // joined so nothing live still touches it; see StagingIndex.
@@ -107,6 +109,10 @@ class LeaderLogProcessor(
     ) : AutoCloseable {
 
         val isCompleted: Boolean get() = append.isCompleted
+
+        // onJoin, not onAwait: join fires on failure too, letting settleAppend's own await rethrow
+        // the fault inside the persister's try/catch, which routes it through notifyError.
+        val onJoin get() = append.onJoin
 
         suspend fun settle() {
             val metadatas = append.await()
@@ -197,7 +203,13 @@ class LeaderLogProcessor(
     }
 
 
-    private sealed interface PersisterTask {
+    // What the persister wakes up for: a task from one of the channels, or the in-flight append
+    // completing (Settle). Settle is select-driven — with ext-source handlers no longer draining,
+    // this arm is what promotes their batches even when no task is queued.
+    private sealed interface PersisterWork
+    private data object Settle : PersisterWork
+
+    private sealed interface PersisterTask : PersisterWork {
         val onComplete: CompletableDeferred<Unit>
     }
 
@@ -392,7 +404,14 @@ class LeaderLogProcessor(
                 task.result.completeExceptionally(e)
                 throw e
             }
-            drainStaging()
+            kickAppend()
+            trySettleAppend()
+            // Safety bound: never accumulate more than a block's worth of rows — a bursty source
+            // must not grow staging without limit behind one slow commit (nor leave durability to
+            // the ~5-min FlushBlock). Rows, not bytes: it's the dimension the block-sizing machinery
+            // (isFull/rowsPerBlock) already manages, and the drain it triggers is ordinary
+            // backpressure, not a failure.
+            if (stagingIndex.rowCount > maxStagedRows) drainStaging()
         } finally {
             openTx.close()
         }
@@ -492,31 +511,63 @@ class LeaderLogProcessor(
                 var cause: Throwable? = null
                 try {
                     while (true) {
-                        val task: PersisterTask = selectUnbiased {
+                        // Every stage is followed by a kick and every settle re-kicks the accumulated tail,
+                        // so staged txs always have an in-flight append ahead of them; a violation here
+                        // means a wedge, not a race.
+                        check(stagingIndex.isEmpty || inFlight != null) {
+                            "staged txs with no in-flight append — nothing will kick them"
+                        }
+
+                        val work = selectUnbiased<PersisterWork> {
+                            // onJoin, not onAwait: join fires on failure too, and settleAppend's own await
+                            // rethrows the fault inside the try below, routing it through notifyError.
+                            inFlight?.let { batch -> batch.onJoin { Settle } }
                             sourceLogCh.onReceive { it }
                             extSourceCh.onReceive { it }
                             gcCh.onReceive { it }
                         }
-                        try {
-                            when (task) {
-                                is SourceLogTask.Batch -> handleSourceLogBatch(task.records)
-                                is ExtSourceTask.IndexTx -> handleIndexTx(task)
-                                is GcTask.TriesDeleted -> handleTriesDeleted(task)
+
+                        when (work) {
+                            // Mirrors the task catches below: interrupts are shutdown signals, not
+                            // ingestion faults — they mustn't poison the watchers on their way out.
+                            Settle ->
+                                try {
+                                    settleAppend()
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: InterruptedException) {
+                                    throw e
+                                } catch (e: Interrupted) {
+                                    throw e
+                                } catch (e: Throwable) {
+                                    watchers.notifyError(e)
+                                    throw e
+                                }
+
+                            is PersisterTask -> {
+                                val task = work
+                                try {
+                                    when (task) {
+                                        is SourceLogTask.Batch -> handleSourceLogBatch(task.records)
+                                        is ExtSourceTask.IndexTx -> handleIndexTx(task)
+                                        is GcTask.TriesDeleted -> handleTriesDeleted(task)
+                                    }
+                                    task.onComplete.complete(Unit)
+                                } catch (e: CancellationException) {
+                                    task.onComplete.cancel(e)
+                                    throw e
+                                } catch (e: InterruptedException) {
+                                    task.onComplete.completeExceptionally(e)
+                                    throw e
+                                } catch (e: Interrupted) {
+                                    task.onComplete.completeExceptionally(e)
+                                    throw e
+                                } catch (e: Throwable) {
+                                    watchers.notifyError(e)
+                                    task.onComplete.completeExceptionally(e)
+                                    throw e
+                                }
                             }
-                            task.onComplete.complete(Unit)
-                        } catch (e: CancellationException) {
-                            task.onComplete.cancel(e)
-                            throw e
-                        } catch (e: InterruptedException) {
-                            task.onComplete.completeExceptionally(e)
-                            throw e
-                        } catch (e: Interrupted) {
-                            task.onComplete.completeExceptionally(e)
-                            throw e
-                        } catch (e: Throwable) {
-                            watchers.notifyError(e)
-                            task.onComplete.completeExceptionally(e)
-                            throw e
                         }
                     }
                 } catch (_: CancellationException) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -117,10 +117,12 @@ class LeaderLogProcessor(
                 watchers.notifyTx(resolvedTx.txResult, resolvedTx.srcMsgId, resolvedTx.externalSourceToken)
             }
 
-            if (liveIndex.isFull()) {
-                val last = txs.last()
-                finishBlock(last.srcMsgId, last.externalSourceToken)
-            }
+            // Watchers-derived rather than txs.last(): the promote loop above has just notified every
+            // tx in send order, so latestSourceMsgId equals the last tx's, and the token null-coalesces
+            // to the batch's last non-null — for a mixed source-log/ext-source batch, txs.last() could
+            // be a source-log tx whose null token would drop the CDC resume point from the boundary.
+            // Matches the FlushBlock path, which already cuts blocks from the watchers' view.
+            if (liveIndex.isFull()) finishBlock(watchers.latestSourceMsgId, watchers.externalSourceToken)
         }
 
         override fun close() {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -97,7 +97,7 @@ class LeaderLogProcessor(
     // Resolver-owned staging area: resolved-but-not-yet-durable txs, seeded at the durable head. The
     // resolver is its sole accessor (no lock). Freed in close() (phase 2), once the resolver job is
     // joined so nothing live still touches it; see StagingIndex.
-    private val stagingIndex = StagingIndex(allocator, liveIndex.latestCompletedTx)
+    private val stagingIndex = StagingIndex(liveIndex.latestCompletedTx)
 
     /**
      * A sealed batch: the txs bound for one replica-log producer transaction, in send order, together

--- a/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/OpenTx.kt
@@ -87,6 +87,17 @@ class OpenTx @JvmOverloads constructor(
 
     internal val tables: Iterable<Map.Entry<TableRef, Table>> get() = tableTxs.entries
 
+    /**
+     * Transfers ownership of every table's written rows (relation + iid trie, which already points at
+     * the relation's `_iid` vector) out of this tx, so they outlive it — the resolver stages them and
+     * closes the OpenTx immediately after. Ownership is presence in the table map: sealing empties it,
+     * so [close] frees exactly the un-sealed tables — an aborted or faulted tx that never seals still
+     * frees everything, with no transferred-ness flag to guard.
+     */
+    internal fun sealTables(): List<ResolvedTx.Table> =
+        tableTxs.map { (ref, table) -> ResolvedTx.Table(ref, table.txRelation, table.trie) }
+            .also { tableTxs.clear() }
+
     internal fun writeTxRow(error: Throwable?, userMetadata: Map<*, *>?) {
         val txId = txKey.txId
         val systemTimeMicros = txKey.systemTime.asMicros

--- a/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CompletableDeferred
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
@@ -32,14 +33,18 @@ import xtdb.util.safelyOpening
  * slice. So a ResolvedTx outlives its OpenTx — the resolver closes the OpenTx right after staging — and
  * its lifetime is its own (freed at [close], on promote/teardown).
  *
- * No durability handle: the single async replica-log commit is what confirms durability, and the per-tx
- * replica-log positions for the apply cursor come back from that commit — not from here.
+ * An ext-source tx carries the [pending] deferred its submitter awaits: it is completed with this tx's
+ * [txResult] once the replica-log commit settles, or failed on any path where that will never happen
+ * (writer throw, append fault, term cancellation, undelivered send).
+ * Source-log txs carry null — durability is confirmed by the replica-log commit itself, and nobody
+ * awaits durability per-tx on that path.
  */
 class ResolvedTx private constructor(
     val txKey: TransactionKey,
     val srcMsgId: MessageId,
     val txResult: TransactionResult,
     val externalSourceToken: ExternalSourceToken?,
+    val pending: CompletableDeferred<TransactionResult>?,
     private val dbOp: DbOp?,
     private val tables: Map<TableRef, Table>,
 ) : AutoCloseable {
@@ -105,6 +110,7 @@ class ResolvedTx private constructor(
         fun stage(
             al: BufferAllocator, openTx: OpenTx, srcMsgId: MessageId,
             txResult: TransactionResult, dbOp: DbOp?,
+            pending: CompletableDeferred<TransactionResult>?,
         ): ResolvedTx =
             mutableListOf<Table>().closeAllOnCatch { staged ->
                 // Every table the tx touched, including 0-row ones: `CREATE TABLE` declares columns with no
@@ -117,7 +123,7 @@ class ResolvedTx private constructor(
                 }
 
                 ResolvedTx(
-                    openTx.txKey, srcMsgId, txResult, openTx.externalSourceToken, dbOp,
+                    openTx.txKey, srcMsgId, txResult, openTx.externalSourceToken, pending, dbOp,
                     staged.associateBy { it.ref }
                 )
             }

--- a/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
@@ -16,22 +16,22 @@ import xtdb.table.TableRef
 import xtdb.trie.ColumnName
 import xtdb.trie.MemoryHashTrie
 import xtdb.util.closeAll
-import xtdb.util.closeAllOnCatch
 import xtdb.util.safelyOpening
 
 /**
  * A committed-but-not-yet-durable transaction, held in memory between the resolver committing it and the
  * replica-log producer confirming it durable. Carries the salient facts of the [OpenTx] that produced it
- * — its key, result, any db-op, source-log position and external-source token — plus independent slices
- * of its relations. Distinct from [OpenTx] on purpose: a resolved tx is no longer *open* — it can't be
+ * — its key, result, any db-op, source-log position and external-source token — plus ownership of its
+ * table relations. Distinct from [OpenTx] on purpose: a resolved tx is no longer *open* — it can't be
  * written to or queried. It exists only to be (a) read by later txs resolving behind it (read-your-writes
  * across the in-flight batch) and (b) imported into the durable live tables once its replica-log commit
  * lands.
  *
- * The relation slices are taken from the [OpenTx] at [stage] via `openDirectSlice` (which transfers the
- * buffers into the staging allocator), with a trie sharing the tx's heap `rootNode` re-pointed at the
- * slice. So a ResolvedTx outlives its OpenTx — the resolver closes the OpenTx right after staging — and
- * its lifetime is its own (freed at [close], on promote/teardown).
+ * The relations are the [OpenTx]'s own, ownership transferred out at [stage] (see `OpenTx.sealTables`) —
+ * a reference move, not a slice: re-materializing every vector in the tree cost real time per tx, and the
+ * trie already points at the relation's `_iid` vector so it moves as-is. So a ResolvedTx outlives its
+ * OpenTx — the resolver closes the (now table-less) OpenTx right after staging — and its lifetime is its
+ * own (freed at [close], on promote/teardown).
  *
  * An ext-source tx carries the [pending] deferred its submitter awaits: it is completed with this tx's
  * [txResult] once the replica-log commit settles, or failed on any path where that will never happen
@@ -49,7 +49,7 @@ class ResolvedTx private constructor(
     private val tables: Map<TableRef, Table>,
 ) : AutoCloseable {
 
-    /** One table's staged writes: an owned slice of the tx's relation plus its iid trie. */
+    /** One table's staged writes: the tx's own relation (ownership moved at [stage]) plus its iid trie. */
     class Table(val ref: TableRef, val relation: Relation, private val trie: MemoryHashTrie) : AutoCloseable {
 
         /**
@@ -103,29 +103,22 @@ class ResolvedTx private constructor(
 
     companion object {
         /**
-         * Resolve a committed [openTx]: take independent slices of its table relations into [al] (the
-         * staging allocator) so they outlive the OpenTx. The caller closes the OpenTx after.
+         * Resolve a committed [openTx]: take ownership of its table relations (a reference move — see
+         * `OpenTx.sealTables`) so they outlive the OpenTx. The caller closes the OpenTx after.
          */
         @JvmStatic
         fun stage(
-            al: BufferAllocator, openTx: OpenTx, srcMsgId: MessageId,
+            openTx: OpenTx, srcMsgId: MessageId,
             txResult: TransactionResult, dbOp: DbOp?,
             pending: CompletableDeferred<TransactionResult>?,
         ): ResolvedTx =
-            mutableListOf<Table>().closeAllOnCatch { staged ->
+            ResolvedTx(
+                openTx.txKey, srcMsgId, txResult, openTx.externalSourceToken, pending, dbOp,
                 // Every table the tx touched, including 0-row ones: `CREATE TABLE` declares columns with no
                 // rows, and it must register in the durable index on promotion. `Table.openSnapshot` drops
                 // the empty relation for row-reads, but the table's existence still reaches resolution via
                 // its `columnTypes` (see `Snapshot.open`), and `toReplicaMessage` serializes it for the replica.
-                for ((ref, tableTx) in openTx.tables) {
-                    val slice = tableTx.txRelation.openDirectSlice(al)
-                    staged.add(Table(ref, slice, tableTx.trie.withIidReader(slice["_iid"])))
-                }
-
-                ResolvedTx(
-                    openTx.txKey, srcMsgId, txResult, openTx.externalSourceToken, pending, dbOp,
-                    staged.associateBy { it.ref }
-                )
-            }
+                openTx.sealTables().associateBy { it.ref }
+            )
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -40,6 +40,11 @@ class StagingIndex(
     /** Staged predecessors for resolution layering (read-your-writes), oldest→newest. */
     val resolvedTxs: List<ResolvedTx> get() = accumulating.toList()
 
+    /** Rows across the accumulating slot's staged txs — derived, so it can't drift. */
+    val rowCount: Long get() = accumulating.sumOf { tx -> tx.allTables.sumOf { it.relation.rowCount.toLong() } }
+
+    val isEmpty: Boolean get() = accumulating.isEmpty()
+
     /**
      * Stage a resolved [openTx]: take independent slices of its writes into the staging allocator, hold
      * them in the accumulating slot, and advance the applied head. The caller closes [openTx] afterwards.

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -1,7 +1,6 @@
 package xtdb.indexer
 
 import kotlinx.coroutines.CompletableDeferred
-import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
 import xtdb.api.log.DbOp
@@ -13,8 +12,8 @@ import xtdb.util.closeAll
  * [LeaderLogProcessor] owns from construction and frees in its two-phase close (after the resolver
  * job is joined); the resolver is its sole accessor, so it needs no lock.
  *
- * As each tx resolves, the resolver holds it ([ResolvedTx], owning its row slices) in the `accumulating`
- * slot and advances the [applied head][latestCompletedTx]. Nothing is appended to a producer transaction
+ * As each tx resolves, the resolver holds it ([ResolvedTx], owning the tx's table relations) in the
+ * `accumulating` slot and advances the [applied head][latestCompletedTx]. Nothing is appended to a producer transaction
  * here — the resolver [seal]s the accumulated txs into a batch (a single fenced producer permits only
  * one open transaction at a time, so appends are queued into one transaction and committed together)
  * and from then on owns them itself: the batch rides the leader's in-flight slot until its background
@@ -25,11 +24,8 @@ import xtdb.util.closeAll
  * advanced by promotion) by the txs staged but not yet promoted.
  */
 class StagingIndex(
-    allocator: BufferAllocator,
     latestCompletedTx: TransactionKey?,
 ) : AutoCloseable {
-
-    private val allocator = allocator.newChildAllocator("staging-index", 0, Long.MAX_VALUE)
 
     // Resolver-confined (its sole accessor), so a plain var — no cross-thread sharing to guard.
     var latestCompletedTx: TransactionKey? = latestCompletedTx
@@ -46,12 +42,12 @@ class StagingIndex(
     val isEmpty: Boolean get() = accumulating.isEmpty()
 
     /**
-     * Stage a resolved [openTx]: take independent slices of its writes into the staging allocator, hold
-     * them in the accumulating slot, and advance the applied head. The caller closes [openTx] afterwards.
+     * Stage a resolved [openTx]: take ownership of its written tables (a reference move — see
+     * `OpenTx.sealTables`), hold them in the accumulating slot, and advance the applied head.
+     * The caller closes the (now table-less) [openTx] afterwards.
      */
     fun stage(openTx: OpenTx, srcMsgId: MessageId, txResult: TransactionResult, dbOp: DbOp?, pending: CompletableDeferred<TransactionResult>?) {
-        // ResolvedTx.stage cleans up its own partial slices on throw; nothing else here can leak.
-        accumulating.addLast(ResolvedTx.stage(allocator, openTx, srcMsgId, txResult, dbOp, pending))
+        accumulating.addLast(ResolvedTx.stage(openTx, srcMsgId, txResult, dbOp, pending))
         latestCompletedTx = openTx.txKey
     }
 
@@ -68,8 +64,5 @@ class StagingIndex(
     fun seal(): List<ResolvedTx>? =
         accumulating.toList().takeIf { it.isNotEmpty() }.also { this.accumulating.clear() }
 
-    override fun close() {
-        accumulating.closeAll()
-        allocator.close()
-    }
+    override fun close() = accumulating.closeAll()
 }

--- a/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/StagingIndex.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CompletableDeferred
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
@@ -43,11 +44,17 @@ class StagingIndex(
      * Stage a resolved [openTx]: take independent slices of its writes into the staging allocator, hold
      * them in the accumulating slot, and advance the applied head. The caller closes [openTx] afterwards.
      */
-    fun stage(openTx: OpenTx, srcMsgId: MessageId, txResult: TransactionResult, dbOp: DbOp?) {
+    fun stage(openTx: OpenTx, srcMsgId: MessageId, txResult: TransactionResult, dbOp: DbOp?, pending: CompletableDeferred<TransactionResult>?) {
         // ResolvedTx.stage cleans up its own partial slices on throw; nothing else here can leak.
-        accumulating.addLast(ResolvedTx.stage(allocator, openTx, srcMsgId, txResult, dbOp))
+        accumulating.addLast(ResolvedTx.stage(allocator, openTx, srcMsgId, txResult, dbOp, pending))
         latestCompletedTx = openTx.txKey
     }
+
+    /**
+     * Fail every pending deferred in the accumulating slot. Called on teardown paths where staged txs
+     * will never settle — the persister is exiting and nobody else will complete them.
+     */
+    fun failPending(cause: Throwable) = accumulating.forEach { it.pending?.completeExceptionally(cause) }
 
     /**
      * Take the accumulated txs as an ordered batch (send order), or null if nothing is staged, clearing

--- a/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import xtdb.api.TransactionResult
 import xtdb.database.ExternalSourceToken
 import java.time.Instant
 
@@ -25,16 +26,18 @@ interface TxIndexer {
 
     /**
      * Indexes one external-source transaction: opens an [OpenTx], runs [writer] to populate it, then commits
-     * or aborts per the returned [TxResult].
+     * or aborts per the returned [TxResult]. Returns only once the tx is durably replicated.
      *
      * [externalSourceToken] is persisted with the tx so the source can resume after it. [systemTime]
-     * default to the next monotonic time.
+     * defaults to the next monotonic time.
+     *
+     * @return the durably-replicated outcome, carrying the [xtdb.api.TransactionKey] assigned to the tx.
      */
     suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?,
         systemTime: Instant? = null,
         writer: suspend (OpenTx) -> TxResult,
-    ): TxResult
+    ): TransactionResult
 
     /**
      * Like [executeTx], but hands the transaction off and returns without waiting for its [TxResult] — for a

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -42,6 +42,7 @@ import xtdb.util.closeAll
 import java.time.Instant
 import java.time.InstantSource
 import java.time.ZoneId
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
 class LeaderLogProcessorTest {
@@ -437,5 +438,145 @@ class LeaderLogProcessorTest {
         // A hang on either fires runTest's timeout.
         assertTrue(runCatching { t1.await() }.isFailure, "the in-writer executeTx must fail, not hang")
         assertTrue(runCatching { t2.await() }.isFailure, "the buffered executeTx must fail, not hang")
+    }
+
+    @Test
+    fun `a slow append pipelines subsequent ext-source txs`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+        val producerBatchSizes = mutableListOf<Int>()
+
+        // Counts each producer transaction's size, and gates every append handle so the first batch's
+        // settle stalls on the gate (a slow commit-ack) without blocking any thread.
+        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
+            object : Log.AtomicProducer<ReplicaMessage> {
+                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
+                    val tx = inner.openTx()
+                    var count = 0
+                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
+                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
+                            count++
+                            val real = tx.appendMessage(message)
+                            appendStarted.complete(Unit)
+                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
+                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
+                            }
+                        }
+
+                        override fun commit() {
+                            tx.commit()
+                            producerBatchSizes += count
+                        }
+                    }
+                }
+
+                override fun close() = inner.close()
+            }
+        }
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
+            // Explicit null head: the relaxed default returns a mock TransactionKey whose txId is 0,
+            // which would seed the staging index at 0 and shift the ext-source txIds to 1..5.
+            liveIndex = mockk(relaxed = true) { every { latestCompletedTx } returns null },
+            wrapProducer = wrapProducer,
+        )
+
+        // tx 0: stages an ext-source tx and kicks the gated append
+        lp.submitTx(null) { TxIndexer.TxResult.Committed() }
+        appendStarted.await()
+
+        // txs 1-4: submitted while the append is in-flight; they pipeline behind it.
+        // Launched so the test body doesn't block on the cap-1 channel send.
+        repeat(4) { backgroundScope.launch { lp.submitTx(null) { TxIndexer.TxResult.Committed() } } }
+
+        testScheduler.advanceUntilIdle()
+
+        // Open the gate: the in-flight append for tx0 completes; the persister settles it via the
+        // select arm and kicks whatever has accumulated behind it.
+        gate.complete(Unit)
+
+        // Durability of tx4 confirms the full pipeline drained — every settle runs through the
+        // select arm, so a broken arm shows up here as a hang, not a wrong count.
+        watchers.awaitTx(4)
+
+        // The batch SHAPE is emergent: scheduling decides how many producer transactions carry
+        // txs 1-4 (staging crosses launch → channel → persister, unlike a source-log poll batch),
+        // so assert correctness-under-accumulation and leave the coalescing factor to the
+        // kafka-source benchmark. tx 0 always seals alone — nothing else was staged when it kicked.
+        assertEquals(1, producerBatchSizes.first(), "tx 0 kicked its append alone")
+        assertEquals(5, producerBatchSizes.sum(), "every tx reached the replica log exactly once")
+
+        val resolvedTxs = replicaLog.readRecords(0, replicaLog.latestSubmittedMsgId + 1)
+            .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
+        assertEquals((0 until 5L).toList(), resolvedTxs.map { it.txId }, "all 5 txs land, in send order")
+    }
+
+    @Test
+    fun `block boundaries carry the latest external-source token, not the last tx's`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+
+        // Test-controlled block fullness: false while the ext-source tx settles, flipped to true so
+        // the cut lands at the settle of a batch whose LAST tx is a token-less source-log tx.
+        val cutNow = AtomicBoolean(false)
+        val liveIndex = mockk<LiveIndex>(relaxed = true) {
+            every { finishBlock(any(), any()) } returns emptyMap()
+            every { latestCompletedTx } returns null
+            every { isFull() } answers { cutNow.get() }
+        }
+        val trieCatalog = mockk<TrieCatalog>(relaxed = true) {
+            every { getPartitions(any()) } returns emptyList()
+        }
+        val tableCatalog = mockk<TableCatalog>(relaxed = true) {
+            every { finishBlock(any(), any(), any()) } returns emptyMap()
+        }
+        val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
+        val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
+        val blockCatalog = BlockCatalog("test", null)
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val replicaProducer = replicaLog.openAtomicProducer("test-leader")
+        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, StandardTestDispatcher(testScheduler))
+
+        val lp = LeaderLogProcessor(
+            allocator, nodeBase, dbStorage, mockk(relaxed = true),
+            dbState, blockUploader, watchers,
+            extSource = null, replicaProducer = replicaProducer,
+            skipTxs = setOf(10), dbCatalog = null,
+            partition = 0, afterReplicaMsgId = -1,
+            scope = backgroundScope,
+        ).also(leadersToClose::add)
+
+        val token = byteArrayOf(1, 2, 3)
+
+        // The ext-source tx carries the CDC resume token; awaiting its durability (txId 0) pins the
+        // ordering without any producer gating — no block is cut while cutNow is false.
+        lp.submitTx(token) { TxIndexer.TxResult.Committed() }
+        watchers.awaitTx(0)
+
+        cutNow.set(true)
+
+        // Source-log record with msgId 10 (skipTxs covers it, so no Arrow payload needed; and its
+        // txId must exceed the ext tx's for watchers' monotonicity check). Its settle cuts the block:
+        // the batch's last tx is this token-less source-log tx, so txs.last() would write a null
+        // token — the boundary must instead carry the ext tx's token from the watchers' view.
+        lp.processRecords(listOf(
+            Log.Record(0, 10, Instant.now(), SourceMessage.Tx(ByteArray(0), null, ZoneId.of("UTC"), null, null))
+        ))
+
+        val boundaries = replicaLog.readRecords(0, replicaLog.latestSubmittedMsgId + 1)
+            .mapNotNull { it.message as? ReplicaMessage.BlockBoundary }.toList()
+
+        assertEquals(1, boundaries.size, "exactly one BlockBoundary should be written")
+        assertArrayEquals(
+            token, boundaries.single().externalSourceToken,
+            "BlockBoundary must carry the ext-source tx's token, not the source-log tx's null token"
+        )
     }
 }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -3,8 +3,10 @@ package xtdb.indexer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.NodeBase
+import xtdb.api.TransactionResult
 import xtdb.api.log.InMemoryLog
 import xtdb.api.log.Log
 import xtdb.api.log.MessageId
@@ -309,5 +312,130 @@ class LeaderLogProcessorTest {
         val resolvedTxs = replicaLog.readRecords(0, replicaLog.latestSubmittedMsgId + 1)
             .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
         assertEquals((0 until n).toList(), resolvedTxs.map { it.txId }, "all $n txs land, in send order")
+    }
+
+    @Test
+    fun `executeTx returns only once its tx is durable`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+
+        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
+            object : Log.AtomicProducer<ReplicaMessage> {
+                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
+                    val tx = inner.openTx()
+                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
+                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
+                            val real = tx.appendMessage(message)
+                            appendStarted.complete(Unit)
+                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
+                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
+                            }
+                        }
+                    }
+                }
+
+                override fun close() = inner.close()
+            }
+        }
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
+            wrapProducer = wrapProducer,
+        )
+
+        // launch the executeTx so we can observe its completion state without blocking the test
+        val txJob = backgroundScope.async { lp.executeTx(null) { TxIndexer.TxResult.Committed() } }
+
+        appendStarted.await()
+
+        assertFalse(txJob.isCompleted, "executeTx must not return before the replica-log append settles")
+
+        gate.complete(Unit)
+        val result = txJob.await()
+
+        assertTrue(result is TransactionResult.Committed, "executeTx returns Committed once durable")
+    }
+
+    @Test
+    fun `closing the leader term fails an awaiting executeTx rather than hanging`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        // Gate that is never opened — the append will stall indefinitely unless the term is cancelled.
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+
+        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
+            object : Log.AtomicProducer<ReplicaMessage> {
+                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
+                    val tx = inner.openTx()
+                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
+                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
+                            val real = tx.appendMessage(message)
+                            appendStarted.complete(Unit)
+                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
+                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
+                            }
+                        }
+                    }
+                }
+
+                override fun close() = inner.close()
+            }
+        }
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
+            wrapProducer = wrapProducer,
+        )
+
+        // Capture the executeTx failure; the runTest timeout guards against a hang if it never completes.
+        val thrown = CompletableDeferred<Throwable>()
+        backgroundScope.launch {
+            try {
+                lp.executeTx(null) { TxIndexer.TxResult.Committed() }
+            } catch (e: CancellationException) {
+                thrown.complete(e)
+                throw e
+            } catch (e: Throwable) {
+                thrown.complete(e)
+            }
+        }
+
+        appendStarted.await()
+
+        // Cancel the leader term — the gate will never open, so without term-close propagation
+        // executeTx would hang until the runTest timeout.
+        lp.cancelAndJoin()
+
+        // If executeTx hangs, thrown never completes and runTest's timeout fires — that's the hang guard.
+        thrown.await()
+    }
+
+    @Test
+    fun `closing the leader term fails a buffered, never-received executeTx`() = runTest(timeout = 5.seconds) {
+        val writerEntered = CompletableDeferred<Unit>()
+        val writerGate = CompletableDeferred<Unit>()
+
+        val lp = leaderProc(StandardTestDispatcher(testScheduler))
+
+        // t1 parks the persister inside its writer, so t2's task sits buffered in the channel —
+        // never received, so never staged: only the exit drain can unblock its caller.
+        val t1 = backgroundScope.async {
+            lp.executeTx(null) { writerEntered.complete(Unit); writerGate.await(); TxIndexer.TxResult.Committed() }
+        }
+        writerEntered.await()
+        val t2 = backgroundScope.async { lp.executeTx(null) { TxIndexer.TxResult.Committed() } }
+        testScheduler.advanceUntilIdle()
+
+        lp.cancelAndJoin()
+
+        // t1 fails via the pre-stage catch (cancelled mid-writer); t2 via the buffered-task drain.
+        // A hang on either fires runTest's timeout.
+        assertTrue(runCatching { t1.await() }.isFailure, "the in-writer executeTx must fail, not hang")
+        assertTrue(runCatching { t2.await() }.isFailure, "the buffered executeTx must fail, not hang")
     }
 }

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -927,12 +927,10 @@ rule ResolverPromotesBatch {
     --
     -- The per-tx replica-log positions carried on resolved_batch are the append
     -- positions from the per-tx handles the resolver obtained at SEAL time, i-th ↔ i-th
-    -- tx in send order. durable_token is the token as of the batch's last tx.
+    -- tx in send order.
     when: BatchCommitted(staging_index, resolved_batch)
 
     requires: log_processor.mode = Leader or log_processor.mode = ExternalSourceLeader
-
-    let durable_token = resolved_batch.last.external_source_token
 
     ensures:
         -- Promote each tx in send order. Each resolved tx carries its own replica-log
@@ -953,11 +951,20 @@ rule ResolverPromotesBatch {
 
         let durable_tx = resolved_batch.last.tx_key
 
+        -- The block boundary's resume token comes from the WATCHERS' view, which the
+        -- promote loop above just advanced (notifyTx null-coalesces the tracked token to
+        -- the last non-null it saw). A MIXED batch's last tx can be a source-log tx whose
+        -- token is null; reading resolved_batch.last.external_source_token would drop the
+        -- CDC resume point in that case. watchers.external_source_token holds the batch's
+        -- last NON-NULL token instead, so the boundary carries a live resume point.
+        let durable_token = watchers.external_source_token
+
         -- BlockBoundary closes the batch: finish the block once durable and full,
         -- by which point staging is drained (see live-index FinishBlock). An
         -- external-source batch carries a non-null token and finishes via
-        -- ExternalSourceFinishesBlock so it is persisted in the Block; the
-        -- client-driven leader carries null and finishes via LeaderFinishesBlock.
+        -- ExternalSourceFinishesBlock so it is persisted in the Block; a pure client-
+        -- driven batch has never seen a token (watchers' token stays null) and finishes
+        -- via LeaderFinishesBlock.
         if live_index.is_full:
             if durable_token != null:
                 ExternalSourceFinishesBlock(durable_tx.tx_id, durable_token)
@@ -1174,7 +1181,16 @@ rule ExternalSourceIndexesTx {
         -- append happens at seal.
         let tx_key = live_index.beginStagedTx(staging_index, system_time, external_source_token, writer)
 
-        -- Tx-boundary decision: seal the batch if appropriate.
+        -- Tx-boundary decision: seal the batch if appropriate. The tx coalesces behind the
+        -- (at most one) in-flight batch and settles when that commit lands — it is NOT
+        -- drained per-tx here.
+        --
+        -- Staging row cap: after staging, if the accumulating slot holds more than a
+        -- block's worth of rows (rows_per_block — the dimension the block-sizing machinery
+        -- already manages), the resolver instead falls back to a full SYNCHRONOUS drain —
+        -- seal, await the commit, promote — before taking another task, so a bursty source
+        -- cannot grow staging without limit behind one slow commit. Ordinary backpressure,
+        -- not a failure. See live-index.allium StagingIndex.over_row_cap.
         MaybeSealBatch(staging_index)
 }
 

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIndexerTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIndexerTest.kt
@@ -3,6 +3,7 @@ package xtdb.postgres
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.postgresql.util.PSQLException
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import xtdb.api.Xtdb
@@ -76,7 +77,15 @@ class PostgresSourceIndexerTest : PostgresSourceTestBase() {
             // from the projection (proving the drop) — `name` survives
             val gadgets = await(
                 done = { rows: List<Map<String, Any?>> -> rows.isNotEmpty() },
-            ) { xtQuery(node, database = "cdc", sql = "SELECT * FROM gadgets") }
+            ) {
+                // `gadgets` only exists once the rerouted tx lands, and planning throws for unknown
+                // tables (#4467) — during CDC catch-up that's "no rows yet", not a failure.
+                try {
+                    xtQuery(node, database = "cdc", sql = "SELECT * FROM gadgets")
+                } catch (e: PSQLException) {
+                    if (e.message?.contains("Table not found") == true) emptyList() else throw e
+                }
+            }
 
             assertEquals(1, gadgets.size)
             assertEquals("anvil", gadgets[0]["name"])

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -138,7 +138,7 @@
     (util/with-open [staging-alloc (util/->child-allocator (.getAllocator tu/*node*) "staging")]
       (util/with-open [staged (with-open [create-tx (tu/->open-tx tx-key)]
                                 (.executeSql create-tx "CREATE TABLE foo (_id, bar)")
-                                (ResolvedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil))
+                                (ResolvedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil nil))
                        observer-tx (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-01T00:00:01Z"})
                        snap (.openSnapshot live-index [staged] observer-tx)]
         (t/is (.containsKey (.getTableInfo snap) table)

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -135,11 +135,10 @@
   (let [live-index (.getLiveIndex (db/primary-db tu/*node*))
         table #xt/table foo
         tx-key #xt/tx-key {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"}]
-    (util/with-open [staging-alloc (util/->child-allocator (.getAllocator tu/*node*) "staging")]
-      (util/with-open [staged (with-open [create-tx (tu/->open-tx tx-key)]
-                                (.executeSql create-tx "CREATE TABLE foo (_id, bar)")
-                                (ResolvedTx/stage staging-alloc create-tx 0 (TransactionResult$Committed. tx-key) nil nil))
-                       observer-tx (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-01T00:00:01Z"})
-                       snap (.openSnapshot live-index [staged] observer-tx)]
-        (t/is (.containsKey (.getTableInfo snap) table)
-              "a table CREATEd in a still-staged tx is visible to a later tx resolving behind it")))))
+    (util/with-open [staged (with-open [create-tx (tu/->open-tx tx-key)]
+                              (.executeSql create-tx "CREATE TABLE foo (_id, bar)")
+                              (ResolvedTx/stage create-tx 0 (TransactionResult$Committed. tx-key) nil nil))
+                     observer-tx (tu/->open-tx #xt/tx-key {:tx-id 1, :system-time #xt/instant "2020-01-01T00:00:01Z"})
+                     snap (.openSnapshot live-index [staged] observer-tx)]
+      (t/is (.containsKey (.getTableInfo snap) table)
+            "a table CREATEd in a still-staged tx is visible to a later tx resolving behind it"))))

--- a/src/testFixtures/kotlin/xtdb/api/storage/SimulatedObjectStore.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/SimulatedObjectStore.kt
@@ -15,7 +15,9 @@ enum class StoreOperation {
 }
 
 class SimulatedObjectStore(
-    val calls: MutableList<StoreOperation> = mutableListOf(),
+    // Synchronized: uploadMultipartBuffers calls uploadPart from concurrent coroutines (up to
+    // MAX_CONCURRENT_PART_UPLOADS), so a plain ArrayList races on add and intermittently throws AIOOBE.
+    val calls: MutableList<StoreOperation> = Collections.synchronizedList(mutableListOf()),
     val buffers: NavigableMap<Path, ByteBuffer> = TreeMap()
 ) : ObjectStore, SupportsMultipart<ByteBuffer> {
 


### PR DESCRIPTION
Part of #5507.

## Summary

External-source transactions no longer wait for their replica-log producer commit: `handleIndexTx` stages the tx, kicks a background append if none is in flight, and returns to the persister's select loop; the tx coalesces behind the (at most one) in-flight append and its caller's durability handle completes at settle. This is the ext-source increment #5788 deliberately deferred to "one coherent increment... if the CDC benchmark justifies them" — #5790's benchmark did: the Kafka Connect source drained at ~60–65 rows/sec on cluster (one broker RTT per record), ~120x slower than CDC on identical rows.

Local drain rate on the same machine (`./gradlew kafka-source -PmessageCount=100000`): **~1,750 rows/sec at the branch base → ~6.6k with the pipelining → ~8.8k with the stage-time ownership transfer (commit 5)** — and locally the removed wait is sub-ms, so the cluster factor against the ~60 rows/sec baseline should be larger; the nightly kafka-source bench validates that after merge.

`executeTx` still returns only once its tx is durable — Postgres's WAL-slot ack stays honest, and PG stays batch-of-one by construction. The win is emergent for the connect source's fire-and-forget `submitTx`. No driver code changes.

## Changes

1. `tidy(indexer): derive block-boundary args from watchers at settle` — behaviour-preserving today (batches are never mixed under the per-tx drain); load-bearing for commit 3, where an ext-source tx lingering in staging can seal together with a source-log tx whose `txs.last().externalSourceToken` is null and would drop the CDC resume point from the boundary.
2. `refactor(indexer): complete ext-source results at settle, not at drain` — behaviour-preserving: the per-tx drain stays, only the completion site moves. `ResolvedTx` carries a nullable `CompletableDeferred<TransactionResult>` (null = source-log tx, nobody awaits; incomplete = awaiting the commit; completed = durable or failed), completed with the `txResult` it already owns as settle's last step. Consequence: `TxIndexer.executeTx` returns `TransactionResult` rather than `TxResult` — strictly more informative (it carries the assigned txKey) and discarded by every existing caller. Also carries the persister-exit drain of buffered-but-never-received tasks (last row of the hang-class table below).
3. `feat(indexer): pipeline ext-source txs behind the in-flight replica append` — drops the drain, adds the select arm and the staging row cap, updates the allium specs, and carries the postgres-source poll robustness fix its timing shift exposed.
4. `test(storage): synchronize SimulatedObjectStore's call log` — standalone: a latent fixture race independent of this branch (details below), kept separate so it can be cherry-picked on its own.
5. `perf(indexer): transfer table ownership out of OpenTx at stage, not slice` — follow-on hot-path win: staging re-materialized every vector in the tx's tree via `openDirectSlice` (zero-copy in bytes, but per-vector ledger transfers + object churn — ~10-12% of drain time in profile). `OpenTx.sealTables()` now moves each table's relation + iid trie out wholesale; ownership is presence in the tx's table map, so un-sealed (abort/fault) paths free everything with no transferred-ness flag. `ResolvedTx.stage` loses its allocator param and `StagingIndex` loses its child allocator entirely. Local kafka-source drain: ~6.6k → ~8.8k rows/sec like-for-like.

## Implementation notes

**Durability handles are a hang-class** (the #5783 lesson): every terminal path must complete or fail the caller's deferred. The coverage, per path:

| Path | Covered by |
|---|---|
| settles normally | `settle()`'s last statement, after the promote loop and any block cut |
| writer/openTx/stage throws pre-stage | `handleIndexTx`'s catch — deliberately including `CancellationException`: a term cancel mid-writer leaves the tx unstaged, outside `failPending`'s reach |
| append/settle fault after staging | persister `finally` → `failPending` on the in-flight batch and staging |
| term cancelled (benign demote) | same `finally` (runs on cancellation) |
| task never delivered | `extSourceCh`'s `onUndeliveredElement` |
| task buffered-but-never-received at persister exit | the `finally` drains the channel via `tryReceive` and fails what it finds — `close(cause)` doesn't visit buffered elements (only `cancel()` does), and the task was never staged, so nothing else could reach it |
| enqueue after persister death | the channel send throws the close cause |

**Completion happens after the whole settle, including the block cut** — per-tx signalling mid-loop let a caller race ahead of `finishBlock`; a hard cancel then orphaned a `BlockBoundary` with no `BlockUploaded` (LogProcessorSimTest caught this at 15/300 in the #5783 cut).

**The select arm uses `onJoin`, not `onAwait`** — join fires on failure too, so `settleAppend`'s own await rethrows the fault inside a try that routes it through `notifyError`; its catch discipline mirrors the task path's (interrupts are shutdown signals and must not poison the watchers). There is no idle-drain arm: "staging non-empty ⟹ an append is in flight" is a checked progress invariant — every stage is followed by a kick and every settle re-kicks the tail.

**The staging cap is a row cap** — past a block's worth of accumulated rows (`rowsPerBlock`), the resolver falls back to a full synchronous drain. Without a bound, a merely bursty source that keeps the channel non-empty could grow staging without limit behind one slow commit, with nothing durable until the ~5-min FlushBlock. Rows rather than bytes (review call): it's the dimension the block-sizing machinery (`isFull`) already manages, so the bound needs no invented constant — and the drain it triggers is ordinary backpressure, not a failure path.

**Batch shape isn't unit-assertable for ext-source txs**, exactly as the #5507 chalk predicted: staging crosses launch → channel → persister, and a gated `[1, 4]` assertion came back `[1, 1, 3]` under runTest. The pipelining test asserts correctness-under-accumulation (first batch seals alone, none lost, send order, durability through the select arm); the coalescing factor belongs to the benchmark. The boundary-token test pins commit 1's fix deterministically instead — a cut on a batch whose last tx is a token-less source-log tx must carry the watchers' (last non-null) token.

**Allium**: `live-index.allium` models the new behaviour; one deliberate divergence is labelled in-spec — the spec's `PromoteNext` frees the batch before the cut, so it collects handles onto a `pending_handles` list that has no code counterpart (the implementation keeps them on the batch's `ResolvedTx`s; same population, same completion point, different carrier). `dev/doc/db.allium` still models the older committer-coroutine design and self-labels spec-ahead-of-code; only its genuinely stale token-source line changed — reconciling it to the settle model is its own pass.

**Liveness review** (reviewer question: can the last rows never commit?): two adversarial passes traced the progress argument — every stage is followed by a kick, every settle re-kicks the tail, and `onJoin` fires on completion or failure with no lost wakeup at registration (an already-completed deferred is immediately selectable). Quiet-tail promotion needs no further traffic; `selectUnbiased` plus the opportunistic settles rule out starvation; the row-cap drain terminates; no cross-coroutine wait cycles (including `finishBlock` → `uploadBlock` at settle). A claimed CDC double-import window (append durable but no `BlockBoundary` written before a term transition) was refuted: followers re-notify `watchers` with every replayed `ResolvedTx`'s token (`FollowerLogProcessor.kt`), so the resume point recovers per-tx from the replica log, not per-boundary — a caller may see a `CancellationException` for a tx that is in fact durable, but the restarted source resumes after it (at-least-once boundary, same as the pre-pipelining drain). The one gap found — a task buffered-but-never-received at persister exit would strand a caller outside the term scope — is closed by the exit drain above, with a deterministic test.

## Fallout fixes

- `test(storage)` (standalone commit): `RemoteStorageTest` failed once under full-suite load — `SimulatedObjectStore`'s call log is a plain `ArrayList` mutated by up to 4 concurrent multipart part-uploads (by design in `uploadMultipartBuffers`), a latent fixture race independent of this branch. Now a synchronized list; three consecutive green runs.
- Folded into the feat commit: `PostgresSourceIndexerTest`'s poll now treats planning's "Table not found" as "no rows yet" during CDC catch-up — its `await` helper's first probe runs straight through, and full-suite load stretched the catch-up window past it once (3/3 green in isolation; the pipelining preserves the visibility contract — a handle completes only after its import).

## Out of scope

- The batching `RecordIndexer` (one tx per connect-source poll batch) — #5790's other lever; it changes tx granularity, so it's its own increment.
- Postgres pipelining (moving the WAL-slot ack behind durable import so `executeTx` → `submitTx`).
- Cross-poll source-log run-ahead — still gated on moving the leader demote off Kafka's poll thread.

## Test plan

- Full `./gradlew test` green on the final tree, plus both integration suites (`:modules:xtdb-kafka:integration-test`, `:modules:xtdb-postgres-source:integration-test`).
- Sims: `LogProcessorSimTest` 900 + `NodeSimulationTest` 2400 executions @300 iterations, 0 failures.
- No allocator leaks or RefCnt violations anywhere in the runs — the failure mode to fear for commit 5's ownership move.
- Local bench arc as above (`kafka-source`, 100k messages); cluster validation rides the nightly kafka-source bench after merge.