### PR TITLE
refactor(api): converge SQL execution onto Xtdb.Connection.Statement

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -46,7 +46,7 @@
            xtdb.JsonSerde
            xtdb.JsonLdSerde
            xtdb.NodeBase
-           (xtdb.query PreparedQuery SqlParser SqlPlanner
+           (xtdb.query SqlParser SqlPlanner
                        ParsedStatement ParsedStatement$Visitor ParsedStatement$Begin
                        ParsedStatement$Commit ParsedStatement$CommitMode ParsedStatement$Query ParsedStatement$Dml
                        ParsedStatement$ShowVariable ParsedStatement$CopyIn ParsedStatement$Execute)
@@ -751,24 +751,27 @@
   (letfn [(prepare-parsed []
             (let [^Xtdb$Statement statement
                   (with-auth-check conn
-                    (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare)))
-                  ^PreparedQuery pq (.getPreparedQuery statement)]
-              (when-let [warnings (.getWarnings pq)]
+                    (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare)))]
+              (when-let [warnings (.getWarnings statement)]
                 (doseq [warning warnings]
                   (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning)))))
 
               (let [param-oids (->> (concat param-oids (repeat 0))
-                                    (into [] (take (.getParamCount pq))))
+                                    (into [] (take (count (.getFields (.getParameterSchema statement))))))
                     param-types (map #(some-> (PgType/fromOid %) .getXtType) param-oids)
                     pg-cols (if (some nil? param-types)
-                              ;; if we're unsure on some of the col-types, return all output cols as the fallback type (#4455)
-                              (for [col-name (map str (.getColumnNames pq))]
+                              ;; if we're unsure on some of the col-types, return all output cols as the fallback
+                              ;; type (#4455). we take names off the plan rather than emitting: a relation-typed
+                              ;; param (e.g. XTQL `rel` args) can't emit against unknown (fromLegs) param types.
+                              (for [col-name (.getColumnNames statement)]
                                 {:pg-type PgType/PG_DEFAULT, :col-name col-name})
 
-                              (->> (.getColumnFields pq (->> param-types
-                                                             (into [] (comp (map types/->nullable-type)
-                                                                            (map-indexed (fn [idx vt]
-                                                                                           (types/->field (str "?_" idx) vt)))))))
+                              ;; all params known — resolve the output types against the client-supplied OIDs
+                              (->> (.getFields (.executeSchema statement
+                                                               (->> param-types
+                                                                    (into [] (comp (map types/->nullable-type)
+                                                                                   (map-indexed (fn [idx vt]
+                                                                                                  (types/->field (str "?_" idx) vt))))))))
                                    (mapv field->pg-col)))]
                 (assoc stmt
                        :statement statement
@@ -793,7 +796,7 @@
                        (with-auth-check conn
                          (util/with-open [^Xtdb$Statement statement
                                           (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare))]
-                           (when-let [warnings (.getWarnings (.getPreparedQuery statement))]
+                           (when-let [warnings (.getWarnings statement)]
                              (doseq [warning warnings]
                                (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning)))))))
                        (catch Throwable e

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -35,7 +35,7 @@
            [javax.net.ssl KeyManagerFactory SSLContext]
            (org.apache.arrow.memory BufferAllocator)
            org.apache.arrow.vector.types.pojo.Field
-           (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config Xtdb$Connection Xtdb$ExecutedTx Xtdb$SubmittedTx)
+           (xtdb.api Authenticator DataSource DataSource$ConnectionBuilder OAuthResult ServerConfig Xtdb Xtdb$Config Xtdb$Connection Xtdb$Statement Xtdb$ExecutedTx Xtdb$SubmittedTx)
            xtdb.api.module.XtdbModule
            (xtdb.arrow Relation Relation$ILoader VectorType)
            xtdb.arrow.RelationReader
@@ -138,6 +138,9 @@
 
     (doseq [portal (vals (:portals @conn-state))]
       (util/close (:cursor portal)))
+
+    (doseq [prepared-stmt (vals (:prepared-statements @conn-state))]
+      (util/close (:statement prepared-stmt)))
 
     (let [{:keys [server-state]} server]
       (swap! server-state update :connections dissoc cid))
@@ -521,6 +524,7 @@
         (doseq [portal-name (:portals stmt)]
           (close-portal conn portal-name))
 
+        (util/close (:statement stmt))
         (swap! conn-state update :prepared-statements dissoc close-name)))
 
     :portal
@@ -745,8 +749,10 @@
 (defn- prep-stmt [{:keys [conn-state] :as conn} {:keys [param-oids ^ParsedStatement parsed] :as stmt}]
   ;; queries, EXECUTE and SHOW all prepare through the connection; everything else passes through.
   (letfn [(prepare-parsed []
-            (let [^PreparedQuery pq (with-auth-check conn
-                                      (.getPreparedQuery (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare))))]
+            (let [^Xtdb$Statement statement
+                  (with-auth-check conn
+                    (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare)))
+                  ^PreparedQuery pq (.getPreparedQuery statement)]
               (when-let [warnings (.getWarnings pq)]
                 (doseq [warning warnings]
                   (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning)))))
@@ -765,7 +771,7 @@
                                                                                            (types/->field (str "?_" idx) vt)))))))
                                    (mapv field->pg-col)))]
                 (assoc stmt
-                       :prepared-query pq
+                       :statement statement
                        :param-oids param-oids
                        :prepared-pg-cols pg-cols
                        :pg-cols pg-cols))))]
@@ -784,11 +790,12 @@
                  (visitDml [_ _]
                    (when (empty? param-oids)
                      (try
-                       (let [^PreparedQuery pq (with-auth-check conn
-                                                 (.getPreparedQuery (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare))))]
-                         (when-let [warnings (.getWarnings pq)]
-                           (doseq [warning warnings]
-                             (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning))))))
+                       (with-auth-check conn
+                         (util/with-open [^Xtdb$Statement statement
+                                          (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare))]
+                           (when-let [warnings (.getWarnings (.getPreparedQuery statement))]
+                             (doseq [warning warnings]
+                               (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning)))))))
                        (catch Throwable e
                          (log/debug e "Error planning DML statement for warnings"))))
                    stmt)
@@ -813,6 +820,8 @@
       (assert (nil? more-stmts) (format "TODO: found %d statements in parse" (inc (count more-stmts))))
 
       (let [prepared-stmt (prep-stmt conn (-> stmt (assoc :param-oids param-oids)))]
+        ;; re-parsing a name replaces its statement — close the old one so its bound-args slice isn't leaked
+        (util/close (:statement (get-in @conn-state [:prepared-statements stmt-name])))
         (swap! conn-state (fn [conn-state]
                             (-> conn-state
                                 (assoc-in [:prepared-statements stmt-name] prepared-stmt)))))
@@ -829,6 +838,8 @@
 (defn cmd-prepare [{:keys [conn-state] :as conn} statement-name inner-ps]
   ;; the grammar allows a single inner statement, already parsed by the enclosing PREPARE
   (let [prepared-stmt (prep-stmt conn {:parsed inner-ps})]
+    ;; re-PREPARE of a name replaces its statement — close the old one so its bound-args slice isn't leaked
+    (util/close (:statement (get-in @conn-state [:prepared-statements statement-name])))
     (swap! conn-state assoc-in [:prepared-statements statement-name]
            (assoc prepared-stmt
                   :statement-name statement-name))
@@ -876,21 +887,22 @@
           pg-types
           result-formats)))
 
-(defn bind-stmt [{:keys [conn-state ^BufferAllocator allocator] :as conn} {:keys [^ParsedStatement parsed ^PreparedQuery prepared-query args result-format] :as stmt}]
+(defn bind-stmt [{:keys [conn-state ^BufferAllocator allocator] :as conn} {:keys [^ParsedStatement parsed ^Xtdb$Statement statement args result-format] :as stmt}]
   (let [{:keys [^Xtdb$Connection node-conn]} @conn-state
         xt-args (xtify-args conn args stmt)]
 
-    ;; the connection owns the QueryOpts (basis / tz / tracer) and the read access-mode gate — pgwire drives its
-    ;; own cursor but opens it through the connection. checked? reads through the gate (openQuery); an internal
+    ;; the connection owns the QueryOpts (basis / tz / tracer) and the read access-mode gate — pgwire binds its
+    ;; args onto the statement and opens through it. checked? reads through the gate (openQuery); an internal
     ;; args-eval opens unchecked. A user query in a write tx is the pgjdbc carve-out that verify-permissibility
     ;; let through, so it too opens unchecked (openQuery would reject it). SHOW opens checked but the connection
-    ;; gate-exempts it off its parsed statement.
-    (letfn [(->cursor ^xtdb.ResultCursor [^PreparedQuery pq xt-args checked?]
+    ;; gate-exempts it off its parsed statement. bind copies the args, so we close our own relation once opened.
+    (letfn [(->cursor ^xtdb.ResultCursor [^Xtdb$Statement statement xt-args checked?]
               (with-auth-check conn
-                (util/with-close-on-catch [args-rel (vw/open-args allocator xt-args)]
+                (util/with-open [args-rel (vw/open-args allocator xt-args)]
+                  (.bind statement args-rel)
                   (if (and checked? (not (.isTxReadWrite node-conn)))
-                    (.openQuery node-conn pq args-rel)
-                    (.openUncheckedQuery node-conn pq args-rel)))))
+                    (.openQuery statement)
+                    (.openUncheckedQuery statement)))))
 
             (->pg-cols [prepared-pg-cols ^ResultCursor cursor]
               (let [resolved-pg-cols (mapv (fn [[col-name vec-type]] (type->pg-col col-name vec-type)) (.getResultTypes cursor))]
@@ -907,7 +919,7 @@
                 (with-result-formats prepared-pg-cols result-format)))
 
             (bind-query-portal []
-              (util/with-close-on-catch [cursor (->cursor prepared-query xt-args true)]
+              (util/with-close-on-catch [cursor (->cursor statement xt-args true)]
                 (-> stmt
                     (assoc :cursor cursor,
                            :pg-cols (->pg-cols (:pg-cols stmt) cursor)))))]
@@ -921,10 +933,10 @@
                  (visitShowVariable [_ _] (bind-query-portal))
 
                  (visitExecute [_ ps]
-                   (util/with-open [^ResultCursor args-cursor (->cursor prepared-query xt-args false)]
+                   (util/with-open [^ResultCursor args-cursor (->cursor statement xt-args false)]
                      ;; we've bound the args query rather than the inner query; now bind the inner query and
                      ;; pretend this was the one we were running all along
-                     (let [{^PreparedQuery inner-pq :prepared-query, :as inner} (get-in @conn-state [:prepared-statements (.getName ps)])
+                     (let [{^Xtdb$Statement inner-stmt :statement, :as inner} (get-in @conn-state [:prepared-statements (.getName ps)])
                            ^ParsedStatement inner-parsed (:parsed inner)
                            !args (object-array 1)]
 
@@ -932,13 +944,15 @@
                                           (fn [^RelationReader args-rel]
                                             (aset !args 0 (.openSlice args-rel allocator))))
 
-                       (let [^RelationReader args-rel (aget !args 0)]
+                       ;; bind copies the derived args onto the inner statement, so we own (and close) this slice
+                       (util/with-open [^RelationReader args-rel (aget !args 0)]
                          (cond
                            (instance? ParsedStatement$Query inner-parsed)
                            (with-auth-check conn
-                             (util/with-close-on-catch [inner-cursor (if (.isTxReadWrite node-conn)
-                                                                       (.openUncheckedQuery node-conn inner-pq args-rel)
-                                                                       (.openQuery node-conn inner-pq args-rel))]
+                             (util/with-close-on-catch [inner-cursor (do (.bind inner-stmt args-rel)
+                                                                         (if (.isTxReadWrite node-conn)
+                                                                           (.openUncheckedQuery inner-stmt)
+                                                                           (.openQuery inner-stmt)))]
                                (-> inner
                                    (assoc :cursor inner-cursor
                                           :pg-cols (-> (->pg-cols (:pg-cols inner) inner-cursor)
@@ -946,16 +960,13 @@
 
                            (instance? ParsedStatement$Dml inner-parsed)
                            (let [arg-types (.getResultTypes args-cursor)]
-                             (try
-                               (-> inner
-                                   (assoc :args (vec (for [col-name (keys arg-types)]
-                                                       (-> (.vectorForOrNull args-rel col-name)
-                                                           (.getObject 0))))
-                                          :param-oids (->> arg-types
-                                                           (mapv (fn [[_col-name ^VectorType vec-type]]
-                                                                   (PgType/.getOid (PgType/fromVectorType vec-type)))))))
-                               (finally
-                                 (util/close args-rel))))
+                             (-> inner
+                                 (assoc :args (vec (for [col-name (keys arg-types)]
+                                                     (-> (.vectorForOrNull args-rel col-name)
+                                                         (.getObject 0))))
+                                        :param-oids (->> arg-types
+                                                         (mapv (fn [[_col-name ^VectorType vec-type]]
+                                                                 (PgType/.getOid (PgType/fromVectorType vec-type))))))))
 
                            :else (throw (err/unsupported ::unsupported-execute "EXECUTE only supports a prepared query or DML statement")))))))
 

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -545,7 +545,7 @@
     (case access-mode
       :read-only (.beginReadOnly node-conn)
       :read-write (.beginWriteOnly node-conn nil nil false)
-      (.beginTx node-conn))
+      (.begin node-conn))
     (swap! conn-state assoc :implicit-tx? true)))
 
 (defn- end-transaction
@@ -746,7 +746,7 @@
   ;; queries, EXECUTE and SHOW all prepare through the connection; everything else passes through.
   (letfn [(prepare-parsed []
             (let [^PreparedQuery pq (with-auth-check conn
-                                      (.prepare ^Xtdb$Connection (:node-conn @conn-state) parsed))]
+                                      (.getPreparedQuery (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare))))]
               (when-let [warnings (.getWarnings pq)]
                 (doseq [warning warnings]
                   (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning)))))
@@ -785,7 +785,7 @@
                    (when (empty? param-oids)
                      (try
                        (let [^PreparedQuery pq (with-auth-check conn
-                                                 (.prepare ^Xtdb$Connection (:node-conn @conn-state) parsed))]
+                                                 (.getPreparedQuery (doto (.createStatement ^Xtdb$Connection (:node-conn @conn-state) parsed) (.prepare))))]
                          (when-let [warnings (.getWarnings pq)]
                            (doseq [warning warnings]
                              (pgio/cmd-send-notice conn (notice-warning (sql/error-string warning))))))
@@ -997,7 +997,7 @@
 
 (defn- verify-permissibility
   [{:keys [conn-state server]} {:keys [^ParsedStatement parsed]}]
-  ;; the connection gates access-mode too (executeDml / resolveForQuery), but pgwire keeps these checks for
+  ;; the connection gates access-mode too (executeTxOp / resolveForQuery), but pgwire keeps these checks for
   ;; their own error codes/messages, the read-only-server rule (a server property, not connection state), and
   ;; the pgjdbc type-query special case — so it reads the tx's resolved access-mode off the connection.
   (let [^Xtdb$Connection node-conn (:node-conn @conn-state)
@@ -1070,7 +1070,7 @@
 
     ;; hand the op to the connection — it buffers, coalescing consecutive same-SQL ops, and submits at COMMIT.
     ;; no-param DML passes nil args (not an empty relation), matching the connection's own DML path.
-    (.executeDml node-conn (TxOp$Sql. query (when (seq args) (vw/open-args allocator args))))
+    (.executeTxOp node-conn (TxOp$Sql. query (when (seq args) (vw/open-args allocator args))))
 
     ;; oid is always 0 (legacy pg); row count is 0 because we're async
     (pgio/cmd-write-msg conn pgio/msg-command-complete
@@ -1230,7 +1230,7 @@
 
                (visitBegin [_ stmt]
                  ;; pass the portal's bound args — a BEGIN option can be a parameter placeholder (e.g. AWAIT_TOKEN = $1)
-                 (.beginParsedTx ^Xtdb$Connection (:node-conn @conn-state) (.getTxOptions stmt) (:args portal))
+                 (.begin ^Xtdb$Connection (:node-conn @conn-state) (.getTxOptions stmt) (:args portal))
                  (swap! conn-state assoc :implicit-tx? false)
                  (pgio/cmd-write-msg conn pgio/msg-command-complete {:command "BEGIN"}))
 
@@ -1376,7 +1376,7 @@
     (when (.isTxReadOnly node-conn)
       (throw (err/incorrect :xtdb/copy-in-read-only-tx
                             "COPY is not allowed in a READ ONLY transaction")))
-    (.executeDml node-conn (xt-log/open-tx-op client-op allocator {:default-tz (.getDefaultTz node-conn)}))))
+    (.executeTxOp node-conn (xt-log/open-tx-op client-op allocator {:default-tz (.getDefaultTz node-conn)}))))
 
 (defn- copy-transit-batch ^long [{:keys [conn-state ^BufferAllocator allocator] :as conn} {:keys [table-name format, ^Path copy-file]}]
   (let [^Xtdb$Connection node-conn (:node-conn @conn-state)

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -365,7 +365,8 @@
 
           (reify PreparedQuery
             (getParamCount [_] (:param-count (plan-query* @!table-info)))
-            (getColumnNames [_] (:col-names (plan-query* @!table-info)))
+            ;; the plan carries these as symbols; the PreparedQuery contract is List<String>
+            (getColumnNames [_] (mapv str (:col-names (plan-query* @!table-info))))
             (getParsed [_] stmt)
 
             (getColumnFields [_ param-fields]

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -388,14 +388,16 @@
 
             (openQuery [_ args opts]
               (let [default-tz (or (.getDefaultTz opts) default-tz)]
-              (util/with-close-on-catch [^BufferAllocator allocator (if allocator
+              ;; we own the args from here: closed on any failure below, else handed to the cursor (which
+              ;; closes them on close). the caller must not close them itself.
+              (util/with-close-on-catch [^RelationReader args (or args vw/empty-args)
+                                         ^BufferAllocator allocator (if allocator
                                                                       (util/->child-allocator allocator "BoundQuery/openCursor")
                                                                       (RootAllocator.))
                                          snaps (open-snaps)]
                 (let [query-opts (-> query-opts (assoc :default-tz default-tz))
                       table-info (reset! !table-info (->table-info))
                       planned-query (plan-query* table-info)
-                      ^RelationReader args (or args vw/empty-args)
 
                       {:keys [vec-types ->cursor] :as emitted-query} (emit-query planned-query scan-emitter db-cat snaps (->arg-types args) query-opts)
                       current-time (or (some-> (or (:current-time planned-query) (.getCurrentTime opts))
@@ -461,7 +463,6 @@
 
                     (catch Throwable t
                       (.release ref-ctr)
-                      (util/close args)
                       (throw t))))))))))))
 
   (prepareTxSql [this sql db-cat opts]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -107,10 +107,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         val parsedStatement: ParsedStatement?
         val preparedQuery: PreparedQuery?
 
-        // open a cursor on the (prepared, if not already) query. the no-arg form reads through the connection —
-        // its access-mode gate and basis/tz/tracer; the [opts] form opens at exactly those opts, independent of
-        // the connection's tx state (for internal system reads).
+        // open a cursor on the (prepared, if not already) query, at the connection's basis/tz/tracer. [openQuery]
+        // reads through the access-mode gate; [openUncheckedQuery] skips it (a frontend's driver-compatibility
+        // probe that must run in any tx — pgwire's pgjdbc type query inside a write tx). The [opts] form opens at
+        // exactly those opts, independent of the connection's tx state (for internal system reads).
         fun openQuery(): ResultCursor
+        fun openUncheckedQuery(): ResultCursor
         fun openQuery(opts: QueryOpts): ResultCursor
 
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
@@ -402,27 +404,29 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     if (preparedQuery == null) prepare()
                 }
 
-                // SHOW is gate-exempt — the connection's openQuery dispatches it to openUncheckedQuery off the pq.
+                // Gated open at the connection's basis: resolves the tx's access mode and basis (rejecting a read
+                // in a write tx, resolving an unresolved tx to read-only). SHOW bypasses the gate — session
+                // introspection, valid in any tx. The gate and opts run before the args are opened: once handed to
+                // [PreparedQuery.openQuery] the args slice is the cursor's — freed on both success and failure — so
+                // the steps that can reject must not have opened it yet.
                 override fun openQuery(): ResultCursor {
                     ensurePrepared()
-                    val queryArgs = openQueryArgs()
-                    return try {
-                        openQuery(preparedQuery!!, queryArgs)
-                    } catch (t: Throwable) {
-                        queryArgs?.close()
-                        throw t
-                    }
+                    if (preparedQuery!!.parsed !is ParsedStatement.ShowVariable) resolveForQuery()
+                    val opts = queryOpts()
+                    return preparedQuery!!.openQuery(openQueryArgs(), opts)
+                }
+
+                // Open WITHOUT the access-mode gate — a frontend's driver-compatibility probe that must run in any
+                // tx (pgwire's pgjdbc type query inside a write tx). Reads at the connection's current basis.
+                override fun openUncheckedQuery(): ResultCursor {
+                    ensurePrepared()
+                    val opts = queryOpts()
+                    return preparedQuery!!.openQuery(openQueryArgs(), opts)
                 }
 
                 override fun openQuery(opts: QueryOpts): ResultCursor {
                     ensurePrepared()
-                    val queryArgs = openQueryArgs()
-                    return try {
-                        preparedQuery!!.openQuery(queryArgs, opts)
-                    } catch (t: Throwable) {
-                        queryArgs?.close()
-                        throw t
-                    }
+                    return preparedQuery!!.openQuery(openQueryArgs(), opts)
                 }
 
                 override fun executeQuery(): QueryResult {
@@ -805,26 +809,6 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             )
         }
 
-        // Open a cursor on an already-prepared query: resolves the tx's access mode and basis (rejecting a read
-        // in a write tx, resolving an unresolved tx to read-only), then opens at the connection's basis, tz and
-        // tracer. SHOW bypasses the gate — it's session introspection, valid in any tx — dispatched on the
-        // originating statement, not the pq's concrete type. A frontend owns the cursor for wire serialization,
-        // but the gate and QueryOpts stay the connection's — no callsite reconstructs them, nor decides the gate.
-        fun openQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor =
-            when (pq.parsed) {
-                is ParsedStatement.ShowVariable -> openUncheckedQuery(pq, args)
-                else -> {
-                    resolveForQuery()
-                    pq.openQuery(args, queryOpts())
-                }
-            }
-
-        // Open a read WITHOUT the access-mode gate — for a frontend's driver-compatibility probe that must be
-        // permitted in any transaction (pgwire allows the pgjdbc type-metadata query inside a write tx, where
-        // the gate would otherwise reject it). Reads at the connection's current basis; inside a write tx that
-        // is latest-committed data, not the tx's buffered writes.
-        fun openUncheckedQuery(pq: PreparedQuery, args: RelationReader?): ResultCursor = pq.openQuery(args, queryOpts())
-
         // A SHOW answered from connection / catalog state as a zero-param [PreparedQuery]. [rows] is a thunk so
         // values snapshot at openQuery; [parsed] drives the gate exemption in [openQuery].
         private class ShowPreparedQuery(
@@ -1001,6 +985,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 override val preparedQuery: PreparedQuery? get() = null
 
                 override fun openQuery(): ResultCursor =
+                    throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
+
+                override fun openUncheckedQuery(): ResultCursor =
                     throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
 
                 override fun openQuery(opts: QueryOpts): ResultCursor =

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -104,6 +104,15 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
     fun executeTx(ops: List<TxOp>, opts: TxOpts = TxOpts()): ExecutedTx
 
     interface Statement : AdbcStatement {
+        val parsedStatement: ParsedStatement?
+        val preparedQuery: PreparedQuery?
+
+        // open a cursor on the (prepared, if not already) query. the no-arg form reads through the connection —
+        // its access-mode gate and basis/tz/tracer; the [opts] form opens at exactly those opts, independent of
+        // the connection's tx state (for internal system reads).
+        fun openQuery(): ResultCursor
+        fun openQuery(opts: QueryOpts): ResultCursor
+
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
     }
 
@@ -181,7 +190,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         val sessionParameters: Map<String, String?> get() = _sessionParameters
 
         // the sanctioned external writer, for a frontend's SET (pgwire funnels its startup defaults + SET here).
-        fun setSessionParameter(name: String, value: String?) { _sessionParameters[name] = value }
+        fun setSessionParameter(name: String, value: String?) {
+            _sessionParameters[name] = value
+        }
 
         // the default access mode for a subsequently-opened bare BEGIN, set by SET SESSION CHARACTERISTICS;
         // null leaves a bare BEGIN unresolved (resolved by its first statement). Readable for the frontend.
@@ -267,11 +278,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 if (txRes.txKey.txId == txId) return txRes.toExecutedTx()
             }
 
-            return Relation.openFromRows(allocator, listOf(mapOf("?_0" to txId)))
-                .closeOnCatch { args ->
-                    prepareSql("SELECT system_time, committed, error FROM xt.txs FOR ALL VALID_TIME WHERE _id = ?", awaitDb)
-                        .openQuery(args, QueryOpts(null, defaultTz))
-                }
+            // rare fallback: the tx completed but a later tx is now the latest, so awaitTxBlocking returned null.
+            // read the tx's own record from xt.txs by id, against awaitDb, at latest (its own basis, not the
+            // connection's). the id is a trusted internal long, so it's inlined rather than bound.
+            val sql = "SELECT system_time, committed, error FROM xt.txs FOR ALL VALID_TIME WHERE _id = $txId"
+            return openStatement(parseStatement(sql), awaitDb)
+                .openQuery(QueryOpts(null, defaultTz))
                 .use { c ->
                     var result: ExecutedTx? = null
                     c.tryAdvance { rel ->
@@ -287,161 +299,183 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 }
         }
 
-        fun prepareSql(sql: String, defaultDb: DatabaseName = dbName): PreparedQuery {
-            dbCat.awaitAll(awaitToken, awaitTimeout)
-            return qSrc.prepareQuery(
-                parseStatement(sql),
-                dbCat,
-                PrepareOpts(defaultTz = defaultTz, defaultDb = defaultDb)
-            )
-        }
-
-        // Plans a pre-classified statement; its query text and EXPLAIN flag derive from the AST. tz, db,
-        // await-token and await bound come from the connection.
-        private fun prepareSql(stmt: ParsedStatement): PreparedQuery {
-            dbCat.awaitAll(awaitToken, awaitTimeout)
-            return qSrc.prepareQuery(
-                stmt,
-                dbCat,
-                PrepareOpts(defaultTz = defaultTz, defaultDb = dbName)
-            )
-        }
-
-        // Prepare a pre-classified statement (pgwire's dispatch path), so queries, DML and SHOWs prepare through
-        // one entry — SHOW bypasses the access-mode gate off [PreparedQuery.parsed] in [openQuery]. DML doesn't
-        // execute through the returned query (it buffers as a tx op, planned server-side); pgwire prepares it
-        // only to surface planning warnings.
-        fun prepare(parsed: ParsedStatement): PreparedQuery =
-            when (parsed) {
-                is ParsedStatement.Query, is ParsedStatement.Execute, is ParsedStatement.Dml -> prepareSql(parsed)
-                is ParsedStatement.ShowVariable -> showPreparedQuery(parsed)
-                else -> throw Incorrect("not a preparable query: ${parsed::class.simpleName}", "xtdb/not-a-query")
-            }
-
         fun openSqlQuery(sql: String): ResultCursor =
-            openQuery(prepareSql(sql), null)
+            createStatement(sql).openQuery()
 
-        override fun createStatement() = object : Statement {
-            private var sql: String? = null
-            private var prepared: PreparedQuery? = null
-            private var args: RelationReader? = null
+        fun prepareStatement(sql: String): Statement = createStatement(sql).apply { prepare() }
 
-            private fun clearArgs() {
-                args.also { args = null }?.close()
-            }
+        fun createStatement(sql: String): Statement = openStatement(parseStatement(sql))
 
-            private fun openQueryArgs(): RelationReader? =
-                args?.openSlice(allocator)?.closeOnCatch { sliced ->
-                    RelationReader.from(
-                        sliced.vectors.mapIndexed { idx, v -> v.withName("?_$idx") },
-                        sliced.rowCount
+        // for a frontend that has already classified the statement (pgwire), so it prepares through the same
+        // Statement path without re-parsing.
+        fun createStatement(parsed: ParsedStatement): Statement = openStatement(parsed)
+
+        override fun createStatement(): Statement = openStatement(null)
+
+        // [targetDb] is the connection's own db bar the internal cross-db tx-result read (awaitTx), which
+        // prepares against the awaited database.
+        private fun openStatement(initialParsed: ParsedStatement?, targetDb: DatabaseName = dbName): Statement =
+            object : Statement {
+                override var parsedStatement: ParsedStatement? = initialParsed
+                    private set
+
+                override var preparedQuery: PreparedQuery? = null
+                    private set
+
+                private var args: RelationReader? = null
+
+                private fun clearArgs() {
+                    args.also { args = null }?.close()
+                }
+
+                override fun setSqlQuery(sql: String) {
+                    this.parsedStatement = parseStatement(sql)
+                    this.preparedQuery = null
+                    clearArgs()
+                }
+
+                override fun prepare() {
+                    val parsedStatement =
+                        this.parsedStatement ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
+                    preparedQuery = when (parsedStatement) {
+                        // SHOW reads session/node state and must not await — only a real query/DML awaits its basis.
+                        is ParsedStatement.Query, is ParsedStatement.Execute, is ParsedStatement.Dml -> {
+                            dbCat.awaitAll(awaitToken, awaitTimeout)
+                            qSrc.prepareQuery(
+                                parsedStatement, dbCat,
+                                PrepareOpts(defaultTz = defaultTz, defaultDb = targetDb)
+                            )
+                        }
+
+                        is ParsedStatement.ShowVariable -> showPreparedQuery(parsedStatement)
+                        else -> throw Incorrect(
+                            "not a preparable query: ${parsedStatement::class.simpleName}",
+                            "xtdb/not-a-query"
+                        )
+                    }
+                }
+
+                override fun getParameterSchema(): Schema {
+                    val pq = preparedQuery ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
+                    return Schema(
+                        (0 until pq.paramCount).map { idx -> "\$$idx" ofType VectorType.fromLegs() }
                     )
                 }
 
-            override fun setSqlQuery(sql: String) {
-                this.sql = sql
-                this.prepared = null
-                clearArgs()
-            }
+                override fun executeSchema(): Schema {
+                    val pq = preparedQuery ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
 
-            override fun prepare() {
-                val sql = this.sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-                prepared = prepareSql(sql)
-            }
+                    val paramFields = (0 until pq.paramCount).map { idx -> "?_$idx" ofType VectorType.fromLegs() }
 
-            override fun getParameterSchema(): Schema {
-                val pq = prepared ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
-                return Schema(
-                    (0 until pq.paramCount).map { idx -> "\$$idx" ofType VectorType.fromLegs() }
-                )
-            }
+                    return Schema(pq.getColumnFields(paramFields))
+                }
 
-            override fun executeSchema(): Schema {
-                val pq = prepared ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
-
-                val paramFields = (0 until pq.paramCount).map { idx -> "?_$idx" ofType VectorType.fromLegs() }
-
-                return Schema(pq.getColumnFields(paramFields))
-            }
-
-            override fun bind(root: VectorSchemaRoot) {
-                clearArgs()
-                args = Relation(allocator, root.schema).closeOnCatch { copy ->
-                    Relation.fromRoot(allocator, root).use { src ->
-                        copy.append(src)
+                override fun bind(root: VectorSchemaRoot) {
+                    clearArgs()
+                    args = Relation(allocator, root.schema).closeOnCatch { copy ->
+                        Relation.fromRoot(allocator, root).use { src ->
+                            copy.append(src)
+                        }
+                        copy
                     }
-                    copy
+                }
+
+                override fun bind(rel: RelationReader) {
+                    clearArgs()
+                    args = rel.openSlice(allocator)
+                }
+
+                private fun openQueryArgs(): RelationReader? =
+                    args?.openSlice(allocator)?.closeOnCatch { sliced ->
+                        RelationReader.from(
+                            sliced.vectors.mapIndexed { idx, v -> v.withName("?_$idx") },
+                            sliced.rowCount
+                        )
+                    }
+
+                private fun ensurePrepared() {
+                    if (preparedQuery == null && args != null)
+                        throw Incorrect(
+                            "call prepare() before executing when parameters are bound",
+                            "xtdb.adbc/bind-without-prepare",
+                        )
+                    if (preparedQuery == null) prepare()
+                }
+
+                // SHOW is gate-exempt — the connection's openQuery dispatches it to openUncheckedQuery off the pq.
+                override fun openQuery(): ResultCursor {
+                    ensurePrepared()
+                    val queryArgs = openQueryArgs()
+                    return try {
+                        openQuery(preparedQuery!!, queryArgs)
+                    } catch (t: Throwable) {
+                        queryArgs?.close()
+                        throw t
+                    }
+                }
+
+                override fun openQuery(opts: QueryOpts): ResultCursor {
+                    ensurePrepared()
+                    val queryArgs = openQueryArgs()
+                    return try {
+                        preparedQuery!!.openQuery(queryArgs, opts)
+                    } catch (t: Throwable) {
+                        queryArgs?.close()
+                        throw t
+                    }
+                }
+
+                override fun executeQuery(): QueryResult {
+                    if (parsedStatement == null) throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
+                    return QueryResult(-1, openQuery().toArrowReader())
+                }
+
+                override fun executeUpdate(): UpdateResult {
+                    val stmt = parsedStatement ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
+
+                    when (stmt) {
+                        is ParsedStatement.Begin -> begin(stmt.txOptions)
+
+                        is ParsedStatement.Commit -> when (stmt.mode) {
+                            ParsedStatement.CommitMode.SYNC -> commitSync()
+                            ParsedStatement.CommitMode.ASYNC -> commitAsync()
+                            null -> if (isTxAsync) commitAsync() else commitSync()
+                        }
+
+                        is ParsedStatement.Rollback -> rollbackTx()
+
+                        is ParsedStatement.Dml -> executeTxOp(TxOp.Sql(stmt.originalSql, openQueryArgs()))
+
+                        is ParsedStatement.SetSessionParameter ->
+                            setSessionParameter(stmt.name, sqlPlanner.evalLiteral(stmt.value, null)?.toString())
+
+                        is ParsedStatement.SetTimeZone -> setTimeZone(
+                            coerceZoneId(
+                                sqlPlanner.evalLiteral(
+                                    stmt.zone,
+                                    null
+                                )
+                            )
+                        )
+
+                        is ParsedStatement.SetAwaitToken -> awaitToken =
+                            coerceAwaitToken(sqlPlanner.evalLiteral(stmt.token, null))
+
+                        is ParsedStatement.SetSessionCharacteristics -> defaultAccessMode = stmt.accessMode
+                        is ParsedStatement.SetTransaction -> {} // isolation is always serializable — accepted, no-op
+                        is ParsedStatement.SetRole -> {} // accepted, no-op (as pgwire)
+
+                        else -> throw Incorrect("not an update", "xtdb.adbc/not-an-update")
+                    }
+
+                    return UpdateResult(-1)
+                }
+
+                override fun close() {
+                    clearArgs()
+                    preparedQuery = null
                 }
             }
-
-            override fun bind(rel: RelationReader) {
-                clearArgs()
-                args = rel.openSlice(allocator)
-            }
-
-            override fun executeQuery(): QueryResult {
-                val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-                // SHOW is answered from connection state, ahead of the access-mode gate — it is session
-                // introspection, valid in any transaction (pgwire's verify-permissibility doesn't gate it).
-                if (prepared == null)
-                    (parseStatements(sql).singleOrNull() as? ParsedStatement.ShowVariable)?.let { stmt ->
-                        val cursor = openQuery(prepare(stmt), null)
-                        return QueryResult(-1, cursorToArrowReader(cursor, Schema(cursor.resultTypes.map { (n, t) -> t.toField(n) })))
-                    }
-                if (prepared == null && args != null)
-                    throw Incorrect(
-                        "call prepare() before executeQuery() when parameters are bound",
-                        "xtdb.adbc/bind-without-prepare",
-                    )
-
-                val queryArgs = openQueryArgs()
-                val cursor = try {
-                    prepared?.let { openQuery(it, queryArgs) } ?: openQuery(prepareSql(sql), null)
-                } catch (t: Throwable) {
-                    queryArgs?.close()
-                    throw t
-                }
-                val schema = Schema(cursor.resultTypes.map { (name, type) -> type.toField(name) })
-                return QueryResult(-1, cursorToArrowReader(cursor, schema))
-            }
-
-            override fun executeUpdate(): UpdateResult {
-                val sql = sql ?: throw Incorrect("SQL query not set", "xtdb.adbc/no-sql")
-
-                val stmt = parseStatements(sql).singleOrNull()
-                    ?: throw Incorrect(
-                        "executeUpdate expects exactly one SQL statement",
-                        "xtdb.adbc/expected-single-statement",
-                        mapOf("sql" to sql)
-                    )
-                when (stmt) {
-                    is ParsedStatement.Begin -> beginParsedTx(stmt.txOptions)
-
-                    is ParsedStatement.Commit -> when (stmt.mode) {
-                        ParsedStatement.CommitMode.SYNC -> commitSync()
-                        ParsedStatement.CommitMode.ASYNC -> commitAsync()
-                        null -> if (isTxAsync) commitAsync() else commitSync()
-                    }
-                    is ParsedStatement.Rollback -> rollbackTx()
-
-                    is ParsedStatement.SetSessionParameter ->
-                        setSessionParameter(stmt.name, sqlPlanner.evalLiteral(stmt.value, null)?.toString())
-                    is ParsedStatement.SetTimeZone -> setTimeZone(coerceZoneId(sqlPlanner.evalLiteral(stmt.zone, null)))
-                    is ParsedStatement.SetAwaitToken -> awaitToken = coerceAwaitToken(sqlPlanner.evalLiteral(stmt.token, null))
-                    is ParsedStatement.SetSessionCharacteristics -> defaultAccessMode = stmt.accessMode
-                    is ParsedStatement.SetTransaction -> {} // isolation is always serializable — accepted, no-op
-                    is ParsedStatement.SetRole -> {} // accepted, no-op (as pgwire)
-
-                    else -> executeDml(TxOp.Sql(sql, openQueryArgs()))
-                }
-                return UpdateResult(-1)
-            }
-
-            override fun close() {
-                clearArgs()
-                prepared = null
-            }
-        }
 
         // Manual-tx DML buffer: consecutive same-SQL ops coalesce, their args appended into the last op's own
         // relation, so a prepared INSERT in a loop becomes one multi-row op.
@@ -521,22 +555,22 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // Open an explicit transaction (SQL BEGIN). [accessMode] fixes the mode — READ ONLY rejects writes,
         // READ WRITE buffers them; a bare BEGIN leaves it unresolved until the first statement resolves it.
         // [readBasis] pins the begin-time read snapshot (null for an explicit READ WRITE — writes don't read).
-        // Coexists with autoCommit — an open tx captures subsequent DML (see executeDml) until COMMIT/ROLLBACK.
-        private fun beginTx(accessMode: AccessMode?, readBasis: ReadBasis?, tz: ZoneId = defaultTz, awaitToken: String? = null) {
+        // Coexists with autoCommit — an open tx captures subsequent DML (see executeTxOp) until COMMIT/ROLLBACK.
+        private fun beginTx(
+            accessMode: AccessMode?,
+            readBasis: ReadBasis?,
+            tz: ZoneId = defaultTz,
+            awaitToken: String? = null
+        ) {
             if (tx != null) throw Incorrect("transaction already started", "xtdb/tx-already-open")
-            tx = Transaction(accessMode, readBasis, txDefaultTz = tz, sessionDefaultTz = defaultTz, awaitToken = awaitToken)
-        }
 
-        // a bare BEGIN takes the session default access mode (SET SESSION CHARACTERISTICS); with none set it
-        // stays unresolved, pinning a basis anyway — a query resolving it to read-only inherits the basis, DML
-        // resolving it to read-write ignores it.
-        // @JvmOverloads: a frontend (pgwire) calls these reflectively with the shorter arities, taking the
-        // default session tz — the defaulted `tz` param alone wouldn't emit those JVM overloads.
-        @JvmOverloads
-        fun beginTx(tz: ZoneId = defaultTz) = when (defaultAccessMode) {
-            ParsedStatement.AccessMode.READ_ONLY -> beginReadOnly(tz)
-            ParsedStatement.AccessMode.READ_WRITE -> beginWriteOnly(tz = tz)
-            null -> beginTx(null, pinReadBasis(), tz)
+            tx = Transaction(
+                accessMode,
+                readBasis,
+                txDefaultTz = tz,
+                sessionDefaultTz = defaultTz,
+                awaitToken = awaitToken
+            )
         }
 
         // the default access mode a bare BEGIN (explicit or implicit) takes; set by SET SESSION CHARACTERISTICS.
@@ -548,18 +582,22 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         fun beginReadOnly(tz: ZoneId = defaultTz) = beginTx(ReadOnly, pinReadBasis(), tz)
 
         @JvmOverloads
-        fun beginWriteOnly(systemTime: Instant? = null, userMetadata: Map<*, *>? = null, async: Boolean = false,
-                           tz: ZoneId = defaultTz) =
+        fun beginWriteOnly(
+            systemTime: Instant? = null, userMetadata: Map<*, *>? = null, async: Boolean = false,
+            tz: ZoneId = defaultTz
+        ) =
             beginTx(ReadWrite(systemTime, userMetadata, async), null, tz)
 
         // tx status for the frontend's ready-state + commit/abort decisions. A failed tx rejects further work
         // until ROLLBACK (Postgres' "current transaction is aborted").
         val isTxOpen: Boolean get() = tx != null
         val isTxFailed: Boolean get() = tx?.failed != null
+
         // resolved access-mode of the open tx (an unresolved bare tx is neither); the frontend's permissibility
         // checks read these to keep their own error messages + special-cases (e.g. pgwire's pgjdbc type query).
         val isTxReadWrite: Boolean get() = tx?.mode is ReadWrite
         val isTxReadOnly: Boolean get() = tx?.mode is ReadOnly
+
         // the begin-time async flag (WITH (ASYNC)) of the open write tx; false when unset / not a write tx.
         // A bare COMMIT (no SYNC/ASYNC) and the programmatic commit() commit through it.
         val isTxAsync: Boolean get() = (tx?.mode as? ReadWrite)?.async ?: false
@@ -623,12 +661,15 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             tx?.let { it.txDefaultTz = zone; it.sessionDefaultTz = zone } ?: run { defaultTz = zone }
         }
 
+        // a bare BEGIN (no WITH options) — takes the session default access mode, pinning a begin-time basis.
+        fun begin() = begin(ParsedStatement.TxOptions())
+
         // Begin an explicit tx from parsed WITH options, evaluating each option expression via the injected
         // SqlPlanner with the supplied bound args (null for the ADBC path, whose BEGIN options are literals;
         // pgwire passes its portal args, since a BEGIN option can be a parameter placeholder). Public for the
         // frontends. WITH (TIMEZONE) overrides the tx zone (tx-scoped); WITH (AWAIT_TOKEN) sets a READ ONLY tx's
         // await bound.
-        fun beginParsedTx(opts: ParsedStatement.TxOptions, args: List<*>? = null) {
+        fun begin(opts: ParsedStatement.TxOptions, args: List<*>? = null) {
             val tz = opts.defaultTz?.let { coerceZoneId(sqlPlanner.evalLiteral(it, args)) } ?: defaultTz
 
             when (opts.accessMode) {
@@ -643,7 +684,8 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 ParsedStatement.AccessMode.READ_ONLY -> {
                     // SNAPSHOT_TOKEN / SNAPSHOT_TIME / CLOCK_TIME override the begin-time auto-pin; AWAIT_TOKEN
                     // sets the await bound for this tx's snapshot, defaulting to the connection's own token.
-                    val awaitTok = opts.awaitToken?.let { coerceAwaitToken(sqlPlanner.evalLiteral(it, args)) } ?: awaitToken
+                    val awaitTok =
+                        opts.awaitToken?.let { coerceAwaitToken(sqlPlanner.evalLiteral(it, args)) } ?: awaitToken
                     val snapshotToken = opts.snapshotToken?.let { sqlPlanner.evalLiteral(it, args) } as String?
                     val snapshotTime = coerceInstant(opts.snapshotTime?.let { sqlPlanner.evalLiteral(it, args) }, tz)
                     val currentTime = coerceInstant(opts.clockTime?.let { sqlPlanner.evalLiteral(it, args) }, tz)
@@ -651,7 +693,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     beginTx(ReadOnly, pinReadBasis(snapshotToken, snapshotTime, currentTime, awaitTok), tz, awaitTok)
                 }
 
-                null -> beginTx(tz)
+                null -> when (defaultAccessMode) {
+                    ParsedStatement.AccessMode.READ_ONLY -> beginReadOnly(tz)
+                    ParsedStatement.AccessMode.READ_WRITE -> beginWriteOnly(tz = tz)
+                    null -> beginTx(null, pinReadBasis(), tz)
+                }
             }
         }
 
@@ -664,7 +710,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             this.tx = null
             defaultTz = tx.sessionDefaultTz   // a mid-tx SET TIME ZONE persists; a WITH (TIMEZONE) override doesn't
             val mode = tx.mode as? ReadWrite ?: return null
-            val opts = TxOpts(systemTime = mode.systemTime, user = user, userMetadata = mode.userMetadata, defaultTz = tx.txDefaultTz)
+            val opts = TxOpts(
+                systemTime = mode.systemTime,
+                user = user,
+                userMetadata = mode.userMetadata,
+                defaultTz = tx.txDefaultTz
+            )
             return expandStaticOps(mode.buffer.drain(), tx.txDefaultTz) to opts
         }
 
@@ -697,7 +748,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 out
             }
 
-        fun executeDml(op: TxOp) {
+        fun executeTxOp(op: TxOp) {
             // auto-execute only when no explicit tx is open; an open tx (from beginTx) buffers even under autoCommit.
             if (autoCommit && tx == null) {
                 expandStaticOps(listOf(op), defaultTz).useAll { ops -> executeTx(ops, TxOpts(user = user)) }
@@ -716,16 +767,18 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             }
         }
 
-        // The read counterpart of executeDml's access-mode resolution: a query resolves an unresolved tx to
+        // The read counterpart of executeTxOp's access-mode resolution: a query resolves an unresolved tx to
         // read-only, and is rejected in a read-write (DML) tx — in XTDB a write tx is write-only. Applied by
         // openQuery, so every read gates through one place.
         private fun resolveForQuery() {
             val tx = tx
             if (tx == null) {
-                // manual mode mirrors executeDml's lazy open: a query opens a read-only tx pinning the
+                // manual mode mirrors executeTxOp's lazy open: a query opens a read-only tx pinning the
                 // begin-time basis, so subsequent reads share its snapshot. Under autocommit there is no open
                 // tx — the query reads latest at the connection's current basis, unchanged.
-                if (!autoCommit) this.tx = Transaction(ReadOnly, pinReadBasis(), txDefaultTz = defaultTz, sessionDefaultTz = defaultTz)
+                if (!autoCommit)
+                    this.tx =
+                        Transaction(ReadOnly, pinReadBasis(), txDefaultTz = defaultTz, sessionDefaultTz = defaultTz)
                 return
             }
             when (tx.mode) {
@@ -743,7 +796,13 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         // planner's own, so a frontend-pinned clock is authoritative.
         private fun queryOpts() = tx.let { t ->
             val b = t?.readBasis
-            QueryOpts(b?.currentTime ?: clock.instant(), t?.txDefaultTz ?: defaultTz, b?.snapshotToken, b?.snapshotTime, tracer)
+            QueryOpts(
+                b?.currentTime ?: clock.instant(),
+                t?.txDefaultTz ?: defaultTz,
+                b?.snapshotToken,
+                b?.snapshotTime,
+                tracer
+            )
         }
 
         // Open a cursor on an already-prepared query: resolves the tx's access mode and basis (rejecting a read
@@ -812,7 +871,10 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 show(linkedMapOf(col to VectorType.maybe(VectorType.UTF8))) { listOf(mapOf(col to value())) }
 
             // awaitAll first, so node-status reflects this connection's own writes
-            fun byPartition(msgIdCol: SequencedMap<String, VectorType>, read: (Database, DatabasePartition) -> Map<String, Any?>) =
+            fun byPartition(
+                msgIdCol: SequencedMap<String, VectorType>,
+                read: (Database, DatabasePartition) -> Map<String, Any?>
+            ) =
                 show(msgIdCol) {
                     dbCat.awaitAll(awaitToken, awaitTimeout)
                     dbCat.databaseNames.flatMap { dbName ->
@@ -823,21 +885,30 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     }
                 }
 
-            val msgIdCols = linkedMapOf("db_name" to VectorType.UTF8, "part" to VectorType.I32,
-                                        "msg_id" to VectorType.maybe(VectorType.I64))
+            val msgIdCols = linkedMapOf(
+                "db_name" to VectorType.UTF8, "part" to VectorType.I32,
+                "msg_id" to VectorType.maybe(VectorType.I64)
+            )
 
             return when (val variable = stmt.variable) {
                 // 0 rows until this connection's first submit; system_time/committed/error null for a fire-and-forget submit
                 "latest_submitted_tx" -> show(
-                    linkedMapOf("tx_id" to VectorType.maybe(VectorType.I64),
-                                "system_time" to VectorType.maybe(VectorType.INSTANT),
-                                "committed" to VectorType.maybe(VectorType.BOOL),
-                                "error" to VectorType.maybe(VectorType.TRANSIT),
-                                "await_token" to VectorType.maybe(VectorType.UTF8))) {
+                    linkedMapOf(
+                        "tx_id" to VectorType.maybe(VectorType.I64),
+                        "system_time" to VectorType.maybe(VectorType.INSTANT),
+                        "committed" to VectorType.maybe(VectorType.BOOL),
+                        "error" to VectorType.maybe(VectorType.TRANSIT),
+                        "await_token" to VectorType.maybe(VectorType.UTF8)
+                    )
+                ) {
                     lastSubmittedTx?.let {
-                        listOf(mapOf("tx_id" to it.txId, "system_time" to it.systemTime,
-                                     "committed" to it.committed, "error" to it.error,
-                                     "await_token" to effectiveAwaitToken))
+                        listOf(
+                            mapOf(
+                                "tx_id" to it.txId, "system_time" to it.systemTime,
+                                "committed" to it.committed, "error" to it.error,
+                                "await_token" to effectiveAwaitToken
+                            )
+                        )
                     } ?: emptyList()
                 }
 
@@ -850,14 +921,19 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 }
 
                 "latest_completed_txs" -> show(
-                    linkedMapOf("db_name" to VectorType.UTF8, "part" to VectorType.I32,
-                                "tx_id" to VectorType.maybe(VectorType.I64),
-                                "system_time" to VectorType.maybe(VectorType.INSTANT))) {
+                    linkedMapOf(
+                        "db_name" to VectorType.UTF8, "part" to VectorType.I32,
+                        "tx_id" to VectorType.maybe(VectorType.I64),
+                        "system_time" to VectorType.maybe(VectorType.INSTANT)
+                    )
+                ) {
                     dbCat.awaitAll(awaitToken, awaitTimeout)
                     dbCat.latestCompletedTxs().flatMap { (dbName, txs) ->
                         txs.mapIndexed { part, txKey ->
-                            mapOf("db_name" to dbName, "part" to part,
-                                  "tx_id" to txKey?.txId, "system_time" to txKey?.systemTime)
+                            mapOf(
+                                "db_name" to dbName, "part" to part,
+                                "tx_id" to txKey?.txId, "system_time" to txKey?.systemTime
+                            )
                         }
                     }
                 }
@@ -870,6 +946,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                         }
                     }
                 }
+
                 "latest_processed_msg_ids" -> byPartition(msgIdCols) { _, partition -> mapOf("msg_id" to partition.watchers.latestSourceMsgId) }
 
                 else -> show1(variable) { sessionParameters[variable] }
@@ -914,6 +991,21 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             val schemaName = splitTable.getOrNull(1) ?: "public"
 
             return object : Statement {
+                override val parsedStatement
+                    get() =
+                        throw Incorrect(
+                            "Bulk ingest doesn't support parsedStatement",
+                            "xtdb.adbc/bulk-ingest-no-parsed-statement"
+                        )
+
+                override val preparedQuery: PreparedQuery? get() = null
+
+                override fun openQuery(): ResultCursor =
+                    throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
+
+                override fun openQuery(opts: QueryOpts): ResultCursor =
+                    throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
+
                 override fun executeQuery(): QueryResult =
                     throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
 
@@ -944,20 +1036,22 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     val docs = docs.also { this.docs = null } ?: return UpdateResult(0)
                     val rowCount = docs.rowCount.toLong()
                     // TODO valid-from/valid-to for the batch
-                    executeDml(TxOp.PutDocs(schemaName, tableName, docs = docs))
+                    executeTxOp(TxOp.PutDocs(schemaName, tableName, docs = docs))
                     return UpdateResult(rowCount)
                 }
             }
         }
 
-        private fun cursorToArrowReader(cursor: ResultCursor, schema: Schema): ArrowReader =
-            object : ArrowReader(allocator) {
+        private fun ResultCursor.toArrowReader(): ArrowReader {
+            val schema = Schema(resultTypes.map { (name, type) -> type.toField(name) })
+
+            return object : ArrowReader(allocator) {
                 override fun readSchema() = schema
 
                 override fun loadNextBatch(): Boolean =
-                    cursor.tryAdvance { inRel ->
-                        inRel.openDirectSlice(allocator).use { rel ->
-                            val loader = VectorLoader(vectorSchemaRoot)
+                    tryAdvance { inRel ->
+                        inRel.openDirectSlice(this.allocator).use { rel ->
+                            val loader = VectorLoader(this.vectorSchemaRoot)
                             rel.openArrowRecordBatch().use { rb ->
                                 loader.load(rb)
                             }
@@ -966,8 +1060,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 override fun bytesRead() = -1L
 
-                override fun closeReadSource() = cursor.close()
+                override fun closeReadSource() = this@toArrowReader.close()
             }
+        }
 
         /**
          * Returns an ArrowReader that yields a single batch, built from a pre-populated VectorSchemaRoot.

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -105,7 +105,15 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
     interface Statement : AdbcStatement {
         val parsedStatement: ParsedStatement?
-        val preparedQuery: PreparedQuery?
+
+        // planning warnings raised while preparing (empty until prepared / for a non-query statement)
+        val warnings: List<String>
+
+        // the output column names, carried by the plan — resolvable without binding params or emitting the
+        // query. A frontend that can't resolve its param types (pgwire, when a client OID is unknown — #4455)
+        // needs the names alone: it can't call [executeSchema], since emitting against unknown (fromLegs) params
+        // fails for a relation-typed parameter that the query reads columns out of.
+        val columnNames: List<String>
 
         // open a cursor on the (prepared, if not already) query, at the connection's basis/tz/tracer. [openQuery]
         // reads through the access-mode gate; [openUncheckedQuery] skips it (a frontend's driver-compatibility
@@ -114,6 +122,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         fun openQuery(): ResultCursor
         fun openUncheckedQuery(): ResultCursor
         fun openQuery(opts: QueryOpts): ResultCursor
+
+        // the output columns given the bound-parameter types. The no-arg [executeSchema] resolves them with
+        // unknown (fromLegs) params; this form lets a frontend that knows its param types (pgwire, from client
+        // OIDs) supply them so the output types resolve against them.
+        fun executeSchema(paramFields: List<Field>): Schema
 
         fun bind(rel: RelationReader): Unit = unsupported("bind(RelationReader) not supported")
     }
@@ -321,8 +334,13 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 override var parsedStatement: ParsedStatement? = initialParsed
                     private set
 
-                override var preparedQuery: PreparedQuery? = null
-                    private set
+                private var preparedQuery: PreparedQuery? = null
+
+                override val warnings get() = preparedQuery?.warnings.orEmpty()
+
+                override val columnNames
+                    get() = (preparedQuery ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared"))
+                        .columnNames
 
                 private var args: RelationReader? = null
 
@@ -366,9 +384,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 override fun executeSchema(): Schema {
                     val pq = preparedQuery ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
+                    return executeSchema((0 until pq.paramCount).map { idx -> "?_$idx" ofType VectorType.fromLegs() })
+                }
 
-                    val paramFields = (0 until pq.paramCount).map { idx -> "?_$idx" ofType VectorType.fromLegs() }
-
+                override fun executeSchema(paramFields: List<Field>): Schema {
+                    val pq = preparedQuery ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
                     return Schema(pq.getColumnFields(paramFields))
                 }
 
@@ -982,7 +1002,10 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                             "xtdb.adbc/bulk-ingest-no-parsed-statement"
                         )
 
-                override val preparedQuery: PreparedQuery? get() = null
+                override val warnings get() = emptyList<String>()
+
+                override val columnNames: List<String>
+                    get() = throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
 
                 override fun openQuery(): ResultCursor =
                     throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
@@ -994,6 +1017,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
 
                 override fun executeQuery(): QueryResult =
+                    throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
+
+                override fun executeSchema(paramFields: List<Field>): Schema =
                     throw Incorrect("Bulk ingest does not support queries", "xtdb.adbc/bulk-ingest-no-query")
 
                 override fun prepare(): Unit =

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -214,7 +214,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     }
 
     private fun execDml(op: TxOp, ctx: CallContext?, txHandle: TxHandle?) {
-        txOrSessionConnection(ctx, txHandle).executeDml(op)
+        txOrSessionConnection(ctx, txHandle).executeTxOp(op)
     }
 
     override fun acceptPutStatement(

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -16,7 +16,8 @@
             [xtdb.serde :as serde]
             [xtdb.test-util :as tu]
             [xtdb.time :as time]
-            [xtdb.util :as util])
+            [xtdb.util :as util]
+            [xtdb.vector.writer :as vw])
   (:import [java.nio.file Path]
            [java.time ZoneId ZonedDateTime]
            [xtdb.api ServerConfig Xtdb$Config Xtdb$Connection]
@@ -689,107 +690,121 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
   (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 1 :a "one" :b 2}]
                             [:put-docs :unrelated-table {:xt/id 1 :a "a-string"}]])
 
-  (let [pq (with-open [conn (.connect tu/*node*)]
-             (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT foo.*, ? FROM foo")))
-        column-fields [#xt/field {"_id" :i64}
-                       #xt/field {"a" :utf8}
-                       #xt/field {"b" :i64}]
-        column-types {"_id" #xt/type :i64
-                      "a" #xt/type :utf8
-                      "b" #xt/type :i64}]
+  (with-open [conn (.connect tu/*node*)
+              stmt (.prepareStatement ^Xtdb$Connection conn "SELECT foo.*, ? FROM foo")]
+    (let [al (.getAllocator tu/*node*)
+          column-fields [#xt/field {"_id" :i64}
+                         #xt/field {"a" :utf8}
+                         #xt/field {"b" :i64}]
+          column-types {"_id" #xt/type :i64
+                        "a" #xt/type :utf8
+                        "b" #xt/type :i64}]
 
-    (t/is (= (conj column-fields #xt/field {"_column_2" :i64})
-             (.getColumnFields pq [#xt/field {"?_0" :i64}]))
-          "param type is assumed to be nullable")
+      (t/is (= (conj column-fields #xt/field {"_column_2" :i64})
+               (.getFields (.executeSchema stmt [#xt/field {"?_0" :i64}])))
+            "param type is assumed to be nullable")
 
-    (with-open [cursor (.openQuery pq (tu/open-args [42]) (QueryOpts.))]
+      (with-open [args (vw/open-args al [42])]
+        (.bind stmt args)
+        (with-open [cursor (.openQuery stmt (QueryOpts.))]
 
-      (t/is (= (assoc column-types "_column_2" #xt/type :i64)
-               (into {} (.getResultTypes cursor)))
-            "now param value has been supplied we know its type is non-null")
+          (t/is (= (assoc column-types "_column_2" #xt/type :i64)
+                   (into {} (.getResultTypes cursor)))
+                "now param value has been supplied we know its type is non-null")
 
-      (t/is (= [[{:xt/id 1, :a "one", :b 2, :xt/column-2 42}]]
-               (tu/<-cursor cursor))))
+          (t/is (= [[{:xt/id 1, :a "one", :b 2, :xt/column-2 42}]]
+                   (tu/<-cursor cursor)))))
 
-    (t/testing "preparedQuery rebound with different param types"
-      (with-open [cursor (.openQuery pq (tu/open-args ["fish"]) (QueryOpts.))]
+      (t/testing "rebound with different param types"
+        (with-open [args (vw/open-args al ["fish"])]
+          (.bind stmt args)
+          (with-open [cursor (.openQuery stmt (QueryOpts.))]
 
-        (t/is (= (assoc column-types "_column_2" #xt/type :utf8)
-                 (into {} (.getResultTypes cursor)))
-              "now param value has been supplied we know its type is non-null")
+            (t/is (= (assoc column-types "_column_2" #xt/type :utf8)
+                     (into {} (.getResultTypes cursor)))
+                  "now param value has been supplied we know its type is non-null")
 
-        (t/is (= [[{:xt/id 1, :a "one", :b 2, :xt/column-2 "fish"}]]
-                 (tu/<-cursor cursor)))))
+            (t/is (= [[{:xt/id 1, :a "one", :b 2, :xt/column-2 "fish"}]]
+                     (tu/<-cursor cursor))))))
 
-    (t/testing "statement invalidation"
-      (with-open [args (tu/open-args [42])]
-        (let [res [[{:xt/id 2, :a "two", :b 3, :xt/column-2 42}
-                    {:xt/id 1, :a "one", :b 2, :xt/column-2 42}]]]
+      (t/testing "statement invalidation"
+        (with-open [args (vw/open-args al [42])]
+          (let [res [[{:xt/id 2, :a "two", :b 3, :xt/column-2 42}
+                      {:xt/id 1, :a "one", :b 2, :xt/column-2 42}]]]
 
-          (t/testing "relevant schema unchanged since preparing query"
-            (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 2 :a "two" :b 3}]])
+            (t/testing "relevant schema unchanged since preparing query"
+              (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 2 :a "two" :b 3}]])
 
-            (with-open [cursor (.openQuery pq (.openSlice args tu/*allocator*) (QueryOpts.))]
-              (t/is (= res (tu/<-cursor cursor)))))
+              (.bind stmt args)
+              (with-open [cursor (.openQuery stmt (QueryOpts.))]
+                (t/is (= res (tu/<-cursor cursor)))))
 
-          (t/testing "irrelevant schema changed since preparing query"
+            (t/testing "irrelevant schema changed since preparing query"
 
-            (xt/execute-tx tu/*node* [[:put-docs :unrelated-table {:xt/id 2 :a 222}]])
+              (xt/execute-tx tu/*node* [[:put-docs :unrelated-table {:xt/id 2 :a 222}]])
 
-            (with-open [cursor (.openQuery pq (.openSlice args tu/*allocator*) (QueryOpts.))]
-              (t/is (= res (tu/<-cursor cursor)))))
+              (.bind stmt args)
+              (with-open [cursor (.openQuery stmt (QueryOpts.))]
+                (t/is (= res (tu/<-cursor cursor)))))
 
-          (t/testing "a -> union, but prepared query is still fine outside of pgwire"
-            (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 3 :a 1 :b 4}]])
+            (t/testing "a -> union, but prepared query is still fine outside of pgwire"
+              (xt/execute-tx tu/*node* [[:put-docs :foo {:xt/id 3 :a 1 :b 4}]])
 
-            (with-open [cursor (.openQuery pq (.openSlice args tu/*allocator*) (QueryOpts.))]
-              (t/is (= [[{:xt/id 2, :a "two", :b 3, :xt/column-2 42}
-                         {:xt/id 1, :a "one", :b 2, :xt/column-2 42}
-                         {:xt/id 3, :a 1, :b 4, :xt/column-2 42}]]
-                       (tu/<-cursor cursor))))))))))
+              (.bind stmt args)
+              (with-open [cursor (.openQuery stmt (QueryOpts.))]
+                (t/is (= [[{:xt/id 2, :a "two", :b 3, :xt/column-2 42}
+                           {:xt/id 1, :a "one", :b 2, :xt/column-2 42}
+                           {:xt/id 3, :a 1, :b 4, :xt/column-2 42}]]
+                         (tu/<-cursor cursor)))))))))))
 
 (deftest test-prepared-statements-default-tz
   (t/testing "default-tz supplied at prepare"
-    (let [ptz #xt/zone "America/New_York"
-          pq (with-open [conn (.connect tu/*node*)]
-               (.setTimeZone ^Xtdb$Connection conn ptz)
-               (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x")))]
+    (let [ptz #xt/zone "America/New_York"]
+      (with-open [conn (.connect tu/*node*)]
+        (.setTimeZone ^Xtdb$Connection conn ptz)
+        (with-open [stmt (.prepareStatement ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x")]
 
-      (t/testing "and not at bind"
-        (with-open [cursor (.openQuery pq nil (QueryOpts.))]
-          (t/is (= ptz (.getZone ^ZonedDateTime (:x (ffirst (tu/<-cursor cursor))))))))
+          (t/testing "and not at open"
+            (with-open [cursor (.openQuery stmt (QueryOpts.))]
+              (t/is (= ptz (.getZone ^ZonedDateTime (:x (ffirst (tu/<-cursor cursor))))))))
 
-      (t/testing "and and also at bind"
-        (let [tz #xt/zone "Asia/Bangkok"]
-          (with-open [cursor (.openQuery pq nil (QueryOpts. nil tz))]
-            (t/is (= tz (.getZone ^ZonedDateTime (:x (ffirst (tu/<-cursor cursor)))))))))))
+          (t/testing "and and also at open"
+            (let [tz #xt/zone "Asia/Bangkok"]
+              (with-open [cursor (.openQuery stmt (QueryOpts. nil tz))]
+                (t/is (= tz (.getZone ^ZonedDateTime (:x (ffirst (tu/<-cursor cursor)))))))))))))
 
   (t/testing "default-tz not supplied at prepare"
-    (let [pq (with-open [conn (.connect tu/*node*)]
-               (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x")))]
+    (with-open [conn (.connect tu/*node*)
+                stmt (.prepareStatement ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x")]
 
       (t/testing "and not at open"
-        (with-open [cursor (.openQuery pq nil (QueryOpts.))]
+        (with-open [cursor (.openQuery stmt (QueryOpts.))]
           (t/is (= #xt/zone "Z" (.getZone ^ZonedDateTime (:x (ffirst (tu/<-cursor cursor))))))))
 
-      (t/testing "but at bind"
+      (t/testing "but at open"
         (let [tz #xt/zone "Asia/Bangkok"]
-          (with-open [cursor (.openQuery pq nil (QueryOpts. nil tz))]
+          (with-open [cursor (.openQuery stmt (QueryOpts. nil tz))]
             (t/is (= tz (.getZone ^ZonedDateTime (:x (ffirst (tu/<-cursor cursor))))))))))))
 
 (deftest test-default-param-types
-  (let [pq (with-open [conn (.connect tu/*node*)]
-             (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT ? v")))]
-    (t/testing "preparedQuery rebound with args matching the assumed type"
+  (with-open [conn (.connect tu/*node*)
+              stmt (.prepareStatement conn "SELECT ? v")]
+    (let [al (.getAllocator tu/*node*)]
+      (t/testing "rebound with args matching the assumed type"
 
-      (with-open [cursor (.openQuery pq (tu/open-args ["42"]) (QueryOpts.))]
-        (t/is (= [[{:v "42"}]]
-                 (tu/<-cursor cursor))))
+        (with-open [args (vw/open-args al ["42"])]
+          (.bind stmt args)
+          (with-open [cursor (.openQuery stmt (QueryOpts.))]
+            (t/is (= [[{:v "42"}]]
+                     (tu/<-cursor cursor)))))
 
-      (t/testing "or can be rebound with a different type"
-        (with-open [cursor (.openQuery pq (tu/open-args [44]) (QueryOpts.))]
-          (t/is (= [[{:v 44}]]
-                   (tu/<-cursor cursor))))))))
+        (t/testing "or can be rebound with a different type"
+          (with-open [args (vw/open-args al [44])]
+            (.bind stmt args)
+
+            (with-open [cursor (.openQuery stmt (QueryOpts.))]
+              (t/is (= [[{:v 44}]]
+                       (tu/<-cursor cursor))))))))))
 
 (deftest test-schema-ee-entry-points
   ;;test is using regclass to verify that expected EE entrypoints have access

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -690,7 +690,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
                             [:put-docs :unrelated-table {:xt/id 1 :a "a-string"}]])
 
   (let [pq (with-open [conn (.connect tu/*node*)]
-             (.prepareSql ^Xtdb$Connection conn "SELECT foo.*, ? FROM foo" "xtdb"))
+             (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT foo.*, ? FROM foo")))
         column-fields [#xt/field {"_id" :i64}
                        #xt/field {"a" :utf8}
                        #xt/field {"b" :i64}]
@@ -753,7 +753,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
     (let [ptz #xt/zone "America/New_York"
           pq (with-open [conn (.connect tu/*node*)]
                (.setTimeZone ^Xtdb$Connection conn ptz)
-               (.prepareSql ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x" "xtdb"))]
+               (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x")))]
 
       (t/testing "and not at bind"
         (with-open [cursor (.openQuery pq nil (QueryOpts.))]
@@ -766,7 +766,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
   (t/testing "default-tz not supplied at prepare"
     (let [pq (with-open [conn (.connect tu/*node*)]
-               (.prepareSql ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x" "xtdb"))]
+               (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT CURRENT_TIMESTAMP x")))]
 
       (t/testing "and not at open"
         (with-open [cursor (.openQuery pq nil (QueryOpts.))]
@@ -779,7 +779,7 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 
 (deftest test-default-param-types
   (let [pq (with-open [conn (.connect tu/*node*)]
-             (.prepareSql ^Xtdb$Connection conn "SELECT ? v" "xtdb"))]
+             (.getPreparedQuery (.prepareStatement ^Xtdb$Connection conn "SELECT ? v")))]
     (t/testing "preparedQuery rebound with args matching the assumed type"
 
       (with-open [cursor (.openQuery pq (tu/open-args ["42"]) (QueryOpts.))]

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -421,7 +421,7 @@
   ([node query] (q-sql node query {}))
   ([node query opts]
    (with-open [conn (.connect ^xtdb.api.Xtdb node)]
-     (let [^PreparedQuery prepared-q (.prepareSql ^xtdb.api.Xtdb$Connection conn query (get opts :default-db "xtdb"))]
+     (let [^PreparedQuery prepared-q (.getPreparedQuery (.prepareStatement ^xtdb.api.Xtdb$Connection conn query))]
        {:res (xt/q node query opts)
         :res-type (mapv (juxt #(.getName ^Field %) types/->type) (.getColumnFields prepared-q []))}))))
 

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -30,7 +30,7 @@
            (org.apache.arrow.vector.types.pojo ArrowType$Struct Field Schema)
            (org.testcontainers.containers GenericContainer)
            (xtdb ICursor PagesCursor)
-           (xtdb.api TransactionKey Xtdb Xtdb$Connection)
+           (xtdb.api TransactionKey Xtdb)
            (xtdb.test.log RecordingLog$Factory)
            xtdb.api.query.IKeyFn
            (xtdb.arrow Relation RelationReader Vector VectorType)
@@ -230,8 +230,8 @@
       (->> (into {}))
       (update-vals vec)))
 
-(defn await-token [node]
-  (with-open [conn ^Xtdb$Connection (.connect ^Xtdb node)]
+(defn await-token [^Xtdb node]
+  (with-open [conn (.connect node)]
     (basis/->tx-basis-str (.latestSubmittedMsgIds conn))))
 
 (defn <-cursor
@@ -419,11 +419,11 @@
 (defn q-sql
   "Like xtdb.api/q, but also returns the result type."
   ([node query] (q-sql node query {}))
-  ([node query opts]
-   (with-open [conn (.connect ^xtdb.api.Xtdb node)]
-     (let [^PreparedQuery prepared-q (.getPreparedQuery (.prepareStatement ^xtdb.api.Xtdb$Connection conn query))]
-       {:res (xt/q node query opts)
-        :res-type (mapv (juxt #(.getName ^Field %) types/->type) (.getColumnFields prepared-q []))}))))
+  ([^Xtdb node query opts]
+   (with-open [conn (.connect node)
+               stmt (.prepareStatement conn query)]
+     {:res (xt/q node query opts)
+      :res-type (mapv (juxt #(.getName ^Field %) types/->type) (.getFields (.executeSchema stmt [])))})))
 
 (defn with-container [^GenericContainer c, f]
   (if (.getContainerId c)


### PR DESCRIPTION
Part of the pre-2.2 public-API review — trimming and tidying what calcifies as public in the 2.2 release.

`Xtdb.Connection.Statement` is the SPI the protocol frontends prepare and execute SQL through. It's public only because pgwire is Clojure and Kotlin `internal` name-mangles across that boundary, so this is an effectively-internal reshape rather than a user-facing API change — and behaviour-preserving throughout, bar the one latent-bug fix called out below.

Two things were scattered across the surface. Preparation had two entry points — `prepare` and a private `prepareSql`. And execution was lopsided: pgwire held the `PreparedQuery` a Statement had prepared and opened cursors straight off it via `Connection.openQuery(pq, args)`, reading the parameter count, column fields and warnings off it too — so `PreparedQuery` leaked out through the public `Statement` interface. This converges both onto the Statement and pulls `PreparedQuery` back behind it.

**Before → after**

- Prepare: `prepare` plus a private `prepareSql` → a single path, `Statement.prepare()`.
- Open a cursor: pgwire opened `Connection.openQuery(pq, args)` off a held `PreparedQuery` → pgwire holds the `Statement`, binds its args onto it, and opens via `openQuery()` / `openUncheckedQuery()`.
- Metadata: parameter count / column fields / warnings read off the `PreparedQuery` → off the `Statement` (`getParameterSchema`, `executeSchema(paramFields)`, `warnings`).
- `PreparedQuery`: a public member of `Statement` → a private detail of the connection's Statement.

**A latent double-free, fixed along the way**

Routing pgwire's error paths through the Statement surfaced a pre-existing double-free (`RefCnt has gone negative`) on any query that fails *with* bound args — e.g. `SETTING SNAPSHOT_TOKEN = ? SELECT …` with a basis past the latest tx. `IQuerySource.openQuery` freed its `args` only on failures *after* it acquired the query ref-counter, while the caller also freed them on catch, so a post-acquire failure closed the slice twice. `openQuery` now owns `args` on every path — freed on any failure, otherwise handed to the cursor — and the Statement runs the gate and opts (which can reject) before opening the args, so no caller double-frees. This half of the change is independent of the refactor and cherry-pickable to `main` on its own, since `main` carries the same latent double-free.

**Commits (reviewer reading order)**

1. `refactor(api): make Xtdb.Connection.Statement the single prepare/execute hub` — collapse `prepareSql`, add `openQuery()` / `openQuery(opts)`, rename `executeDml` → `executeTxOp` and `beginParsedTx` → `begin`.
2. `refactor(pgwire): drive cursors through the held Statement` — add `openUncheckedQuery`, move the access-mode gate and QueryOpts down onto the Statement (deleting the now-unused pq-taking `Connection` methods), pgwire holds / binds / closes the Statement; includes the args-ownership fix above.
3. `refactor(api): encapsulate PreparedQuery behind the Statement` — resolve metadata via the schema methods, expose `warnings` on the Statement, drop the public `preparedQuery`, and migrate the node / test-util callers onto the Statement API.

**Out of scope**

- The `query.clj` arg-ownership fix could land on `main` independently as its own `fix:`.
- pgwire still keeps the coarse #4455 fallback (any unknown client OID → all output columns reported as the default type). A real `Any` (top) type would let that become per-column-precise; noted, not pursued here.

**Testing**

Each increment ran green locally across `pgwire_test`, the `xtdb.pgwire.*` suites, `api_test`, `node_test`, `flight_sql_test`, and the ADBC / Flight SQL Kotlin tests. Kept as a draft until the final rebased tree comes back green (verification in progress; CI will confirm).