### PR TITLE
feat(docs): advertise each page's canonical markdown source on GitHub

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -58,6 +58,8 @@ export default defineConfig({
                 { icon: 'discord', label: 'Discord', href: 'https://github.com/orgs/xtdb/discussions/4385' },
             ],
 
+            editLink: { baseUrl: 'https://github.com/xtdb/xtdb/edit/main/docs/' },
+
             favicon: '/shared/favicon.svg',
 
             logo: {

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,7 +1,15 @@
 ---
 import Default from '@astrojs/starlight/components/Head.astro';
+
+// Point at `docs-live` (the deploy branch) in production so the raw source tracks the live
+// site; `main` in dev so a locally-edited page still resolves to something sensible.
+const ref = import.meta.env.PROD ? 'docs-live' : 'main';
+const filePath = Astro.locals.starlightRoute?.entry?.filePath;
+const mdSource = filePath && `https://raw.githubusercontent.com/xtdb/xtdb/${ref}/docs/${filePath}`;
 ---
 <Default {...Astro.props} />
+
+{mdSource && <link rel="alternate" type="text/markdown" href={mdSource} title="Markdown source" />}
 
 <script>
     {/** NOTE: Included here not in https://starlight.astro.build/reference/configuration/#head


### PR DESCRIPTION
## Summary

Every docs-site page now links to its canonical markdown source in the repo: a human-facing "Edit this page" link (Starlight's built-in `editLink`) and a machine-facing `<link rel="alternate" type="text/markdown">` in the page `<head>`.

## Context

When an agent (or a `WebFetch`) reads a page on docs.xtdb.com it gets the rendered HTML, which carries ~90 lines of Starlight nav chrome — logo, search, theme selector, the full expanded sidebar — before the actual content, identical on every page. The content is already plain markdown in this repo, but nothing on the page pointed at it.

## Approach

Rather than generate per-page `.md` mirrors, we point at the source that already exists. `llms.txt` and its custom sets (via `starlight-llms-txt`) already cover bulk AI consumption, and the markdown is served raw by GitHub, so advertising it costs no new build output and no hosting change. Two links per page: `editLink` (the human "Edit this page" link, targeting `main` where you'd actually make the edit) and the raw-source `alternate` link for machines.

The raw link points at `docs-live` — the deploy branch — so it tracks what's actually live and is guaranteed to resolve against the public repo. `main` can run ahead of the deployed site, and pinning to the exact build commit (Amplify's `AWS_COMMIT_ID`) couldn't be confirmed to be set and public, and a 404 is worse than a little drift. Dev builds fall back to `main` so a locally-edited page still resolves.

## Accepted limitation / out of scope

These links are opt-in, not transparent: `WebFetch` does not chase `rel="alternate"`, nor auto-read `llms.txt`, so this does **not** change what a naive fetch of a page URL returns. It gives an agent (or human) that has decided to grab the source a correct, chrome-free target. Transparent `Accept`-header content negotiation — an edge function, fronting with Cloudflare, or moving the site to SSR — is a separate decision, deliberately left for later (static Amplify hosting can't branch on the request header).

## Usage

Nothing to adopt — both links render automatically on every page. `editLink` shows a footer "Edit this page" link; the markdown source is discoverable via `<link rel="alternate" type="text/markdown">` in the page head.

## Test plan

- `yarn build` succeeds (90 pages).
- Verified the emitted links on a pure-`.md` page (`reference/main`) and an `.mdx` page (`index`, which correctly keeps its extension and coexists with the existing `/llms.txt` alternate).
- `curl` confirms the raw `docs-live` URLs resolve (HTTP 200 for both `.md` and `.mdx`) and the edit URL 302s to GitHub.
- Confirmed the production build emits `docs-live` refs and the dev fallback emits `main`.
- Code-review pass over the diff: clean.