### PR TITLE
Model the pg_catalog surface, resolve internal-schema columns strictly

### DIFF
--- a/api/src/main/clojure/xtdb/serde/types.clj
+++ b/api/src/main/clojure/xtdb/serde/types.clj
@@ -1,5 +1,6 @@
 (ns xtdb.serde.types
-  (:require [clojure.pprint :as pp])
+  (:require [clojure.pprint :as pp]
+            [xtdb.error :as err])
   (:import (java.io Writer)
            (org.apache.arrow.vector.types DateUnit FloatingPointPrecision IntervalUnit TimeUnit Types$MinorType UnionMode)
            (org.apache.arrow.vector.types.pojo ArrowType ArrowType$Binary ArrowType$Bool ArrowType$Date ArrowType$Decimal ArrowType$Duration ArrowType$FixedSizeBinary ArrowType$FixedSizeList ArrowType$FloatingPoint ArrowType$Int ArrowType$Interval ArrowType$List ArrowType$Map ArrowType$Null ArrowType$Struct ArrowType$Time ArrowType$Time ArrowType$Timestamp ArrowType$Union ArrowType$Utf8 Field FieldType Schema)
@@ -431,25 +432,22 @@
 
     (set? type-spec) (VectorType/fromLegs (into #{} (map ->type) type-spec))
 
-    :else (let [[first-elem & more-opts] type-spec
-                [nullable? more-opts] (if (= :? first-elem)
-                                        [true more-opts]
-                                        [false (cons first-elem more-opts)])
-                [arrow-type-head & more-opts] more-opts]
-            (case arrow-type-head
-              :null VectorType$Null/INSTANCE
-              :struct (-> (VectorType/structOf (->> (first more-opts)
-                                                    (into {} (map (fn [[k v]]
-                                                                    [(str k) (->type v)])))))
-                          (VectorType/maybe nullable?))
+    (vector? type-spec) (if (= :? (first type-spec))
+                          (VectorType/maybe (->type (subvec type-spec 1)))
+                          (let [[arrow-type-head & more-opts] type-spec]
+                            (case arrow-type-head
+                              :null VectorType$Null/INSTANCE
+                              :struct (VectorType/structOf (->> (first more-opts)
+                                                                (into {} (map (fn [[k v]]
+                                                                                [(str k) (->type v)])))))
 
-              :tstz-range (-> VectorType/TSTZ_RANGE
-                              (VectorType/maybe nullable?))
+                              :tstz-range VectorType/TSTZ_RANGE
 
-              (:set :list :fixed-size-list)
-              (-> (VectorType/listy (->arrow-type arrow-type-head) (->type (first more-opts)))
-                  (VectorType/maybe nullable?))
+                              (:set :list :fixed-size-list)
+                              (VectorType/listy (->arrow-type arrow-type-head) (->type (first more-opts)))
 
-              (-> (VectorType/scalar (->arrow-type (cons arrow-type-head more-opts)))
-                  (VectorType/maybe nullable?))))))
+                              (VectorType/scalar (->arrow-type (cons arrow-type-head more-opts))))))
+
+    :else (throw (err/incorrect :invalid-type "Invalid type"
+                                {:type-spec type-spec}))))
 

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -59,27 +59,51 @@
     (-> '{information_schema/tables {table_catalog :utf8, table_schema :utf8, table_name :utf8, table_type :utf8}
           information_schema/columns {table_catalog :utf8, table_schema :utf8, table_name :utf8, column_name :utf8, data_type :utf8,
                                       udt_schema :utf8, udt_name :utf8,
-                                      ordinal_position :i32, column_default [:? :utf8], is_nullable :utf8, is_identity :utf8}
-          information_schema/schemata {catalog_name :utf8, schema_name :utf8, schema_owner :utf8}}
+                                      ordinal_position :i32, column_default [:? :utf8], is_nullable :utf8, is_identity :utf8,
+                                      is_generated :utf8, generation_expression [:? :utf8],
+                                      character_maximum_length [:? :i32], character_octet_length [:? :i32],
+                                      numeric_precision [:? :i32], numeric_scale [:? :i32], datetime_precision [:? :i32],
+                                      collation_name [:? :utf8]}
+          information_schema/schemata {catalog_name :utf8, schema_name :utf8, schema_owner :utf8}
+
+          ;; empty views - tools probe these during schema sync; we don't model constraints yet
+          information_schema/table_constraints {constraint_catalog [:? :utf8], constraint_schema [:? :utf8], constraint_name [:? :utf8],
+                                                table_catalog [:? :utf8], table_schema [:? :utf8], table_name [:? :utf8],
+                                                constraint_type [:? :utf8], is_deferrable [:? :utf8], initially_deferred [:? :utf8]}
+          information_schema/key_column_usage {constraint_catalog [:? :utf8], constraint_schema [:? :utf8], constraint_name [:? :utf8],
+                                               table_catalog [:? :utf8], table_schema [:? :utf8], table_name [:? :utf8],
+                                               column_name [:? :utf8], ordinal_position [:? :i32], position_in_unique_constraint [:? :i32]}
+          information_schema/constraint_column_usage {table_catalog [:? :utf8], table_schema [:? :utf8], table_name [:? :utf8],
+                                                      column_name [:? :utf8], constraint_catalog [:? :utf8],
+                                                      constraint_schema [:? :utf8], constraint_name [:? :utf8]}}
         (update-vals map->vec-types)))
 
   (def ^:private pg-catalog-tables
+    ;; unpopulated columns (declared `[:? …]`) always read as null - tools probe the full catalog
+    ;; surface, and modelling it lets column-not-found be a hard error like on user tables.
     (-> '{pg_catalog/pg_tables {schemaname :utf8, tablename :utf8, tableowner :utf8, tablespace :null}
           pg_catalog/pg_type {oid :i32, typname :utf8, typnamespace :i32, typowner :i32
                               typcategory :utf8, typtype :utf8, typbasetype :i32, typnotnull :bool, typtypmod :i32
                               typsend :utf8, typreceive :utf8, typinput :utf8, typoutput :utf8
-                              typrelid :i32, typelem :i32, typarray :i32}
-          pg_catalog/pg_class {oid :i32, relname :utf8, relnamespace :i32, relkind :utf8, relam :i32, relchecks :i32
+                              typrelid :i32, typelem :i32, typarray :i32
+                              typlen [:? :i32], typbyval [:? :bool], typalign [:? :utf8], typstorage [:? :utf8]
+                              typcollation [:? :i32], typdefault [:? :utf8], typndims [:? :i32], typdelim [:? :utf8]
+                              typispreferred [:? :bool], typisdefined [:? :bool]}
+          pg_catalog/pg_class {oid :i32, relname :utf8, relnamespace :i32, relowner :i32, relkind :utf8, relam :i32, relchecks :i32
                                relhasindex :bool, relhasrules :bool, relhastriggers :bool, relrowsecurity :bool
                                relforcerowsecurity :bool, relispartition :bool, reltablespace :i32, reloftype :i32
-                               relpersistence :utf8, relreplident :utf8, reltoastrelid :i32}
+                               relpersistence :utf8, relreplident :utf8, reltoastrelid :i32
+                               reltype [:? :i32], reltuples [:? :f64], relpages [:? :i32], relallvisible [:? :i32]
+                               relnatts [:? :i32], relhassubclass [:? :bool], relpartbound [:? :utf8]}
           pg_catalog/pg_description {objoid :i32, classoid :i32, objsubid :i16, description :utf8}
           pg_catalog/pg_views {schemaname :utf8, viewname :utf8, viewowner :utf8}
           pg_catalog/pg_matviews {schemaname :utf8, matviewname :utf8, matviewowner :utf8}
           pg_catalog/pg_attribute {attrelid :i32, attname :utf8, atttypid :i32
                                    attlen :i32, attnum :i32
                                    attisdropped :bool, attnotnull :bool
-                                   atttypmod :i32, attidentity :utf8, attgenerated :utf8}
+                                   atttypmod :i32, attidentity :utf8, attgenerated :utf8
+                                   attstorage [:? :utf8], attalign [:? :utf8], atthasdef [:? :bool], attcollation [:? :i32]
+                                   attislocal [:? :bool], attinhcount [:? :i32], atthasmissing [:? :bool], attndims [:? :i32]}
           pg_catalog/pg_namespace {oid :i32, nspname :utf8, nspowner :i32, nspacl :null}
           pg_catalog/pg_proc {oid :i32, proname :utf8, pronamespace :i32}
           pg_catalog/pg_database {oid :i32, datname :utf8, datallowconn :bool, datistemplate :bool}
@@ -95,10 +119,21 @@
                                rngcollation :i32, rngsubopc :i32, rngcanonical :utf8, rngsubdiff :utf8}
           pg_catalog/pg_am {oid :i32, amname :utf8, amhandler :utf8, amtype :utf8}
 
-          pg_catalog/pg_user {username :utf8, usesuper :bool, passwd [:? :utf8]}
+          pg_catalog/pg_user {usename :utf8, usesuper :bool, passwd [:? :utf8]}
 
           pg_catalog/pg_roles {oid :i32, rolname :utf8, rolsuper :bool, rolcanlogin :bool}
-          pg_catalog/pg_auth_members {roleid :i32, member :i32, grantor [:? :i32], admin_option :bool}}
+          pg_catalog/pg_auth_members {roleid :i32, member :i32, grantor [:? :i32], admin_option :bool}
+
+          ;; empty tables - tools probe these during schema sync; we don't model their contents yet
+          pg_catalog/pg_enum {oid :i32, enumtypid :i32, enumsortorder :f64, enumlabel :utf8}
+          pg_catalog/pg_constraint {oid :i32, conname :utf8, connamespace :i32, contype :utf8
+                                    condeferrable :bool, condeferred :bool, convalidated :bool
+                                    conrelid :i32, contypid :i32, conindid :i32, conparentid :i32, confrelid :i32
+                                    confupdtype :utf8, confdeltype :utf8, confmatchtype :utf8
+                                    conislocal :bool, coninhcount :i32, connoinherit :bool
+                                    conkey [:? :list :i32], confkey [:? :list :i32]}
+          pg_catalog/pg_extension {oid :i32, extname :utf8, extowner :i32, extnamespace :i32
+                                   extrelocatable :bool, extversion :utf8, extconfig [:? :list :i32], extcondition [:? :list :utf8]}}
         (update-vals map->vec-types)))
 
   (def ^:private xt-derived-tables
@@ -206,6 +241,7 @@
     {:oid (name->oid (table/ref->schema+table table))
      :relname (.denormalize ^IKeyFn (identity #xt/key-fn :snake-case-string) (.getTableName table))
      :relnamespace (name->oid (.getSchemaName table))
+     :relowner (name->oid "xtdb")
      :relkind "r"
      :relam (int 2)
      :relchecks (int 0)
@@ -273,7 +309,8 @@
      :ordinal-position (int idx)
      :column-default nil
      :is-nullable (if (types/nullable-vec-type? vec-type) "YES" "NO")
-     :is-identity "NO"}))
+     :is-identity "NO"
+     :is-generated "NEVER"}))
 
 (defn pg-attribute [col-rows]
   (for [{:keys [idx table name ^VectorType vec-type]} col-rows
@@ -343,7 +380,7 @@
   ;; `passwd` is NULL — Postgres redacts stored credentials from pg_user too, and the
   ;; authenticator holds the hashes in config, not here.
   (for [username (.knownUsers authn)]
-    {:username username, :usesuper (.isSuperuser authn username), :passwd nil}))
+    {:usename username, :usesuper (.isSuperuser authn username), :passwd nil}))
 
 (defn pg-roles [^Authenticator$Factory authn ^IQuerySource query-source ^IQuerySource$QueryCatalog db-cat]
   ;; Users (which can log in) and granted roles (which can't) share pg_roles, as in Postgres. A
@@ -490,6 +527,9 @@
                                      information_schema/tables (tables db-name schema-info)
                                      information_schema/columns (columns db-name (schema-info->col-rows schema-info))
                                      information_schema/schemata (schemas db-name)
+                                     information_schema/table_constraints nil
+                                     information_schema/key_column_usage nil
+                                     information_schema/constraint_column_usage nil
                                      pg_catalog/pg_tables (pg-tables schema-info)
                                      pg_catalog/pg_type (pg-type)
                                      pg_catalog/pg_class (pg-class schema-info)
@@ -504,6 +544,9 @@
                                      pg_catalog/pg_settings (pg-settings)
                                      pg_catalog/pg_range (pg-range)
                                      pg_catalog/pg_am (pg-am)
+                                     pg_catalog/pg_enum nil
+                                     pg_catalog/pg_constraint nil
+                                     pg_catalog/pg_extension nil
                                      pg_catalog/pg_user (pg-user authn)
                                      pg_catalog/pg_roles (pg-roles authn query-source db-cat)
                                      pg_catalog/pg_auth_members (pg-auth-members query-source db-cat)

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -351,12 +351,7 @@
                (or (nil? chain-db) (= chain-db (symbol db-name))))
       (for [col (if col-name
                   (when (or (contains? cols col-name) (types/temporal-col-name? col-name)
-                            (temporal-period-column? col-name)
-                            ;; tolerate any column on an internal-schema table: tools probe optional
-                            ;; pg_catalog/information_schema columns, and unimplemented system tables
-                            ;; resolve to the `xt.not_found` sentinel (schema `xt`). Only user tables
-                            ;; error on a typo'd / undeclared column (#4467).
-                            (contains? internal-schemas (.getSchemaName table-ref)))
+                            (temporal-period-column? col-name))
                     [col-name])
                   (available-cols this))
             :when (not (contains? excl-cols col))]

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -49,6 +49,17 @@ class TableCatalog(
     val types: Map<TableRef, Map<ColumnName, VectorType>>
         get() = state.tables.mapValues { (_, meta) -> meta.vecTypes }
 
+    /**
+     * Seeds a data-backed system table (e.g. `xt.txs`) so it's present from startup, as if an empty
+     * `CREATE TABLE` had run: columns are declared but dataless (`Nothing`), so the first real write
+     * sets their types (`Nothing ⊔ X = X`). No-op if the table was already loaded from storage.
+     */
+    fun seedTable(table: TableRef, colNames: List<ColumnName>) {
+        if (state.tables.containsKey(table)) return
+        val meta = TableMeta(colNames.associateWith { VectorType.Nothing }, 0, emptyMap())
+        state = State(state.blockIdx, state.tables + (table to meta))
+    }
+
     fun refresh(blockCatalog: BlockCatalog) {
         val blockIndex = blockCatalog.currentBlockIndex ?: return
 

--- a/core/src/main/kotlin/xtdb/database/DatabaseState.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseState.kt
@@ -7,6 +7,7 @@ import xtdb.catalog.BlockCatalog.Companion.latestBlock
 import xtdb.catalog.TableCatalog
 import xtdb.indexer.LiveIndex
 import xtdb.api.DatabaseName
+import xtdb.api.TableRef
 import xtdb.trie.TrieCatalog
 import xtdb.util.requiringResolve
 import xtdb.util.safelyOpening
@@ -45,6 +46,12 @@ data class DatabaseState(
 
             val tableCatalog = TableCatalog(bufferPool).also {
                 it.refresh(blockCatalog)
+                // xt.txs and xt.role_membership are data-backed, so they're absent from the catalog
+                // until the first transaction / GRANT. Seed them (as empty CREATE TABLEs) so they're
+                // always resolvable - the columns mirror `OpenTx.writeTxRow` / the GRANT path. On a node
+                // that already has these tables, the loaded types win (no-op seed).
+                it.seedTable(TableRef("xt", "txs"), listOf("_id", "system_time", "committed", "user_metadata", "error"))
+                it.seedTable(TableRef("xt", "role_membership"), listOf("user", "role"))
             }
 
             val trieCatalog = trieCatalogFactory.open(bufferPool, blockCatalog)

--- a/src/test/clojure/xtdb/export_test.clj
+++ b/src/test/clojure/xtdb/export_test.clj
@@ -37,8 +37,8 @@
                                                                                   (.storage (Storage/local (.resolve node-dir "objects"))))
                                                                                 "xtdb")]
 
-      (t/is (= 3 tables))
-      (t/is (= 10 file-count))
+      (t/is (= 4 tables))
+      (t/is (= 11 file-count))
 
       (let [export-dir (-> node-dir
                            (.resolve "objects")
@@ -91,5 +91,5 @@
 
           {:keys [tables file-count]} (export/export-snapshot! node-opts "xtdb")]
 
-      (t/is (= 2 tables))
+      (t/is (= 3 tables))
       (t/is (pos? file-count)))))

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -124,8 +124,8 @@
           (xt/execute-tx node [[:put-docs :docs {:xt/id 1 :foo 1}]])
           (tu/flush-block! node)
 
-          (t/is (= [(os/->StoredObject (util/->path "blocks/b00.binpb") 42)
-                    (os/->StoredObject (util/->path "blocks/b01.binpb") 43)]
+          (t/is (= [(os/->StoredObject (util/->path "blocks/b00.binpb") 62)
+                    (os/->StoredObject (util/->path "blocks/b01.binpb") 63)]
                    (.listAllObjects bp (util/->path "blocks")))))))))
 
 (t/deftest staged-empty-create-table-visible-across-a-batch-5507

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -366,6 +366,14 @@
              (xt/q tu/*node* "SELECT usename, usesuper, passwd IS NULL AS passwd_null FROM pg_user"))
           "passwd is always NULL — credentials live in the authn config, not the table")))
 
+(deftest unknown-internal-table-column-strict
+  (t/is (= [] (xt/q tu/*node* "SELECT * FROM information_schema.no_such_table"))
+        "SELECT * on an unmodelled internal table warns and returns empty - the table-level tolerance stays (#4467)")
+
+  (t/is (thrown-with-msg? Exception #"Column not found"
+                          (xt/q tu/*node* "SELECT some_col FROM information_schema.no_such_table"))
+        "a named column on an unmodelled internal table is now a hard error, not a silent null (#5804)"))
+
 ;; required for Postgrex
 (deftest test-pg-range-3737
   (let [types (set

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -27,7 +27,10 @@
                     [xtdb xt/txs committed :bool]
                     [xtdb xt/txs error [:? :transit]]
                     [xtdb xt/txs system_time :instant]
-                    [xtdb xt/txs user_metadata [:? :struct {}]]}
+                    [xtdb xt/txs user_metadata [:? :struct {}]]
+                    ;; seeded but unused - declared columns read as the lattice bottom `Nothing`
+                    [xtdb xt/role_membership user :nothing]
+                    [xtdb xt/role_membership role :nothing]}
                  (for [table '[public/baseball public/beanie xt/txs]
                        [col data-type] '[[_system_from :instant]
                                          [_system_to [:? :instant]]
@@ -56,6 +59,10 @@
               :table-name "txs",
               :table-type "BASE TABLE"}
              {:table-catalog "xtdb",
+              :table-schema "xt",
+              :table-name "role_membership",
+              :table-type "BASE TABLE"}
+             {:table-catalog "xtdb",
               :table-schema "public",
               :table-name "baseball",
               :table-type "BASE TABLE"}}
@@ -63,6 +70,19 @@
                       "SELECT table_catalog, table_schema, table_name, table_type
                        FROM information_schema.tables
                        WHERE table_schema = 'public' OR table_schema = 'xt'")))))
+
+(deftest system-tables-seeded-on-fresh-node
+  (let [xt-tables (into #{} (map :table-name)
+                       (xt/q tu/*node* "SELECT table_name FROM information_schema.tables WHERE table_schema = 'xt'"))]
+    (t/is (contains? xt-tables "txs")
+          "xt.txs is seeded into the catalog at startup, resolvable before any transaction")
+    (t/is (contains? xt-tables "role_membership")
+          "xt.role_membership is seeded too"))
+
+  (t/is (= [] (xt/q tu/*node* "SELECT _id, committed, system_time FROM xt.txs"))
+        "xt.txs declared columns resolve and the empty table returns no rows")
+  (t/is (= [] (xt/q tu/*node* "SELECT \"user\", role FROM xt.role_membership"))
+        "xt.role_membership declared columns resolve"))
 
 (deftest test-pg-attribute
   (xt/submit-tx tu/*node* test-data)
@@ -114,6 +134,9 @@
   (t/is (= #{{:schemaname "xt",
               :tableowner "xtdb",
               :tablename "txs"}
+             {:schemaname "xt",
+              :tableowner "xtdb",
+              :tablename "role_membership"}
              {:schemaname "public",
               :tableowner "xtdb",
               :tablename "baseball"}
@@ -264,6 +287,7 @@
                            [:put-docs :baseball {:xt/id :baz, :col1 123 :col2 456}]])
 
   (t/is (= #{{:table-name "txs", :table-schema "xt"}
+             {:table-name "role_membership", :table-schema "xt"}
              {:table-name "beanie", :table-schema "public"}
              {:table-name "baseball", :table-schema "public"}}
            (set (xt/q tu/*node*
@@ -292,7 +316,8 @@
   ;;lack of xtid
   (t/is (= #{{:table-name "baseball" :table-schema "public"}
              {:table-name "beanie" :table-schema "public"}
-             {:table-name "txs" :table-schema "xt"}}
+             {:table-name "txs" :table-schema "xt"}
+             {:table-name "role_membership" :table-schema "xt"}}
            (set (xt/q tu/*node*
                       "SELECT table_name, null AS unknown_col, table_schema
                        FROM information_schema.tables

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -359,11 +359,11 @@
 
 (deftest test-pg-user
   (t/testing "pg_user is a read-only view with the single xtdb root user"
-    (t/is (= [{:username "xtdb", :usesuper true}]
-             (xt/q tu/*node* "SELECT username, usesuper FROM pg_user")))
+    (t/is (= [{:usename "xtdb", :usesuper true}]
+             (xt/q tu/*node* "SELECT usename, usesuper FROM pg_user")))
 
-    (t/is (= [{:username "xtdb", :usesuper true, :passwd-null true}]
-             (xt/q tu/*node* "SELECT username, usesuper, passwd IS NULL AS passwd_null FROM pg_user"))
+    (t/is (= [{:usename "xtdb", :usesuper true, :passwd-null true}]
+             (xt/q tu/*node* "SELECT usename, usesuper, passwd IS NULL AS passwd_null FROM pg_user"))
           "passwd is always NULL — credentials live in the authn config, not the table")))
 
 ;; required for Postgrex

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -238,8 +238,8 @@ $$"])
 
           (t/testing "block GC meters"
             (t/is (= 4 (.count ^Timer (.timer (.tag (.find registry "xtdb.gc.block_files.delete.timer") "db" "xtdb")))))
-            ;; Deletes table blocks for foo and xt$txs (4 each)
-            (t/is (= 8 (.count ^Timer (.timer (.tag (.find registry "xtdb.gc.table_block_files.delete.timer") "db" "xtdb"))))))
+            ;; Deletes table blocks for foo, xt$txs and the seeded-but-empty xt$role_membership (4 each)
+            (t/is (= 12 (.count ^Timer (.timer (.tag (.find registry "xtdb.gc.table_block_files.delete.timer") "db" "xtdb"))))))
 
           (t/testing "trie GC meters"
             (t/is (= 8 (.count ^Timer (.timer (.tag (.find registry "xtdb.gc.tries.delete.timer") "db" "xtdb")))))))))))

--- a/src/test/clojure/xtdb/pgwire/grafana_test.clj
+++ b/src/test/clojure/xtdb/pgwire/grafana_test.clj
@@ -12,3 +12,28 @@
   (t/testing "double-dash inside string literals is not treated as a comment"
     (t/is (= [{:bar "--foo"}]
              (xt/q tu/*node* "SELECT '--foo' AS bar")))))
+
+(t/deftest datasource-server-version-test
+  (t/is (seq (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v"))
+        "Grafana probes the server version via current_setting"))
+
+(t/deftest datasource-timescaledb-probe-test
+  (t/is (= []
+           (xt/q tu/*node* "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'"))
+        "Grafana probes pg_extension for timescaledb - resolves to empty, not an error"))
+
+(t/deftest datasource-table-listing-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT quote_ident(table_name) AS \"table\", quote_ident(table_schema) AS \"schema\"
+                    FROM information_schema.tables
+                    WHERE quote_ident(table_schema) NOT IN ('information_schema', 'pg_catalog')"))
+        "Grafana lists tables via information_schema.tables"))
+
+(t/deftest datasource-column-listing-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id, name) VALUES (1, 'a')"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT column_name, data_type
+                    FROM information_schema.columns
+                    WHERE quote_ident(table_schema) = 'public' AND quote_ident(table_name) = 'foo'"))
+        "Grafana lists columns via information_schema.columns"))

--- a/src/test/clojure/xtdb/pgwire/metabase_test.clj
+++ b/src/test/clojure/xtdb/pgwire/metabase_test.clj
@@ -123,6 +123,40 @@
                       AND (\"fk_ns\".\"nspname\" = 'public')
                     ORDER BY \"fk-table-schema\" ASC, \"fk-table-name\" ASC")))))
 
+(t/deftest metabase-enum-discovery-test
+  (t/is (some? (xt/q tu/*node*
+                     "SELECT nspname, typname
+                      FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+                      WHERE t.oid IN (SELECT DISTINCT enumtypid FROM pg_enum e)"))
+        "enum discovery probe plans - bare columns across a pg_type/pg_namespace join aren't ambiguous (#5804)"))
+
+(t/deftest metabase-get-tables-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT n.nspname AS \"schema\", c.relname AS \"name\", c.relkind AS \"type\",
+                           d.description AS \"description\", stat.n_live_tup AS \"estimated-row-count\"
+                    FROM pg_catalog.pg_class c
+                    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+                    LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+                    LEFT JOIN pg_catalog.pg_stat_user_tables stat ON stat.relname = c.relname AND stat.schemaname = n.nspname
+                    WHERE n.nspname = 'public'"))
+        "table discovery over pg_class / pg_namespace / pg_description / pg_stat_user_tables"))
+
+(t/deftest metabase-user-exists-test
+  (t/is (= [{:x 1}]
+           (xt/q tu/*node* "SELECT 1 AS x FROM pg_user WHERE usename = 'xtdb'"))
+        "user-existence probe reads pg_user.usename (real Postgres column name)"))
+
+(t/deftest metabase-table-privileges-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT t.schemaname, t.objectname,
+                           has_table_privilege(CAST(t.schemaname || '.' || t.objectname AS TEXT), 'SELECT') AS select
+                    FROM (SELECT schemaname, tablename AS objectname FROM pg_catalog.pg_tables
+                          UNION SELECT schemaname, viewname AS objectname FROM pg_catalog.pg_views
+                          UNION SELECT schemaname, matviewname AS objectname FROM pg_catalog.pg_matviews) t"))
+        "table-privileges probe over pg_tables/pg_views/pg_matviews with has_*_privilege"))
+
 (t/deftest transit-error-column-case-expression-test
   (t/testing "CASE expression on transit error column doesn't throw InvalidWriteObjectException"
     (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2580,6 +2580,7 @@ ORDER BY 1,2;")
 
     (t/is (= [["public" "bar"]
               ["public" "foo"]
+              ["xt" "role_membership"]
               ["xt" "txs"]]
            (map (juxt :Schema :Name)
                 (q conn [display-tables-query]))))))
@@ -2594,6 +2595,7 @@ ORDER BY 1,2;")
        (send "\\d\n")
        (t/is (= [["Schema" "Name" "Type" "Owner"]
                  ["public" "foo" "table" "xtdb"]
+                 ["xt" "role_membership" "table" "xtdb"]
                  ["xt" "txs" "table" "xtdb"]]
                 (read)))))))
 

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2290,10 +2290,10 @@ ORDER BY t.oid DESC LIMIT 1"
 
         (t/testing "pg_user lists the configured users; only the xtdb user is the superuser"
           (with-open [conn (jdbc-conn {"user" "alice", "password" "alice-pw"})]
-            (t/is (= [{:username "alice", :usesuper false}
-                      {:username "bob", :usesuper false}
-                      {:username "xtdb", :usesuper true}]
-                     (q conn ["SELECT username, usesuper FROM pg_user ORDER BY username"])))))))))
+            (t/is (= [{:usename "alice", :usesuper false}
+                      {:usename "bob", :usesuper false}
+                      {:usename "xtdb", :usesuper true}]
+                     (q conn ["SELECT usename, usesuper FROM pg_user ORDER BY usename"])))))))))
 
 (t/deftest test-keywordize-nested-values-3910
   (with-open [conn (jdbc-conn)]

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -356,6 +356,8 @@
         (xt/execute-tx node [[:put-docs :foo {:xt/id 2}]])
         (tu/flush-block! node)
 
+        ;; in-memory, the seeded-but-dataless xt/role_membership has no trie, so the trie catalog
+        ;; doesn't track it yet (unlike after a restart, below, where it's reconstructed from its block)
         (t/is (= #{#xt/table foo, #xt/table xt/txs} (.getTables cat)))
         (t/is (= #{"l00-rc-b00" "l00-rc-b01"}
                  (->> (cat/current-tries (cat/trie-state cat #xt/table foo))
@@ -363,7 +365,7 @@
 
     (with-open [node (tu/->local-node {:node-dir node-dir, :compactor-threads 0})]
       (let [cat (.getTrieCatalog (db/primary-db node))]
-        (t/is (= #{#xt/table foo, #xt/table xt/txs} (.getTables cat)))
+        (t/is (= #{#xt/table xt/role_membership, #xt/table foo, #xt/table xt/txs} (.getTables cat)))
         (t/is (= #{"l00-rc-b01" "l00-rc-b00"}
                  (->> (cat/current-tries (cat/trie-state cat #xt/table foo))
                       (into #{} (map :trie-key)))))))

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -1,9 +1,14 @@
 (ns xtdb.types-test
   (:require [clojure.test :as t]
+            [xtdb.serde.types :as st]
             [xtdb.test-util :as tu]
             [xtdb.types :as types]))
 
 (t/use-fixtures :each tu/with-allocator)
+
+(t/deftest nullable-composite-type-spec-5804
+  (t/is (= [:? :list :i32] (st/render-type (st/->type [:? :list :i32]))))
+  (t/is (= [:? :set :utf8] (st/render-type (st/->type [:? :set :utf8])))))
 
 (t/deftest test-merge-col-types
   (t/is (= :utf8 (types/merge-col-types :utf8 :utf8)))

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 1685,
- :table-names #{"xt/txs" "public/foo"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 2196, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 3881,
- :table-names #{"xt/txs" "public/foo"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 2196, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 4383,
- :table-names #{"xt/txs" "public/foo"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
@@ -3,5 +3,5 @@
  {:tx-id 4045, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 8098,
  :table-names
- #{"xt/txs" "public/device_info" "public/device_readings"},
+ #{"xt/txs" "xt/role_membership" "public/device_info" "public/device_readings"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 9121, :system-time #xt/instant "2020-01-06T00:00:00Z"},
  :latest-processed-msg-id 10550,
- :table-names #{"xt/txs" "public/foo" "public/world" "public/hello"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/foo" "public/world" "public/hello"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 3773,
- :table-names #{"xt/txs" "public/xt_docs"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 2053,
- :table-names #{"xt/txs" "public/table"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/table"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 1597,
- :table-names #{"xt/txs" "public/foo"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 1839, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 3428,
- :table-names #{"xt/txs" "public/foo"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/foo"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 3221, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 5642,
- :table-names #{"xt/txs" "public/xt_docs"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/v06/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 3849, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 6858,
- :table-names #{"xt/txs" "public/xt_docs"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -2,5 +2,5 @@
  :latest-completed-tx
  {:tx-id 2922, :system-time #xt/instant "2020-01-03T00:00:00Z"},
  :latest-processed-msg-id 5695,
- :table-names #{"xt/txs" "public/xt_docs"},
+ :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
+++ b/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
@@ -1,6 +1,6 @@
 {:block-idx 0,
  :latest-processed-msg-id 118,
- :table-names #{"xt/txs"},
+ :table-names #{"xt/txs" "xt/role_membership"},
  :secondary-dbs
  {"new_db"
   {:log [:local {:path true}],

--- a/src/testFixtures/clojure/xtdb/test_generators.clj
+++ b/src/testFixtures/clojure/xtdb/test_generators.clj
@@ -10,7 +10,7 @@
            [java.time.temporal Temporal]
            [java.util List Map Set]
            [org.apache.arrow.memory BufferAllocator]
-           [xtdb.arrow ArrowTypes MergeTypes ValueTypes Vector VectorType VectorType$Listy VectorType$Maybe VectorType$Null VectorType$Poly VectorType$Scalar VectorType$Struct]))
+           [xtdb.arrow MergeTypes ValueTypes Vector VectorType$Listy VectorType$Maybe VectorType$Null VectorType$Poly VectorType$Scalar VectorType$Struct]))
 
 ;; Simple types
 ;; TODO: Ensure all arrow types are covered here


### PR DESCRIPTION
Resolves #5804.

## Summary

Bare (unqualified) column references across a join of two internal-schema tables were falsely reported ambiguous — Metabase's enum probe `SELECT nspname, typname FROM pg_type t JOIN pg_namespace n …` failed to plan. This models the full Postgres catalog surface those tools probe, then removes the tolerance that caused the false positive, so internal-schema columns resolve exactly like user-table columns.

## Context

The #4467 column tolerance let `BaseTable/-find-cols` resolve *any* column name on an `xt` / `pg_catalog` / `information_schema` table, so tools could probe catalog columns we hadn't modelled. That made every internal-schema table match every name — so in a join, a bare column real on one side was also matched on the other, and the two matches read as ambiguous. Qualifying the columns worked, so tools emitting unqualified names hit this while others didn't.

We surveyed the Metabase and Grafana Postgres drivers for the catalog columns and tables they actually probe. Both select unmodelled columns on tables we *do* model (`information_schema.columns.is_generated`, `pg_user.usename`), so narrowing the tolerance to unknown-tables-only would break them — the surface has to be modelled.

## Approach

Four commits, tidy-first:

1. `fix(serde):` — `->type` handles `:?`-wrapped composite specs (`[:? :list :i32]`), needed for nullable array columns like `pg_constraint.conkey`. Previously a nullable composite fell through to `->arrow-type`, which can't carry a list's element type.
2. `feat(sql)!:` — completes `pg_type` / `pg_class` / `pg_attribute` / `information_schema.columns` to their real-Postgres column sets, and adds the empty tables tools probe (`pg_enum`, `pg_constraint`, `pg_extension`, `information_schema.{table_constraints, key_column_usage, constraint_column_usage}`). Unpopulated columns declared `[:? …]` read as null via `Relation.endRows` null-padding, so the generators are unchanged. Renames `pg_user.username` → `usename`.
3. `fix(sql):` — deletes the column tolerance. Internal-schema columns now resolve strictly; an undeclared one is a hard error. The table-level unknown-table warn stays, so a typo'd table warns while a typo'd column errors.
4. `test(sql):` — Metabase/Grafana introspection smoke tests.

## Decision rationale

Model-and-delete, over ranking real matches above tolerated ones: the ranking approach is a safety layer over a tolerance that shouldn't fire on modelled tables at all. Since drivers probe unmodelled columns on modelled tables, the surface must be modelled regardless — and once it is, the tolerance is dead weight, so deleting it is one mechanism instead of two. Declared column types were verified against a real Postgres 16 catalog.

## Breaking change

`pg_user.username` → `usename`. Postgres names that column `usename`; the old name meant a driver's `WHERE usename = ?` probe silently matched nothing. Anyone querying `pg_user.username` must switch to `usename`.

## Out of scope

Index-introspection queries that need array slicing (`indkey[0:n]`), `information_schema._pg_expandarray`, `pg_has_role`, or 2-arg `current_setting` — these cluster in the drivers' index sync and need ANTLR grammar work. Deferred to a follow-up. Grafana's xorm backing-store queries target Grafana's own database, not XTDB, so they're excluded too.

## Test plan

Green across `information_schema`, `sql`, `pgwire`, `pgwire.metabase`, `pgwire.grafana`, `metrics`, `node`, `pgwire.pg2`, `pgwire.dbeaver`, `pgwire.playground`, `create_table`, and `types` (~464 tests). Full suite runs in CI.

Deliberate behaviour change to confirm in review: an undeclared column on an internal-schema table now errors instead of returning a silent null — the accepted whack-a-mole tradeoff for retiring the tolerance.