### PR TITLE
fix(adbc,flight-sql): bind the schema/table/column metadata filters

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -1231,52 +1231,54 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
             // resolve information_schema against `catalog`, not the connection's own database — openStatement's
             // targetDb scopes it (information_schema is per-database); openUncheckedQuery so metadata reads
-            // aren't gated by the connection's transaction access-mode.
-            fun runOnCatalog(sql: String) = openStatement(parseStatement(sql), catalog).openUncheckedQuery()
+            // aren't gated by the connection's transaction access-mode. Filter patterns bind to the `?`s in
+            // `sql` positionally, in `params` order — never interpolated, so any pattern is safe (a raw literal
+            // would choke the lexer on e.g. a newline). Each condition and its param below are appended in lockstep.
+            fun runOnCatalog(sql: String, params: List<String>, onRow: (RelationReader) -> Unit) =
+                openStatement(parseStatement(sql), catalog).use { stmt ->
+                    if (params.isNotEmpty()) {
+                        stmt.prepare()
+                        Relation.openFromRows(allocator, listOf(params.withIndex().associate { (i, p) -> "?_$i" to p }))
+                            .use { stmt.bind(it) }
+                    }
+                    stmt.openUncheckedQuery().use { cursor -> cursor.forEachRemaining { onRow(it) } }
+                }
 
             val conditions = mutableListOf<String>()
-            dbSchemaPattern?.let { conditions.add("table_schema LIKE '${it.replace("'", "''")}'") }
-            tableNamePattern?.let { conditions.add("table_name LIKE '${it.replace("'", "''")}'") }
+            val params = mutableListOf<String>()
+            dbSchemaPattern?.let { conditions += "table_schema LIKE ?"; params += it }
+            tableNamePattern?.let { conditions += "table_name LIKE ?"; params += it }
 
-            val where = if (conditions.isNotEmpty()) "WHERE ${conditions.joinToString(" AND ")}" else ""
+            fun whereOf(conds: List<String>) = if (conds.isEmpty()) "" else "WHERE ${conds.joinToString(" AND ")}"
 
             if (depth == GetObjectsDepth.DB_SCHEMAS) {
-                val sql = "SELECT DISTINCT table_schema FROM information_schema.tables $where ORDER BY table_schema"
+                val sql = "SELECT DISTINCT table_schema FROM information_schema.tables ${whereOf(conditions)} ORDER BY table_schema"
                 val result = linkedMapOf<String, List<TableInfo>>()
-                runOnCatalog(sql).use { cursor ->
-                    cursor.forEachRemaining { rel ->
-                        for (i in 0 until rel.rowCount) {
-                            result[rel["table_schema"].getObject(i).toString()] = emptyList()
-                        }
+                runOnCatalog(sql, params) { rel ->
+                    for (i in 0 until rel.rowCount) {
+                        result[rel["table_schema"].getObject(i).toString()] = emptyList()
                     }
                 }
                 return result
             }
 
-            val needColumns = depth == GetObjectsDepth.ALL
-            val sql = if (needColumns) {
-                val colConditions = conditions.toMutableList()
-                columnNamePattern?.let { colConditions.add("column_name LIKE '${it.replace("'", "''")}'") }
-                val colWhere = if (colConditions.isNotEmpty()) "WHERE ${colConditions.joinToString(" AND ")}" else ""
-                "SELECT table_schema, table_name, column_name, data_type FROM information_schema.columns $colWhere ORDER BY table_schema, table_name, ordinal_position"
-            } else {
-                "SELECT DISTINCT table_schema, table_name FROM information_schema.tables $where ORDER BY table_schema, table_name"
-            }
-
             val result = linkedMapOf<String, MutableList<TableInfo>>()
 
-            if (needColumns) {
+            if (depth == GetObjectsDepth.ALL) {
+                val colConditions = conditions + listOfNotNull(columnNamePattern?.let { "column_name LIKE ?" })
+                val colParams = params + listOfNotNull(columnNamePattern)
+                val sql = "SELECT table_schema, table_name, column_name, data_type FROM information_schema.columns ${whereOf(colConditions)} ORDER BY table_schema, table_name, ordinal_position"
+
+                // information_schema.columns is one row per column; gather each table's columns, then fold into TableInfos
                 val tableColumns = linkedMapOf<Pair<String, String>, MutableList<ColumnInfo>>()
-                runOnCatalog(sql).use { cursor ->
-                    cursor.forEachRemaining { rel ->
-                        for (i in 0 until rel.rowCount) {
-                            val schema = rel["table_schema"].getObject(i).toString()
-                            val table = rel["table_name"].getObject(i).toString()
-                            val column = rel["column_name"].getObject(i).toString()
-                            val dataType = rel["data_type"].getObject(i).toString()
-                            tableColumns.getOrPut(schema to table) { mutableListOf() }
-                                .add(ColumnInfo(column, dataType))
-                        }
+                runOnCatalog(sql, colParams) { rel ->
+                    for (i in 0 until rel.rowCount) {
+                        val schema = rel["table_schema"].getObject(i).toString()
+                        val table = rel["table_name"].getObject(i).toString()
+                        val column = rel["column_name"].getObject(i).toString()
+                        val dataType = rel["data_type"].getObject(i).toString()
+                        tableColumns.getOrPut(schema to table) { mutableListOf() }
+                            .add(ColumnInfo(column, dataType))
                     }
                 }
                 for ((key, cols) in tableColumns) {
@@ -1284,14 +1286,13 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                         .add(TableInfo(key.second, cols))
                 }
             } else {
-                runOnCatalog(sql).use { cursor ->
-                    cursor.forEachRemaining { rel ->
-                        for (i in 0 until rel.rowCount) {
-                            val schema = rel["table_schema"].getObject(i).toString()
-                            val table = rel["table_name"].getObject(i).toString()
-                            result.getOrPut(schema) { mutableListOf() }
-                                .add(TableInfo(table, emptyList()))
-                        }
+                val sql = "SELECT DISTINCT table_schema, table_name FROM information_schema.tables ${whereOf(conditions)} ORDER BY table_schema, table_name"
+                runOnCatalog(sql, params) { rel ->
+                    for (i in 0 until rel.rowCount) {
+                        val schema = rel["table_schema"].getObject(i).toString()
+                        val table = rel["table_name"].getObject(i).toString()
+                        result.getOrPut(schema) { mutableListOf() }
+                            .add(TableInfo(table, emptyList()))
                     }
                 }
             }

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -262,6 +262,39 @@ class FlightSqlAdbcTest {
     }
 
     @Test
+    fun `getSchemas db_schema_filter_pattern excludes non-matching schemas`() {
+        insertData("INSERT INTO foo (_id) VALUES (1)")
+        insertData("INSERT INTO reporting.bar (_id) VALUES (1)")
+
+        val schemaNames = fsqlClient.getSchemas(null, "reporting", *emptyCallOpts).readRows()
+            .map { it["db_schema_name"] }.toSet()
+        assertEquals(setOf("reporting"), schemaNames)
+    }
+
+    @Test
+    fun `getTables filters by db_schema and table_name patterns`() {
+        insertData("INSERT INTO foo (_id) VALUES (1)")
+        insertData("INSERT INTO reporting.bar (_id) VALUES (1)")
+
+        val bySchema = fsqlClient.getTables(null, "reporting", null, null, false, *emptyCallOpts)
+            .readRows().map { it["table_name"] }.toSet()
+        assertEquals(setOf("bar"), bySchema)
+
+        val byName = fsqlClient.getTables(null, null, "foo", null, false, *emptyCallOpts)
+            .readRows().map { it["table_name"] }.toSet()
+        assertEquals(setOf("foo"), byName)
+    }
+
+    @Test
+    fun `getTables with an empty catalog string matches no catalog`() {
+        insertData("INSERT INTO foo (_id) VALUES (1)")
+
+        // FlightSQL: an empty catalog string selects objects "without a catalog"; XTDB has none.
+        val rows = fsqlClient.getTables("", null, null, null, false, *emptyCallOpts).readRows()
+        assertTrue(rows.isEmpty(), "empty catalog matches nothing: $rows")
+    }
+
+    @Test
     fun `test FlightSQL getSqlInfo`() {
         val rows = fsqlClient.getSqlInfo(intArrayOf(), *emptyCallOpts).readRows()
         assertTrue(rows.isNotEmpty(), "Expected at least one info row")

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -861,11 +861,24 @@ class InProcessAdbcTest {
     private fun Any?.asList() = this as List<*>
     private fun Any?.asMap() = this as Map<*, *>
 
-    private fun VectorSchemaRoot.publicTables(catalog: String): Set<String> {
+    private fun VectorSchemaRoot.dbSchemasOf(catalog: String): List<Map<*, *>> {
         val row = (0 until rowCount).first { getVector("catalog_name").getObject(it).toString() == catalog }
-        val schemas = (getVector("catalog_db_schemas") as ListVector).getObject(row).asList()
-        val public = schemas.first { it.asMap()["db_schema_name"].toString() == "public" }.asMap()
-        return public["db_schema_tables"].asList().map { it.asMap()["table_name"].toString() }.toSet()
+        return (getVector("catalog_db_schemas") as ListVector).getObject(row).asList().map { it.asMap() }
+    }
+
+    private fun VectorSchemaRoot.schemaNames(catalog: String): Set<String> =
+        dbSchemasOf(catalog).map { it["db_schema_name"].toString() }.toSet()
+
+    private fun VectorSchemaRoot.tablesOf(catalog: String, schema: String): Set<String> =
+        dbSchemasOf(catalog).first { it["db_schema_name"].toString() == schema }["db_schema_tables"]
+            .asList().map { it.asMap()["table_name"].toString() }.toSet()
+
+    private fun VectorSchemaRoot.publicTables(catalog: String) = tablesOf(catalog, "public")
+
+    private fun VectorSchemaRoot.columnsOf(catalog: String, schema: String, table: String): Set<String> {
+        val tables = dbSchemasOf(catalog).first { it["db_schema_name"].toString() == schema }["db_schema_tables"].asList()
+        return tables.first { it.asMap()["table_name"].toString() == table }.asMap()["table_columns"]
+            .asList().map { it.asMap()["column_name"].toString() }.toSet()
     }
 
     @Test
@@ -941,6 +954,46 @@ class InProcessAdbcTest {
             val schema = conn.getTableSchema("new_db", "public", "bar")
             assertEquals(setOf("_id", "b"), schema.fields.map { it.name }.toSet(),
                 "resolves against the named catalog, not the connection's own db")
+        }
+    }
+
+    @Test
+    fun `getObjects dbSchemaPattern filters schemas via SQL LIKE`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}")
+        insertData("INSERT INTO reporting.bar RECORDS {_id: 1}")
+
+        xtdb.connect().use { conn ->
+            conn.getObjects(GetObjectsDepth.TABLES, null, "reporting", null, null, null).use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                val root = rdr.vectorSchemaRoot
+                assertEquals(setOf("reporting"), root.schemaNames("xtdb"))
+                assertEquals(setOf("bar"), root.tablesOf("xtdb", "reporting"))
+            }
+        }
+    }
+
+    @Test
+    fun `getObjects tableNamePattern filters tables via SQL LIKE`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1}")
+        insertData("INSERT INTO bar RECORDS {_id: 1}")
+
+        xtdb.connect().use { conn ->
+            conn.getObjects(GetObjectsDepth.TABLES, null, null, "foo", null, null).use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                assertEquals(setOf("foo"), rdr.vectorSchemaRoot.tablesOf("xtdb", "public"))
+            }
+        }
+    }
+
+    @Test
+    fun `getObjects columnNamePattern filters columns via SQL LIKE`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1, name: 'a', age: 2}")
+
+        xtdb.connect().use { conn ->
+            conn.getObjects(GetObjectsDepth.ALL, null, null, "foo", null, "name").use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                assertEquals(setOf("name"), rdr.vectorSchemaRoot.columnsOf("xtdb", "public", "foo"))
+            }
         }
     }
 }

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -996,4 +996,18 @@ class InProcessAdbcTest {
             }
         }
     }
+
+    @Test
+    fun `getObjects tolerates schema table column patterns that aren't valid SQL string literals`() {
+        insertData("INSERT INTO foo RECORDS {_id: 1, name: 'a'}")
+
+        // a newline can't appear in a raw SQL string literal; the patterns are bound as parameters, so these
+        // match nothing rather than throwing a parse error — cf. the catalogPattern case above
+        xtdb.connect().use { conn ->
+            conn.getObjects(GetObjectsDepth.ALL, null, "n\no", "n\no", null, "n\no").use { rdr ->
+                assertTrue(rdr.loadNextBatch())
+                assertEquals(emptySet<String>(), rdr.vectorSchemaRoot.schemaNames("xtdb"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to the cross-catalog metadata fix (#5799), which parameterised the catalog filter but left the schema/table/column filters behind it inlined — flagged there as a separate change. This is that change.

## Context

`getObjects` (ADBC) and `getSchemas`/`getTables` (FlightSQL) filter schema/table/column names with SQL `LIKE`, by routing an information_schema query through the engine. The catalog pattern was bound as a parameter when the cross-catalog work landed, but the other three — `dbSchemaPattern`, `tableNamePattern`, `columnNamePattern` — were still spliced into the query text with quote-escaping:

```kotlin
conditions.add("table_schema LIKE '${it.replace("'", "''")}'")
```

Escaping the quote stops breakout, but not patterns that can't be a raw SQL string literal at all: a newline chokes XTDB's lexer, so a newline in one of these threw a parse error rather than matching nothing — where the catalog filter, being bound, just matched nothing. They were also untested; every existing `getObjects` call passed `null` for them.

## The change

Two commits, in reading order:

1. `test(…)` — characterization tests first, pinning current behaviour so the refactor is demonstrably behaviour-preserving: each pattern narrows to the matching schema/table/column, a non-matching pattern excludes, and the FlightSQL empty-catalog edge returns nothing.
2. `fix(…)` — the filters now build the `WHERE` from fixed fragments (`table_schema LIKE ?`) and bind the values, the shape `catalogNamesLike` already uses. The newline case that would have thrown against the old SQL is tested here and now matches nothing.

Conditions are emitted only for filters the caller actually passed, so a no-filter call runs no predicate. `runOnCatalog` also now `use`s the statement it opens, closing a gap where the per-catalog statement leaked.

## Alternatives considered

- **Always emit `LIKE ?`, bind `%` for absent filters** — fully static query, no conditional assembly, but evaluates a match-all predicate per row on `getObjects(ALL, null, …)`, which already fans out over every catalog. Rejected: no reason to pay for a filter that filters nothing on the hot path.
- **Drop SQL, read the catalog directly** (as `getTableSchema`/`getColumnTypes` do for one table) — removes query-building entirely, but means re-implementing `LIKE` ourselves, which is exactly what routing through the engine buys us. Rejected as a much bigger change that re-opens a settled decision.

## Invariant

Patterns bind positionally (`?_0`/`?_1`/`?_2` ← the `?`s left-to-right), so each condition and its parameter are appended in lockstep. A wrong count errors at runtime; a swap would silently filter the wrong column — hence the comment. XTDB SQL has no named parameters (only `?` / `$n`), so positional is the only option — and it's within the ADBC contract, where parameters are ordinal and names optional.

## Test plan

`InProcessAdbcTest` + `FlightSqlAdbcTest` — 109 tests green, no reflection/boxed-math warnings. Behaviour-preserving for every realistic pattern (the characterization tests); the sole behavioural change is that a pattern which isn't a valid SQL string literal now matches nothing instead of throwing.