### PR TITLE
build(docs): restore Kotlin API docs to the docs site

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -9,7 +9,8 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.dokka)
-    
+    alias(libs.plugins.dokka.javadoc)
+
     alias(libs.plugins.protobuf)
 }
 
@@ -70,7 +71,7 @@ kotlin {
     }
 }
 
-tasks.dokkaHtmlPartial {
+dokka {
     moduleName.set("xtdb-api")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,6 @@ import dev.clojurephant.plugin.clojure.tasks.ClojureCompile
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
-import org.jetbrains.dokka.base.DokkaBase
-import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jreleaser.gradle.plugin.dsl.deploy.maven.MavenDeployer
 import org.jreleaser.gradle.plugin.tasks.JReleaserDeployTask
 import org.jreleaser.model.Active
@@ -22,12 +20,6 @@ val gitCommitProvider: Provider<String> =
         isIgnoreExitValue = true
     }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
 
-buildscript {
-    dependencies {
-        classpath("org.jetbrains.dokka:dokka-base:1.9.10")
-    }
-}
-
 plugins {
     `java-library`
     `java-test-fixtures`
@@ -37,6 +29,8 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.dokka)
+    // declared so :xtdb-api / :xtdb-core can apply it for their javadoc jars; not applied at root
+    alias(libs.plugins.dokka.javadoc) apply false
     alias(libs.plugins.jreleaser)
     alias(libs.plugins.ben.manes.versions)
 }
@@ -170,12 +164,13 @@ allprojects {
         if (plugins.hasPlugin("org.jetbrains.dokka")) {
             // Modules without a public Java API publish a stub (empty) javadoc jar to satisfy
             // Maven Central's requirement without paying the dokka cost on every deploy.
-            // Real dokka javadoc is still produced for :xtdb-api and :xtdb-core.
+            // Real dokka javadoc is still produced for :xtdb-api and :xtdb-core (which additionally
+            // apply the dokka-javadoc plugin for the dokkaGeneratePublicationJavadoc task).
             val modulesWithPublicJavaApi = setOf(":xtdb-api", ":xtdb-core")
             if (proj.path in modulesWithPublicJavaApi) {
                 tasks.register<Jar>("dokkaJavadocJar") {
-                    dependsOn(tasks.dokkaJavadoc)
-                    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+                    dependsOn("dokkaGeneratePublicationJavadoc")
+                    from(layout.buildDirectory.dir("dokka/javadoc"))
                     archiveClassifier.set("javadoc")
                 }
             } else {
@@ -526,8 +521,11 @@ jreleaser {
 
 project(":xtdb-core").run {
     tasks["sourcesJar"].dependsOn("generateGrammarSource")
-    tasks["dokkaJavadoc"].dependsOn("generateGrammarSource")
-    tasks["dokkaHtmlPartial"].dependsOn("generateGrammarSource")
+
+    // every dokka source-analysing task (module + publication, html + javadoc) reads the generated grammar
+    tasks.matching { it.name.startsWith("dokkaGenerate") }.configureEach {
+        dependsOn("generateGrammarSource")
+    }
 }
 
 dependencies {
@@ -555,6 +553,16 @@ dependencies {
     projectDep(":modules:bench")
     projectDep(":modules:xtdb-datasets")
     projectDep(":modules:xtdb-kafka-connect")
+
+    // Modules aggregated into the published Kotlin API docs (docs.xtdb.com/drivers/kotlin/kdoc).
+    // xtdb-kafka-connect is configured via Kafka Connect properties, not a JVM API, so it's excluded.
+    dokka(project(":xtdb-api"))
+    dokka(project(":xtdb-core"))
+    dokka(project(":modules:xtdb-aws"))
+    dokka(project(":modules:xtdb-azure"))
+    dokka(project(":modules:xtdb-google-cloud"))
+    dokka(project(":modules:xtdb-kafka"))
+    dokka(project(":modules:xtdb-postgres-source"))
 
     // testFixtures dependencies
     testFixturesImplementation(project(":xtdb-api"))
@@ -871,18 +879,15 @@ createBench(
 
 createBench("ts-devices", mapOf("size" to "--size"))
 
-tasks.dokkaHtmlMultiModule {
+dokka {
     moduleName.set("")
     moduleVersion.set("2.x-SNAPSHOT")
 
-    inputs.file("dokka/logo-styles.css")
-    inputs.file("dokka/logo-icon.svg")
+    pluginsConfiguration.html {
+        customAssets.from("dokka/logo-icon.svg")
+        customStyleSheets.from("dokka/logo-styles.css")
 
-    pluginConfiguration<DokkaBase, DokkaBaseConfiguration> {
-        customAssets = listOf(file("dokka/logo-icon.svg"))
-        customStyleSheets = listOf(file("dokka/logo-styles.css"))
-
-        footerMessage = "© ${Year.now().value} JUXT Ltd"
+        footerMessage.set("© ${Year.now().value} JUXT Ltd")
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.dokka.javadoc)
     antlr
 
     alias(libs.plugins.protobuf)
@@ -144,8 +145,8 @@ protobuf {
     }
 }
 
-tasks.dokkaHtmlPartial {
-    dokkaSourceSets["main"].run {
+dokka {
+    dokkaSourceSets.named("main") {
         perPackageOption {
             matchingRegex.set(".*")
             suppress.set(true)

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -214,8 +214,16 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         // unwrap ExecutionException → cause (mirrors util/rethrowing-cause), counting Anomalies on the way out
-        private fun doSubmit(ops: List<TxOp>, opts: TxOpts): SubmittedTx =
-            try {
+        private fun doSubmit(ops: List<TxOp>, opts: TxOpts): SubmittedTx {
+            // submitTx/executeTx are autonomous - they open, submit and (for executeTx) await their own transaction,
+            // so they can't be mixed with an explicit BEGIN. Reads are fine mid-transaction; writes are not.
+            if (isTxOpen)
+                throw Incorrect(
+                    "Cannot submit a transaction while another is in progress on this connection - commit or roll back first",
+                    "xtdb/tx-already-in-progress"
+                )
+
+            return try {
                 try {
                     db(dbName).submitTxBlocking(ops, opts.withFallbackTz(defaultTz))
                 } catch (e: ExecutionException) {
@@ -225,6 +233,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 txErrorCounter?.increment()
                 throw e
             }
+        }
 
         fun submitTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): SubmittedTx =
             txSubmitTimer.timed { doSubmit(ops, opts) }.record(dbName)

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,6 +3,7 @@ dist/
 
 # generated docs
 public/drivers/clojure/codox
+public/drivers/kotlin/kdoc
 
 # generated types
 .astro/

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -352,8 +352,8 @@ export default defineConfig({
             ignoreVisit: (url, { el, event } = {}) => {
                 // Extract pathname if url is a full URL
                 const pathname = url.startsWith('http') ? new URL(url).pathname : url;
-                // Ignore visits to codox documentation or elements marked with data-no-swup
-                return pathname.startsWith('/drivers/clojure/codox') || el?.closest('[data-no-swup]');
+                // Ignore visits to generated API docs (codox/kdoc) or elements marked with data-no-swup
+                return pathname.startsWith('/drivers/clojure/codox') || pathname.startsWith('/drivers/kotlin/kdoc') || el?.closest('[data-no-swup]');
             },
         }),
     ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "build-api-docs": "mkdir -p public/drivers/clojure && rm -rf public/drivers/clojure/codox && cd ../ && ./gradlew build-codox"
+    "build-api-docs": "mkdir -p public/drivers/clojure public/drivers/kotlin && rm -rf public/drivers/clojure/codox public/drivers/kotlin/kdoc && cd ../ && ./gradlew build-codox :dokkaGeneratePublicationHtml && cp -r build/dokka/html docs/public/drivers/kotlin/kdoc"
   },
   "devDependencies": {
     "@astrojs/sitemap": "3.7.2",

--- a/docs/src/content/docs/drivers/java.md
+++ b/docs/src/content/docs/drivers/java.md
@@ -88,6 +88,10 @@ One caveat there: that client doesn't query `getSessionOptions`, so `getCurrentC
 
 See the [ADBC reference](/adbc/reference) for the full supported surface.
 
+## API Reference
+
+The [Kotlin/Java API documentation](/drivers/kotlin/kdoc) covers the `xtdb-api` and `xtdb-core` node and configuration APIs, along with the storage, log and source modules (S3, Azure Blob Storage, Google Cloud Storage, Kafka, Postgres).
+
 ## Examples
 
 For more examples and tests, see the [XTDB driver-examples repository](https://github.com/xtdb/driver-examples), which contains comprehensive test suites demonstrating various features and use cases.

--- a/docs/src/content/docs/drivers/kotlin.md
+++ b/docs/src/content/docs/drivers/kotlin.md
@@ -81,6 +81,10 @@ One caveat there: that client doesn't query `getSessionOptions`, so `getCurrentC
 
 See the [ADBC reference](/adbc/reference) for the full supported surface (its examples are in Kotlin).
 
+## API Reference
+
+The [Kotlin/Java API documentation](/drivers/kotlin/kdoc) covers the `xtdb-api` and `xtdb-core` node and configuration APIs, along with the storage, log and source modules (S3, Azure Blob Storage, Google Cloud Storage, Kafka, Postgres).
+
 ## Examples
 
 For more examples and tests, see the [XTDB driver-examples repository](https://github.com/xtdb/driver-examples), which contains comprehensive test suites demonstrating various features and use cases.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 org.gradle.workers.max=4
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kafka = "4.1.1"
 kotest = "6.1.11"
 kotlin = "2.3.0"
 kotlin-coroutines = "1.10.2"
-dokka = "1.9.10"
+dokka = "2.2.0"
 clojurephant = "0.9.1"
 shadow = "8.3.6"
 freefair-javadoc = "8.13.1"
@@ -198,6 +198,7 @@ tpch = { group = "io.airlift.tpch", name = "tpch", version = "0.10" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 clojurephant = { id = "dev.clojurephant.clojure", version.ref = "clojurephant" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 freefair-javadoc = { id = "io.freefair.aggregate-javadoc-legacy", version.ref = "freefair-javadoc" }

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -515,6 +515,7 @@ class KafkaCluster(
             )
     }
 
+    /** @suppress */
     interface AtomicProducer<M> : Log.AtomicProducer<M> {
         override fun openTx(): Tx<M>
 

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgOutputMessage.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgOutputMessage.kt
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets
  * Parsed pgoutput logical replication protocol messages.
  *
  * See: https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
+ *
+ * @suppress
  */
 sealed interface PgOutputMessage {
 

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -44,6 +44,7 @@ private val IDLE_POLL_PAUSE = 50.milliseconds
 private fun coerceText(text: String, typeOid: Int): Any? =
     PgType.fromOid(typeOid)?.readText(text.toByteArray()) ?: text
 
+/** @suppress */
 class PgWireDriver(
     private val dbName: String,
     private val hostname: String,

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresDriver.kt
@@ -2,6 +2,7 @@ package xtdb.postgres
 
 import java.time.Instant
 
+/** @suppress */
 sealed interface RowOp {
     val schema: String
     val table: String
@@ -15,6 +16,8 @@ sealed interface RowOp {
  *
  * The real implementation ([PgWireDriver]) talks to PostgreSQL via pgjdbc.
  * Tests can substitute a fake that yields predetermined data.
+ *
+ * @suppress
  */
 interface PostgresDriver : AutoCloseable {
 

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -626,6 +626,18 @@ class InProcessAdbcTest {
     }
 
     @Test
+    fun `submitTx and executeTx are rejected while a transaction is open`() {
+        xtdb.connect().use { conn ->
+            conn.update("BEGIN")
+
+            // the autonomous helpers can't be mixed with an explicit tx - they'd fire an independent
+            // transaction, ignoring the buffered one
+            assertThrows(Incorrect::class.java) { conn.submitTx(emptyList()) }
+            assertThrows(Incorrect::class.java) { conn.executeTx(emptyList()) }
+        }
+    }
+
+    @Test
     fun `executeUpdate rejects multi-statement input`() {
         xtdb.connect().use { conn ->
             assertThrows(Incorrect::class.java) { conn.update("BEGIN; COMMIT") }


### PR DESCRIPTION
## Summary

Restores the Kotlin/Java API reference to docs.xtdb.com and moves the docs build onto Dokka Gradle Plugin v2 (2.2.0).

## Context

The API reference stopped shipping when #4786 dropped `dokkaHtmlMultiModule` from the `build-api-docs` step (Sep 2025). Even before that it was only half-built: the root multimodule task aggregates its *direct* children (api, core) but not the nested `modules/*` projects, so the storage, log and source modules never appeared in the output despite each applying the plugin. There's no surrounding issue — this is a standalone docs-infra fix.

## Approach

DGP v2 replaces the `tasks.dokkaHtmlMultiModule {}` block with an explicit `dependencies { dokka(project(...)) }` list on the root project. That reaches nested subprojects (fixing the aggregation gap) and, more usefully, makes the documented module set an explicit decision rather than "whatever applied the plugin". The set is `xtdb-api`, `xtdb-core`, and the five storage/log/source modules (`aws`, `azure`, `google-cloud`, `kafka`, `postgres-source`) — the modules a user configures against a JVM API. `xtdb-kafka-connect` is configured through Kafka Connect properties, not a JVM API, so it's excluded.

## Hiding Clojure-interop internals

Several classes are `public` only because Clojure refers to them. Those are hidden with `@suppress`: the pgoutput wire-protocol types (`PgOutputMessage`) and the pgjdbc driver abstraction (`PostgresDriver`, `PgWireDriver`, `RowOp`) in postgres-source, and the transactional-producer plumbing (`KafkaCluster.AtomicProducer`) in kafka. The storage modules already suppressed their SPI `Registration` classes, so they needed no change.

The documented extension SPIs `PgIndexer` and `RecordIndexer` are deliberately *kept* visible. Their reference implementations (`DirectMirror`, `DocsIndexer`) are user-facing, so suppressing the interface they implement would leave a dangling supertype in the docs. This is a small refinement on the original plan, which had listed `PgIndexer`/`RecordIndexer` for suppression.

## Maven publish path (behaviour preserved)

The v2 javadoc format moved to a separate `org.jetbrains.dokka-javadoc` plugin, declared once at the root with `apply false` (so subprojects can apply it without re-specifying the version, since it ships in the same artifact as `org.jetbrains.dokka`). api and core apply it and emit the real javadoc jars Maven Central requires; every other module keeps emitting the empty stub jar, exactly as before.

## Verification

- `./gradlew dokkaGenerate` — all seven modules present in the aggregate (nested ones under `modules/`); suppressed internals (`PgWireDriver`, `PgOutputMessage`, `PostgresDriver`, `RowOp`, `TransformChain`) absent; config classes and kept SPIs present; custom logo/stylesheet applied.
- `./gradlew :xtdb-api:dokkaJavadocJar :xtdb-core:dokkaJavadocJar :modules:xtdb-aws:dokkaJavadocJar` — api/core jars carry real content (208 files), aws jar is the intended manifest-only stub.
- `cd docs && yarn build-api-docs && yarn build` — `dist/drivers/kotlin/kdoc/index.html` ships and both JVM driver pages link `/drivers/kotlin/kdoc`.
- `:modules:xtdb-postgres-source:test` and `:modules:xtdb-kafka:test` green (the `@suppress` edits are doc-comment-only).

`amplify.yml` is unchanged — it already runs `yarn run build-api-docs`, which now regenerates the kdoc aggregate alongside codox.