### PR TITLE
Run an ingest-only node from YAML config / Docker

### DIFF
--- a/core/src/main/clojure/xtdb/node.clj
+++ b/core/src/main/clojure/xtdb/node.clj
@@ -3,11 +3,12 @@
 
   It lives in the `com.xtdb/xtdb-core` artifact - ensure you've included this in your dependency manager of choice to use in-process nodes."
   (:require [clojure.tools.logging :as log]
+            [xtdb.error :as err]
             [xtdb.time :as time])
   (:import [java.io File]
            [java.nio.file Path]
            [java.time ZoneId]
-           [xtdb.api Xtdb Xtdb$Config]))
+           [xtdb.api IngestNode IngestNode$Config Xtdb Xtdb$Config]))
 
 (defmulti ^:no-doc apply-config!
   #_{:clj-kondo/ignore [:unused-binding]}
@@ -131,3 +132,21 @@
   For more information on the configuration options, see the relevant module pages in the [Clojure docs](https://docs.xtdb.com/drivers/clojure/codox/xtdb.api.html)"
   ^xtdb.api.Xtdb$CompactorNode [opts]
   (.openCompactor (->config opts)))
+
+(defn start-ingest-node
+  "Starts an in-process ingest-only node (see `xtdb.api.IngestNode`) with the given configuration.
+
+  Accepts various parameter types:
+  - An instance of 'xtdb.api.IngestNode$Config'.
+  - An instance of 'java.io.File' pointing to an existing '.yaml' configuration file.
+  - An instance of 'java.nio.file.Path' pointing to an existing '.yaml' configuration file.
+
+  This node *must* be closed when it is no longer needed (through `.close`, or `with-open`) so that it can clean up its resources."
+  ^xtdb.api.IngestNode [opts]
+  (cond
+    (instance? IngestNode$Config opts) (IngestNode/openIngestNode ^IngestNode$Config opts)
+    (instance? Path opts) (IngestNode/openIngestNode ^Path opts)
+    (instance? File opts) (start-ingest-node (.toPath ^File opts))
+    :else (throw (err/incorrect ::invalid-ingest-config
+                                "Ingest node config must be an IngestNode$Config or a '.yaml' config file"
+                                {:opts opts}))))

--- a/core/src/main/kotlin/xtdb/api/IngestNode.kt
+++ b/core/src/main/kotlin/xtdb/api/IngestNode.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.cache.DiskCache
@@ -14,17 +15,21 @@ import xtdb.database.DatabaseName
 import xtdb.error.Incorrect
 import xtdb.util.closeAll
 import xtdb.util.closeOnCatch
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.UUID.randomUUID
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.io.path.extension
 
 /**
  * A node that does nothing but ingest from external sources — it runs a [Database] per configured
  * external source, joins leader election, and runs the source only on the database for which it's
  * elected leader. There's no query/client surface: no pgwire, no Flight SQL, no healthz.
  *
- * Intended for embedding in a custom JVM application that supplies its own indexer programmatically.
- * Because the configuration lives in code and is handed in fresh on every boot, an external source's
- * indexer factory needn't be serialisable — it never travels as persisted secondary-database config.
+ * Started either from YAML config (`xtdb.main ingest`, [readConfig]) with registered external sources,
+ * or embedded in a custom JVM application that supplies its own indexer programmatically.
+ * Because the configuration is handed in fresh on every boot, a programmatically-supplied external
+ * source's indexer factory needn't be serialisable — it never travels as persisted secondary-database config.
  */
 class IngestNode internal constructor(
     private val base: NodeBase,
@@ -50,24 +55,25 @@ class IngestNode internal constructor(
         }
     }
 
-    class Config {
-        var allocator: BufferAllocator? = null
-
-        var logClusters: Map<RemoteAlias, Remote.Factory<*>> = emptyMap()
-        var remotes: Map<RemoteAlias, Remote.Factory<*>> = emptyMap()
+    @Serializable
+    class Config(
+        var logClusters: Map<RemoteAlias, Remote.Factory<*>> = emptyMap(),
+        var remotes: Map<RemoteAlias, Remote.Factory<*>> = emptyMap(),
 
         /**
          * The databases to ingest into, keyed by name. Each carries an `externalSource` whose indexer
          * may be a programmatically-supplied, non-serialisable factory.
          */
-        var databases: Map<DatabaseName, Database.Config> = emptyMap()
+        var databases: Map<DatabaseName, Database.Config> = emptyMap(),
 
-        val memoryCache: MemoryCache.Factory = MemoryCache.Factory()
-        var diskCache: DiskCache.Factory? = null
+        val memoryCache: MemoryCache.Factory = MemoryCache.Factory(),
+        var diskCache: DiskCache.Factory? = null,
 
-        val indexer: IndexerConfig = IndexerConfig()
+        val indexer: IndexerConfig = IndexerConfig(),
 
-        var nodeId: String = System.getenv("XTDB_NODE_ID") ?: randomUUID().toString().takeWhile { it != '-' }
+        var nodeId: String = System.getenv("XTDB_NODE_ID") ?: randomUUID().toString().takeWhile { it != '-' },
+    ) {
+        var allocator: BufferAllocator? = null
 
         fun logClusters(clusters: Map<RemoteAlias, Remote.Factory<*>>) = apply { logClusters += clusters }
         fun logCluster(alias: RemoteAlias, cluster: Remote.Factory<*>) = apply { logClusters += alias to cluster }
@@ -143,8 +149,26 @@ class IngestNode internal constructor(
 
     companion object {
         @JvmStatic
+        fun readConfig(path: Path): Config {
+            if (path.extension != "yaml") {
+                throw IllegalArgumentException("Invalid config file type - must be '.yaml'")
+            } else if (!path.toFile().exists()) {
+                throw IllegalArgumentException("Provided config file does not exist")
+            }
+
+            return ingestNodeConfig(Files.readString(path))
+        }
+
+        @JvmStatic
         @JvmOverloads
         fun openIngestNode(config: Config = Config()) = config.open()
+
+        /**
+         * Opens an ingest node using a YAML configuration file - will throw an exception if the specified path
+         * does not exist or is not a valid `.yaml` extension file.
+         */
+        @JvmStatic
+        fun openIngestNode(path: Path) = readConfig(path).open()
 
         @JvmSynthetic
         fun openIngestNode(configure: Config.() -> Unit) = openIngestNode(Config().also(configure))

--- a/core/src/main/kotlin/xtdb/api/YamlSerde.kt
+++ b/core/src/main/kotlin/xtdb/api/YamlSerde.kt
@@ -90,3 +90,11 @@ fun nodeConfig(yamlString: String): Xtdb.Config {
     val root = resolveEnvVars(YAML_SERDE.parseToYamlNode(yamlString))
     return YAML_SERDE.decodeFromYamlNode(root)
 }
+
+/**
+ * @suppress
+ */
+fun ingestNodeConfig(yamlString: String): IngestNode.Config {
+    val root = resolveEnvVars(YAML_SERDE.parseToYamlNode(yamlString))
+    return YAML_SERDE.decodeFromYamlNode(root)
+}

--- a/docker/README.adoc
+++ b/docker/README.adoc
@@ -8,6 +8,19 @@
   The `--clean` flag can be used to ensure the xtdb uberjar is rebuilt.
 * To run: `docker run -ti --rm -p 5432:5432 xtdb/xtdb` (this will run the server, exposing port 5432)
 
+== Running other node modes
+
+The image's `ENTRYPOINT` invokes `xtdb.main`, with the container command supplying its arguments (defaulting to `-f config.yaml`).
+Override the command to run any other top-level `xtdb.main` command — e.g. a compactor-only or ingest-only node:
+
+[source,bash]
+----
+docker run -ti --rm -v ./my-config.yaml:/config/xtdb.yaml xtdb/xtdb ingest -f /config/xtdb.yaml
+docker run -ti --rm -v ./my-config.yaml:/config/xtdb.yaml xtdb/xtdb compactor -f /config/xtdb.yaml
+----
+
+(In Kubernetes, set `args:` on the container to achieve the same.)
+
 == Customizing the local image
 
 If you wish to build the local image with a different default configuration included, you can change the content of the `standalone/local_config.edn` file prior to building, or create a new file and replace references to `local_config.edn` with the new config file.

--- a/main/src/main/clojure/xtdb/main.clj
+++ b/main/src/main/clojure/xtdb/main.clj
@@ -19,6 +19,7 @@
   (println "XTDB has several top-level commands to choose from:")
   (println " * `node` (default, can be omitted): starts an XT node")
   (println " * `compactor`: runs a compactor-only node")
+  (println " * `ingest`: runs an ingest-only node, ingesting from configured external sources")
   (println " * `playground`: starts a 'playground', an in-memory node which accepts any database name, creating it if required")
   (println " * `reset-compactor <db-name>`: resets the compacted files on the given node.")
   (println " * `export-snapshot <db-name>`: exports a consistent snapshot of object storage for the given database.")
@@ -115,6 +116,31 @@
 
     (util/with-open [_node ((requiring-resolve 'xtdb.node/start-compactor) (file->node-opts file))]
       (log/info "Compactor started")
+      @(shutdown-hook-promise))))
+
+(def ingest-cli-spec
+  [["-f" "--file CONFIG_FILE" "Config file to load XTDB ingest-node options from - YAML"
+    :id :file
+    :parse-fn io/file
+    :validate [if-it-exists "Config file doesn't exist"
+               #(= "yaml" (util/file-extension %)) "Config file must be .yaml"]]
+   ["-h" "--help"]])
+
+(defn- start-ingest-node [args]
+  (let [{{:keys [file]} :options} (-> (parse-args args ingest-cli-spec)
+                                      (handling-arg-errors-or-help))
+        file (or file
+                 (some-> (io/file "xtdb.yaml") if-it-exists)
+                 (some-> (io/resource "xtdb.yaml") (io/file)))]
+    (when (nil? file)
+      (binding [*out* *err*]
+        (println "Missing config file: `ingest -f <config-file.yaml>`")
+        (System/exit 2)))
+
+    (log/info "Starting in ingest-only mode...")
+
+    (util/with-open [_node ((requiring-resolve 'xtdb.node/start-ingest-node) file)]
+      (log/info "Ingest node started")
       @(shutdown-hook-promise))))
 
 (def playground-cli-spec
@@ -306,6 +332,7 @@
     (try
       (case cmd
         "compactor" (start-compactor more-args)
+        "ingest" (start-ingest-node more-args)
         "playground" (start-playground more-args)
         "node" (start-node more-args)
 

--- a/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/IngestNodeConfigTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/IngestNodeConfigTest.kt
@@ -1,0 +1,48 @@
+package xtdb.kafka.connectsrc
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.api.ingestNodeConfig
+import xtdb.api.log.KafkaCluster
+
+class IngestNodeConfigTest {
+
+    @Test
+    fun `decodes a full ingest-node YAML config`() {
+        val yaml = """
+            logClusters:
+              main-kafka: !Kafka
+                bootstrapServers: kafka:9092
+            remotes:
+              src-kafka: !Kafka
+                bootstrapServers: upstream:9092
+            databases:
+              orders:
+                log: !Kafka
+                  cluster: main-kafka
+                  topic: orders-log
+                externalSource: !KafkaConnect
+                  remote: src-kafka
+                  topic: orders-events
+                  connectConfig:
+                    key.converter: org.apache.kafka.connect.storage.StringConverter
+                    value.converter: org.apache.kafka.connect.json.JsonConverter
+                  indexer: !Docs
+                    table: orders
+            nodeId: ingest-1
+        """.trimIndent()
+
+        val config = ingestNodeConfig(yaml)
+
+        assertEquals("ingest-1", config.nodeId)
+        assertEquals("kafka:9092", (config.logClusters["main-kafka"] as KafkaCluster.ClusterFactory).bootstrapServers)
+
+        val db = config.databases["orders"]!!
+        assertEquals("orders-log", (db.log as KafkaCluster.LogFactory).topic)
+
+        val source = db.externalSource as KafkaConnectSource.Factory
+        assertEquals("src-kafka", source.remote)
+        assertEquals("orders-events", source.topic)
+        assertEquals("orders", (source.indexer as DocsIndexer.Factory).table)
+    }
+}


### PR DESCRIPTION
Github action runs: https://github.com/danmason/xtdb/actions/workflows/build.yml?query=branch%3Afeat%2Fingestion-node-main-option

IngestNode was previously programmatic-only - you had to embed it in your own JVM app.
  
This PR makes it a first-class deployment mode:
- IngestNode.Config is now YAML-serializable — logClusters, remotes, databases (with !KafkaConnect external sources and !Docs indexers), caches, nodeId, the lot. Plus IngestNode.readConfig(path) / openIngestNode(path), mirroring Xtdb.
- New xtdb.main ingest command — xtdb.main ingest -f config.yaml starts an ingest-only node from config, alongside the existing compactor and playground modes.
- xtdb.node/start-ingest-node for the Clojure API, accepting a Config, File, or Path.
- No Dockerfile changes needed — the image's CMD already supplies xtdb.main's args, so docker run xtdb/xtdb ingest -f /config/xtdb.yaml (or k8s args:) just works; documented in docker/README.adoc.

Indexers stay explicit in config (indexer: !Docs {table: ...}) — no implicit defaulting.

Test: IngestNodeConfigTest round-trips a full ingest-node YAML config (Kafka log cluster, remote, !KafkaConnect source, !Docs indexer) in the kafka module, where the registered source impls live.
