### PR TITLE
tidy(log): widen Log<M> for partition-awareness (#5557)

### DIFF
--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -139,7 +139,7 @@
                                                    (try
                                                      (doseq [^Database db dbs]
                                                        (let [flush-msg (SourceMessage$FlushBlock. (or (.getCurrentBlockIndex (.getBlockCatalog db)) -1))]
-                                                         (.appendMessageBlocking (.getSourceLog db) flush-msg)))
+                                                         (.appendMessageBlocking (.getSourceLog db) flush-msg 0)))
                                                      {:status 200,
                                                       :body (format "Block flush message sent to %d database(s)." (count dbs))}
                                                      (catch Exception e
@@ -182,7 +182,7 @@
                                           (for [^String db-name (.getDatabaseNames db-cat)
                                                 :let [^Database db (.databaseOrNull db-cat db-name)]
                                                 :when db]
-                                            [db-name [(.getLatestSubmittedMsgId (.getSourceLog db))]]))
+                                            [db-name [(.latestSubmittedMsgId (.getSourceLog db) 0)]]))
 
          ^Server server (-> (handler (merge {:meter-registry (.getMeterRegistry base)
                                              :db-cat db-cat

--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -92,7 +92,7 @@
   (.awaitSourceBlocking db msg-id timeout))
 
 (defn sync-db [^Database db, ^Duration timeout]
-  (let [msg-id (.getLatestSubmittedMsgId (.getSourceLog db))]
+  (let [msg-id (.latestSubmittedMsgId (.getSourceLog db) 0)]
     (await-source db msg-id timeout)))
 
 (defn await-node [node token timeout]

--- a/core/src/main/clojure/xtdb/log_tables.clj
+++ b/core/src/main/clojure/xtdb/log_tables.clj
@@ -241,7 +241,7 @@
                               (case lower-op :>= v, :> (inc v))))
           to-msg-id (long (let [v (long upper-val)]
                             (case upper-op :<= (inc v), :< v)))
-          record-seq (.readRecords log from-msg-id to-msg-id)
+          record-seq (.readRecords log 0 from-msg-id to-msg-id)
           record-iter (.iterator record-seq)
           decode-tx-ops? (and source? (contains? col-names "tx_ops"))]
 

--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -22,9 +22,10 @@ import java.time.InstantSource
 import java.time.temporal.ChronoUnit.MICROS
 import kotlin.time.Duration.Companion.minutes
 
-class InMemoryLog<M>(
+class InMemoryLog<M> @JvmOverloads constructor(
     private val instantSource: InstantSource,
     override val epoch: Int,
+    val partitions: Int = 1,
 ) : Log<M> {
 
     @SerialName("!InMemory")
@@ -36,47 +37,58 @@ class InMemoryLog<M>(
         fun instantSource(instantSource: InstantSource) = apply { this.instantSource = instantSource }
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
 
-        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>) =
-            InMemoryLog<SourceMessage>(instantSource, epoch)
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            InMemoryLog<SourceMessage>(instantSource, epoch, partitions)
 
-        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLog(openSourceLog(remotes))
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLog(openSourceLog(remotes, partitions))
 
-        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>) =
-            InMemoryLog<ReplicaMessage>(instantSource, epoch)
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            InMemoryLog<ReplicaMessage>(instantSource, epoch, partitions)
 
-        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLog(openReplicaLog(remotes))
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLog(openReplicaLog(remotes, partitions))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.inMemoryLog = inMemoryLog { }
         }
     }
 
-    private val committedCh = MutableSharedFlow<Record<M>>(replay = REPLAY_BUFFER_SIZE)
-
     companion object {
         private const val REPLAY_BUFFER_SIZE = 4096
     }
 
-    private val mutex = Mutex()
+    // A msgId embeds the epoch but not the partition — partition is implicit in *which partition it
+    // came from*.
+    private inner class PartitionState {
+        val committedCh = MutableSharedFlow<Record<M>>(replay = REPLAY_BUFFER_SIZE)
+        val mutex = Mutex()
 
-    @Volatile
-    override var latestSubmittedOffset: LogOffset = -1
-        private set
-
-    // Mutex ensures offset assignment + emission are atomic,
-    // so subscribers always see records in offset order.
-    // We only use the instantSource for Tx messages so that the tests
-    // that check files can be deterministic.
-    override suspend fun appendMessage(message: M): MessageMetadata = mutex.withLock {
-        val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
-        val record = Record(epoch, ++latestSubmittedOffset, ts.truncatedTo(MICROS), message)
-        committedCh.emit(record)
-        MessageMetadata(epoch, record.logOffset, ts.truncatedTo(MICROS))
+        @Volatile
+        var latestSubmittedOffset: LogOffset = -1
     }
 
-    override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
+    private val partitionStates = List(partitions) { PartitionState() }
+
+    private fun state(partition: Int): PartitionState =
+        partitionStates.getOrNull(partition)
+            ?: error("no such partition $partition (partitions=$partitions)")
+
+    override fun latestSubmittedOffset(partition: Int): LogOffset = state(partition).latestSubmittedOffset
+
+    // Mutex ensures offset assignment + emission are atomic per partition,
+    // so subscribers always see records in offset order.
+    override suspend fun appendMessage(message: M, partition: Int): MessageMetadata {
+        val ps = state(partition)
+        return ps.mutex.withLock {
+            val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
+            val record = Record(epoch, ++ps.latestSubmittedOffset, ts.truncatedTo(MICROS), message)
+            ps.committedCh.emit(record)
+            MessageMetadata(epoch, record.logOffset, ts.truncatedTo(MICROS))
+        }
+    }
+
+    override fun openAtomicProducer(transactionalId: String, partition: Int) = object : AtomicProducer<M> {
         override fun openTx() = object : AtomicProducer.Tx<M> {
             private val buffer = mutableListOf<Pair<M, CompletableDeferred<MessageMetadata>>>()
             private var isOpen = true
@@ -92,7 +104,7 @@ class InMemoryLog<M>(
                 isOpen = false
                 runBlocking {
                     for ((message, res) in buffer) {
-                        res.complete(this@InMemoryLog.appendMessage(message))
+                        res.complete(this@InMemoryLog.appendMessage(message, partition))
                     }
                 }
             }
@@ -111,22 +123,22 @@ class InMemoryLog<M>(
         override fun close() {}
     }
 
-    override fun readLastMessage(): M? = null
+    override fun readLastMessage(partition: Int): M? = null
 
-    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId) = sequence {
+    override fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId) = sequence {
         if (MsgIdUtil.msgIdToEpoch(fromMsgId) != epoch || MsgIdUtil.msgIdToEpoch(toMsgId) != epoch) return@sequence
         val fromOffset = msgIdToOffset(fromMsgId)
         val toOffset = msgIdToOffset(toMsgId)
-        for (rec in committedCh.replayCache) {
+        for (rec in state(partition).committedCh.replayCache) {
             if (rec.logOffset >= toOffset) break
             if (rec.logOffset >= fromOffset) yield(rec)
         }
     }
 
-    override suspend fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
+    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
         var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-        val ch = committedCh
+        val ch = state(partition).committedCh
             .filter {
                 val logOffset = it.logOffset
                 check(logOffset <= latestCompletedOffset + 1) {
@@ -150,10 +162,19 @@ class InMemoryLog<M>(
         }
     }
 
-    override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) {
-        listener.launchTransition(listOf(0)).await()
-        val spec = listener.commitLeader(listOf(0))
-        tailAll(spec.afterMsgId, spec.processor)
+    // No rebalance to simulate — one launch per partition, each running the full state machine.
+    override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) = coroutineScope {
+        for (p in 0 until partitions) {
+            launch {
+                try {
+                    listener.launchTransition(p).await()
+                    val spec = listener.commitLeader(p)
+                    tailAll(p, spec.afterMsgId, spec.processor)
+                } finally {
+                    withContext(NonCancellable) { listener.demoteLeader(p) }
+                }
+            }
+        }
     }
 
     override fun close() {}

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -42,14 +42,15 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.Int.Companion.SIZE_BYTES as INT_BYTES
 import kotlin.Long.Companion.SIZE_BYTES as LONG_BYTES
 
-class LocalLog<M>(
-    rootPath: Path,
+class LocalLog<M> @JvmOverloads constructor(
+    private val rootPath: Path,
     private val codec: MessageCodec<M>,
     private val instantSource: InstantSource,
     override val epoch: Int,
     val useInstantSourceForNonTx: Boolean,
     coroutineContext: CoroutineContext = Dispatchers.IO,
-    logFileName: String = "LOG"
+    private val baseFileName: String = "LOG",
+    val partitions: Int = 1,
 ) : Log<M> {
     private val scope = CoroutineScope(coroutineContext)
     companion object {
@@ -116,14 +117,31 @@ class LocalLog<M>(
         val onCommit: CompletableDeferred<Record<M>>
     )
 
-    private val appendCh = Channel<NewMessage<M>>(capacity = 10)
+    // N=1 keeps the pre-#5557 path (byte-identical layout, existing directories/fixtures survive). N>1
+    // nests under a role directory. Partition count is immutable post-attach so the two shapes never
+    // coexist for the same rootPath.
+    private fun fileNameFor(partition: Int): String =
+        if (partitions == 1) baseFileName else "$baseFileName/$partition"
 
-    private val logFilePath = rootPath.resolve(logFileName)
+    private inner class PartitionState(val partition: Int) {
+        val logFilePath: Path = rootPath.resolve(fileNameFor(partition))
+        val logFileChannel: FileChannel =
+            FileChannel.open(logFilePath.createParentDirectories(), CREATE, WRITE, APPEND)
+        val appendCh = Channel<NewMessage<M>>(capacity = 10)
+        val committedCh = MutableSharedFlow<Record<M>>(extraBufferCapacity = 100)
+        val mutex = Mutex()
 
-    private val logFileChannel =
-        FileChannel.open(logFilePath.createParentDirectories(), CREATE, WRITE, APPEND)
+        @Volatile
+        var latestSubmittedOffset: LogOffset = readLatestSubmittedOffset(logFilePath)
+    }
 
-    private fun writeMessages(msgs: List<NewMessage<M>>): Array<Record<M>> {
+    private val partitionStates: List<PartitionState> = List(partitions) { PartitionState(it) }
+
+    private fun state(partition: Int): PartitionState =
+        partitionStates.getOrNull(partition)
+            ?: error("no such partition $partition (partitions=$partitions)")
+
+    private fun PartitionState.writeMessages(msgs: List<NewMessage<M>>): Array<Record<M>> {
         val initialOffset = logFileChannel.position()
 
         try {
@@ -160,62 +178,56 @@ class LocalLog<M>(
         }
     }
 
-    @Volatile
-    override var latestSubmittedOffset: LogOffset = readLatestSubmittedOffset(logFilePath)
-        private set
-
-    @Volatile
-    private var committedCh = MutableSharedFlow<Record<M>>(extraBufferCapacity = 100)
-
-    private val mutex = Mutex()
+    override fun latestSubmittedOffset(partition: Int): LogOffset = state(partition).latestSubmittedOffset
 
     init {
-        scope.launch {
-            try {
-                while (true) {
-                    val msgs = mutableListOf(appendCh.receive())
-
+        for (ps in partitionStates) {
+            scope.launch {
+                try {
                     while (true) {
-                        if (msgs.size >= 10) break
-                        msgs.add(appendCh.tryReceive().getOrNull() ?: break)
-                    }
+                        val msgs = mutableListOf(ps.appendCh.receive())
 
-                    val records = writeMessages(msgs)
+                        while (true) {
+                            if (msgs.size >= 10) break
+                            msgs.add(ps.appendCh.tryReceive().getOrNull() ?: break)
+                        }
 
-                    msgs.forEachIndexed { idx, msg ->
-                        records[idx].also {
-                            mutex.withLock {
-                                committedCh.emit(it)
-                                latestSubmittedOffset = it.logOffset
+                        val records = ps.writeMessages(msgs)
+
+                        msgs.forEachIndexed { idx, msg ->
+                            records[idx].also {
+                                ps.mutex.withLock {
+                                    ps.committedCh.emit(it)
+                                    ps.latestSubmittedOffset = it.logOffset
+                                }
+                                msg.onCommit.complete(it)
                             }
-                            msg.onCommit.complete(it)
                         }
                     }
+                } catch (_: ClosedByInterruptException) {
+                    cancel()
+                } catch (_: InterruptedException) {
+                    cancel()
                 }
-            } catch (_: ClosedByInterruptException) {
-                cancel()
-            } catch (_: InterruptedException) {
-                cancel()
             }
-        }
-
-        scope.launch {
         }
     }
 
-    override suspend fun appendMessage(message: M): MessageMetadata =
-        CompletableDeferred<MessageMetadata>()
+    override suspend fun appendMessage(message: M, partition: Int): MessageMetadata {
+        val ps = state(partition)
+        return CompletableDeferred<MessageMetadata>()
             .also { res ->
                 scope.launch {
                     val onCommit = CompletableDeferred<Record<M>>()
-                    appendCh.send(NewMessage(message, onCommit))
+                    ps.appendCh.send(NewMessage(message, onCommit))
                     val record = onCommit.await()
                     res.complete(MessageMetadata(epoch, record.logOffset, record.logTimestamp))
                 }
             }
             .await()
+    }
 
-    override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
+    override fun openAtomicProducer(transactionalId: String, partition: Int) = object : AtomicProducer<M> {
         override fun openTx() = object : AtomicProducer.Tx<M> {
             private val buffer = mutableListOf<Pair<M, CompletableDeferred<MessageMetadata>>>()
             private var isOpen = true
@@ -231,7 +243,7 @@ class LocalLog<M>(
                 isOpen = false
                 runBlocking {
                     for ((message, res) in buffer) {
-                        res.complete(this@LocalLog.appendMessage(message))
+                        res.complete(this@LocalLog.appendMessage(message, partition))
                     }
                 }
             }
@@ -250,22 +262,24 @@ class LocalLog<M>(
         override fun close() {}
     }
 
-    override fun readLastMessage(): M? {
-        if (latestSubmittedOffset < 0) return null
+    override fun readLastMessage(partition: Int): M? {
+        val ps = state(partition)
+        if (ps.latestSubmittedOffset < 0) return null
 
-        return FileChannel.open(logFilePath).use { ch ->
-            ch.position(latestSubmittedOffset)
+        return FileChannel.open(ps.logFilePath).use { ch ->
+            ch.position(ps.latestSubmittedOffset)
             ch.readMessage()?.message
         }
     }
 
-    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId) = sequence {
+    override fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId) = sequence {
         if (MsgIdUtil.msgIdToEpoch(fromMsgId) != epoch || MsgIdUtil.msgIdToEpoch(toMsgId) != epoch) return@sequence
+        val ps = state(partition)
         val fromOffset = msgIdToOffset(fromMsgId)
         val toOffset = msgIdToOffset(toMsgId)
-        if (fromOffset > latestSubmittedOffset || fromOffset >= toOffset) return@sequence
+        if (fromOffset > ps.latestSubmittedOffset || fromOffset >= toOffset) return@sequence
 
-        FileChannel.open(logFilePath).use { ch ->
+        FileChannel.open(ps.logFilePath).use { ch ->
             ch.position(fromOffset)
             while (ch.position() < ch.size()) {
                 val record = ch.readMessage() ?: continue
@@ -275,19 +289,20 @@ class LocalLog<M>(
         }
     }
 
-    override suspend fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
+    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
+        val ps = state(partition)
         var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
         val ch = Channel<Record<M>>(100)
 
         launch {
-            committedCh
+            ps.committedCh
                 .onSubscription {
-                    val targetOffset = mutex.withLock { latestSubmittedOffset }
+                    val targetOffset = ps.mutex.withLock { ps.latestSubmittedOffset }
                     if (targetOffset < 0) return@onSubscription
 
                     val catchUpRecords = runInterruptible {
-                        FileChannel.open(logFilePath).use { fileCh ->
+                        FileChannel.open(ps.logFilePath).use { fileCh ->
                             val latestCompleted = latestCompletedOffset
                             if (latestCompleted >= 0) {
                                 fileCh.position(latestCompleted)
@@ -335,15 +350,23 @@ class LocalLog<M>(
         }
     }
 
-    override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) {
-        listener.launchTransition(listOf(0)).await()
-        val spec = listener.commitLeader(listOf(0))
-        tailAll(spec.afterMsgId, spec.processor)
+    override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) = coroutineScope {
+        for (p in 0 until partitions) {
+            launch {
+                try {
+                    listener.launchTransition(p).await()
+                    val spec = listener.commitLeader(p)
+                    tailAll(p, spec.afterMsgId, spec.processor)
+                } finally {
+                    withContext(NonCancellable) { listener.demoteLeader(p) }
+                }
+            }
+        }
     }
 
     override fun close() {
         runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
-        logFileChannel.close()
+        for (ps in partitionStates) ps.logFileChannel.close()
     }
 
     /**
@@ -377,17 +400,17 @@ class LocalLog<M>(
         fun useInstantSourceForNonTx() = apply { this.useInstantSourceForNonTx = true }
         fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
-        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>) =
-            LocalLog(path, SourceMessage.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext)
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            LocalLog(path, SourceMessage.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext, partitions = partitions)
 
-        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLocalLog(path, SourceMessage.Codec, epoch, coroutineContext)
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLocalLog(path, SourceMessage.Codec, epoch, coroutineContext, partitions = partitions)
 
-        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>) =
-            LocalLog(path, ReplicaMessage.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext, logFileName = "REPLICA_LOG")
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            LocalLog(path, ReplicaMessage.Codec, instantSource, epoch, useInstantSourceForNonTx, coroutineContext, baseFileName = "REPLICA_LOG", partitions = partitions)
 
-        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLocalLog(path, ReplicaMessage.Codec, epoch, coroutineContext, logFileName = "REPLICA_LOG")
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLocalLog(path, ReplicaMessage.Codec, epoch, coroutineContext, baseFileName = "REPLICA_LOG", partitions = partitions)
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.localLog = localLog {

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -35,10 +35,10 @@ interface MessageCodec<M> {
 interface Log<M> : AutoCloseable {
 
     interface Factory {
-        fun openSourceLog(remotes: Map<RemoteAlias, Remote>): Log<SourceMessage>
-        fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>): Log<SourceMessage>
-        fun openReplicaLog(remotes: Map<RemoteAlias, Remote>): Log<ReplicaMessage>
-        fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>): Log<ReplicaMessage>
+        fun openSourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int = 1): Log<SourceMessage>
+        fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int = 1): Log<SourceMessage>
+        fun openReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int = 1): Log<ReplicaMessage>
+        fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int = 1): Log<ReplicaMessage>
 
         fun writeTo(dbConfig: DatabaseConfig.Builder)
 
@@ -96,12 +96,11 @@ interface Log<M> : AutoCloseable {
      * so that if we're starting up a new node it catches up to the latest offset,
      * then it's the latest-submitted-offset of _this_ node.
      */
-    val latestSubmittedOffset: LogOffset
+    fun latestSubmittedOffset(partition: Int = 0): LogOffset
 
     val epoch: Int
 
-    val latestSubmittedMsgId: MessageId
-        get() = offsetToMsgId(epoch, latestSubmittedOffset)
+    fun latestSubmittedMsgId(partition: Int = 0): MessageId = offsetToMsgId(epoch, latestSubmittedOffset(partition))
 
     class MessageMetadata(
         val epoch: Int,
@@ -111,15 +110,16 @@ interface Log<M> : AutoCloseable {
         val msgId: MessageId get() = offsetToMsgId(epoch, logOffset)
     }
 
-    suspend fun appendMessage(message: M): MessageMetadata
+    suspend fun appendMessage(message: M, partition: Int = 0): MessageMetadata
 
-    fun appendMessageBlocking(message: M): MessageMetadata = runBlocking { appendMessage(message) }
+    fun appendMessageBlocking(message: M, partition: Int = 0): MessageMetadata =
+        runBlocking { appendMessage(message, partition) }
 
     /**
      * @param transactionalId uniquely identifies this producer for Kafka's transaction coordinator.
      *   Must be stable across restarts for transaction recovery.
      */
-    fun openAtomicProducer(transactionalId: String): AtomicProducer<M>
+    fun openAtomicProducer(transactionalId: String, partition: Int): AtomicProducer<M>
 
     interface AtomicProducer<M> : AutoCloseable {
         fun openTx(): Tx<M>
@@ -148,24 +148,21 @@ interface Log<M> : AutoCloseable {
         }
     }
 
-    fun readLastMessage(): M?
+    fun readLastMessage(partition: Int = 0): M?
 
     /**
      * Reads records in the range [fromMsgId, toMsgId) (start-inclusive, end-exclusive).
      * Returns a lazy sequence of decoded records in offset order.
      * If toMsgId exceeds the latest submitted offset, reads up to the latest available record.
      */
-    fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): Sequence<Record<M>>
+    fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId): Sequence<Record<M>>
 
-    suspend fun tailAll(afterMsgId: MessageId, processor: RecordProcessor<M>)
+    suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: RecordProcessor<M>)
     suspend fun openGroupSubscription(listener: SubscriptionListener<M>)
 
     /**
-     * The transport's handle on a partition's leader election, driven as a three-step state
+     * The transport's handle on one partition's leader election, driven as a three-step state
      * machine (follower → prepared → leading). See allium/log-processor-lifecycle.allium.
-     *
-     * Each method takes the partition(s) the event is for — a single partition today, but the parameter
-     * is kept so a listener can route per-partition as Kafka's partition guards relax (#5557).
      *
      * [launchTransition] launches the follower→leader transition on the listener's *own* scope and
      * returns its [Deferred] — it builds the leader term but does NOT commit the role, so it runs off the
@@ -176,9 +173,9 @@ interface Log<M> : AutoCloseable {
      * committed role single-writer while the unbounded catch-up runs off the poll thread.
      */
     interface SubscriptionListener<M> {
-        fun launchTransition(partitions: Collection<Int>): Deferred<Unit>
-        fun commitLeader(partitions: Collection<Int>): TailSpec<M>
-        suspend fun demoteLeader(partitions: Collection<Int>)
+        fun launchTransition(partition: Int): Deferred<Unit>
+        fun commitLeader(partition: Int): TailSpec<M>
+        suspend fun demoteLeader(partition: Int)
     }
 
     data class TailSpec<M>(val afterMsgId: MessageId, val processor: RecordProcessor<M>)

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -33,16 +33,16 @@ import kotlin.Long.Companion.SIZE_BYTES as LONG_BYTES
  *
  * @suppress
  */
-class ReadOnlyLocalLog<M>(
+class ReadOnlyLocalLog<M> @JvmOverloads constructor(
     private val rootPath: Path,
     private val codec: MessageCodec<M>,
     override val epoch: Int,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-    private val logFileName: String = "LOG"
+    private val baseFileName: String = "LOG",
+    val partitions: Int = 1,
 ) : Log<M> {
 
     private val scope = CoroutineScope(coroutineContext)
-    private val logFilePath = rootPath.resolve(logFileName)
 
     companion object {
         private fun messageSizeBytes(size: Int) = 1 + INT_BYTES + LONG_BYTES + size + LONG_BYTES
@@ -95,31 +95,47 @@ class ReadOnlyLocalLog<M>(
             .also { position(pos + messageSizeBytes(size)) }
     }
 
-    override val latestSubmittedOffset: LogOffset
-        get() = readLatestSubmittedOffset(logFilePath)
+    // See LocalLog.fileNameFor — same nested-for-N>1, plain-file-for-N=1 layout.
+    private fun fileNameFor(partition: Int): String =
+        if (partitions == 1) baseFileName else "$baseFileName/$partition"
 
-    override suspend fun appendMessage(message: M): MessageMetadata =
+    private fun logFilePath(partition: Int): Path = rootPath.resolve(fileNameFor(partition))
+
+    private fun requirePartition(partition: Int) {
+        require(partition in 0 until partitions) { "no such partition $partition (partitions=$partitions)" }
+    }
+
+    override fun latestSubmittedOffset(partition: Int): LogOffset {
+        requirePartition(partition)
+        return readLatestSubmittedOffset(logFilePath(partition))
+    }
+
+    override suspend fun appendMessage(message: M, partition: Int): MessageMetadata =
         throw Incorrect("Cannot append to read-only database log")
 
-    override fun openAtomicProducer(transactionalId: String) =
+    override fun openAtomicProducer(transactionalId: String, partition: Int) =
         throw Incorrect("Cannot open atomic producer on read-only database log")
 
-    override fun readLastMessage(): M? {
-        if (latestSubmittedOffset < 0) return null
+    override fun readLastMessage(partition: Int): M? {
+        val latest = latestSubmittedOffset(partition)
+        if (latest < 0) return null
 
-        return FileChannel.open(logFilePath, READ).use { ch ->
-            ch.position(latestSubmittedOffset)
+        return FileChannel.open(logFilePath(partition), READ).use { ch ->
+            ch.position(latest)
             ch.readMessage()?.message
         }
     }
 
-    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId) = sequence {
+    override fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId) = sequence {
         if (MsgIdUtil.msgIdToEpoch(fromMsgId) != epoch || MsgIdUtil.msgIdToEpoch(toMsgId) != epoch) return@sequence
+        requirePartition(partition)
+        val filePath = logFilePath(partition)
+        val latest = readLatestSubmittedOffset(filePath)
         val fromOffset = msgIdToOffset(fromMsgId)
         val toOffset = msgIdToOffset(toMsgId)
-        if (fromOffset > latestSubmittedOffset || fromOffset >= toOffset) return@sequence
+        if (fromOffset > latest || fromOffset >= toOffset) return@sequence
 
-        FileChannel.open(logFilePath, READ).use { ch ->
+        FileChannel.open(filePath, READ).use { ch ->
             ch.position(fromOffset)
             while (ch.position() < ch.size()) {
                 val record = ch.readMessage() ?: continue
@@ -129,17 +145,26 @@ class ReadOnlyLocalLog<M>(
         }
     }
 
-    override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
+    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
+        requirePartition(partition)
+        val filePath = logFilePath(partition)
+        // Watch the partition file's parent — rootPath at N=1, rootPath/LOG at N>1 — because WatchService
+        // events are direct-children only, not recursive. Match against the file's last segment (its name
+        // in that parent), which is baseFileName at N=1 and the partition index at N>1.
+        val watchDir = filePath.parent
+        val watchedName = filePath.fileName.toString()
         val ch = Channel<Log.Record<M>>(100)
 
         launch {
             var currentOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
             FileSystems.getDefault().newWatchService().use { watchService ->
-                rootPath.register(watchService, ENTRY_MODIFY)
+                // Idempotent — the writer's process may not have created the parent yet at N>1.
+                java.nio.file.Files.createDirectories(watchDir)
+                watchDir.register(watchService, ENTRY_MODIFY)
 
                 try {
-                    readNewMessages(currentOffset, ch)?.let { currentOffset = it }
+                    readNewMessages(filePath, currentOffset, ch)?.let { currentOffset = it }
 
                     while (true) {
                         val key: WatchKey = runInterruptible(Dispatchers.IO) { watchService.take() }
@@ -147,13 +172,13 @@ class ReadOnlyLocalLog<M>(
                         var logModified = false
                         for (event in key.pollEvents()) {
                             val changedPath = event.context() as? Path
-                            if (changedPath?.name == logFileName) {
+                            if (changedPath?.name == watchedName) {
                                 logModified = true
                             }
                         }
 
                         if (logModified) {
-                            readNewMessages(currentOffset, ch)?.let { currentOffset = it }
+                            readNewMessages(filePath, currentOffset, ch)?.let { currentOffset = it }
                         }
 
                         if (!key.reset()) {
@@ -176,13 +201,21 @@ class ReadOnlyLocalLog<M>(
         }
     }
 
-    override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {
-        listener.launchTransition(listOf(0)).await()
-        val spec = listener.commitLeader(listOf(0))
-        tailAll(spec.afterMsgId, spec.processor)
+    override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) = coroutineScope {
+        for (p in 0 until partitions) {
+            launch {
+                try {
+                    listener.launchTransition(p).await()
+                    val spec = listener.commitLeader(p)
+                    tailAll(p, spec.afterMsgId, spec.processor)
+                } finally {
+                    withContext(NonCancellable) { listener.demoteLeader(p) }
+                }
+            }
+        }
     }
 
-    private suspend fun readNewMessages(currentOffset: LogOffset, ch: Channel<Log.Record<M>>): LogOffset? {
+    private suspend fun readNewMessages(logFilePath: Path, currentOffset: LogOffset, ch: Channel<Log.Record<M>>): LogOffset? {
         val newLatestOffset = readLatestSubmittedOffset(logFilePath)
 
         if (newLatestOffset <= currentOffset) return null

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLog.kt
@@ -4,12 +4,12 @@ import xtdb.api.error.Incorrect
 
 /** @suppress */
 class ReadOnlyLog<M>(private val delegate: Log<M>) : Log<M> by delegate {
-    override suspend fun appendMessage(message: M): Log.MessageMetadata =
+    override suspend fun appendMessage(message: M, partition: Int): Log.MessageMetadata =
         throw Incorrect("Cannot append to read-only database log")
 
-    override fun appendMessageBlocking(message: M): Nothing =
+    override fun appendMessageBlocking(message: M, partition: Int): Nothing =
         throw Incorrect("Cannot append to read-only database log")
 
-    override fun openAtomicProducer(transactionalId: String): Nothing =
+    override fun openAtomicProducer(transactionalId: String, partition: Int): Nothing =
         throw Incorrect("Cannot open atomic producer on read-only database log")
 }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -229,7 +229,7 @@ class Database(
             val processedOffset = msgIdToOffset(latestProcessedMsgId)
             val processedEpoch = msgIdToEpoch(latestProcessedMsgId)
             val logEpoch = log.epoch
-            val latestSubmittedOffset = log.latestSubmittedOffset
+            val latestSubmittedOffset = log.latestSubmittedOffset()
 
             when {
                 processedEpoch != logEpoch -> logNewEpoch()
@@ -250,6 +250,17 @@ class Database(
         ): Database = safelyOpening {
             val indexerConfig = base.config.indexer
             val readOnly = dbConfig.isReadOnly
+
+            // Attach-time gate: the type signatures admit N throughout, but per-partition BufferPool
+            // layout (unit 6), TableCatalog wrappers + UNION-at-scan (unit 7) and xt.txs_$partition
+            // naming (unit 8) haven't landed. Lifting this gate is unit 9.
+            if (dbConfig.partitions > 1)
+                throw Incorrect(
+                    "multi-partition external-source databases are not yet enabled " +
+                            "(config declared partitions=${dbConfig.partitions})",
+                    "xtdb/multi-partition-not-yet-enabled",
+                    mapOf("db-name" to dbName, "partitions" to dbConfig.partitions)
+                )
 
             val allocator = open { base.allocator.newChildAllocator("database/$dbName", 0, Long.MAX_VALUE) }
             val storage = open { DatabaseStorage.open(allocator, base, dbName, dbConfig) }
@@ -340,13 +351,13 @@ class Database(
                         (state.liveIndex.latestCompletedTx?.txId ?: -1).toDouble()
                     },
                     gauge("node.tx.latestSubmittedMsgId") {
-                        storage.sourceLog.latestSubmittedMsgId.toDouble()
+                        storage.sourceLog.latestSubmittedMsgId().toDouble()
                     },
                     gauge("node.tx.latestProcessedMsgId") {
                         watchers.latestSourceMsgId.toDouble()
                     },
                     gauge("node.tx.lag.MsgId") {
-                        maxOf(storage.sourceLog.latestSubmittedMsgId - watchers.latestSourceMsgId, 0).toDouble()
+                        maxOf(storage.sourceLog.latestSubmittedMsgId() - watchers.latestSourceMsgId, 0).toDouble()
                     },
                 )
             } ?: emptyList()
@@ -371,17 +382,15 @@ class Database(
             )
 
             if (indexerConfig.enabled && !readOnly) {
-                // Route each partition's leader-election events to that partition's own LogProcessor.
-                // One partition today (index 0); #5557 grows `db.partitions` and this fans out to N.
                 val listener = object : Log.SubscriptionListener<SourceMessage> {
-                    override fun launchTransition(partitions: Collection<Int>) =
-                        db.partitions.getValue(partitions.single()).logProcessor!!.launchTransition(partitions)
+                    override fun launchTransition(partition: Int) =
+                        db.partitions.getValue(partition).logProcessor!!.launchTransition(partition)
 
-                    override fun commitLeader(partitions: Collection<Int>) =
-                        db.partitions.getValue(partitions.single()).logProcessor!!.commitLeader(partitions)
+                    override fun commitLeader(partition: Int) =
+                        db.partitions.getValue(partition).logProcessor!!.commitLeader(partition)
 
-                    override suspend fun demoteLeader(partitions: Collection<Int>) {
-                        for (idx in partitions) db.partitions[idx]?.logProcessor?.demoteLeader(listOf(idx))
+                    override suspend fun demoteLeader(partition: Int) {
+                        db.partitions[partition]?.logProcessor?.demoteLeader(partition)
                     }
                 }
                 scope.launch { storage.sourceLog.openGroupSubscription(listener) }
@@ -420,12 +429,18 @@ class Database(
         val mode: Mode = Mode.READ_WRITE,
         val externalSource: ExternalSource.Factory? = null,
         val critical: Boolean = false,
+        val partitions: Int = 1,
     ) {
+        init {
+            require(partitions >= 1) { "partitions must be >= 1, got $partitions" }
+        }
+
         fun log(log: Log.Factory) = copy(log = log)
         fun storage(storage: Storage.Factory) = copy(storage = storage)
         fun mode(mode: Mode) = copy(mode = mode)
         fun externalSource(externalSource: ExternalSource.Factory?) = copy(externalSource = externalSource)
         fun critical(critical: Boolean) = copy(critical = critical)
+        fun partitions(partitions: Int) = copy(partitions = partitions)
 
         val isReadOnly: Boolean get() = mode == Mode.READ_ONLY
 
@@ -437,6 +452,7 @@ class Database(
                     dbConfig.mode = mode.toProto()
                     externalSource?.let { dbConfig.externalSource = ExternalSource.Factory.toProto(it) }
                     dbConfig.critical = critical
+                    dbConfig.partitions = partitions
                 }.build()
 
         companion object {
@@ -452,12 +468,14 @@ class Database(
                     .externalSource(dbConfig.externalSource.takeIf { dbConfig.hasExternalSource() }
                         ?.let { ExternalSource.Factory.fromProto(it) })
                     .critical(dbConfig.critical)
+                    // Pre-#5557 records don't carry the field; proto's default of 0 becomes 1.
+                    .partitions(dbConfig.partitions.coerceAtLeast(1))
         }
     }
 
     interface Catalog : ILookup, Seqable, Iterable<Database>, IQuerySource.QueryCatalog {
         companion object {
-            private suspend fun Database.sync() = watchers.awaitSource(sourceLog.latestSubmittedMsgId)
+            private suspend fun Database.sync() = watchers.awaitSource(sourceLog.latestSubmittedMsgId())
 
             private suspend fun Catalog.awaitAll0(token: String) = coroutineScope {
                 val basis = token.decodeTxBasisToken()
@@ -526,13 +544,10 @@ class Database(
                 }
             }.toMap()
 
-        // #5557 unit 5: the source log's latestSubmittedMsgId is database-level for now, so the same value
-        // fills every partition slot.
         fun latestSubmittedMsgIds(): Map<DatabaseName, List<MessageId>> =
             databaseNames.mapNotNull { dbName ->
                 databaseOrNull(dbName)?.let { db ->
-                    val latest = db.sourceLog.latestSubmittedMsgId
-                    dbName to List(db.partitions.size) { latest }
+                    dbName to db.partitions.keys.sorted().map { db.sourceLog.latestSubmittedMsgId(it) }
                 }
             }.toMap()
 

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -51,13 +51,13 @@ class DatabaseStorage(
             val metadataManager = open { PageMetadata.factory(allocator, bufferPool) }
 
             val sourceLog = open {
-                if (readOnly) dbConfig.log.openReadOnlySourceLog(remotes)
-                else dbConfig.log.openSourceLog(remotes)
+                if (readOnly) dbConfig.log.openReadOnlySourceLog(remotes, dbConfig.partitions)
+                else dbConfig.log.openSourceLog(remotes, dbConfig.partitions)
             }
 
             val replicaLog = open {
-                if (readOnly) dbConfig.log.openReadOnlyReplicaLog(remotes)
-                else dbConfig.log.openReplicaLog(remotes)
+                if (readOnly) dbConfig.log.openReadOnlyReplicaLog(remotes, dbConfig.partitions)
+                else dbConfig.log.openReplicaLog(remotes, dbConfig.partitions)
             }
 
             DatabaseStorage(sourceLog, replicaLog, bufferPool, metadataManager)

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -293,7 +293,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     // Launched last so every field the tail touches is initialised before the first record.
     private val job = scope.launch {
         try {
-            replicaLog.tailAll(afterReplicaMsgId, this@FollowerLogProcessor)
+            replicaLog.tailAll(partition = 0, afterReplicaMsgId, this@FollowerLogProcessor)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -151,7 +151,7 @@ class LogProcessor(
         }
     }
 
-    override fun launchTransition(partitions: Collection<Int>): Deferred<Unit> {
+    override fun launchTransition(partition: Int): Deferred<Unit> {
         // Transport contract: transition only from Following (see SubscriptionListener). A raw cast
         // would surface an out-of-order call as a cryptic ClassCastException; name it instead.
         val followerSys = (state as? Following)?.system
@@ -165,7 +165,7 @@ class LogProcessor(
 
     private suspend fun runTransition(followerSys: FollowerSystem) {
         try {
-            replicaLog.openAtomicProducer("$dbName-leader").closeOnCatch { replicaProducer ->
+            replicaLog.openAtomicProducer("$dbName-leader", partition = 0).closeOnCatch { replicaProducer ->
                 val followerProc = followerSys.proc
 
                 // NoOp to get a known msgId we can await — latestSubmittedMsgId won't do, because Kafka's
@@ -237,7 +237,7 @@ class LogProcessor(
         }
     }
 
-    override fun commitLeader(partitions: Collection<Int>): Log.TailSpec<SourceMessage> {
+    override fun commitLeader(partition: Int): Log.TailSpec<SourceMessage> {
         val prepared = (state as? Prepared)
             ?: throw Fault("[$dbName] commitLeader without a prepared leader (${state::class.simpleName})", "xtdb/log-commit-not-prepared")
         state = Leading(prepared.system)
@@ -245,7 +245,7 @@ class LogProcessor(
         return Log.TailSpec(prepared.resumeAfterMsgId, prepared.system.proc)
     }
 
-    override suspend fun demoteLeader(partitions: Collection<Int>) {
+    override suspend fun demoteLeader(partition: Int) {
         // Genuine revoke (Leading) and abandoning an uncommitted leader (Prepared) tear down the
         // same way; an already-following listener is a no-op.
         val leaderSys = when (val s = state) {

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -34,37 +34,38 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         fun instantSource(instantSource: InstantSource) = apply { this.instantSource = instantSource }
         fun messages(messages: List<SourceMessage>) = apply { this.messages = messages }
 
-        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>) = RecordingLog(instantSource, messages)
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) = RecordingLog(instantSource, messages)
 
-        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLog(openSourceLog(remotes))
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLog(openSourceLog(remotes, partitions))
 
-        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>) =
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
             RecordingLog<ReplicaMessage>(instantSource, emptyList())
 
-        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLog(openReplicaLog(remotes))
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLog(openReplicaLog(remotes, partitions))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) = Unit
     }
 
     @Volatile
-    override var latestSubmittedOffset: LogOffset = -1
-        private set
+    private var latestSubmittedOffset0: LogOffset = -1
 
-    override suspend fun appendMessage(message: M): Log.MessageMetadata {
+    override fun latestSubmittedOffset(partition: Int): LogOffset = latestSubmittedOffset0
+
+    override suspend fun appendMessage(message: M, partition: Int): Log.MessageMetadata {
         messages.add(message)
 
         val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
-        val offset = ++latestSubmittedOffset
+        val offset = ++latestSubmittedOffset0
         records.add(Log.Record(epoch, offset, ts.truncatedTo(ChronoUnit.MICROS), message))
 
         return Log.MessageMetadata(epoch, offset, ts.truncatedTo(ChronoUnit.MICROS))
     }
 
-    override fun readLastMessage(): M? = messages.lastOrNull()
+    override fun readLastMessage(partition: Int): M? = messages.lastOrNull()
 
-    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId) = sequence {
+    override fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId) = sequence {
         if (msgIdToEpoch(fromMsgId) != epoch || msgIdToEpoch(toMsgId) != epoch) return@sequence
         val fromOffset = msgIdToOffset(fromMsgId)
         val toOffset = msgIdToOffset(toMsgId)
@@ -74,7 +75,7 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         }
     }
 
-    override fun openAtomicProducer(transactionalId: String) = object : Log.AtomicProducer<M> {
+    override fun openAtomicProducer(transactionalId: String, partition: Int) = object : Log.AtomicProducer<M> {
         override fun openTx() = object : Log.AtomicProducer.Tx<M> {
             private val buffer = mutableListOf<Pair<M, CompletableDeferred<Log.MessageMetadata>>>()
             private var isOpen = true
@@ -90,7 +91,7 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
                 isOpen = false
                 runBlocking {
                     for ((message, res) in buffer) {
-                        res.complete(this@RecordingLog.appendMessage(message))
+                        res.complete(this@RecordingLog.appendMessage(message, partition))
                     }
                 }
             }
@@ -109,7 +110,7 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         override fun close() {}
     }
 
-    override suspend fun tailAll(afterMsgId: Long, processor: Log.RecordProcessor<M>): Unit = error("tailAll")
+    override suspend fun tailAll(partition: Int, afterMsgId: Long, processor: Log.RecordProcessor<M>): Unit = error("tailAll")
 
     override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Unit = error("openGroupSubscription")
 

--- a/core/src/main/proto/xtdb/database/proto/db.proto
+++ b/core/src/main/proto/xtdb/database/proto/db.proto
@@ -50,5 +50,9 @@ message DatabaseConfig {
     DatabaseMode mode = 7;
     google.protobuf.Any external_source = 8;
     bool critical = 9;
+
+    // Number of source-log partitions this database consumes from. Immutable post-attach.
+    // fromProto coerces 0 -> 1 on read to handle pre-#5557 records with no field. See #5557.
+    int32 partitions = 10;
 }
 

--- a/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
@@ -1,10 +1,12 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
+import xtdb.api.log.Log.Record
 import java.time.InstantSource
 import java.util.concurrent.Executors
 import kotlin.time.Duration.Companion.seconds
@@ -39,15 +41,123 @@ class InMemoryLogTest {
 
             runBlocking(dispatcher) {
                 withTimeout(5.seconds) {
-                    log.openAtomicProducer("test").withTx { tx ->
+                    log.openAtomicProducer("test", 0).withTx { tx ->
                         tx.appendMessage(ReplicaMessage.NoOp())
                     }
                 }
             }
 
-            assertEquals(0, log.latestSubmittedOffset)
+            assertEquals(0, log.latestSubmittedOffset())
         } finally {
             dispatcher.close()
+        }
+    }
+
+    @Test
+    fun `writes to different partitions are isolated`() = runTest {
+        val log = InMemoryLog<SourceMessage>(InstantSource.system(), 0, partitions = 2)
+        log.use {
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 1)
+
+            // InMemoryLog has no readLastMessage backing — use readRecords to prove per-partition
+            // isolation. Bound the scan by each partition's latest msgId so the epoch guard passes.
+            val p0 = log.readRecords(0, 0L, log.latestSubmittedMsgId(0) + 1).toList()
+            val p1 = log.readRecords(1, 0L, log.latestSubmittedMsgId(1) + 1).toList()
+
+            assertEquals(1, p0.size)
+            assertEquals(1, p1.size)
+            assertArrayEquals(byteArrayOf(-1, 1), (p0[0].message as SourceMessage.LegacyTx).payload)
+            assertArrayEquals(byteArrayOf(-1, 2), (p1[0].message as SourceMessage.LegacyTx).payload)
+
+            assertEquals(0L, log.latestSubmittedOffset(0))
+            assertEquals(0L, log.latestSubmittedOffset(1))
+        }
+    }
+
+    @Test
+    fun `offsets advance independently per partition`() = runTest {
+        val log = InMemoryLog<SourceMessage>(InstantSource.system(), 0, partitions = 2)
+        log.use {
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 0)
+            log.appendMessage(txMessage(3), partition = 0)
+            log.appendMessage(txMessage(4), partition = 1)
+            log.appendMessage(txMessage(5), partition = 1)
+
+            assertEquals(2L, log.latestSubmittedOffset(0))
+            assertEquals(1L, log.latestSubmittedOffset(1))
+        }
+    }
+
+    @Test
+    fun `tailAll only sees its own partition`() = runTest(timeout = 5.seconds) {
+        val log = InMemoryLog<SourceMessage>(InstantSource.system(), 0, partitions = 2)
+        log.use {
+            val ch0 = Channel<Record<SourceMessage>>(Channel.UNLIMITED)
+            val ch1 = Channel<Record<SourceMessage>>(Channel.UNLIMITED)
+
+            val job0 = backgroundScope.launch {
+                log.tailAll(0, -1L) { recs -> recs.forEach { ch0.send(it) } }
+            }
+            val job1 = backgroundScope.launch {
+                log.tailAll(1, -1L) { recs -> recs.forEach { ch1.send(it) } }
+            }
+
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 1)
+
+            val r0 = ch0.receive()
+            val r1 = ch1.receive()
+
+            assertArrayEquals(byteArrayOf(-1, 1), (r0.message as SourceMessage.LegacyTx).payload)
+            assertArrayEquals(byteArrayOf(-1, 2), (r1.message as SourceMessage.LegacyTx).payload)
+
+            // No cross-delivery: nothing else waiting on either channel.
+            assertTrue(ch0.tryReceive().isFailure, "partition 0's subscriber received a partition 1 write")
+            assertTrue(ch1.tryReceive().isFailure, "partition 1's subscriber received a partition 0 write")
+
+            job0.cancelAndJoin()
+            job1.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `openGroupSubscription drives the listener lifecycle for every partition`() = runTest(timeout = 5.seconds) {
+        val log = InMemoryLog<SourceMessage>(InstantSource.system(), 0, partitions = 3)
+        log.use {
+            val listener = RecordingListener<SourceMessage>()
+
+            val job = backgroundScope.launch { log.openGroupSubscription(listener) }
+
+            // Wait for all N partitions to have been transitioned + committed.
+            while (listener.committed.size < 3) yield()
+
+            job.cancelAndJoin()
+
+            assertEquals(setOf(0, 1, 2), listener.transitioned.toSet())
+            assertEquals(setOf(0, 1, 2), listener.committed.toSet())
+            assertEquals(setOf(0, 1, 2), listener.demoted.toSet())
+        }
+    }
+
+    private class RecordingListener<M> : Log.SubscriptionListener<M> {
+        val transitioned = mutableListOf<Int>()
+        val committed = mutableListOf<Int>()
+        val demoted = mutableListOf<Int>()
+
+        override fun launchTransition(partition: Int): Deferred<Unit> {
+            transitioned.add(partition)
+            return CompletableDeferred(Unit)
+        }
+
+        override fun commitLeader(partition: Int): Log.TailSpec<M> {
+            committed.add(partition)
+            return Log.TailSpec(-1L) { _ -> }
+        }
+
+        override suspend fun demoteLeader(partition: Int) {
+            demoted.add(partition)
         }
     }
 }

--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -1,14 +1,22 @@
 package xtdb.api.log
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import xtdb.api.log.Log.Record
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.time.Duration.Companion.seconds
 
@@ -19,25 +27,31 @@ class LocalLogTest {
 
     @Tag("integration")
     @RepeatedTest(5000)
-    fun `close should cancel all subscription coroutines without leaking`() = runTest(timeout = 10.seconds) {
-        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap())
+    fun `close should cancel all subscription coroutines without leaking - N=1`() = runTest(timeout = 10.seconds) {
+        closeCancelsSubscriptionCoroutines(partitions = 1)
+    }
 
-        // Create a subscription
-        val receivedRecords = mutableListOf<Record<SourceMessage>>()
-        val job = launch {
-            log.tailAll(
-                -1L,
-                object : Log.RecordProcessor<SourceMessage> {
-                    override suspend fun processRecords(records: List<Record<SourceMessage>>) {
-                        records.forEach { receivedRecords.add(it) }
-                    }
-                }
-            )
+    @Tag("integration")
+    @RepeatedTest(500)
+    fun `close should cancel all subscription coroutines without leaking - N=2`() = runTest(timeout = 10.seconds) {
+        closeCancelsSubscriptionCoroutines(partitions = 2)
+    }
+
+    private suspend fun TestScope.closeCancelsSubscriptionCoroutines(partitions: Int) {
+        val log = LocalLog.Factory(tempDir.resolve("log-$partitions"))
+            .openSourceLog(emptyMap(), partitions)
+
+        val jobs = List(partitions) { p ->
+            launch {
+                log.tailAll(p, -1L, object : Log.RecordProcessor<SourceMessage> {
+                    override suspend fun processRecords(records: List<Record<SourceMessage>>) = Unit
+                })
+            }
         }
 
-        log.appendMessage(SourceMessage.FlushBlock(1))
+        log.appendMessage(SourceMessage.FlushBlock(1), partition = 0)
 
-        job.cancelAndJoin()
+        jobs.forEach { it.cancelAndJoin() }
 
         log.close()
     }
@@ -77,6 +91,156 @@ class LocalLogTest {
             assertNotNull(lastMessage)
             assertTrue(lastMessage is SourceMessage.LegacyTx)
             assertArrayEquals(byteArrayOf(-1, 3), (lastMessage as SourceMessage.LegacyTx).payload)
+        }
+    }
+
+    @Test
+    fun `writes to different partitions are isolated`() = runTest {
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap(), partitions = 2)
+        log.use {
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 1)
+            log.appendMessage(txMessage(3), partition = 0)
+
+            val last0 = log.readLastMessage(0) as SourceMessage.LegacyTx
+            val last1 = log.readLastMessage(1) as SourceMessage.LegacyTx
+            assertArrayEquals(byteArrayOf(-1, 3), last0.payload)
+            assertArrayEquals(byteArrayOf(-1, 2), last1.payload)
+        }
+    }
+
+    @Test
+    fun `offsets advance independently per partition`() = runTest {
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap(), partitions = 2)
+        log.use {
+            val emptyOffset = log.latestSubmittedOffset(0)
+            assertEquals(emptyOffset, log.latestSubmittedOffset(1))
+
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 0)
+            log.appendMessage(txMessage(3), partition = 1)
+
+            // Partition 0 has advanced past partition 1 (two writes vs one); LocalLog offsets
+            // are file positions, so ordering suffices as the isolation check.
+            assertTrue(log.latestSubmittedOffset(0) > log.latestSubmittedOffset(1))
+            assertTrue(log.latestSubmittedOffset(1) > emptyOffset)
+        }
+    }
+
+    @Test
+    fun `tailAll only sees its own partition`() = runTest(timeout = 5.seconds) {
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap(), partitions = 2)
+        log.use {
+            val ch0 = Channel<Record<SourceMessage>>(Channel.UNLIMITED)
+            val ch1 = Channel<Record<SourceMessage>>(Channel.UNLIMITED)
+
+            val job0 = backgroundScope.launch {
+                log.tailAll(0, -1L) { recs -> recs.forEach { ch0.send(it) } }
+            }
+            val job1 = backgroundScope.launch {
+                log.tailAll(1, -1L) { recs -> recs.forEach { ch1.send(it) } }
+            }
+
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 1)
+
+            val r0 = ch0.receive()
+            val r1 = ch1.receive()
+
+            assertArrayEquals(byteArrayOf(-1, 1), (r0.message as SourceMessage.LegacyTx).payload)
+            assertArrayEquals(byteArrayOf(-1, 2), (r1.message as SourceMessage.LegacyTx).payload)
+
+            assertTrue(ch0.tryReceive().isFailure, "partition 0's subscriber received a partition 1 write")
+            assertTrue(ch1.tryReceive().isFailure, "partition 1's subscriber received a partition 0 write")
+
+            job0.cancelAndJoin()
+            job1.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `openGroupSubscription drives the listener lifecycle for every partition`() = runTest(timeout = 5.seconds) {
+        val log = LocalLog.Factory(tempDir.resolve("log")).openSourceLog(emptyMap(), partitions = 3)
+        log.use {
+            val listener = RecordingListener<SourceMessage>()
+
+            val job = backgroundScope.launch { log.openGroupSubscription(listener) }
+
+            while (listener.committed.size < 3) yield()
+
+            job.cancelAndJoin()
+
+            assertEquals(setOf(0, 1, 2), listener.transitioned.toSet())
+            assertEquals(setOf(0, 1, 2), listener.committed.toSet())
+            assertEquals(setOf(0, 1, 2), listener.demoted.toSet())
+        }
+    }
+
+    @Test
+    fun `multi-partition files land under the nested layout`() = runTest {
+        val root = tempDir.resolve("log")
+        val log = LocalLog.Factory(root).openSourceLog(emptyMap(), partitions = 2)
+        log.use {
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 1)
+
+            // N>1 nests under a role directory.
+            assertTrue(Files.isDirectory(root.resolve("LOG")), "root/LOG should be a directory at N>1")
+            assertTrue(Files.isRegularFile(root.resolve("LOG/0")), "root/LOG/0 should exist")
+            assertTrue(Files.isRegularFile(root.resolve("LOG/1")), "root/LOG/1 should exist")
+        }
+    }
+
+    @Test
+    fun `single-partition uses the pre-#5557 bare LOG file`() = runTest {
+        val root = tempDir.resolve("log")
+        val log = LocalLog.Factory(root).openSourceLog(emptyMap())  // partitions = 1 (default)
+        log.use {
+            log.appendMessage(txMessage(1))
+
+            // N=1 keeps the pre-#5557 layout — a plain file at rootPath.
+            assertTrue(Files.isRegularFile(root.resolve("LOG")), "root/LOG should be a file at N=1")
+        }
+    }
+
+    @Test
+    fun `restart recovers per-partition state from disk`() = runTest {
+        val root = tempDir.resolve("log")
+        val factory = LocalLog.Factory(root)
+
+        factory.openSourceLog(emptyMap(), partitions = 2).use { log ->
+            log.appendMessage(txMessage(1), partition = 0)
+            log.appendMessage(txMessage(2), partition = 1)
+            log.appendMessage(txMessage(3), partition = 0)
+        }
+
+        factory.openSourceLog(emptyMap(), partitions = 2).use { log ->
+            val last0 = log.readLastMessage(0) as SourceMessage.LegacyTx
+            val last1 = log.readLastMessage(1) as SourceMessage.LegacyTx
+            assertArrayEquals(byteArrayOf(-1, 3), last0.payload)
+            assertArrayEquals(byteArrayOf(-1, 2), last1.payload)
+
+            assertTrue(log.latestSubmittedOffset(0) > log.latestSubmittedOffset(1))
+        }
+    }
+
+    private class RecordingListener<M> : Log.SubscriptionListener<M> {
+        val transitioned = mutableListOf<Int>()
+        val committed = mutableListOf<Int>()
+        val demoted = mutableListOf<Int>()
+
+        override fun launchTransition(partition: Int): Deferred<Unit> {
+            transitioned.add(partition)
+            return CompletableDeferred(Unit)
+        }
+
+        override fun commitLeader(partition: Int): Log.TailSpec<M> {
+            committed.add(partition)
+            return Log.TailSpec(-1L) { _ -> }
+        }
+
+        override suspend fun demoteLeader(partition: Int) {
+            demoted.add(partition)
         }
     }
 }

--- a/core/src/test/kotlin/xtdb/api/log/ReadOnlyLocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/ReadOnlyLocalLogTest.kt
@@ -1,0 +1,63 @@
+package xtdb.api.log
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import xtdb.api.log.Log.Record
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
+
+class ReadOnlyLocalLogTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun txMessage(id: Byte) = SourceMessage.LegacyTx(byteArrayOf(-1, id))
+
+    @Test
+    fun `tailAll observes external writes at N=1`(): Unit = runBlocking {
+        observesExternalWrites(partitions = 1)
+    }
+
+    @Test
+    fun `tailAll observes external writes at N greater than 1`(): Unit = runBlocking {
+        observesExternalWrites(partitions = 2)
+    }
+
+    // msg1's arrival via catch-up is a synchronisation barrier: it proves the reader has finished
+    // its initial scan and is in the watch loop. msg2 can then only be delivered by the watcher.
+    private suspend fun observesExternalWrites(partitions: Int) = coroutineScope {
+        val root = tempDir.resolve("log")
+        val factory = LocalLog.Factory(root)
+        val readPartition = partitions - 1
+
+        factory.openSourceLog(emptyMap(), partitions).use { writer ->
+            writer.appendMessage(txMessage(1), readPartition)
+
+            factory.openReadOnlySourceLog(emptyMap(), partitions).use { reader ->
+                val ch = Channel<Record<SourceMessage>>(Channel.UNLIMITED)
+                val job = launch(Dispatchers.IO) {
+                    reader.tailAll(readPartition, -1L) { recs -> recs.forEach { ch.send(it) } }
+                }
+                try {
+                    val msg1 = withTimeoutOrNull(3.seconds) { ch.receive() }
+                    assertNotNull(msg1, "catch-up should deliver the pre-existing record")
+
+                    writer.appendMessage(txMessage(2), readPartition)
+
+                    val msg2 = withTimeoutOrNull(3.seconds) { ch.receive() }
+                    assertNotNull(msg2, "watcher should deliver the post-subscription record")
+                } finally {
+                    job.cancelAndJoin()
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -113,7 +113,7 @@ class ExternalSourceTest {
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader"))
+        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope)
 
@@ -137,11 +137,11 @@ class ExternalSourceTest {
         extSource.channel.send(null)
         delay(500.milliseconds)
 
-        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+        assertTrue(replicaLog.latestSubmittedOffset() >= 0, "replica log should have received a message")
 
         val replicaMessages = mutableListOf<ReplicaMessage>()
         backgroundScope.launch {
-            replicaLog.tailAll(-1) { records ->
+            replicaLog.tailAll(0, -1) { records ->
                 replicaMessages.addAll(records.map { it.message })
             }
         }
@@ -170,7 +170,7 @@ class ExternalSourceTest {
 
         val resolvedTxs = mutableListOf<ReplicaMessage.ResolvedTx>()
         backgroundScope.launch {
-            replicaLog.tailAll(-1) { records ->
+            replicaLog.tailAll(0, -1) { records ->
                 records.forEach { (it.message as? ReplicaMessage.ResolvedTx)?.let(resolvedTxs::add) }
             }
         }
@@ -195,7 +195,7 @@ class ExternalSourceTest {
 
         delay(500.milliseconds)
 
-        assertTrue(replicaLog.latestSubmittedOffset >= 0, "source records should flow through to the leader")
+        assertTrue(replicaLog.latestSubmittedOffset() >= 0, "source records should flow through to the leader")
     }
 
     @Test
@@ -263,7 +263,7 @@ class ExternalSourceTest {
 
         val resolvedTxs = mutableListOf<ReplicaMessage.ResolvedTx>()
         backgroundScope.launch {
-            replicaLog.tailAll(-1) { records ->
+            replicaLog.tailAll(0, -1) { records ->
                 records.forEach { (it.message as? ReplicaMessage.ResolvedTx)?.let(resolvedTxs::add) }
             }
         }

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -62,7 +62,7 @@ class FollowerLogProcessorTest {
         // The processor self-launches its replica tail; park it so it idles while the test drives
         // processRecords directly — a relaxed mock would return immediately and tear the proc down.
         replicaLog = mockk(relaxed = true)
-        coEvery { replicaLog.tailAll(any(), any()) } coAnswers { awaitCancellation() }
+        coEvery { replicaLog.tailAll(any(), any(), any()) } coAnswers { awaitCancellation() }
 
         every { bufferPool.epoch } returns 1
     }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -83,7 +83,7 @@ class LeaderLogProcessorTest {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader"))
+        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
 
         return LeaderLogProcessor(
@@ -119,7 +119,7 @@ class LeaderLogProcessorTest {
         watchers.awaitSource(0)
 
         verify { trieCatalog.addTries(any(), any(), any()) }
-        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have received a message")
+        assertTrue(replicaLog.latestSubmittedOffset() >= 0, "replica log should have received a message")
     }
 
     @Test
@@ -141,7 +141,7 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader")
+        val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -163,7 +163,7 @@ class LeaderLogProcessorTest {
         verify { liveIndex.finishBlock(any(), eq(0)) }
         verify { liveIndex.nextBlock() }
         verify { compactor.signalBlock() }
-        assertTrue(replicaLog.latestSubmittedOffset >= 0, "replica log should have block messages")
+        assertTrue(replicaLog.latestSubmittedOffset() >= 0, "replica log should have block messages")
     }
 
     @Test
@@ -212,7 +212,7 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader")
+        val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -232,7 +232,7 @@ class LeaderLogProcessorTest {
         watchers.awaitSource(0)
 
         val replicaMessages = mutableListOf<ReplicaMessage>()
-        backgroundScope.launch { replicaLog.tailAll(-1) { records ->
+        backgroundScope.launch { replicaLog.tailAll(0, -1) { records ->
             replicaMessages.addAll(records.map { it.message })
         } }
 
@@ -310,7 +310,7 @@ class LeaderLogProcessorTest {
             "record 0 kicked its append alone; 1-4 resolved behind it and rode the next producer transaction"
         )
 
-        val resolvedTxs = replicaLog.readRecords(0, replicaLog.latestSubmittedMsgId + 1)
+        val resolvedTxs = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
             .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
         assertEquals((0 until n).toList(), resolvedTxs.map { it.txId }, "all $n txs land, in send order")
     }
@@ -510,7 +510,7 @@ class LeaderLogProcessorTest {
         assertEquals(1, producerBatchSizes.first(), "tx 0 kicked its append alone")
         assertEquals(5, producerBatchSizes.sum(), "every tx reached the replica log exactly once")
 
-        val resolvedTxs = replicaLog.readRecords(0, replicaLog.latestSubmittedMsgId + 1)
+        val resolvedTxs = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
             .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
         assertEquals((0 until 5L).toList(), resolvedTxs.map { it.txId }, "all 5 txs land, in send order")
     }
@@ -541,7 +541,7 @@ class LeaderLogProcessorTest {
 
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader")
+        val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
 
         val lp = LeaderLogProcessor(
@@ -570,7 +570,7 @@ class LeaderLogProcessorTest {
             Log.Record(0, 10, Instant.now(), SourceMessage.Tx(ByteArray(0), null, ZoneId.of("UTC"), null, null))
         ))
 
-        val boundaries = replicaLog.readRecords(0, replicaLog.latestSubmittedMsgId + 1)
+        val boundaries = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
             .mapNotNull { it.message as? ReplicaMessage.BlockBoundary }.toList()
 
         assertEquals(1, boundaries.size, "exactly one BlockBoundary should be written")

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -125,7 +125,7 @@ class LogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log with a transaction
-        val replicaProducer = replicaLog.openAtomicProducer("setup")
+        val replicaProducer = replicaLog.openAtomicProducer("setup", 0)
         replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
         replicaProducer.close()
 

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -19,8 +19,9 @@ private val LOG = SimLog::class.logger
 internal class SimLog<M>(private val name: String, private val rand: Random) : Log<M> {
     override val epoch: Int get() = 0
 
-    override var latestSubmittedOffset: LogOffset = -1
-        private set
+    private var latestSubmittedOffset0: LogOffset = -1
+
+    override fun latestSubmittedOffset(partition: Int): LogOffset = latestSubmittedOffset0
 
     /**
      * A consumer that participates in leader election (Kafka consumer group semantics).
@@ -146,11 +147,11 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
         // abandons a Prepared leader or is a no-op if recovery already re-followed. Mirrors Kafka revoke.
         pending?.let { p ->
             p.transition.cancelAndJoin()
-            p.leader.listener.demoteLeader(listOf(0))
+            p.leader.listener.demoteLeader(0)
         }
         leader?.let { old ->
             LOG.debug("$name/chooseLeader: revoking old leader")
-            old.listener.demoteLeader(listOf(0))
+            old.listener.demoteLeader(0)
             old.tailSpec = null
         }
         pending = null
@@ -159,7 +160,7 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
         if (groupConsumers.isNotEmpty()) {
             val newLeader = groupConsumers.random(rand)
             LOG.debug("$name/chooseLeader: launching transition for new leader")
-            pending = Pending(newLeader, newLeader.listener.launchTransition(listOf(0)))
+            pending = Pending(newLeader, newLeader.listener.launchTransition(0))
             // installed by commitPendingLeader (group-loop select clause) once the transition completes
         } else {
             LOG.debug("$name/chooseLeader: no consumers, no leader elected")
@@ -171,7 +172,7 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
         val newLeader = pending?.leader ?: return
         pending = null
         LOG.debug("$name/chooseLeader: committing new leader")
-        val tailSpec = newLeader.listener.commitLeader(listOf(0))
+        val tailSpec = newLeader.listener.commitLeader(0)
         newLeader.tailSpec = tailSpec
         newLeader.nextOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, tailSpec.afterMsgId) + 1).toInt()
         leader = newLeader
@@ -188,7 +189,7 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
     }
 
     private fun appendSync(message: M): Log.MessageMetadata {
-        val offset = ++latestSubmittedOffset
+        val offset = ++latestSubmittedOffset0
         val ts = Instant.now()
         LOG.debug("$name/append: offset=$offset message=${message!!::class.simpleName}")
         topic += Log.Record(epoch, offset, ts, message)
@@ -197,10 +198,10 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
         return Log.MessageMetadata(epoch, offset, ts)
     }
 
-    override suspend fun appendMessage(message: M): Log.MessageMetadata =
+    override suspend fun appendMessage(message: M, partition: Int): Log.MessageMetadata =
         appendSync(message)
 
-    override fun openAtomicProducer(transactionalId: String) = object : Log.AtomicProducer<M> {
+    override fun openAtomicProducer(transactionalId: String, partition: Int) = object : Log.AtomicProducer<M> {
         override fun openTx() = object : Log.AtomicProducer.Tx<M> {
             private val buffer = mutableListOf<Pair<M, CompletableDeferred<Log.MessageMetadata>>>()
             private var isOpen = true
@@ -235,15 +236,15 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
         override fun close() {}
     }
 
-    override fun readLastMessage(): M? = topic.lastOrNull()?.message
+    override fun readLastMessage(partition: Int): M? = topic.lastOrNull()?.message
 
-    override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId): Sequence<Log.Record<M>> {
+    override fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId): Sequence<Log.Record<M>> {
         val fromOffset = MsgIdUtil.msgIdToOffset(fromMsgId).toInt()
         val toOffset = MsgIdUtil.msgIdToOffset(toMsgId).toInt()
         return topic.subList(fromOffset.coerceAtLeast(0), toOffset.coerceAtMost(topic.size)).asSequence()
     }
 
-    override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) {
+    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: Log.RecordProcessor<M>) {
         val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId) + 1).toInt()
         LOG.debug("$name/tailAll: startOffset=$startOffset topicSize=${topic.size}")
         val consumer = PlainConsumer(processor, startOffset, coroutineContext.job)

--- a/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLogTest.kt
@@ -22,7 +22,7 @@ class SimLogTest : SimulationTestBase() {
                 SimLog<String>("test", rand).use { log ->
                     launchSimLog(log)
 
-                    launch { log.tailAll(afterMsgId = -1) { _ -> error("plainConsumer failure") } }
+                    launch { log.tailAll(partition = 0, afterMsgId = -1) { _ -> error("plainConsumer failure") } }
 
                     log.appendMessage("trigger")
                 }
@@ -41,11 +41,11 @@ class SimLogTest : SimulationTestBase() {
 
                     launch {
                         log.openGroupSubscription(object : Log.SubscriptionListener<String> {
-                            override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
-                            override fun commitLeader(partitions: Collection<Int>) =
+                            override fun launchTransition(partition: Int) = CompletableDeferred(Unit)
+                            override fun commitLeader(partition: Int) =
                                 Log.TailSpec<String>(afterMsgId = -1L) { _ -> error("groupConsumer failure") }
 
-                            override suspend fun demoteLeader(partitions: Collection<Int>) {}
+                            override suspend fun demoteLeader(partition: Int) {}
                         })
                     }
 

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -209,7 +209,7 @@ class KafkaCluster(
                 // paused (never fetched) and re-seeked to the real offset before resume at commit.
                 consumer.seekToEnd(listOf(tp))
 
-                val transition = listener.launchTransition(listOf(tp.partition()))
+                val transition = listener.launchTransition(tp.partition())
                 val transitioning = Transitioning<M>(transition)
                 listenerState = transitioning
 
@@ -235,7 +235,7 @@ class KafkaCluster(
                 // is cancellable) and lets the transition's own recovery settle `state`. Then demote:
                 // Prepared→abandon, Leading→teardown, Following→no-op. Back to Following either way.
                 (listenerState as? Transitioning)?.transition?.cancelAndJoin()
-                listener.demoteLeader(listOf(partitions.single().partition()))
+                listener.demoteLeader(partitions.single().partition())
                 listenerState = Following()
             }
 
@@ -257,7 +257,7 @@ class KafkaCluster(
             fun onTransitionComplete(cmd: GroupCommand.TransitionComplete) {
                 if (listenerState !== cmd.transitioning) return
 
-                val tailSpec = listener.commitLeader(listOf(cmd.tp.partition()))
+                val tailSpec = listener.commitLeader(cmd.tp.partition())
                 listenerState = LeaderCommitted(tailSpec.processor)
                 consumer.seekToAfterMsgId(cmd.tp, epoch, tailSpec.afterMsgId)   // seek before resume — #5633
                 consumer.resume(listOf(cmd.tp))
@@ -540,9 +540,9 @@ class KafkaCluster(
             }
 
         private val latestSubmittedOffset0 = AtomicLong(readLatestSubmittedMessage(kafkaConfigMap))
-        override val latestSubmittedOffset get() = latestSubmittedOffset0.get()
+        override fun latestSubmittedOffset(partition: Int) = latestSubmittedOffset0.get()
 
-        override suspend fun appendMessage(message: M): Log.MessageMetadata =
+        override suspend fun appendMessage(message: M, partition: Int): Log.MessageMetadata =
             CompletableDeferred<Log.MessageMetadata>()
                 .also { res ->
                     producer.send(
@@ -561,7 +561,7 @@ class KafkaCluster(
                 }
                 .await()
 
-        override fun readLastMessage(): M? =
+        override fun readLastMessage(partition: Int): M? =
             kafkaConfigMap.openConsumer().use { c ->
                 val tp = TopicPartition(topic, 0)
                 val lastOffset = c.endOffsets(listOf(tp))[tp]?.minus(1)?.takeIf { it >= 0 } ?: return null
@@ -572,7 +572,7 @@ class KafkaCluster(
                 records.firstOrNull()?.let { record -> codec.decode(record.value()) }
             }
 
-        override fun readRecords(fromMsgId: MessageId, toMsgId: MessageId) = sequence {
+        override fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId) = sequence {
             if (msgIdToEpoch(fromMsgId) != epoch || msgIdToEpoch(toMsgId) != epoch) return@sequence
             val fromOffset = msgIdToOffset(fromMsgId)
             val toOffset = msgIdToOffset(toMsgId)
@@ -598,7 +598,7 @@ class KafkaCluster(
             }
         }
 
-        override fun openAtomicProducer(transactionalId: String) = object : AtomicProducer<M> {
+        override fun openAtomicProducer(transactionalId: String, partition: Int) = object : AtomicProducer<M> {
             private val prefixedTxId = listOfNotNull(transactionalIdPrefix, transactionalId).joinToString("-")
 
             init {
@@ -696,7 +696,7 @@ class KafkaCluster(
                 throw InterruptedException().initCause(e)
             }
 
-        override suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
+        override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
             kafkaConfigMap.openConsumer().use { c ->
                 val tp = TopicPartition(topic, 0)
                 c.assign(listOf(tp))
@@ -738,7 +738,7 @@ class KafkaCluster(
         fun autoCreateTopic(autoCreateTopic: Boolean) = apply { this.autoCreateTopic = autoCreateTopic }
         fun epoch(epoch: Int) = apply { this.epoch = epoch }
 
-        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>): Log<SourceMessage> {
+        override fun openSourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int): Log<SourceMessage> {
             val clusterAlias = this.cluster
             val cluster = requireNotNull(remotes[clusterAlias] as? KafkaCluster) {
                 "missing Kafka cluster: '$clusterAlias'"
@@ -753,10 +753,10 @@ class KafkaCluster(
             return cluster.KafkaLog(SourceMessage.Codec, topic, epoch)
         }
 
-        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLog(openSourceLog(remotes))
+        override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLog(openSourceLog(remotes, partitions))
 
-        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>): Log<ReplicaMessage> {
+        override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int): Log<ReplicaMessage> {
             val clusterAlias = this.replicaCluster
             val cluster = requireNotNull(remotes[clusterAlias] as? KafkaCluster) {
                 "missing Kafka cluster: '$clusterAlias'"
@@ -771,8 +771,8 @@ class KafkaCluster(
             return cluster.KafkaLog(ReplicaMessage.Codec, replicaTopic, epoch)
         }
 
-        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>) =
-            ReadOnlyLog(openReplicaLog(remotes))
+        override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
+            ReadOnlyLog(openReplicaLog(remotes, partitions))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.setOtherLog(ProtoAny.pack(kafkaLogConfig {

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaAtomicProducerTest.kt
@@ -63,9 +63,9 @@ class KafkaAtomicProducerTest {
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster)).use { log ->
-                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        val tailJob = launch { log.tailAll(0, -1, subscriber) }
                         try {
-                            log.openAtomicProducer("tx-producer-1").use { producer ->
+                            log.openAtomicProducer("tx-producer-1", 0).use { producer ->
                                 producer.withTx { tx ->
                                     tx.appendMessage(txMessage(1))
                                     tx.appendMessage(txMessage(2))
@@ -107,9 +107,9 @@ class KafkaAtomicProducerTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        val tailJob = launch { log.tailAll(0, -1, subscriber) }
                         try {
-                            log.openAtomicProducer("tx-producer-1").use { producer ->
+                            log.openAtomicProducer("tx-producer-1", 0).use { producer ->
                                 // Abort this transaction
                                 producer.openTx().use { tx ->
                                     tx.appendMessage(txMessage(1))
@@ -157,9 +157,9 @@ class KafkaAtomicProducerTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        val tailJob = launch { log.tailAll(0, -1, subscriber) }
                         try {
-                            log.openAtomicProducer("tx-producer-1").use { producer ->
+                            log.openAtomicProducer("tx-producer-1", 0).use { producer ->
                                 producer.withTx { tx -> tx.appendMessage(txMessage(1)) }
                                 producer.withTx { tx ->
                                     tx.appendMessage(txMessage(2))
@@ -197,9 +197,9 @@ class KafkaAtomicProducerTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        val tailJob = launch { log.tailAll(-1, subscriber) }
+                        val tailJob = launch { log.tailAll(0, -1, subscriber) }
                         try {
-                            log.openAtomicProducer("tx-producer-1").use { producer ->
+                            log.openAtomicProducer("tx-producer-1", 0).use { producer ->
                                 producer.openTx().use { tx ->
                                     tx.appendMessage(txMessage(1))
 
@@ -264,9 +264,9 @@ class KafkaAtomicProducerTest {
                 .open().use { cluster ->
                     KafkaCluster.LogFactory("my-cluster", outputTopic)
                         .openSourceLog(mapOf("my-cluster" to cluster)).use { log ->
-                            val tailJob = launch { log.tailAll(-1, subscriber) }
+                            val tailJob = launch { log.tailAll(0, -1, subscriber) }
                             try {
-                                (log.openAtomicProducer("tx-producer-1") as KafkaCluster.AtomicProducer).use { producer ->
+                                (log.openAtomicProducer("tx-producer-1", 0) as KafkaCluster.AtomicProducer).use { producer ->
                                     producer.openTx().use { tx ->
                                         tx.appendMessage(txMessage(1))
                                         tx.sendOffsetsToTransaction(offsets, groupMetadata)

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -101,7 +101,7 @@ class KafkaClusterTest {
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        val job = launch { log.tailAll(-1, subscriber) }
+                        val job = launch { log.tailAll(0, -1, subscriber) }
                         try {
                             val txPayload = ByteBuffer.allocate(9).put(-1).putLong(42).flip().array()
                             log.appendMessage(SourceMessage.LegacyTx(txPayload))
@@ -277,7 +277,7 @@ class KafkaClusterTest {
                         KafkaCluster.LogFactory("my-cluster", topicName, autoCreateTopic = false)
                             .openReplicaLog(mapOf("my-cluster" to cluster))
                             .use { log ->
-                                val job = launch { log.tailAll(-1, subscriber) }
+                                val job = launch { log.tailAll(0, -1, subscriber) }
                                 try {
                                     log.appendMessage(blockUploaded)
 
@@ -357,14 +357,14 @@ class KafkaClusterTest {
 
         private val processor = RecordProcessor<SourceMessage> { recs -> records.addAll(recs) }
 
-        override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
+        override fun launchTransition(partition: Int) = CompletableDeferred(Unit)
 
-        override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> {
+        override fun commitLeader(partition: Int): TailSpec<SourceMessage> {
             assignedPartitions.add(Unit)
             return TailSpec(afterMsgId, processor)
         }
 
-        override suspend fun demoteLeader(partitions: Collection<Int>) {
+        override suspend fun demoteLeader(partition: Int) {
             revokedPartitions.add(Unit)
         }
     }
@@ -441,14 +441,14 @@ class KafkaClusterTest {
 
         // Launch on a real scope (not the runTest virtual dispatcher): the poll thread joins this
         // handle via runBlocking, so a virtual-dispatcher job would never get to run.
-        override fun launchTransition(partitions: Collection<Int>) = scope.async {
+        override fun launchTransition(partition: Int) = scope.async {
             entered.complete(Unit)
             release.await()
         }
 
-        override fun commitLeader(partitions: Collection<Int>) = TailSpec(-1L) { recs -> records.addAll(recs) }
+        override fun commitLeader(partition: Int) = TailSpec(-1L) { recs -> records.addAll(recs) }
 
-        override suspend fun demoteLeader(partitions: Collection<Int>) {}
+        override suspend fun demoteLeader(partition: Int) {}
     }
 
     @Test
@@ -491,9 +491,9 @@ class KafkaClusterTest {
     }
 
     private class ThrowingOnAssignListener(private val toThrow: Throwable) : SubscriptionListener<SourceMessage> {
-        override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred<Unit>().apply { completeExceptionally(toThrow) }
-        override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> = error("unreachable")
-        override suspend fun demoteLeader(partitions: Collection<Int>) {}
+        override fun launchTransition(partition: Int) = CompletableDeferred<Unit>().apply { completeExceptionally(toThrow) }
+        override fun commitLeader(partition: Int): TailSpec<SourceMessage> = error("unreachable")
+        override suspend fun demoteLeader(partition: Int) {}
     }
 
     @Test
@@ -739,7 +739,7 @@ class KafkaClusterTest {
                         val completed = supervisorScope {
                             val job = launch {
                                 try {
-                                    log.tailAll(anchorInTruncatedPrefix, subscriber)
+                                    log.tailAll(0, anchorInTruncatedPrefix, subscriber)
                                 } catch (e: Throwable) {
                                     caught.set(e)
                                 }
@@ -769,11 +769,11 @@ class KafkaClusterTest {
         val anchorInTruncatedPrefix = MsgIdUtil.offsetToMsgId(0, 1L)
         val caught = AtomicReference<Throwable?>(null)
         val listener = object : SubscriptionListener<SourceMessage> {
-            override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
-            override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> =
+            override fun launchTransition(partition: Int) = CompletableDeferred(Unit)
+            override fun commitLeader(partition: Int): TailSpec<SourceMessage> =
                 TailSpec(afterMsgId = anchorInTruncatedPrefix, processor = { _ -> })
 
-            override suspend fun demoteLeader(partitions: Collection<Int>) {}
+            override suspend fun demoteLeader(partition: Int) {}
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
@@ -886,7 +886,7 @@ class KafkaClusterTest {
                         log.appendMessage(txMessage(2))
                         log.appendMessage(txMessage(3))
 
-                        val job = launch { log.tailAll(-1L, subscriber) }
+                        val job = launch { log.tailAll(0, -1L, subscriber) }
                         try {
                             withTimeoutOrNull(5.seconds) {
                                 while (synchronized(msgs) { msgs.flatten().size } < 3) delay(100.milliseconds)
@@ -907,11 +907,11 @@ class KafkaClusterTest {
         val msgs = synchronizedList(mutableListOf<List<Record<SourceMessage>>>())
         val processor = RecordProcessor { records -> msgs.add(records) }
         val listener = object : SubscriptionListener<SourceMessage> {
-            override fun launchTransition(partitions: Collection<Int>) = CompletableDeferred(Unit)
-            override fun commitLeader(partitions: Collection<Int>): TailSpec<SourceMessage> =
+            override fun launchTransition(partition: Int) = CompletableDeferred(Unit)
+            override fun commitLeader(partition: Int): TailSpec<SourceMessage> =
                 TailSpec(afterMsgId = -1L, processor = processor)
 
-            override suspend fun demoteLeader(partitions: Collection<Int>) {}
+            override suspend fun demoteLeader(partition: Int) {}
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -318,7 +318,7 @@ class PostgresSourceIntegrationTest {
                 }
 
                 val txId = cdc.blockCatalog.latestCompletedTx!!.txId
-                val sourceOffset = cdc.sourceLog.latestSubmittedOffset
+                val sourceOffset = cdc.sourceLog.latestSubmittedOffset()
                 assertTrue(
                     txId > sourceOffset,
                     "test precondition: txId ($txId) should exceed source-log offset ($sourceOffset)"

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -318,15 +318,16 @@
   (let [source-log (InMemoryLog. (InstantSource/system) 0)
         replica-log (InMemoryLog. (InstantSource/system) 0)
         log-factory (reify Log$Factory
-                      (openSourceLog [_ _] source-log)
-                      (openReadOnlySourceLog [_ _] (ReadOnlyLog. source-log))
-                      (openReplicaLog [_ _] replica-log)
-                      (openReadOnlyReplicaLog [_ _] (ReadOnlyLog. replica-log))
+                      (openSourceLog [_ _ _] source-log)
+                      (openReadOnlySourceLog [_ _ _] (ReadOnlyLog. source-log))
+                      (openReplicaLog [_ _ _] replica-log)
+                      (openReadOnlyReplicaLog [_ _ _] (ReadOnlyLog. replica-log))
                       (writeTo [_ _]))]
 
     (.appendMessageBlocking replica-log
                             (ReplicaMessage$ResolvedTx. 0 (Instant/now)
-                                                        true nil {} nil nil nil))
+                                                        true nil {} nil nil nil)
+                            0)
 
     (with-open [node (xtn/start-node (doto (Xtdb$Config.)
                                        (.log log-factory)
@@ -345,21 +346,22 @@
   (let [source-log (InMemoryLog. (InstantSource/system) 0)
         replica-log (InMemoryLog. (InstantSource/system) 0)
         log-factory (reify Log$Factory
-                      (openSourceLog [_ _] source-log)
-                      (openReadOnlySourceLog [_ _] (ReadOnlyLog. source-log))
-                      (openReplicaLog [_ _] replica-log)
-                      (openReadOnlyReplicaLog [_ _] (ReadOnlyLog. replica-log))
+                      (openSourceLog [_ _ _] source-log)
+                      (openReadOnlySourceLog [_ _ _] (ReadOnlyLog. source-log))
+                      (openReplicaLog [_ _ _] replica-log)
+                      (openReadOnlyReplicaLog [_ _ _] (ReadOnlyLog. replica-log))
                       (writeTo [_ _]))]
 
     (.appendMessageBlocking replica-log
                             (ReplicaMessage$ResolvedTx. 0 (Instant/now)
-                                                        true nil {} nil nil nil))
+                                                        true nil {} nil nil nil)
+                            0)
 
     ;; offset 0 mirrors replay's txId — leader skips it
-    (.appendMessageBlocking source-log (SourceMessage$DetachDatabase. "missing-db-0"))
+    (.appendMessageBlocking source-log (SourceMessage$DetachDatabase. "missing-db-0") 0)
 
     ;; offset 1 — what we're awaiting
-    (.appendMessageBlocking source-log (SourceMessage$DetachDatabase. "missing-db-1"))
+    (.appendMessageBlocking source-log (SourceMessage$DetachDatabase. "missing-db-1") 0)
 
     (with-open [node (xtn/start-node (doto (Xtdb$Config.) (.log log-factory)))]
       (let [primary (.databaseOrNull (db/<-node node) "xtdb")]

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -3119,7 +3119,7 @@ ORDER BY 1,2;")
     (xt/execute-tx conn [[:put-docs :foo {:xt/id 1}]])
     (t/is (= [{:xt/id 1}] (xt/q conn "SELECT * FROM foo")))
     (doto (.getSourceLog (db/primary-db tu/*node*))
-      (.appendMessageBlocking (SourceMessage$FlushBlock. 1)))
+      (.appendMessageBlocking (SourceMessage$FlushBlock. 1) 0))
     (t/is (= [{:xt/id 1}] (xt/q conn "SELECT * FROM foo")))))
 
 (t/deftest test-database-metadata

--- a/src/test/clojure/xtdb/sql/multi_db_test.clj
+++ b/src/test/clojure/xtdb/sql/multi_db_test.clj
@@ -203,9 +203,9 @@ ATTACH DATABASE new_db WITH $$
 (t/deftest dodgy-yaml
   (with-open [node (xtn/start-node)]
     (t/is (= {:sql-state "08P01"
-              :message "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: critical, externalSource, log, mode, storage" ,
+              :message "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: critical, externalSource, log, mode, partitions, storage" ,
               :detail #xt/error [:incorrect :xtdb/invalid-database-config
-                                 "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: critical, externalSource, log, mode, storage"
+                                 "Invalid database config in `ATTACH DATABASE`: Unknown property 'somethingElse'. Known properties are: critical, externalSource, log, mode, partitions, storage"
                                  {:sql "ATTACH DATABASE new_db WITH $$ somethingElse: $$"}]},
 
              (pgw-test/reading-ex

--- a/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
+++ b/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
@@ -1,5 +1,5 @@
 {:block-idx 0,
- :latest-processed-msg-id 118,
+ :latest-processed-msg-id 120,
  :table-names #{"xt/txs" "xt/role_membership"},
  :secondary-dbs
  {"new_db"


### PR DESCRIPTION
Unit 5 of multi-DB stage 4. Plumbs the type system through for multi-partition external-source databases without enabling them yet — `Database.open` rejects `partitions > 1`, lifted in unit 9.

Four threads through the diff:

- `Database.Config.partitions: Int = 1` joins the persisted config. New proto field `partitions = 10` emitted on every AttachDatabase; `fromProto` coerces the proto default (0) back to 1 so pre-#5557 records still round-trip. `attach-db/b00.binpb.edn`'s `:latest-processed-msg-id` shifts 118 → 120 (two bytes per AttachDatabase: field tag + varint(1)).

- `Log<M>` surfaces partition on every operation that varies per-partition: `latestSubmittedOffset(partition)`, `readRecords(partition, …)`, `tailAll(partition, …)`, `readLastMessage(partition)`, plus a `partition` arg on `appendMessage` and `openAtomicProducer`. `SubscriptionListener` singularises all three methods of #5773's leader-transition state machine — `launchTransition(Int)` / `commitLeader(Int): TailSpec<M>` / `demoteLeader(Int)` — dropping the plural-input / singular-return shape that couldn't represent N partitions' resume info at the same time. Matches `allium/log-processor-lifecycle.allium`, which already models the listener per-partition. Kafka's rebalance callback still hands the transport a `Collection<TopicPartition>`; the loop over that collection moves up one layer to the transport, where it belongs.

- `InMemoryLog` and `LocalLog` gain real partition support behind the new interface. `InMemoryLog` keeps one `MutableSharedFlow` + mutex + offset counter per partition. `LocalLog` (and `ReadOnlyLocalLog`) uses one file per partition: `<rootPath>/LOG` (and `<rootPath>/REPLICA_LOG`) at N=1 — byte-identical to the pre-#5557 layout, so existing on-disk dev directories and checked-in test fixtures keep working without migration; `<rootPath>/LOG/0`, `<rootPath>/LOG/1`, … (and similarly under `REPLICA_LOG/`) at N>1 — nested under the role directory. Partition count is immutable post-attach, so a rootPath is either file-mode N=1 or directory-mode N>1 for its whole lifetime; the two shapes never coexist for the same path. This mirrors the object-store layout planned for unit 6 (no partition marker for N=1, grouped under a marker for N>1). Kotlin default args don't reach Java/Clojure callers, so Clojure sites pass explicit `0` and `InMemoryLog`'s constructor gets `@JvmOverloads`.

  `ReadOnlyLocalLog` additionally registers its `WatchService` on the partition file's parent (`rootPath` at N=1, `rootPath/LOG` at N>1) and matches events by the last path segment — inotify doesn't recurse into subdirectories, so a watch on `rootPath` at N>1 would never observe writes inside `LOG/`. `Files.createDirectories(watchDir)` covers the case where the reader opens before the writer has created the nested directory.

- Kafka adapter: `KafkaCluster.KafkaLog`'s overrides pick up the `partition` args (unused today — Kafka's own per-partition consumer path arrives in unit 9). Its rebalance listener drops the `listOf(...)` wraps around `.partition()` now that the listener interface is singular.

`Database`'s inline `Log.SubscriptionListener<SourceMessage>` collapses to three one-liners that route each `partition` to the matching `DatabasePartition`'s `LogProcessor`. `LogProcessor`'s method signatures follow — `Collection<Int>` becomes `Int` — the arg is redundant inside `LogProcessor` bodies (a LogProcessor already serves exactly one partition after unit 4) but carries the routing key at the interface. `dodgy-yaml`'s expected known-properties list gains `partitions`.

Tests. Multi-partition characterisation for `InMemoryLog` and `LocalLog` — per-partition write isolation, independent offset progression, `tailAll(p)` only sees partition p's records, `openGroupSubscription` drives the listener lifecycle across all N partitions. `LocalLog` additionally verifies the file-layout at both N=1 and N>1, and restart-recovery of per-partition state via `readLatestSubmittedOffset`. New `ReadOnlyLocalLogTest` verifies the watcher observes external writes at both partition counts using a catch-up-then-watch structure that removes timing sensitivity (the pre-existing record's catch-up delivery synchronises the reader into its watch loop before the post-subscription write, so only the watcher can deliver that second record). The existing close-doesn't-leak integration test is parameterised over N=1 (5000 iterations, preserving the historical leak-hunter cadence) and N=2 (500 iterations, sanity check on multi-partition close).

The runtime guard in `Database.open` is deliberate — every type signature now admits N, but the actual N-partition wiring (per-partition `BufferPool` + storage layout in unit 6, `TableCatalog` wrapper + UNION-at-scan in unit 7, `xt.txs_$partition` in unit 8) doesn't land until those units. Rejecting `partitions > 1` at attach time keeps single-partition users at exactly today's behaviour while the rest of the type system bakes.


Refs #5557
