### PR TITLE
fix(adbc,flight-sql): metadata spans every catalog

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -1194,12 +1194,12 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             tableTypes: Array<out String>?,
             columnNamePattern: String?
         ): ArrowReader {
-            val catalogs = dbCat.databaseNames
-                .filter { catalogPattern == null || catalogPattern == "%" || it == catalogPattern }
+            // ADBC's catalogPattern is a SQL LIKE pattern; the shared lister evaluates it via the EE.
+            val catalogs = catalogNames(catalogPattern, exact = false)
 
             // build the payload as nested maps/lists matching GET_OBJECTS_SCHEMA; the typed vector tree comes
-            // from the schema and writeObject fills present keys (omitted keys pad null). only the connection's
-            // current database gets schema detail.
+            // from the schema and writeObject fills present keys (omitted keys pad null). every matching catalog
+            // is expanded to the requested depth, per the ADBC getObjects contract.
             fun tableObj(table: TableInfo): Map<String, Any?> = buildMap {
                 put("table_name", table.name)
                 put("table_type", "TABLE")
@@ -1223,12 +1223,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 for (catalog in catalogs) {
                     catalogNameVec.writeObject(catalog)
 
-                    if (depth == GetObjectsDepth.CATALOGS || catalog != dbName) {
-                        // at CATALOGS depth, or for databases other than the current one, omit schema detail
+                    if (depth == GetObjectsDepth.CATALOGS || dbCat.databaseOrNull(catalog) == null) {
                         dbSchemasVec.writeNull()
                     } else {
                         val schemas =
-                            querySchemas(dbSchemaPattern, tableNamePattern, tableTypes, columnNamePattern, depth)
+                            querySchemas(catalog, dbSchemaPattern, tableNamePattern, tableTypes, columnNamePattern, depth)
                         dbSchemasVec.writeObject(schemas.map { (name, tables) -> schemaObj(name, tables) })
                     }
 
@@ -1237,10 +1236,38 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             }
         }
 
+        // The single catalog (database) enumeration all metadata callers share. Names come from the database
+        // registry; a null or exact filter is applied in-memory, and only a SQL LIKE pattern falls to
+        // pg_catalog.pg_database so the expression engine evaluates it — keeping the common cases off the query
+        // path, which would otherwise materialise a snapshot per database just to return names. The two agree:
+        // pg_database is a view of the same registry.
+        internal fun catalogNames(filter: String?, exact: Boolean): List<String> = when {
+            filter == null -> dbCat.databaseNames.sorted()
+            exact -> if (filter in dbCat.databaseNames) listOf(filter) else emptyList()
+            else -> catalogNamesLike(filter)
+        }
+
+        // A LIKE pattern needs the expression engine, so this one goes through pg_catalog.pg_database — bound
+        // (safe for any pattern) and unchecked (metadata isn't gated by the connection's tx access-mode).
+        private fun catalogNamesLike(pattern: String): List<String> =
+            createStatement("SELECT datname FROM pg_catalog.pg_database WHERE datname LIKE ? ORDER BY datname")
+                .use { stmt ->
+                    stmt.prepare()
+                    Relation.openFromRows(allocator, listOf(mapOf("?_0" to pattern))).use { stmt.bind(it) }
+                    buildList {
+                        stmt.openUncheckedQuery().use { cursor ->
+                            cursor.forEachRemaining { rel ->
+                                for (i in 0 until rel.rowCount) add(rel["datname"].getObject(i).toString())
+                            }
+                        }
+                    }
+                }
+
         internal data class ColumnInfo(val name: String, val dataType: String)
         internal data class TableInfo(val name: String, val columns: List<ColumnInfo>)
 
         internal fun querySchemas(
+            catalog: DatabaseName,
             dbSchemaPattern: String?,
             tableNamePattern: String?,
             tableTypes: Array<out String>?,
@@ -1249,6 +1276,15 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         ): Map<String, List<TableInfo>> {
             // XTDB only has table_type='TABLE' currently
             if (tableTypes != null && "TABLE" !in tableTypes) return emptyMap()
+
+            // A catalog listed a moment ago may have been detached since; skip it rather than letting the
+            // per-catalog prepare throw and abort a cross-catalog caller (getObjects, the FlightSQL handlers).
+            if (dbCat.databaseOrNull(catalog) == null) return emptyMap()
+
+            // resolve information_schema against `catalog`, not the connection's own database — openStatement's
+            // targetDb scopes it (information_schema is per-database); openUncheckedQuery so metadata reads
+            // aren't gated by the connection's transaction access-mode.
+            fun runOnCatalog(sql: String) = openStatement(parseStatement(sql), catalog).openUncheckedQuery()
 
             val conditions = mutableListOf<String>()
             dbSchemaPattern?.let { conditions.add("table_schema LIKE '${it.replace("'", "''")}'") }
@@ -1259,7 +1295,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
             if (depth == GetObjectsDepth.DB_SCHEMAS) {
                 val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
                 val result = linkedMapOf<String, List<TableInfo>>()
-                openSqlQuery(sql).use { cursor ->
+                runOnCatalog(sql).use { cursor ->
                     cursor.forEachRemaining { rel ->
                         for (i in 0 until rel.rowCount) {
                             result[rel["table_schema"].getObject(i).toString()] = emptyList()
@@ -1283,7 +1319,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
             if (needColumns) {
                 val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-                openSqlQuery(sql).use { cursor ->
+                runOnCatalog(sql).use { cursor ->
                     cursor.forEachRemaining { rel ->
                         for (i in 0 until rel.rowCount) {
                             val schema = rel["table_schema"].getObject(i).toString()
@@ -1300,7 +1336,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                         .add(TableInfo(key.second, cols))
                 }
             } else {
-                openSqlQuery(sql).use { cursor ->
+                runOnCatalog(sql).use { cursor ->
                     cursor.forEachRemaining { rel ->
                         for (i in 0 until rel.rowCount) {
                             val schema = rel["table_schema"].getObject(i).toString()

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -708,7 +708,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         val schemaNames =
             if (catalogFilter != null && catalogFilter != dbName) emptyList()
             else connectionFor(ctx, dbName)
-                .querySchemas(schemaFilter, null, null, null, GetObjectsDepth.DB_SCHEMAS)
+                .querySchemas(dbName, schemaFilter, null, null, null, GetObjectsDepth.DB_SCHEMAS)
                 .keys.toList()
 
         singleBatchStream(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA, listener) { root ->
@@ -747,7 +747,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         // querySchemas owns the TABLE-type filter (XTDB only has TABLE) and the LIKE-escaped filters
         val tables =
             if (catalogFilter != null && catalogFilter != dbName) emptyList()
-            else conn.querySchemas(schemaFilter, tableFilter, typeFilters?.toTypedArray(), null, GetObjectsDepth.TABLES)
+            else conn.querySchemas(dbName, schemaFilter, tableFilter, typeFilters?.toTypedArray(), null, GetObjectsDepth.TABLES)
                 .flatMap { (dbSchemaName, ts) -> ts.map { dbSchemaName to it.name } }
 
         singleBatchStream(schema, listener) { root ->

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -683,7 +683,8 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     ): FlightInfo = metadataFlightInfo(request, FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA, descriptor)
 
     override fun getStreamCatalogs(ctx: CallContext?, listener: ServerStreamListener) {
-        val dbNames = node.databaseNames
+        // through the shared catalogNames (no filter) so all three metadata handlers enumerate catalogs one way
+        val dbNames = connectionFor(ctx, resolveDb(ctx)).catalogNames(null, exact = true)
 
         singleBatchStream(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA, listener) { root ->
             val vec = root.getVector("catalog_name") as VarCharVector
@@ -705,20 +706,21 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         val catalogFilter = if (command.hasCatalog()) command.catalog else null
         val schemaFilter = if (command.hasDbSchemaFilterPattern()) command.dbSchemaFilterPattern else null
 
-        val schemaNames =
-            if (catalogFilter != null && catalogFilter != dbName) emptyList()
-            else connectionFor(ctx, dbName)
-                .querySchemas(dbName, schemaFilter, null, null, null, GetObjectsDepth.DB_SCHEMAS)
-                .keys.toList()
+        val conn = connectionFor(ctx, dbName)
+        // FlightSQL's catalog is an exact filter (absent = every catalog); each row keeps its own catalog.
+        val rows = conn.catalogNames(catalogFilter, exact = true).flatMap { catalog ->
+            conn.querySchemas(catalog, schemaFilter, null, null, null, GetObjectsDepth.DB_SCHEMAS)
+                .keys.map { catalog to it }
+        }
 
         singleBatchStream(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA, listener) { root ->
             val catalogVec = root.getVector("catalog_name") as VarCharVector
             val schemaVec = root.getVector("db_schema_name") as VarCharVector
-            schemaNames.forEachIndexed { idx, name ->
-                catalogVec.setSafe(idx, dbName.toByteArray())
+            rows.forEachIndexed { idx, (catalog, name) ->
+                catalogVec.setSafe(idx, catalog.toByteArray())
                 schemaVec.setSafe(idx, name.toByteArray())
             }
-            root.rowCount = schemaNames.size
+            root.rowCount = rows.size
         }
     }
 
@@ -744,11 +746,12 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
 
         val conn = connectionFor(ctx, dbName)
 
-        // querySchemas owns the TABLE-type filter (XTDB only has TABLE) and the LIKE-escaped filters
-        val tables =
-            if (catalogFilter != null && catalogFilter != dbName) emptyList()
-            else conn.querySchemas(dbName, schemaFilter, tableFilter, typeFilters?.toTypedArray(), null, GetObjectsDepth.TABLES)
-                .flatMap { (dbSchemaName, ts) -> ts.map { dbSchemaName to it.name } }
+        // querySchemas owns the TABLE-type filter (XTDB only has TABLE) and the LIKE-escaped filters.
+        // FlightSQL's catalog is an exact filter (absent = every catalog); each row keeps its own catalog.
+        val rows = conn.catalogNames(catalogFilter, exact = true).flatMap { catalog ->
+            conn.querySchemas(catalog, schemaFilter, tableFilter, typeFilters?.toTypedArray(), null, GetObjectsDepth.TABLES)
+                .flatMap { (dbSchemaName, ts) -> ts.map { Triple(catalog, dbSchemaName, it.name) } }
+        }
 
         singleBatchStream(schema, listener) { root ->
             val catalogVec = root.getVector("catalog_name") as VarCharVector
@@ -758,8 +761,8 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
             val tableSchemaVec =
                 if (command.includeSchema) root.getVector("table_schema") as VarBinaryVector else null
 
-            tables.forEachIndexed { idx, (dbSchemaName, tableName) ->
-                catalogVec.setSafe(idx, dbName.toByteArray())
+            rows.forEachIndexed { idx, (catalog, dbSchemaName, tableName) ->
+                catalogVec.setSafe(idx, catalog.toByteArray())
                 schemaVec.setSafe(idx, dbSchemaName.toByteArray())
                 tableVec.setSafe(idx, tableName.toByteArray())
                 typeVec.setSafe(idx, "TABLE".toByteArray())
@@ -767,12 +770,12 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
                 if (tableSchemaVec != null) {
                     tableSchemaVec.setSafe(
                         idx,
-                        conn.getTableSchema(dbName, dbSchemaName, tableName)
+                        conn.getTableSchema(catalog, dbSchemaName, tableName)
                             .serializeAsMessageInterruptibly()
                     )
                 }
             }
-            root.rowCount = tables.size
+            root.rowCount = rows.size
         }
     }
 

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.api.Xtdb
+import xtdb.database.Database
 import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation
 import java.time.ZonedDateTime
@@ -208,6 +209,56 @@ class FlightSqlAdbcTest {
 
         val tableNames = rows.map { it["table_name"] }
         assertTrue("tables_test" in tableNames, "Expected 'tables_test' in $tableNames")
+    }
+
+    private fun attachNewDbWithWidgets() {
+        xtdb.connect().use { it.attachDb("new_db", Database.Config()) }
+        xtdb.connect("new_db").use { c ->
+            c.createStatement().use { it.setSqlQuery("INSERT INTO widgets (_id, w) VALUES (1, 2)"); it.executeUpdate() }
+        }
+    }
+
+    @Test
+    fun `getSchemas and getTables span catalogs`() {
+        insertData("INSERT INTO tables_test (_id) VALUES (1)")
+        attachNewDbWithWidgets()
+
+        val schemaRows = fsqlClient.getSchemas(null, null, *emptyCallOpts).readRows()
+        assertTrue(
+            schemaRows.any { it["catalog_name"] == "new_db" && it["db_schema_name"] == "public" },
+            "new_db's schemas appear over the wire: $schemaRows"
+        )
+
+        val widgetRows = fsqlClient.getTables(null, null, null, null, false, *emptyCallOpts)
+            .readRows().filter { it["table_name"] == "widgets" }
+        assertEquals(
+            listOf("new_db"), widgetRows.map { it["catalog_name"] },
+            "widgets is reported under new_db, not the connection's own catalog"
+        )
+
+        val newDbOnly = fsqlClient.getTables("new_db", null, null, null, false, *emptyCallOpts).readRows()
+        assertEquals(
+            setOf("new_db"), newDbOnly.map { it["catalog_name"] }.toSet(),
+            "an exact catalog filter restricts to that catalog"
+        )
+        assertTrue(newDbOnly.none { it["table_name"] == "tables_test" })
+    }
+
+    @Test
+    fun `getTables includeSchema resolves a table in another catalog`() {
+        attachNewDbWithWidgets()
+
+        val info = fsqlClient.getTables("new_db", null, "widgets", null, true, *emptyCallOpts)
+        fsqlClient.getStream(info.endpoints.first().ticket, *emptyCallOpts).use { stream ->
+            assertTrue(stream.next())
+            val root = stream.root
+            val schemaVec = root.getVector("table_schema") as VarBinaryVector
+            val rowIdx = (0 until root.rowCount).first {
+                (root.getVector("table_name").getObject(it) as? Text)?.toString() == "widgets"
+            }
+            val bytes = schemaVec.getObject(rowIdx) ?: error("table_schema bytes were null")
+            assertEquals(setOf("_id", "w"), bytes.deserialiseArrowSchema().fields.map { it.name }.toSet())
+        }
     }
 
     @Test

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -1,8 +1,11 @@
 package xtdb
 
+import org.apache.arrow.adbc.core.AdbcConnection.GetObjectsDepth
 import org.apache.arrow.adbc.core.AdbcStatement
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,6 +21,7 @@ import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation
 import xtdb.arrow.VectorType.Companion.I64
 import xtdb.arrow.VectorType.Companion.ofType
+import xtdb.database.Database
 import xtdb.database.encodeTimeBasisToken
 import java.time.Instant
 import java.util.UUID
@@ -849,6 +853,94 @@ class InProcessAdbcTest {
                 listOf(mapOf("_id" to 2L)), conn.select("SELECT _id FROM foo ORDER BY _id"),
                 "DELETE isn't statically expandable — it submits the raw Sql op, expanded at index time"
             )
+        }
+    }
+
+    // -- getObjects / getTableSchema across catalogs (databases) --
+
+    private fun Any?.asList() = this as List<*>
+    private fun Any?.asMap() = this as Map<*, *>
+
+    private fun VectorSchemaRoot.publicTables(catalog: String): Set<String> {
+        val row = (0 until rowCount).first { getVector("catalog_name").getObject(it).toString() == catalog }
+        val schemas = (getVector("catalog_db_schemas") as ListVector).getObject(row).asList()
+        val public = schemas.first { it.asMap()["db_schema_name"].toString() == "public" }.asMap()
+        return public["db_schema_tables"].asList().map { it.asMap()["table_name"].toString() }.toSet()
+    }
+
+    @Test
+    fun `getObjects expands every catalog, not just the connected one`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}")
+        xtdb.connect().use { it.attachDb("new_db", Database.Config()) }
+        xtdb.connect("new_db").use { it.update("INSERT INTO bar RECORDS {_id: 2}") }
+
+        xtdb.connect().use { conn ->
+            conn.getObjects(GetObjectsDepth.ALL, null, null, null, null, null).use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                val root = rdr.vectorSchemaRoot
+
+                val catalogs = (0 until root.rowCount)
+                    .map { root.getVector("catalog_name").getObject(it).toString() }.toSet()
+                assertEquals(setOf("new_db", "xtdb"), catalogs, "every catalog is listed")
+
+                assertTrue("foo" in root.publicTables("xtdb"))
+                assertTrue("bar" in root.publicTables("new_db"),
+                    "a catalog other than the connection's own is expanded with its own tables")
+                assertTrue("bar" !in root.publicTables("xtdb"))
+                assertTrue("foo" !in root.publicTables("new_db"))
+            }
+        }
+    }
+
+    @Test
+    fun `getObjects catalogPattern filters catalogs via SQL LIKE`() {
+        xtdb.connect().use { it.attachDb("new_db", Database.Config()) }
+
+        xtdb.connect().use { conn ->
+            conn.getObjects(GetObjectsDepth.CATALOGS, "new%", null, null, null, null).use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                val root = rdr.vectorSchemaRoot
+                val catalogs = (0 until root.rowCount)
+                    .map { root.getVector("catalog_name").getObject(it).toString() }.toSet()
+                assertEquals(setOf("new_db"), catalogs, "LIKE 'new%' matches new_db, not xtdb")
+            }
+        }
+    }
+
+    @Test
+    fun `getObjects is not gated by the connection's transaction access-mode`() {
+        xtdb.connect().use { conn ->
+            conn.beginWriteOnly()
+            conn.getObjects(GetObjectsDepth.CATALOGS, null, null, null, null, null).use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                val root = rdr.vectorSchemaRoot
+                assertEquals(setOf("xtdb"), (0 until root.rowCount)
+                    .map { root.getVector("catalog_name").getObject(it).toString() }.toSet())
+            }
+        }
+    }
+
+    @Test
+    fun `getObjects tolerates a catalogPattern that isn't a valid SQL string literal`() {
+        // a newline can't appear in a raw SQL string literal; the pattern is bound as a parameter, so this
+        // returns no match rather than throwing a parse error
+        xtdb.connect().use { conn ->
+            conn.getObjects(GetObjectsDepth.CATALOGS, "no\nsuch", null, null, null, null).use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                assertEquals(0, rdr.vectorSchemaRoot.rowCount)
+            }
+        }
+    }
+
+    @Test
+    fun `getTableSchema resolves a table in another catalog`() {
+        xtdb.connect().use { it.attachDb("new_db", Database.Config()) }
+        xtdb.connect("new_db").use { it.update("INSERT INTO bar RECORDS {_id: 2, b: 'x'}") }
+
+        xtdb.connect().use { conn ->
+            val schema = conn.getTableSchema("new_db", "public", "bar")
+            assertEquals(setOf("_id", "b"), schema.fields.map { it.name }.toSet(),
+                "resolves against the named catalog, not the connection's own db")
         }
     }
 }


### PR DESCRIPTION
XTDB serves many databases per node, and each surfaces to a client as a catalog — but the metadata calls only ever described the *connected* database.
ADBC `getObjects` listed every catalog's name yet returned null schemas for all but the connection's own; the FlightSQL `GetDbSchemas`/`GetTables` handlers came back empty for a request scoped to any other catalog.
So a client browsing a multi-database node could enumerate the database names but only ever see the tables of the one it connected to — a deviation from both the ADBC `getObjects` contract (the full catalog → schema → table → column tree) and the FlightSQL command semantics (which take a `catalog` filter).

Both surfaces now expand every catalog a request selects.
The schema/table/column detail comes from `information_schema`, which resolves against a query's default database, so `getObjects` runs it once per catalog, targeting each in turn.
Catalog enumeration is unified behind a single `Connection.catalogNames` helper that every metadata caller shares: an in-memory registry read for the no-filter and exact-match cases, falling to a `pg_catalog.pg_database` query (with the pattern *bound*, not interpolated) only when a `LIKE` pattern actually needs the expression engine.
One enumeration path serves both filter contracts — ADBC's `catalogPattern` is a `LIKE` pattern, FlightSQL's `catalog` is exact.

The FlightSQL producer stays a thin projection over the shared Connection primitives (`catalogNames`, `querySchemas`, `getTableSchema`) rather than re-implementing metadata or routing through `getObjects`.
That keeps the ADBC Connection as the one internal metadata API, so the two surfaces can't disagree about what exists — they read the same primitives and only assemble them into their respective nested-vs-flat shapes.
The per-connection scoping special-case the wire handlers used to carry is gone.

Two smaller calls worth flagging for review: a catalog detached between enumeration and its per-catalog query is skipped (via `databaseOrNull`) rather than aborting the whole call; and metadata reads run unchecked, so introspection isn't gated by an open write transaction's access-mode.

Conformance was checked against the `AdbcConnection` javadoc and the FlightSql proto docstrings for the metadata commands, with cross-catalog coverage added to `InProcessAdbcTest`, `FlightSqlAdbcTest`, `AdbcTest` and `multi_db_test`.

Deliberately out of scope: `getObjects`'s schema/table/column filters (`dbSchemaPattern`/`tableNamePattern`/`columnNamePattern`) are pre-existing and spec-correct, but inlined-with-escaping rather than bound, and thinly tested.
Parameterizing them to match the catalog filter (shedding the same fragility on patterns that aren't valid SQL string literals) and adding filter/exclusion tests is a follow-up.