### PR TITLE
fix(sql)!: resolve internal-schema tables and columns strictly

### DIFF
--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -113,25 +113,8 @@
   PlanError
   (error-string [_] (format "Table not found: %s" (str/join "." (filter some? table-chain)))))
 
-(def ^:private internal-schemas #{"xt" "pg_catalog" "information_schema"})
-
-(defn- system-table-chain?
-  "An unknown table in an internal schema stays a warning rather than an error (#4467): a data-backed
-   `xt` table like `xt.txs` is empty - hence absent from the catalog - on a fresh node, and tools probe
-   optional `pg_catalog`/`information_schema` tables; both tolerate an empty result, whereas an unknown
-   user table is a typo. Covers a qualified internal-schema reference (schema is the second-to-last
-   chain element), and a `pg_*` table name: Postgres reserves the `pg_` prefix for system catalogs,
-   so an unresolved `pg_*` probe is tooling, not a user typo - whether it arrives unqualified
-   (`pg_class`) or schema-injected by the DML path (`public.pg_class`), hence we check the table name."
-  [table-chain]
-  (or (and (>= (count table-chain) 2)
-           (contains? internal-schemas
-                      (str (nth table-chain (- (count table-chain) 2)))))
-      (str/starts-with? (str (peek table-chain)) "pg_")))
-
 (defn- table-not-found! [env table-chain]
-  ((if (system-table-chain? table-chain) add-warning! add-err!)
-   env (->BaseTableNotFound table-chain)))
+  (add-err! env (->BaseTableNotFound table-chain)))
 
 (defrecord AmbiguousTableReference [table-chain table-chains]
   PlanError
@@ -350,12 +333,7 @@
                (or (nil? chain-db) (= chain-db (symbol db-name))))
       (for [col (if col-name
                   (when (or (contains? cols col-name) (types/temporal-col-name? col-name)
-                            (temporal-period-column? col-name)
-                            ;; tolerate any column on an internal-schema table: tools probe optional
-                            ;; pg_catalog/information_schema columns, and unimplemented system tables
-                            ;; resolve to the `xt.not_found` sentinel (schema `xt`). Only user tables
-                            ;; error on a typo'd / undeclared column (#4467).
-                            (contains? internal-schemas (.getSchemaName table-ref)))
+                            (temporal-period-column? col-name))
                     [col-name])
                   (available-cols this))
             :when (not (contains? excl-cols col))]
@@ -729,9 +707,9 @@
 
               (let [{:keys [for-valid-time clamp-valid-time?]}
                     (<-table-time-period-specification (.queryValidTimePeriodSpecification ctx))]
-                ;; `table` is nil only on the warning path (an unresolved internal-schema / `pg_*`
-                ;; table - see `system-table-chain?`); user tables have already erred. We scan the
-                ;; empty `xt.not_found` sentinel so those probes return no rows rather than blowing up.
+                ;; `table` is nil when the base table wasn't found - `table-not-found!` has already
+                ;; erred. We still resolve to the empty `xt.not_found` sentinel so plan-building
+                ;; completes (collecting any further column errors) rather than NPEing on a nil ref.
                 (->BaseTable env resolved-db resolved-ref
                              for-valid-time clamp-valid-time?
                              (<-table-time-period-specification (.querySystemTimePeriodSpecification ctx))

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -23,6 +23,7 @@ import java.math.BigDecimal
 import java.nio.file.Files
 import java.nio.file.Path
 import java.sql.DriverManager
+import java.sql.SQLException
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -201,7 +202,17 @@ class PostgresSourceIntegrationTest {
         val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
 
         while (System.currentTimeMillis() < deadline) {
-            if (check()) return
+            // A poll often queries a cdc table before its snapshot has created it. XT now resolves
+            // internal/external-source tables strictly, so that's a hard "Table not found" - which here
+            // just means "not ready yet", so we keep polling. (#5733: the cdc db is a DirectMirror and
+            // rejects client txs, so we can't pre-create the table to avoid this; when that lands, the
+            // poll can query a pre-created empty table and this narrow catch can go.) Anything else propagates.
+            val ready = try {
+                check()
+            } catch (e: SQLException) {
+                if (e.message?.contains("Table not found") == true) false else throw e
+            }
+            if (ready) return
             runInterruptible { Thread.sleep(200) }
         }
 

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceSimulationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceSimulationTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import xtdb.XtdbInternal
 import xtdb.api.Xtdb
 import java.nio.file.Files
+import java.sql.SQLException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -70,7 +71,14 @@ class PostgresSourceSimulationTest : PostgresSourceTestBase() {
         val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
         while (true) {
             cdcIngestionError(node)?.let { fail("cdc ingestion stopped for $table: ${it.message}") }
-            val actual = runCatching { qRows(node, table) }.getOrNull()
+            val actual = try {
+                qRows(node, table)
+            } catch (e: Exception) {
+                // a never-created cdc table now resolves strictly to "Table not found"; for convergence
+                // that's an empty table, not a miss (#5804; #5733 would let us pre-create it). Other
+                // transient failures mid-pipeline just mean "not settled yet" - keep polling (null).
+                if ((e as? SQLException)?.message?.contains("Table not found") == true) emptyList() else null
+            }
             when {
                 actual == expected -> return
                 System.currentTimeMillis() > deadline ->

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -382,6 +382,18 @@
              (xt/q tu/*node* "SELECT usename, usesuper, passwd IS NULL AS passwd_null FROM pg_user"))
           "passwd is always NULL — credentials live in the authn config, not the table")))
 
+(deftest unknown-internal-table-strict
+  ;; #5804: internal-schema tables resolve strictly, exactly like user tables - an unmodelled one is a
+  ;; hard error, not a warning that silently resolves to the empty `xt.not_found` sentinel. Both the
+  ;; qualified-internal-schema and `pg_`-prefixed paths (the two former tolerances) now error.
+  (t/is (thrown-with-msg? Exception #"Table not found"
+                          (xt/q tu/*node* "SELECT * FROM information_schema.no_such_table"))
+        "an unmodelled information_schema table errors, even for SELECT *")
+
+  (t/is (thrown-with-msg? Exception #"Table not found"
+                          (xt/q tu/*node* "SELECT some_col FROM pg_catalog.pg_not_a_table"))
+        "an unmodelled pg_ table errors too - no more silent empty probe"))
+
 ;; required for Postgrex
 (deftest test-pg-range-3737
   (let [types (set

--- a/src/test/clojure/xtdb/metrics_test.clj
+++ b/src/test/clojure/xtdb/metrics_test.clj
@@ -32,10 +32,10 @@
     (t/is (thrown? Exception (jdbc/execute! conn ["SELECT 1/0"]))
           "runtime error via pgwire")
 
-    ;; producing some warnings - a probe of an unimplemented system-schema table stays a warning
-    ;; (tools tolerate it), where unknown user tables/columns are now errors (#4467)
-    (xt/q node "SELECT * FROM information_schema.no_such_table")
-    (jdbc/execute! conn ["SELECT * FROM information_schema.no_such_table"])
+    ;; producing some warnings - a NULLS ordering ignored on an ordered-set function warns (one via
+    ;; the node, one via pgwire), now that unresolved internal-schema tables/columns are errors (#4467, #5804)
+    (xt/q node "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY n NULLS FIRST) AS pc FROM (VALUES (1), (2)) AS t(n)")
+    (jdbc/execute! conn ["SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY n NULLS FIRST) AS pc FROM (VALUES (1), (2)) AS t(n)"])
 
     (t/is (= 2.0 (.count ^Counter (.counter (.find registry "query.error")))))
     (t/is (= 2.0 (.count ^Counter (.counter (.find registry "query.warning")))))))

--- a/src/test/clojure/xtdb/pgwire/grafana_test.clj
+++ b/src/test/clojure/xtdb/pgwire/grafana_test.clj
@@ -12,3 +12,28 @@
   (t/testing "double-dash inside string literals is not treated as a comment"
     (t/is (= [{:bar "--foo"}]
              (xt/q tu/*node* "SELECT '--foo' AS bar")))))
+
+(t/deftest datasource-server-version-test
+  (t/is (seq (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v"))
+        "Grafana probes the server version via current_setting"))
+
+(t/deftest datasource-timescaledb-probe-test
+  (t/is (= []
+           (xt/q tu/*node* "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'"))
+        "Grafana probes pg_extension for timescaledb - resolves to empty, not an error"))
+
+(t/deftest datasource-table-listing-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT quote_ident(table_name) AS \"table\", quote_ident(table_schema) AS \"schema\"
+                    FROM information_schema.tables
+                    WHERE quote_ident(table_schema) NOT IN ('information_schema', 'pg_catalog')"))
+        "Grafana lists tables via information_schema.tables"))
+
+(t/deftest datasource-column-listing-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id, name) VALUES (1, 'a')"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT column_name, data_type
+                    FROM information_schema.columns
+                    WHERE quote_ident(table_schema) = 'public' AND quote_ident(table_name) = 'foo'"))
+        "Grafana lists columns via information_schema.columns"))

--- a/src/test/clojure/xtdb/pgwire/metabase_test.clj
+++ b/src/test/clojure/xtdb/pgwire/metabase_test.clj
@@ -148,3 +148,39 @@
                                     ELSE error
                                END AS error
                         FROM xt.txs"))))))
+
+(t/deftest metabase-enum-discovery-test
+  ;; plans without an "ambiguous column" error (#5804); the result is empty because we model no enums,
+  ;; so the point is that the bare columns across the pg_type/pg_namespace join resolve at all
+  (t/is (= [] (xt/q tu/*node*
+                    "SELECT nspname, typname
+                     FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+                     WHERE t.oid IN (SELECT DISTINCT enumtypid FROM pg_enum e)"))
+        "enum discovery probe plans - bare columns across a pg_type/pg_namespace join aren't ambiguous (#5804)"))
+
+(t/deftest metabase-get-tables-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT n.nspname AS \"schema\", c.relname AS \"name\", c.relkind AS \"type\",
+                           d.description AS \"description\", stat.n_live_tup AS \"estimated-row-count\"
+                    FROM pg_catalog.pg_class c
+                    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+                    LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = 0
+                    LEFT JOIN pg_catalog.pg_stat_user_tables stat ON stat.relname = c.relname AND stat.schemaname = n.nspname
+                    WHERE n.nspname = 'public'"))
+        "table discovery over pg_class / pg_namespace / pg_description / pg_stat_user_tables"))
+
+(t/deftest metabase-user-exists-test
+  (t/is (= [{:x 1}]
+           (xt/q tu/*node* "SELECT 1 AS x FROM pg_user WHERE usename = 'xtdb'"))
+        "user-existence probe reads pg_user.usename (real Postgres column name)"))
+
+(t/deftest metabase-table-privileges-test
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+  (t/is (seq (xt/q tu/*node*
+                   "SELECT t.schemaname, t.objectname,
+                           has_table_privilege(CAST(t.schemaname || '.' || t.objectname AS TEXT), 'SELECT') AS select
+                    FROM (SELECT schemaname, tablename AS objectname FROM pg_catalog.pg_tables
+                          UNION SELECT schemaname, viewname AS objectname FROM pg_catalog.pg_views
+                          UNION SELECT schemaname, matviewname AS objectname FROM pg_catalog.pg_matviews) t"))
+        "table-privileges probe over pg_tables/pg_views/pg_matviews with has_*_privilege"))

--- a/src/test/clojure/xtdb/pgwire/pg2_test.clj
+++ b/src/test/clojure/xtdb/pgwire/pg2_test.clj
@@ -242,12 +242,12 @@
 (deftest error-propagation
   (let [warns (atom [])]
     (with-open [conn (pg-conn {:fn-notice (fn [notice] (swap! warns conj (:message notice)))})]
-      ;; a probe of an unimplemented system-schema table stays a warning (tools tolerate it), one of
-      ;; the few query warnings left now that table/column-not-found on user tables are errors (#4467)
-      (pg/execute conn "SELECT * FROM information_schema.no_such_table")
+      ;; a NULLS ordering ignored on an ordered-set function stays a warning (not an error) and
+      ;; propagates as a notice, now that unresolved internal-schema tables/columns are errors (#4467, #5804)
+      (pg/execute conn "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY n NULLS FIRST) AS pc FROM (VALUES (1), (2)) AS t(n)")
       ;; the fn-notice runs in a separate executor pool
       (Thread/sleep 100)
-      (t/is (= #{"Table not found: information_schema.no_such_table"}
+      (t/is (= #{"NULL ordering is ignored for percentile_cont (nulls are excluded from ordered-set aggregates)"}
                (set @warns))))))
 
 (deftest test-time

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -2054,12 +2054,13 @@ ORDER BY t.oid DESC LIMIT 1"
 
 (deftest error-propagation
   (with-open [conn (jdbc-conn)]
-    ;; a probe of an unimplemented system-schema table stays a warning (tools tolerate it) - one of the
-    ;; few remaining query warnings now that table/column-not-found on user tables are errors (#4467)
-    (with-open [stmt (.prepareStatement conn "SELECT * FROM information_schema.no_such_table")]
+    ;; a NULLS ordering ignored on an ordered-set function stays a warning (not an error) and
+    ;; propagates to the client as a SQLWarning - one of the few remaining query warnings now that
+    ;; unresolved internal-schema tables/columns are errors (#4467, #5804)
+    (with-open [stmt (.prepareStatement conn "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY n NULLS FIRST) AS pc FROM (VALUES (1), (2)) AS t(n)")]
       (.execute stmt)
 
-      (t/is (= #{"Table not found: information_schema.no_such_table"}
+      (t/is (= #{"NULL ordering is ignored for percentile_cont (nulls are excluded from ordered-set aggregates)"}
                (set (map #(.getMessage ^SQLWarning %) (stmt->warnings stmt))))))))
 
 (deftest test-ignore-returning-keys-3668


### PR DESCRIPTION
Resolves #5804.

Builds on the `xt.txs` / `xt.role_membership` seeding (Part 1), now landed on `main` — so this PR is just the two commits below.

## Context

A bare column across a join of two internal-schema tables was falsely reported ambiguous — Metabase's enum probe `SELECT nspname, typname FROM pg_type t JOIN pg_namespace n …` failed to plan, though `nspname` lives only on `pg_namespace` and `typname` only on `pg_type`. Full symptoms and root-cause analysis are in #5804.

## What changes

Internal-schema (`xt` / `pg_catalog` / `information_schema`) and `pg_`-prefixed tables now resolve strictly — exactly like user tables. Two #4467 tolerances kept unmodelled probes quiet: a **column** tolerance that resolved any column name on an internal-schema table, and a **table** tolerance that turned an unknown internal / `pg_` table into a warning resolving to the empty `xt.not_found` sentinel.

The column tolerance is what caused #5804: it made every internal-schema table match every name, so across a join a bare column real on one side also matched the other, and the two matches read as ambiguous. Both tolerances are removed. An unmodelled table or undeclared column is now a hard error, not a silent empty/null — so the bare join is unambiguous.

This is only safe because the catalog surface is now modelled and the data-backed system tables are seeded (Part 1): the fresh-node reads and tool probes the tolerance used to absorb are handled properly now.

## Breaking change

A tool probing a `pg_catalog` / `information_schema` table or column XTDB doesn't model now gets an error instead of an empty result. The modelled surface covers the Metabase and Grafana introspection paths, pinned by new smoke tests; index-introspection beyond that (array slicing, `_pg_expandarray`, `pg_has_role`, 2-arg `current_setting`) is a known follow-up.

## Decision: full strict, not sentinel-scoped

An earlier approach kept a sentinel-scoped tolerance so a not-yet-existing `pg_` table — e.g. a CDC table before its snapshot lands — still returned `[]`. We deliberately dropped that: the empty-return is an accident, not a contract, and erroring on an absent table is the behaviour we want.

## Implementation notes

The only query warnings that keyed on the old tolerance were the system-table probes, which are errors now; the warning-propagation and metrics tests move to the one surviving warning — an ignored `NULLS` ordering on an ordered-set function.

The postgres-source CDC tests poll cdc tables before the snapshot creates them — now "Table not found" rather than empty. Their poll and convergence checks catch that narrowly and treat it as "not ready / empty". We can't pre-create the mirror table to avoid the race because client transactions against external-source databases are rejected (#5733); when that lands, the tolerance can go.

## Commits

1. `fix(sql)!:` — remove both tolerances; repoint the warning tests; add the narrow postgres-source poll tolerance.
2. `test(sql):` — Metabase / Grafana catalog-introspection smoke tests.

## Test plan

- `./gradlew :test` — full core suite green (1626 tests); the #5804 repro plans and runs (`metabase-enum-discovery-test`).
- `./gradlew :modules:xtdb-postgres-source:integration-test :property-test` — green on CI (a local run went red on CDC timing, but that was a machine-suspend artifact, not the change).
- No reflection / boxed-math warnings.