### PR TITLE
fix(adbc): conform SQL parameter naming to the ADBC spec (#5651)

### DIFF
--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -389,11 +389,19 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 override fun bind(root: VectorSchemaRoot) {
                     clearArgs()
-                    args = Relation(allocator, root.schema).closeOnCatch { copy ->
-                        Relation.fromRoot(allocator, root).use { src ->
-                            copy.append(src)
-                        }
-                        copy
+                    // A VSR tolerates duplicate/empty field names, but our Relation keys columns by name —
+                    // so an all-unnamed multi-param bind (what a spec-compliant ADBC client sends against the
+                    // empty parameterSchema) would collapse to a single column. Rename the ordered vectors to
+                    // the canonical $1..$N positional form before they reach the name-keyed Relation; ADBC binds
+                    // by ordinal, so the VSR's own names don't carry meaning. Copy (not slice) into a relation on
+                    // our allocator, since the VSR's vectors don't share our allocator root.
+                    // Set the name on the Vector itself (not a RenamedVector wrapper, whose `.field` delegates
+                    // to the inner vector and would report the original name back through `.schema`).
+                    RelationReader.from(
+                        root.fieldVectors.mapIndexed { i, fv -> Vector.fromArrow(fv).also { it.name = "\$${i + 1}" } },
+                        root.rowCount,
+                    ).use { renamed ->
+                        args = Relation(allocator, renamed.schema).closeOnCatch { copy -> copy.append(renamed); copy }
                     }
                 }
 

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -369,8 +369,11 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 override fun getParameterSchema(): Schema {
                     val pq = preparedQuery ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
+                    // Positional `?` placeholders → empty field names, per ADBC AdbcStatementGetParameterSchema:
+                    // "If the parameter does not have a name … the name of the corresponding field in the schema
+                    // will be an empty string." Order is conveyed by ordinal position.
                     return Schema(
-                        (0 until pq.paramCount).map { idx -> "\$$idx" ofType VectorType.fromLegs() }
+                        (0 until pq.paramCount).map { "" ofType VectorType.fromLegs() }
                     )
                 }
 
@@ -400,12 +403,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                 }
 
                 private fun openQueryArgs(): RelationReader? =
-                    args?.openSlice(allocator)?.closeOnCatch { sliced ->
-                        RelationReader.from(
-                            sliced.vectors.mapIndexed { idx, v -> v.withName("?_$idx") },
-                            sliced.rowCount
-                        )
-                    }
+                    args?.openSlice(allocator)?.closeOnCatch { it.withPositionalParamNames() }
 
                 private fun ensurePrepared(): PreparedQuery {
                     if (preparedQuery == null && args != null)

--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -24,6 +24,7 @@ import xtdb.api.query.PrepareOpts
 import xtdb.api.query.QueryOpts
 import xtdb.query.SqlStatement
 import xtdb.query.parseStatement
+import xtdb.query.withPositionalParamNames
 import xtdb.api.DEFAULT_SCHEMA
 import xtdb.api.SchemaName
 import xtdb.api.TableName
@@ -159,7 +160,8 @@ class OpenTx
     /**
      * Run SQL against the database's live index, with visibility into writes made earlier in this transaction.
      *
-     * Positional `?` parameters are supplied through [args] as a single-row [xtdb.arrow.RelationReader].
+     * Positional `?` parameters are supplied through [args] as a single-row [xtdb.arrow.RelationReader],
+     * matched to the query's `?` placeholders by ordinal position — the columns' names are ignored.
      * Defaults for [opts] are derived from the tx's system-time and the database's default timezone.
      */
     fun openQuery(sql: String, args: RelationReader? = null, opts: QueryOpts = QueryOpts()): ResultCursor {
@@ -171,12 +173,12 @@ class OpenTx
 
         return nodeBase.querySource
             .prepareQuery(parseStatement(sql), queryCatalog, prepareOpts)
-            .openQuery(args, opts.copy(currentTime = currentTime, tracer = opts.tracer ?: tracer))
+            .openQuery(args?.withPositionalParamNames(), opts.copy(currentTime = currentTime, tracer = opts.tracer ?: tracer))
     }
 
     /**
      * Execute a DML/DDL SQL statement against this tx, with visibility into writes made earlier in the same
-     * writer call. Positional `?` parameters come from [args], like [openQuery].
+     * writer call. Positional `?` parameters come from [args], matched by ordinal position, like [openQuery].
      *
      * DML writes to forbidden schemas (`xt`, `information_schema`, `pg_catalog`) will throw.
      */
@@ -200,6 +202,7 @@ class OpenTx
             is SqlStatement.DmlQuery -> {
                 val query = stmt.query
                 checkArgCount(args, query.paramCount)
+                val pArgs = args?.withPositionalParamNames()
 
                 when (stmt) {
                     is SqlStatement.Assert -> {
@@ -208,7 +211,7 @@ class OpenTx
                         fun fail(): Nothing =
                             throw Conflict(msg, "xtdb/assert-failed", emptyMap<String, Any?>())
 
-                        query.openQuery(args, qOpts).use { cursor ->
+                        query.openQuery(pArgs, qOpts).use { cursor ->
                             if (!cursor.tryAdvance { rel -> if (rel.rowCount == 0) fail() }) fail()
                         }
                     }
@@ -216,7 +219,7 @@ class OpenTx
                     is SqlStatement.Put -> {
                         checkNotForbidden(stmt.table)
 
-                        query.openQuery(args, qOpts).use { cursor ->
+                        query.openQuery(pArgs, qOpts).use { cursor ->
                             cursor.forEachRemaining { rel ->
                                 // defer table() until a row is actually written: a 0-row result (no-match
                                 // UPDATE/DELETE, INSERT ... WHERE false) must not register a table — only CREATE TABLE does
@@ -249,7 +252,7 @@ class OpenTx
                     is SqlStatement.Patch -> {
                         checkNotForbidden(stmt.table)
 
-                        query.openQuery(args, qOpts).use { cursor ->
+                        query.openQuery(pArgs, qOpts).use { cursor ->
                             cursor.forEachRemaining { rel ->
                                 if (rel.rowCount > 0)
                                     table(stmt.table).writePuts(rel, currentTimeMicros, MAX_LONG)
@@ -260,7 +263,7 @@ class OpenTx
                     is SqlStatement.Delete -> {
                         checkNotForbidden(stmt.table)
 
-                        query.openQuery(args, qOpts).use { cursor ->
+                        query.openQuery(pArgs, qOpts).use { cursor ->
                             cursor.forEachRemaining { rel ->
                                 if (rel.rowCount > 0)
                                     table(stmt.table).writeDeletes(rel, currentTimeMicros, MAX_LONG)
@@ -271,7 +274,7 @@ class OpenTx
                     is SqlStatement.Erase -> {
                         checkNotForbidden(stmt.table)
 
-                        query.openQuery(args, qOpts).use { cursor ->
+                        query.openQuery(pArgs, qOpts).use { cursor ->
                             cursor.forEachRemaining { rel ->
                                 if (rel.rowCount > 0)
                                     table(stmt.table).writeErases(rel.vectorFor("_iid"))

--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -161,8 +161,9 @@ class OpenTx
      * Run SQL against the database's live index, with visibility into writes made earlier in this transaction.
      *
      * Positional `?` parameters are supplied through [args] as a single-row [xtdb.arrow.RelationReader],
-     * matched to the query's `?` placeholders by ordinal position — the columns' names are ignored.
-     * Defaults for [opts] are derived from the tx's system-time and the database's default timezone.
+     * matched to the query's `?` placeholders by ordinal position. The columns must be supplied unnamed or
+     * named `$1..$N` in order (see [withPositionalParamNames]); mis-ordered names are rejected rather than
+     * silently rebound. Defaults for [opts] are derived from the tx's system-time and the database's default timezone.
      */
     fun openQuery(sql: String, args: RelationReader? = null, opts: QueryOpts = QueryOpts()): ResultCursor {
         val currentTime = opts.currentTime ?: txKey.systemTime
@@ -178,7 +179,8 @@ class OpenTx
 
     /**
      * Execute a DML/DDL SQL statement against this tx, with visibility into writes made earlier in the same
-     * writer call. Positional `?` parameters come from [args], matched by ordinal position, like [openQuery].
+     * writer call. Positional `?` parameters come from [args], supplied and matched by ordinal position like
+     * [openQuery] — unnamed or named `$1..$N` in order.
      *
      * DML writes to forbidden schemas (`xt`, `information_schema`, `pg_catalog`) will throw.
      */

--- a/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
+++ b/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
@@ -2,6 +2,7 @@ package xtdb.query
 
 import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.error.Incorrect
 import xtdb.arrow.RelationReader
 import xtdb.tx.TxOp
 import java.time.ZoneId
@@ -26,11 +27,38 @@ interface SqlPlanner {
 }
 
 /**
- * Rename [this]'s columns to the positional SQL-parameter convention (`?_0`, `?_1`, …) by ordinal position,
- * discarding whatever the caller named them: SQL parameters are matched by position, not name.
+ * Validate that [this]'s columns name their SQL parameters acceptably, then rename them to the internal
+ * positional convention (`?_0`, `?_1`, …) by ordinal position, ready to hand to the planner.
+ *
+ * SQL parameters bind by ordinal position. To stop a caller's evident intent being silently reordered —
+ * e.g. columns named `$3, $2, $1` bound to `$1, $2, $3` by physical order — we accept only columns that
+ * are already correctly ordered:
+ *
+ * - **unnamed** — every name empty, as a spec-compliant ADBC client supplies (positional identity by ordinal);
+ * - **`$1..$N`** — the 1-indexed wire/user convention (also what `bind(VectorSchemaRoot)` normalises to);
+ * - **`?_0..?_{N-1}`** — the 0-indexed internal convention, as pgwire's `open-args` and the planner emit.
+ *
+ * Anything else — arbitrary names, gaps, or out-of-order numbering — throws, rather than binding by position
+ * and quietly ignoring the names.
  *
  * The result is a renaming view over the same vectors — closing it closes them — so it can be handed straight
  * to a cursor that takes ownership of its args (as `openQuery` does), with no copy.
  */
-fun RelationReader.withPositionalParamNames(): RelationReader =
-    RelationReader.from(vectors.mapIndexed { idx, v -> v.withName("?_$idx") }, rowCount)
+fun RelationReader.withPositionalParamNames(): RelationReader {
+    val names = vectors.map { it.name }
+
+    val ok = names.all { it.isEmpty() }
+            || names.withIndex().all { (i, nm) -> nm == "\$${i + 1}" }
+            || names.withIndex().all { (i, nm) -> nm == "?_$i" }
+
+    if (!ok)
+        // The message states the public contract only — the `?_0..` form is an internal convention
+        // (pgwire/the planner) that we deliberately don't advertise to callers.
+        throw Incorrect(
+            "SQL parameters must be supplied unnamed, or named \$1..\$${names.size} in order; got $names",
+            "xtdb/invalid-param-names",
+            mapOf("names" to names),
+        )
+
+    return RelationReader.from(vectors.mapIndexed { idx, v -> v.withName("?_$idx") }, rowCount)
+}

--- a/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
+++ b/core/src/main/kotlin/xtdb/query/SqlPlanner.kt
@@ -24,3 +24,13 @@ interface SqlPlanner {
      */
     fun toStaticOps(sql: String, args: RelationReader?, al: BufferAllocator, defaultTz: ZoneId?): List<TxOp>?
 }
+
+/**
+ * Rename [this]'s columns to the positional SQL-parameter convention (`?_0`, `?_1`, …) by ordinal position,
+ * discarding whatever the caller named them: SQL parameters are matched by position, not name.
+ *
+ * The result is a renaming view over the same vectors — closing it closes them — so it can be handed straight
+ * to a cursor that takes ownership of its args (as `openQuery` does), with no copy.
+ */
+fun RelationReader.withPositionalParamNames(): RelationReader =
+    RelationReader.from(vectors.mapIndexed { idx, v -> v.withName("?_$idx") }, rowCount)

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -2,6 +2,7 @@
 
 package xtdb.indexer
 
+import clojure.lang.Keyword
 import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import xtdb.NodeBase
 import xtdb.NodeBase.Companion.openBase
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
@@ -28,6 +30,7 @@ import xtdb.storage.MemoryStorage
 import xtdb.api.TableRef
 import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation
+import xtdb.api.error.Incorrect
 import xtdb.trie.Bucketer
 import java.nio.ByteBuffer
 import java.time.Instant
@@ -39,6 +42,9 @@ class LiveIndexTest {
 
     private lateinit var nodeBase: NodeBase
     private lateinit var allocator: BufferAllocator
+
+    private val errorCodeKey = Keyword.intern("xtdb.error", "code")
+    private fun Incorrect.errorCode() = data.valAt(errorCodeKey) as Keyword?
 
     @BeforeEach
     fun setUp() {
@@ -113,16 +119,28 @@ class LiveIndexTest {
     }
 
     @Test
-    fun `openQuery matches positional params by position, ignoring arg column names`() {
+    fun `openQuery binds $ N-named args to the placeholders by position`() {
         TestDb().use { db ->
             db.openTx(0, Instant.parse("2020-01-01T00:00:00Z")).use { tx ->
-                // arg columns are not named `?_0`/`?_1`; OpenTx must bind them to the `?` placeholders by
-                // position. openQuery takes ownership of args and frees them when the cursor closes.
-                val args = Relation.openFromRows(allocator, listOf(mapOf("x" to 10L, "y" to 20L)))
+                // openQuery takes ownership of args and frees them when the cursor closes.
+                val args = Relation.openFromRows(allocator, listOf(mapOf("\$1" to 10L, "\$2" to 20L)))
                 tx.openQuery("SELECT ? AS a, ? AS b", args).use { cursor ->
                     val rows = mutableListOf<Map<*, *>>()
                     cursor.forEachRemaining { rel -> rows.addAll(rel.toMaps(SNAKE_CASE_STRING)) }
                     assertEquals(listOf(mapOf("a" to 10L, "b" to 20L)), rows)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `openQuery rejects arg columns whose names aren't the positional convention`() {
+        TestDb().use { db ->
+            db.openTx(0, Instant.parse("2020-01-01T00:00:00Z")).use { tx ->
+                // names that look meaningful but would be silently rebound by position are rejected
+                Relation.openFromRows(allocator, listOf(mapOf("x" to 10L, "y" to 20L))).use { args ->
+                    val e = assertThrows<Incorrect> { tx.openQuery("SELECT ? AS a, ? AS b", args) }
+                    assertEquals(Keyword.intern("xtdb", "invalid-param-names"), e.errorCode())
                 }
             }
         }

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -26,6 +26,8 @@ import xtdb.database.DatabaseStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.MemoryStorage
 import xtdb.api.TableRef
+import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
+import xtdb.arrow.Relation
 import xtdb.trie.Bucketer
 import java.nio.ByteBuffer
 import java.time.Instant
@@ -105,6 +107,22 @@ class LiveIndexTest {
                     val tableSnaps = snap.table(table)
                     assertEquals(2, tableSnaps.size)
                     assertEquals(listOf(1, 1), tableSnaps.map { it.relation.rowCount })
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `openQuery matches positional params by position, ignoring arg column names`() {
+        TestDb().use { db ->
+            db.openTx(0, Instant.parse("2020-01-01T00:00:00Z")).use { tx ->
+                // arg columns are not named `?_0`/`?_1`; OpenTx must bind them to the `?` placeholders by
+                // position. openQuery takes ownership of args and frees them when the cursor closes.
+                val args = Relation.openFromRows(allocator, listOf(mapOf("x" to 10L, "y" to 20L)))
+                tx.openQuery("SELECT ? AS a, ? AS b", args).use { cursor ->
+                    val rows = mutableListOf<Map<*, *>>()
+                    cursor.forEachRemaining { rel -> rows.addAll(rel.toMaps(SNAKE_CASE_STRING)) }
+                    assertEquals(listOf(mapOf("a" to 10L, "b" to 20L)), rows)
                 }
             }
         }

--- a/src/test/clojure/xtdb/flight_sql_test.clj
+++ b/src/test/clojure/xtdb/flight_sql_test.clj
@@ -88,15 +88,15 @@
 
 (t/deftest test-prepared-stmts
   (with-open [ps (.prepare *client* "INSERT INTO users (_id, name) VALUES (?, ?)" empty-call-opts)
-              param-root (VectorSchemaRoot/create (Schema. [#xt/field {"_id" :utf8} #xt/field {"name" :utf8}]) tu/*allocator*)]
+              param-root (VectorSchemaRoot/create (Schema. [#xt/field {"$1" :utf8} #xt/field {"$2" :utf8}]) tu/*allocator*)]
     (.setParameters ps param-root)
 
-    (populate-root param-root [{:_id "jms", :name "James"}
-                               {:_id "mat", :name "Matt"}])
+    (populate-root param-root [{:$1 "jms", :$2 "James"}
+                               {:$1 "mat", :$2 "Matt"}])
     (.executeUpdate ps empty-call-opts)
 
-    (populate-root param-root [{:_id "hak", :name "Håkan"}
-                               {:_id "wot", :name "Dan"}])
+    (populate-root param-root [{:$1 "hak", :$2 "Håkan"}
+                               {:$1 "wot", :$2 "Dan"}])
     (.executeUpdate ps empty-call-opts))
 
   (with-open [ps (.prepare *client* "SELECT users.name FROM users WHERE users._id >= ?" empty-call-opts)
@@ -123,17 +123,17 @@
     (.executeUpdate *client* "CREATE TABLE users (_id, name)" empty-call-opts)
     (let [fsql-tx (.beginTransaction *client* empty-call-opts)]
       (with-open [ps (.prepare *client* "INSERT INTO users (_id, name) VALUES (?, ?)" fsql-tx empty-call-opts)
-                  param-root (VectorSchemaRoot/create (Schema. [#xt/field {"_id" :utf8} #xt/field {"name" :utf8}]) tu/*allocator*)]
+                  param-root (VectorSchemaRoot/create (Schema. [#xt/field {"$1" :utf8} #xt/field {"$2" :utf8}]) tu/*allocator*)]
         (.setParameters ps param-root)
 
-        (populate-root param-root [{:_id "jms", :name "James"}
-                                   {:_id "mat", :name "Matt"}])
+        (populate-root param-root [{:$1 "jms", :$2 "James"}
+                                   {:$1 "mat", :$2 "Matt"}])
         (.executeUpdate ps empty-call-opts)
 
         (t/is (= #{} (q)))
 
-        (populate-root param-root [{:_id "hak", :name "Håkan"}
-                                   {:_id "wot", :name "Dan"}])
+        (populate-root param-root [{:$1 "hak", :$2 "Håkan"}
+                                   {:$1 "wot", :$2 "Dan"}])
         (.executeUpdate ps empty-call-opts)
 
         (t/is (= #{} (q))))

--- a/src/test/java/xtdb/api/AdbcTest.kt
+++ b/src/test/java/xtdb/api/AdbcTest.kt
@@ -5,7 +5,12 @@ import org.apache.arrow.adbc.core.AdbcStatement.QueryResult
 import org.apache.arrow.adbc.core.BulkIngestMode
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.apache.arrow.vector.types.pojo.Schema
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -321,16 +326,61 @@ class AdbcTest {
     }
 
     @Test
-    fun `positional params bind by ordinal position, ignoring arg column names`() {
+    fun `$ N-named params bind by ordinal position`() {
         AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
             db.connect().use { conn ->
-                // arg columns are named neither `?_N` nor the projection aliases — the `?` placeholders
-                // are matched to them by ordinal position, per ADBC, and the names are discarded
+                Relation.openFromRows(allocator, listOf(mapOf("\$1" to 10L, "\$2" to 20L))).use { args ->
+                    conn.createStatement().use { stmt ->
+                        stmt.setSqlQuery("SELECT ? AS a, ? AS b")
+                        stmt.prepare()
+                        (stmt as Xtdb.Statement).bind(args)
+                        stmt.executeQuery().use { res ->
+                            res.consumeAsMaps() shouldBe listOf(mapOf("a" to 10L, "b" to 20L))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `bind rejects arg columns whose names aren't the positional convention`() {
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
                 Relation.openFromRows(allocator, listOf(mapOf("x" to 10L, "y" to 20L))).use { args ->
                     conn.createStatement().use { stmt ->
                         stmt.setSqlQuery("SELECT ? AS a, ? AS b")
                         stmt.prepare()
                         (stmt as Xtdb.Statement).bind(args)
+                        assertThrows(Incorrect::class.java) { stmt.executeQuery() }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `bind(VectorSchemaRoot) with unnamed params doesn't collapse them`() {
+        // regression: a spec-compliant client binds a VSR whose param columns are all empty-named. The VSR
+        // tolerates that; our name-keyed Relation would collapse N empty columns to one unless bind renames
+        // them positionally first.
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
+                val schema = Schema(
+                    listOf(
+                        Field("", FieldType.nullable(ArrowType.Int(64, true)), null),
+                        Field("", FieldType.nullable(ArrowType.Int(64, true)), null),
+                    )
+                )
+                VectorSchemaRoot.create(schema, allocator).use { vsr ->
+                    (vsr.getVector(0) as BigIntVector).apply { allocateNew(); setSafe(0, 10L) }
+                    (vsr.getVector(1) as BigIntVector).apply { allocateNew(); setSafe(0, 20L) }
+                    vsr.setRowCount(1)
+
+                    conn.createStatement().use { stmt ->
+                        stmt.setSqlQuery("SELECT ? AS a, ? AS b")
+                        stmt.prepare()
+                        (stmt as Xtdb.Statement).bind(vsr)
                         stmt.executeQuery().use { res ->
                             res.consumeAsMaps() shouldBe listOf(mapOf("a" to 10L, "b" to 20L))
                         }

--- a/src/test/java/xtdb/api/AdbcTest.kt
+++ b/src/test/java/xtdb/api/AdbcTest.kt
@@ -5,6 +5,7 @@ import org.apache.arrow.adbc.core.AdbcStatement.QueryResult
 import org.apache.arrow.adbc.core.BulkIngestMode
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.types.pojo.ArrowType
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -299,6 +300,41 @@ class AdbcTest {
                     stmt.setSqlQuery("SELECT ? AS p")
                     stmt.prepare()
                     stmt.executeSchema().fields.map { it.name } shouldBe listOf("p")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `parameterSchema reports positional placeholders as empty-named NullType fields, per ADBC spec`() {
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.setSqlQuery("SELECT ?, ?, ?")
+                    stmt.prepare()
+                    // unnamed positional params → empty name; undeterminable type → NA (NullType).
+                    stmt.parameterSchema.fields.map { it.name } shouldBe listOf("", "", "")
+                    stmt.parameterSchema.fields.map { it.type } shouldBe List(3) { ArrowType.Null.INSTANCE }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `positional params bind by ordinal position, ignoring arg column names`() {
+        AdbcDriverFactory().getDriver(allocator).open(emptyMap()).use { db ->
+            db.connect().use { conn ->
+                // arg columns are named neither `?_N` nor the projection aliases — the `?` placeholders
+                // are matched to them by ordinal position, per ADBC, and the names are discarded
+                Relation.openFromRows(allocator, listOf(mapOf("x" to 10L, "y" to 20L))).use { args ->
+                    conn.createStatement().use { stmt ->
+                        stmt.setSqlQuery("SELECT ? AS a, ? AS b")
+                        stmt.prepare()
+                        (stmt as Xtdb.Statement).bind(args)
+                        stmt.executeQuery().use { res ->
+                            res.consumeAsMaps() shouldBe listOf(mapOf("a" to 10L, "b" to 20L))
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -45,6 +45,7 @@ import org.apache.arrow.vector.complex.ListVector
 import org.apache.arrow.vector.ipc.ReadChannel
 import org.apache.arrow.vector.ipc.message.MessageSerializer
 import org.apache.arrow.vector.types.Types
+import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema
@@ -172,6 +173,18 @@ class FlightSqlAdbcTest {
 
                 assertFalse(rdr.loadNextBatch())
             }
+        }
+    }
+
+    @Test
+    fun `test ADBC parameterSchema reports positional placeholders as empty-named NullType fields`() {
+        conn.createStatement().use { stmt ->
+            stmt.setSqlQuery("SELECT ?, ?, ?")
+            stmt.prepare()
+            // per ADBC: unnamed positional params → empty name; undeterminable type → NA (NullType).
+            // asserted on the wire path because both round-trip through IPC schema serialisation.
+            assertEquals(listOf("", "", ""), stmt.parameterSchema.fields.map { it.name })
+            assertEquals(List(3) { ArrowType.Null.INSTANCE }, stmt.parameterSchema.fields.map { it.type })
         }
     }
 

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -103,7 +103,7 @@ class InProcessAdbcTest {
     }
 
     @Test
-    fun `getParameterSchema reports columns in $ N convention`() {
+    fun `getParameterSchema reports unnamed positional params as empty strings`() {
         insertData("CREATE TABLE foo (_id, name)")
 
         xtdb.connect().use { conn ->
@@ -113,8 +113,8 @@ class InProcessAdbcTest {
 
                 val paramSchema = stmt.parameterSchema
                 assertEquals(2, paramSchema.fields.size, "expected 2 parameter slots")
-                assertEquals("\$0", paramSchema.fields[0].name)
-                assertEquals("\$1", paramSchema.fields[1].name)
+                assertEquals("", paramSchema.fields[0].name)
+                assertEquals("", paramSchema.fields[1].name)
                 assertEquals(ArrowType.Null.INSTANCE, paramSchema.fields[0].type)
                 assertEquals(ArrowType.Null.INSTANCE, paramSchema.fields[1].type)
             }


### PR DESCRIPTION
Resolves #5651.

## Summary

Conforms XTDB's ADBC/FlightSQL parameter surface to the ADBC spec and makes positional-parameter binding behave identically across the embedded connection, the ADBC driver, the FlightSQL wire, and the `OpenTx` SPI.

## Parameter-naming requirements

XTDB SQL parameters are positional-only (`?`). Three naming conventions collide at the boundaries, and these rules reconcile them:

- `$1..$N` — 1-indexed; the user/wire convention (what a user writes in SQL, what pgwire emits).
- `?_0..?_{N-1}` — 0-indexed; the planner's internal column name for a parameter.
- *unnamed* (empty string) — what the ADBC spec mandates for a positional parameter's schema field.

The requirements the branch implements:

1. `getParameterSchema` reports each `?` placeholder as an **unnamed** field of Arrow `NullType`. A positional parameter carries identity by ordinal, so a name is redundant and non-conforming; its type is unknown at prepare time, which the spec maps to `NullType`. Both faces conform — the embedded connection and the FlightSQL wire, which serialises the same schema through IPC.

2. Args **bind by ordinal position**, never by name. A caller may supply columns unnamed (spec-compliant ADBC) or named; either way the planner needs its internal `?_0..` names, so both bind boundaries normalise by position before planning.

3. An all-unnamed multi-parameter bind must not lose parameters. `Relation` keys columns by name in a `SequencedMap`, so N empty names would collapse to a single column and the parameters would vanish silently. `bind(VectorSchemaRoot)` renames the ordered `fieldVectors` to `$1..$N` before they reach the name-keyed relation. A `VectorSchemaRoot` itself tolerates duplicate/empty names — the collapse is ours, downstream of the bind.

4. Behaviour is identical across `Xtdb.Connection` and `OpenTx.openQuery`/`executeSql`. An `OpenTx` caller no longer has to pre-name its columns `?_N`, so the internal convention stops leaking out through the SPI (previously only the column *count* was checked, never the names).

## The name contract

Requirement 2 leaves one policy choice: when a caller *does* name its columns, do we trust the names or ignore them?

The contract is **explicit and strict**: a caller supplies its bind columns unnamed, or named `$1..$N` in order, or the bind is rejected. Names are never silently reordered against a caller's evident intent — a bind that named its columns `$3, $2, $1` used to bind them to `$1, $2, $3` by physical order, which this rejects.

The trade-off: a FlightSQL/ADBC application that names its bind columns after their target columns (e.g. `_id, name` for an `INSERT`) must instead supply them unnamed or as `$1, $2`. The FlightSQL prepared-DML tests were doing exactly this and now name their params `$1, $2` to conform. This is the intended contract, not a workaround — positional binding advertises unnamed parameters, and we hold callers to that rather than guessing at arbitrary names.

(A separate FlightSQL error-propagation improvement, tracked apart from this PR, makes a rejected bind surface the `xtdb/invalid-param-names` message on the wire instead of a generic gRPC `INTERNAL`.)

## Changes

1. `8a0e546` — conform the schema (empty parameter names + `NullType`), share `withPositionalParamNames` across both bind boundaries, and lock the field names/types across all three surfaces (embedded, ADBC driver-manager, FlightSQL wire — the wire assertion is load-bearing, since the schema round-trips through IPC where a `NullType` field can silently degrade).
2. `1f1a56a` — add the name validation, fix the unnamed-VSR bind collapse in `bind(VectorSchemaRoot)`, and conform the FlightSQL prepared-DML tests to the contract.

## Test plan

`AdbcTest`, `InProcessAdbcTest`, `FlightSqlAdbcTest`, `flight_sql_test`, and `LiveIndexTest` cover the three surfaces plus the OpenTx SPI — 135 tests, all green. They bind deliberately mis-named columns to prove arbitrary names are rejected and correctly-ordered `$1..$N` binds win, and assert an all-unnamed multi-param VSR bind no longer collapses.
