### PR TITLE
feat(ingest-node): support configuring a healthz server

### DIFF
--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -170,33 +170,42 @@
                                               (InetAddress/getByName host)))
                 (not= ::absent port) (.port port)))))
 
+(defn open-server
+  "Starts the healthz server against `base`'s meter registry and the databases in `db-cat`.
+
+  `extra-handler-opts` are merged into each request seen by the endpoint handlers."
+  (^AutoCloseable [base db-cat config] (open-server base db-cat config {}))
+
+  (^AutoCloseable [^NodeBase base ^Database$Catalog db-cat ^HealthzConfig config extra-handler-opts]
+   (let [^InetAddress host (.getHost config)
+         initial-target-message-ids (into {}
+                                          (for [^String db-name (.getDatabaseNames db-cat)
+                                                :let [^Database db (.databaseOrNull db-cat db-name)]
+                                                :when db]
+                                            [db-name [(.getLatestSubmittedMsgId (.getSourceLog db))]]))
+
+         ^Server server (-> (handler (merge {:meter-registry (.getMeterRegistry base)
+                                             :db-cat db-cat
+                                             :initial-target-message-ids initial-target-message-ids}
+                                            extra-handler-opts))
+                            (j/run-jetty {:host (some-> host (.getHostAddress)), :port (.getPort config), :async? true, :join? false}))]
+
+     (log/info "Healthz server started at" (str (.getURI server))
+               "- startup targets:" (pr-str initial-target-message-ids))
+
+     (reify AutoCloseable
+       (close [_]
+         (.stop server)
+         (log/info "Healthz server stopped."))))))
+
 (defmethod ig/expand-key :xtdb/healthz [k ^HealthzConfig config]
-  {k {:host (.getHost config)
-      :port (.getPort config)
+  {k {:config config
       :base (ig/ref :xtdb/base)
       :db-cat (ig/ref :xtdb/db-catalog)
       :node (ig/ref :xtdb/node)}})
 
-(defmethod ig/init-key :xtdb/healthz [_ {:keys [node, ^InetAddress host, ^long port, ^NodeBase base, ^Database$Catalog db-cat]}]
-  (let [initial-target-message-ids (into {}
-                                         (for [^String db-name (.getDatabaseNames db-cat)
-                                               :let [^Database db (.databaseOrNull db-cat db-name)]
-                                               :when db]
-                                           [db-name [(.getLatestSubmittedMsgId (.getSourceLog db))]]))
-
-        ^Server server (-> (handler {:meter-registry (.getMeterRegistry base)
-                                     :db-cat db-cat
-                                     :initial-target-message-ids initial-target-message-ids
-                                     :node node})
-                           (j/run-jetty {:host (some-> host (.getHostAddress)), :port port, :async? true, :join? false}))]
-
-    (log/info "Healthz server started at" (str (.getURI server))
-              "- startup targets:" (pr-str initial-target-message-ids))
-
-    (reify AutoCloseable
-      (close [_]
-        (.stop server)
-        (log/info "Healthz server stopped.")))))
+(defmethod ig/init-key :xtdb/healthz [_ {:keys [config base db-cat node]}]
+  (open-server base db-cat config {:node node}))
 
 (defmethod ig/halt-key! :xtdb/healthz [_ srv]
   (util/close srv))

--- a/core/src/main/kotlin/xtdb/api/IngestNode.kt
+++ b/core/src/main/kotlin/xtdb/api/IngestNode.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
+import xtdb.api.metrics.HealthzConfig
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.database.Database
@@ -15,6 +16,7 @@ import xtdb.database.DatabaseName
 import xtdb.error.Incorrect
 import xtdb.util.closeAll
 import xtdb.util.closeOnCatch
+import xtdb.util.requiringResolve
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID.randomUUID
@@ -24,7 +26,8 @@ import kotlin.io.path.extension
 /**
  * A node that does nothing but ingest from external sources — it runs a [Database] per configured
  * external source, joins leader election, and runs the source only on the database for which it's
- * elected leader. There's no query/client surface: no pgwire, no Flight SQL, no healthz.
+ * elected leader. There's no query/client surface: no pgwire, no Flight SQL — though it can serve
+ * the healthz endpoints ([Config.healthz]) for metrics and liveness.
  *
  * Started either from YAML config (`xtdb.main ingest`, [readConfig]) with registered external sources,
  * or embedded in a custom JVM application that supplies its own indexer programmatically.
@@ -35,6 +38,7 @@ class IngestNode internal constructor(
     private val base: NodeBase,
     private val databases: Map<DatabaseName, Database>,
     private val rootJob: Job,
+    private val healthzServer: AutoCloseable?,
 ) : AutoCloseable {
     private val closing = AtomicBoolean(false)
 
@@ -46,6 +50,9 @@ class IngestNode internal constructor(
 
     override fun close() {
         if (closing.compareAndSet(false, true)) {
+            // healthz first — it reads the databases we're about to free.
+            healthzServer?.close()
+
             // One cancel stops every database's job tree (Phase 1 — the single thread-parking bridge,
             // at node shutdown); then free the databases (each owns its LogProcessor / external source)
             // before the base, which owns the allocator they're children of.
@@ -53,6 +60,19 @@ class IngestNode internal constructor(
             databases.closeAll()
             base.close()
         }
+    }
+
+    // healthz reports on a Database.Catalog; the ingest node deliberately has no DatabaseCatalog,
+    // so it hands healthz a fixed, read-only view over the databases opened at boot.
+    private class FixedDbCatalog(private val dbs: Map<DatabaseName, Database>) : Database.Catalog {
+        override val databaseNames get() = dbs.keys
+        override fun databaseOrNull(dbName: DatabaseName) = dbs[dbName]
+
+        override fun attach(dbName: DatabaseName, config: Database.Config?): Unit =
+            error("can't attach a database to an ingest node")
+
+        override fun detach(dbName: DatabaseName): Unit =
+            error("can't detach a database from an ingest node")
     }
 
     @Serializable
@@ -68,6 +88,8 @@ class IngestNode internal constructor(
 
         val memoryCache: MemoryCache.Factory = MemoryCache.Factory(),
         var diskCache: DiskCache.Factory? = null,
+
+        var healthz: HealthzConfig? = null,
 
         val indexer: IndexerConfig = IndexerConfig(),
 
@@ -86,6 +108,8 @@ class IngestNode internal constructor(
 
         fun diskCache(diskCache: DiskCache.Factory?) = apply { this.diskCache = diskCache }
 
+        fun healthz(healthz: HealthzConfig) = apply { this.healthz = healthz }
+
         @JvmSynthetic
         fun indexer(configure: IndexerConfig.() -> Unit) = apply { indexer.configure() }
 
@@ -93,9 +117,9 @@ class IngestNode internal constructor(
 
         /**
          * The base components ([NodeBase]) are assembled from an [Xtdb.Config] with no client surface
-         * (`server`, `flightSql`, `healthz` all null). The ingest databases aren't expressed here —
-         * [open] attaches them directly, bypassing the [xtdb.database.DatabaseCatalog] and its "xtdb"
-         * primary entirely.
+         * (`server`, `flightSql`, `healthz` all null — healthz is served by the ingest node itself,
+         * not through the base config). The ingest databases aren't expressed here — [open] attaches
+         * them directly, bypassing the [xtdb.database.DatabaseCatalog] and its "xtdb" primary entirely.
          */
         private fun toBaseConfig(): Xtdb.Config =
             Xtdb.Config(
@@ -131,9 +155,14 @@ class IngestNode internal constructor(
                 val rootJob = SupervisorJob()
                 val rootScope = CoroutineScope(rootJob)
                 val openedDbs = LinkedHashMap<DatabaseName, Database>()
+                val healthzServer: AutoCloseable?
                 try {
                     for ((dbName, dbConfig) in databases)
                         openedDbs[dbName] = Database.open(base, dbName, dbConfig, base.compactor, rootScope)
+
+                    healthzServer = healthz?.let {
+                        openHealthzServer.invoke(base, FixedDbCatalog(openedDbs), it) as AutoCloseable
+                    }
                 } catch (t: Throwable) {
                     // Cancel the job tree (Phase 1) before freeing the already-opened databases
                     // (Phase 2) — closing them while their coroutines still run would free
@@ -142,12 +171,14 @@ class IngestNode internal constructor(
                     openedDbs.values.closeAll()
                     throw t
                 }
-                IngestNode(base, openedDbs, rootJob)
+                IngestNode(base, openedDbs, rootJob, healthzServer)
             }
         }
     }
 
     companion object {
+        private val openHealthzServer by lazy { requiringResolve("xtdb.healthz/open-server") }
+
         @JvmStatic
         fun readConfig(path: Path): Config {
             if (path.extension != "yaml") {

--- a/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import xtdb.api.metrics.HealthzConfig
 import xtdb.error.Incorrect
 import xtdb.api.log.Log
 import xtdb.api.storage.Storage
@@ -12,6 +13,11 @@ import xtdb.database.ExternalSource
 import xtdb.database.ExternalSourceToken
 import xtdb.indexer.TxIndexer
 import xtdb.indexer.TxIndexer.TxResult
+import java.net.ServerSocket
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -92,6 +98,34 @@ class IngestNodeTest {
                 assertTrue(ordersIndexed.await(30, TimeUnit.SECONDS), "orders source ran")
                 assertTrue(paymentsIndexed.await(30, TimeUnit.SECONDS), "payments source ran")
                 assertEquals(setOf("orders", "payments"), leaderFor.toSet())
+            }
+    }
+
+    @Test
+    fun `serves healthz endpoints when configured`() {
+        val indexed = CountDownLatch(1)
+        val source = CountingExternalSource.Factory(1, indexed, ConcurrentLinkedQueue())
+        val port = ServerSocket(0).use { it.localPort }
+
+        IngestNode.Config()
+            .database("orders", extDbConfig(source))
+            .healthz(HealthzConfig(port = port))
+            .open()
+            .use {
+                assertTrue(indexed.await(30, TimeUnit.SECONDS), "the source ran alongside healthz")
+
+                val client = HttpClient.newHttpClient()
+                fun get(path: String): HttpResponse<String> =
+                    client.send(
+                        HttpRequest.newBuilder(URI("http://localhost:$port$path")).build(),
+                        HttpResponse.BodyHandlers.ofString(),
+                    )
+
+                assertEquals(200, get("/healthz/alive").statusCode())
+
+                val metrics = get("/metrics")
+                assertEquals(200, metrics.statusCode())
+                assertTrue(metrics.body().isNotEmpty(), "prometheus scrape returns the node's meters")
             }
     }
 

--- a/docs/src/content/docs/ops/config.md
+++ b/docs/src/content/docs/ops/config.md
@@ -270,7 +270,7 @@ Defaults to UTC.
 
 An ingest-only node runs [external sources](external-sources/overview) and nothing else.
 
-It has no query surface - no Postgres wire-compatible server, no Flight SQL server, no healthz server - making it useful for moving ingestion onto dedicated compute, away from the nodes serving queries.
+It has no query surface - no Postgres wire-compatible server, no Flight SQL server - making it useful for moving ingestion onto dedicated compute, away from the nodes serving queries.
 
 For each configured database, the node joins that database's leader election and runs its external source when elected leader.
 
@@ -302,9 +302,13 @@ databases:
 # Required when any database uses a remote object store
 diskCache:
   path: /var/cache/xtdb
+
+# Serves /metrics and the liveness/readiness probes
+healthz:
+  port: 8080
 ```
 
-The config also accepts [`memoryCache`](#caching), [`indexer`](#indexer) and [node ID](#node-id), with the same semantics as the regular node config.
+The config also accepts [`memoryCache`](#caching), [`indexer`](#indexer), [`healthz`](config/monitoring#healthz-server) and [node ID](#node-id), with the same semantics as the regular node config.
 
 `xtdb` is reserved for the primary database and can't be used as a database name here.
 


### PR DESCRIPTION
Ingest-only nodes (#5795) run headless — no pgwire, no Flight SQL — which also meant no way to scrape their metrics or wire up Kubernetes liveness probes, despite being exactly the kind of long-running deployment that needs them. This PR adds `healthz` to the ingest-node config, starting the same healthz server the full node serves — `/metrics`, `/healthz/started|alive|ready`, `/system/finish-block` — against the ingest node's meter registry and databases.

### Usage

```yaml
databases:
  # ...
healthz:
  port: 8080
```

or programmatically, `IngestNode.Config().healthz(HealthzConfig(port = 8080))`. Documented in the ingest-only-nodes section of the node-config page.

### Implementation notes

The healthz endpoints report over a `Database$Catalog`, which the ingest node deliberately doesn't have — it opens its databases directly, with no attach/detach lifecycle. Rather than growing a real catalog, healthz gets a fixed read-only view over the databases opened at boot (`FixedDbCatalog`; attach/detach throw, same shape as `Catalog.EMPTY`). That's sufficient for every endpoint — startup targets, block lag, ingestion errors and finish-block all only read.

The server is started through `xtdb.healthz/open-server` (extracted from the Integrant component in the first commit) via the same `requiringResolve` bridge `NodeBase` uses for the compactor. The Integrant path's unused `:node` handler opt simply isn't supplied here, rather than passing a nil stand-in. On shutdown the healthz server closes first — its handlers read the databases the node is about to free.

### Changes

1. `tidy(healthz): extract open-server from the ig component` — behaviour-preserving; makes the server lifecycle callable outside Integrant.
2. `feat(ingest-node): support configuring a healthz server` — the config surface, `FixedDbCatalog`, the test, and docs.

### Test plan

- New `IngestNodeTest` case `serves healthz endpoints when configured`: boots an ingest node with healthz on a free port, waits for the source to index, then asserts `/healthz/alive` returns 200 and `/metrics` returns a non-empty Prometheus scrape.
- `xtdb.healthz-test` (full namespace) green after the `open-server` extraction, confirming the tidy commit is behaviour-preserving.

Generated with [Claude Code](https://claude.com/claude-code)