### PR TITLE
perf(postgres-source): flush the replication-slot LSN asynchronously

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -625,22 +625,20 @@ class LeaderLogProcessor(
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
         writer: suspend (OpenTx) -> TxResult,
-    ): TransactionResult {
-        val task = ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer)
-        // enqueue's send throws if the channel is closed (dead indexer) — that's the early-exit signal.
-        // We no longer await onComplete: durability is signalled via task.result, completed at settle.
-        enqueue(task)
-        return task.result.await()
-    }
+    ): TransactionResult =
+        submitTx(externalSourceToken, systemTime, writer).await()
 
     override suspend fun submitTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
         writer: suspend (OpenTx) -> TxResult,
-    ) {
-        // Fire-and-forget: enqueue and return without awaiting the completion handle. The task's
-        // `result`/`onComplete` are completed by the persister but go unawaited here — an unrecoverable
-        // failure closes the channel with its cause, so the next `enqueue` (this or `executeTx`) throws it.
-        enqueue(ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer))
+    ): Deferred<TransactionResult> {
+        val task = ExtSourceTask.IndexTx(externalSourceToken, systemTime, writer)
+        // enqueue's send throws if the channel is closed (dead indexer) — that's the early-exit signal.
+        // The returned handle is `task.result`, completed at settle once the tx is durably replicated; a
+        // fire-and-forget caller may discard it, and an unrecoverable failure also closes the channel with
+        // its cause, so the next `enqueue` throws it.
+        enqueue(task)
+        return task.result
     }
 
     private suspend fun maybeFlushBlock() {

--- a/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxIndexer.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.Deferred
 import xtdb.api.TransactionResult
 import xtdb.database.ExternalSourceToken
 import java.time.Instant
@@ -40,18 +41,19 @@ interface TxIndexer {
     ): TransactionResult
 
     /**
-     * Like [executeTx], but hands the transaction off and returns without waiting for its [TxResult] — for a
-     * high-volume source that only needs ingestion to stay healthy, not each individual result, so it can keep
-     * submitting while the indexer works through the backlog.
+     * Like [executeTx], but hands the transaction off and returns a durability handle without waiting on it — for a
+     * high-volume source that keeps submitting while the indexer works through the backlog, acknowledging progress
+     * out of band once transactions become durable (e.g. the Postgres source advancing its replication-slot LSN).
      *
-     * The hand-off buffer is bounded, so [submitTx] still suspends under backpressure; it just doesn't block on
-     * the result. An unrecoverable ingestion failure surfaces on a subsequent [submitTx] or [executeTx] — the call
-     * throws the failure cause — so a caller can't keep submitting into a dead indexer and have its transactions
-     * silently vanish.
+     * The returned [Deferred] completes with the tx's [TransactionResult] once it's durably replicated, in submission
+     * order. A caller that doesn't need per-tx results may discard it: the hand-off buffer is bounded (so [submitTx]
+     * still suspends under backpressure), and an unrecoverable ingestion failure also surfaces on a subsequent
+     * [submitTx]/[executeTx] — the call throws the failure cause — so transactions can't silently vanish into a dead
+     * indexer.
      */
     suspend fun submitTx(
         externalSourceToken: ExternalSourceToken?,
         systemTime: Instant? = null,
         writer: suspend (OpenTx) -> TxResult,
-    )
+    ): Deferred<TransactionResult>
 }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -216,10 +216,17 @@ class PgWireDriver(
 
         private val relations = mutableMapOf<Int, PgOutputMessage.Relation>()
 
-        override suspend fun nextTransaction(block: suspend (PostgresDriver.Transaction) -> Unit) {
-            var currentTxOps = mutableListOf<RowOp>()
-            var emptyPolls = 0
+        // A transaction spans Begin..(Insert/Update/Delete)*..Commit across multiple `poll()` calls, so its
+        // accumulated ops and the idle hot-poll counter live on the stream, not on a single poll.
+        private var currentTxOps = mutableListOf<RowOp>()
+        private var emptyPolls = 0
 
+        // Last LSN received from the server — advances on commits and protocol keepalives alike, so it tracks
+        // the server's WAL end even while idle. Safe to acknowledge only when nothing polled is still awaiting
+        // durability (see [PostgresDriver.ChangeStream.walEnd]).
+        override val walEnd: Long get() = stream.lastReceiveLSN.asLong()
+
+        override suspend fun poll(): PostgresDriver.Transaction? {
             while (currentCoroutineContext().isActive) {
                 val msg = withContext(Dispatchers.IO) { stream.readPending() }
                 if (msg == null) {
@@ -227,7 +234,7 @@ class PgWireDriver(
                         emptyPolls = 0
                         delay(IDLE_POLL_PAUSE)
                     }
-                    continue
+                    return null
                 }
                 emptyPolls = 0
 
@@ -261,37 +268,32 @@ class PgWireDriver(
                     is PgOutputMessage.Commit -> {
                         val commitLsn = LogSequenceNumber.valueOf(parsed.endLsn)
 
-                        suspend fun acknowledgeLsn() {
-                            LOG.trace { "[$dbName] Acknowledging LSN $commitLsn" }
-                            runInterruptible(Dispatchers.IO) {
-                                stream.setFlushedLSN(commitLsn)
-                                stream.setAppliedLSN(commitLsn)
-                                stream.forceUpdateStatus()
-                            }
-                        }
-
                         if (currentTxOps.isEmpty()) {
                             LOG.trace { "[$dbName] Empty commit at $commitLsn (keepalive)" }
-                            acknowledgeLsn()
                             continue
                         }
 
                         val commitTime = pgTimestampToInstant(parsed.commitTimestamp)
                         LOG.debug { "[$dbName] Commit at $commitLsn: ${currentTxOps.size} ops, commitTime=$commitTime" }
 
-                        block(PostgresDriver.Transaction(
-                            lsn = parsed.endLsn,
-                            commitTime = commitTime,
-                            ops = currentTxOps.toList(),
-                        ))
-
-                        acknowledgeLsn()
-                        return
+                        val ops = currentTxOps
+                        currentTxOps = mutableListOf()
+                        return PostgresDriver.Transaction(parsed.endLsn, commitTime, ops.toList())
                     }
                 }
             }
 
             throw CancellationException("Streaming loop cancelled")
+        }
+
+        override suspend fun acknowledge(lsn: Long) {
+            val lsnObj = LogSequenceNumber.valueOf(lsn)
+            LOG.trace { "[$dbName] Acknowledging LSN $lsnObj" }
+            runInterruptible(Dispatchers.IO) {
+                stream.setFlushedLSN(lsnObj)
+                stream.setAppliedLSN(lsnObj)
+                stream.forceUpdateStatus()
+            }
         }
 
         // stream.close() is unreliable; closing replConn is what releases the slot.

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresDriver.kt
@@ -40,12 +40,34 @@ interface PostgresDriver : AutoCloseable {
     /**
      * Opens a logical replication stream from the given LSN.
      *
-     * [ChangeStream.nextTransaction] blocks until a committed transaction with DML operations is available,
-     * then passes it to [block]. The LSN is acknowledged back to PostgreSQL only if [block] returns normally.
-     * If [block] throws, the LSN is not acknowledged — PG will re-send the changes on the next connection.
+     * Reading ([poll]) and acknowledging ([acknowledge]) are deliberately separate so the caller can advance the
+     * slot's confirmed-flush LSN behind durable import rather than in lockstep with reads. The underlying pgjdbc
+     * stream is not thread-safe, so a single caller must drive both.
      */
     interface ChangeStream : AutoCloseable {
-        suspend fun nextTransaction(block: suspend (Transaction) -> Unit)
+        /**
+         * Reads the next committed transaction with DML operations, or null on an idle tick (nothing currently
+         * available). Relation/begin/empty-keepalive bookkeeping is handled internally. Does not acknowledge —
+         * the caller acks via [acknowledge] once the transaction is durable.
+         */
+        suspend fun poll(): Transaction?
+
+        /**
+         * The latest server WAL position received on the stream (advances on commits and protocol keepalives), used
+         * to let Postgres recycle unrelated WAL while our slot is idle. Safe to [acknowledge] ONLY when nothing read
+         * via [poll] is still awaiting durability: this position is the physical receive LSN, always below the commit
+         * LSN of any transaction whose Commit hasn't arrived yet, and — since the caller submits a transaction the
+         * moment [poll] returns it — "nothing awaiting durability" means no already-committed change sits unimported
+         * at or below it. (Postgres also holds `restart_lsn` at the start of any in-progress transaction regardless
+         * of the confirmed-flush LSN, so an un-committed transaction is always re-sent in full.)
+         */
+        val walEnd: Long
+
+        /**
+         * Advances the slot's confirmed-flush LSN to [lsn] and sends a standby status update. [lsn] MUST NOT exceed
+         * the highest LSN the caller has durably imported — PG recycles WAL up to it.
+         */
+        suspend fun acknowledge(lsn: Long)
     }
 
     suspend fun openStream(startLsn: Long): ChangeStream

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -16,6 +16,7 @@ import org.postgresql.util.PSQLException
 import xtdb.indexer.TxIndexer
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
+import xtdb.api.TransactionResult
 import xtdb.database.ExternalSource
 import xtdb.indexer.TxIndexer.TxResult
 import xtdb.database.ExternalSourceToken
@@ -259,7 +260,10 @@ class PostgresSource(
                         snapshotCompleted = false
                     }.toByteArray()
 
-                    txIndexer.executeTx(token) { openTx ->
+                    // Fire-and-forget: batches pipeline through the indexer, and the snapshot-complete marker
+                    // below is an in-order durability barrier for all of them. A batch ingest failure surfaces
+                    // on a later submit or on the marker's `executeTx`, aborting the snapshot.
+                    txIndexer.submitTx(token) { openTx ->
                         // snapshot has no upstream commit time — use the tx's system-time
                         val snapshotTx = PostgresDriver.Transaction(snapshot.slotLsn, openTx.txKey.systemTime, batch)
                         indexer.indexTx(snapshotTx, openTx)
@@ -272,6 +276,9 @@ class PostgresSource(
                     snapshotCompleted = true
                 }.toByteArray()
 
+                // `executeTx`, not `submitTx`: awaiting the marker's durability guarantees every batch before it
+                // is durable too (the indexer settles in submission order), so the snapshot-complete token is
+                // never durable ahead of the rows it marks complete.
                 LOG.debug { "[$dbName] Writing snapshot-complete marker" }
                 txIndexer.executeTx(completeToken) {
                     TxResult.Committed()
@@ -285,32 +292,77 @@ class PostgresSource(
     private suspend fun streamChanges(txIndexer: TxIndexer, startLsn: Long) {
         driver.openStream(startLsn).use { stream ->
             connectionState.set(1)
+
+            // Transactions submitted to the indexer but not yet known durable, in submission (= LSN) order. We
+            // read + submit ahead of durability so back-to-back CDC txs pipeline through the double-buffered
+            // indexer; `submitTx`'s bounded hand-off buffer suspends us under backpressure, keeping this bounded.
+            val awaitingDurability = ArrayDeque<Pair<PostgresDriver.Transaction, Deferred<TransactionResult>>>()
+
+            // Highest LSN we've durably imported, and the highest we've confirmed to Postgres. Postgres recycles
+            // WAL up to the confirmed-flush LSN, so `confirmedFlushLsn` MUST NOT exceed `durablyImportedLsn`.
+            var durablyImportedLsn = startLsn
+            var confirmedFlushLsn = startLsn
+
+            suspend fun confirmFlushUpTo(lsn: Long) {
+                if (lsn > confirmedFlushLsn) {
+                    stream.acknowledge(lsn)
+                    confirmedFlushLsn = lsn
+                }
+            }
+
+            // Promote every awaiting tx whose durability handle has completed, in order, advancing
+            // `durablyImportedLsn`. `await()` on a completed handle returns immediately, or rethrows an ingest
+            // failure — tearing down the stream so Postgres re-sends from the confirmed-flush LSN. Metrics are
+            // recorded here, at the point the tx is durable ("successful apply"), so a replayed tx isn't double-counted.
+            suspend fun promoteDurable() {
+                while (awaitingDurability.firstOrNull()?.second?.isCompleted == true) {
+                    val (tx, handle) = awaitingDurability.removeFirst()
+                    handle.await()
+                    durablyImportedLsn = tx.lsn
+                    eventsCounter?.increment(tx.ops.size.toDouble())
+                    commitsCounter?.increment()
+                    lastEventEpochSeconds.set(tx.commitTime.epochSecond)
+                    commitLag?.record(
+                        (Instant.now().toEpochMilli() - tx.commitTime.toEpochMilli()) / 1000.0,
+                    )
+                }
+            }
+
+            // Everything up to `startLsn` is already durable (the recovered resume token, or the snapshot's
+            // consistent point). Postgres re-sends from its confirmed-flush LSN — which lags `startLsn` whenever a
+            // crash landed between durable import and ack — so confirm `startLsn` up front to shrink that window,
+            // and skip any tx it still re-delivers at or below it (re-importing would write a redundant
+            // system-time version).
+            stream.acknowledge(startLsn)
+
             try {
                 while (currentCoroutineContext().isActive) {
-                    stream.nextTransaction { tx ->
+                    stream.poll()?.let { tx ->
+                        if (tx.lsn <= startLsn) {
+                            LOG.debug { "[$dbName] Skipping re-delivered tx at LSN ${LogSequenceNumber.valueOf(tx.lsn)} (<= resume LSN)" }
+                            return@let
+                        }
+
                         val token = postgresSourceToken {
                             latestCommittedLsn = tx.lsn
                             snapshotCompleted = true
                         }.toByteArray()
 
-                        // Stays `execute`, NOT fire-and-forget `submit`: `nextTransaction` advances the
-                        // replication slot (`acknowledgeLsn`) as soon as this returns, letting Postgres recycle
-                        // WAL. Blocking until the tx is durably imported is what keeps that ack honest — handing
-                        // off early would ack before durability and lose the tx on a crash. Going async here
-                        // needs the slot ack moved behind durable import first.
-                        txIndexer.executeTx(token, systemTime = tx.commitTime) { openTx ->
+                        val handle = txIndexer.submitTx(token, systemTime = tx.commitTime) { openTx ->
                             indexer.indexTx(tx, openTx)
                             TxResult.Committed()
                         }
-
-                        // Record only on successful apply — failures will replay this tx.
-                        eventsCounter?.increment(tx.ops.size.toDouble())
-                        commitsCounter?.increment()
-                        lastEventEpochSeconds.set(tx.commitTime.epochSecond)
-                        commitLag?.record(
-                            (Instant.now().toEpochMilli() - tx.commitTime.toEpochMilli()) / 1000.0,
-                        )
+                        awaitingDurability.addLast(tx to handle)
                     }
+
+                    promoteDurable()
+                    // Confirm only as far as we've durably imported — except when nothing awaits durability, when
+                    // the whole received prefix (through walEnd) is durable and idle/unrelated WAL can be recycled
+                    // (see [ChangeStream.walEnd]).
+                    confirmFlushUpTo(
+                        if (awaitingDurability.isEmpty()) maxOf(durablyImportedLsn, stream.walEnd)
+                        else durablyImportedLsn
+                    )
                 }
             } finally {
                 connectionState.set(0)


### PR DESCRIPTION
Part of #5507.

## Summary

The Postgres CDC source acknowledged its replication-slot LSN synchronously — blocking on each transaction's durable import before reading the next. This pipelines it: transactions are handed to the indexer and read ahead of durability, and the slot's confirmed-flush LSN advances behind durable import. Back-to-back CDC transactions can now ride the double-buffered replica-log append landed under #5507, rather than each one's append-and-settle sitting on the critical path.

## Context

#5507 double-buffered the leader's replica-log writes and wired the external-source path (`executeTx`) onto background appends that settle via a select arm. The Postgres source couldn't exploit any of it: `streamChanges` called the blocking `executeTx` once per transaction and acked the LSN the instant it returned, so durability sat on the critical path and consecutive transactions never overlapped. The old `streamChanges` comment named the blocker directly — "going async here needs the slot ack moved behind durable import first". This is that follow-on.

## Approach

Reading and acknowledging become separate concerns. `ChangeStream` splits its old `nextTransaction(block)` into `poll()` (the next committed tx, or null on an idle tick) and `acknowledge(lsn)`, plus a `walEnd` property (the server's latest received WAL position). `streamChanges` hands each polled tx to `submitTx` — which now returns a durability handle (commit 1) — keeps reading, and advances the confirmed-flush LSN only as those handles complete, in submission order.

## The durability invariant — for reviewers

The safety property is carried by the names: **`confirmedFlushLsn` MUST NOT exceed `durablyImportedLsn`**, because Postgres recycles WAL up to the confirmed-flush LSN. While work is in flight we confirm only `durablyImportedLsn`.

The one subtle spot is the idle branch. With nothing awaiting durability we advance the confirmed-flush LSN to `walEnd`, so Postgres can still recycle unrelated WAL while our slot is quiet. That is safe for two reasons that the code relies on:

- The source submits a transaction the instant `poll()` returns its Commit. So an empty `awaitingDurability` queue means there is no committed-but-unimported change at or below `walEnd`. `walEnd` is a physical receive position, always below the commit LSN of a transaction whose Commit hasn't arrived yet.
- Postgres pins `restart_lsn` at the start of any in-progress transaction regardless of the confirmed-flush LSN, so an un-committed transaction is re-sent in full after a crash.

Drop the "nothing in flight" guard and this becomes a genuine data-loss bug — that guard is load-bearing.

## Snapshot

The initial snapshot pipelines the same way: batches go through `submitTx`, and the snapshot-complete marker stays on `executeTx`. The marker's awaited durability is an in-order barrier — it can't be durable unless every batch before it is, so a batch failure fails the snapshot loudly rather than silently marking it complete.

## Resume

Acking behind durability widens the window in which Postgres re-delivers transactions on resume — it re-sends from its confirmed-flush LSN, which now lags what we've durably imported. Re-importing a delivered transaction would write a redundant system-time version, so `streamChanges` acks the resume LSN up front and skips any re-delivered tx at or below it.

## Behaviour-preserving split

Commit 1 (`tidy(indexer): submitTx returns the durability handle`) is an equivalence change — `submitTx` hands back the per-tx `Deferred` the persister already held, and `executeTx` collapses to `submitTx(...).await()`. Fire-and-forget callers (the Kafka connect source) are unaffected. It's cherry-pickable to `main` independently of the pg-source behaviour change in commit 2.

## Test plan

- Full postgres-source suite — 39 tests, green on a forced `--rerun-tasks` run (~5m40s, real execution confirmed). Includes `resume from token after restart` and the `random programs converge to the reference model` restart-with-mutations simulation, which would diverge from its reference model if the ack ever led durability.
- Core indexer tests (`LeaderLogProcessorTest`, `ExternalSourceTest`) green — the `submitTx`/`executeTx` reshape is behaviour-neutral.

One caveat worth a reviewer's eye: the widened `confirmed_flush < durablyImported` resume window is covered by the existing restart simulation but not stressed by a dedicated test.