### PR TITLE
tidy(storage): partition-aware BufferPool construction; storage layout (#5557)

### DIFF
--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -13,6 +13,7 @@ import org.apache.arrow.vector.ipc.message.ArrowFooter
 import xtdb.api.PathSerde
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
+import xtdb.api.error.Incorrect
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.database.DatabaseName
@@ -45,6 +46,37 @@ object Storage {
             if (epoch > 0) append("_e${epoch.asLexHex}")
         })
 
+    internal fun validatePartition(partition: Int, totalPartitions: Int) {
+        if (totalPartitions < 1)
+            throw Incorrect(
+                "totalPartitions must be >= 1, got $totalPartitions",
+                "xtdb/invalid-total-partitions",
+                mapOf("total-partitions" to totalPartitions)
+            )
+
+        if (partition !in 0 until totalPartitions)
+            throw Incorrect(
+                "partition must be in 0..<$totalPartitions, got $partition",
+                "xtdb/invalid-partition",
+                mapOf("partition" to partition, "total-partitions" to totalPartitions)
+            )
+    }
+
+    /**
+     * At `totalPartitions == 1` this is byte-identical to the single-partition layout, so existing
+     * object stores and local directories keep working without a key-space migration — load-bearing
+     * for rolling upgrades, since blob stores have no `mv` primitive and re-keying a database would
+     * mean a full copy-and-delete sweep. Only at N > 1 does the `parts/<partition>/` grouping appear.
+     * Partition counts are immutable post-attach, so a store is one shape or the other for its whole
+     * lifetime and the two never collide.
+     */
+    @JvmStatic
+    fun storageRoot(version: StorageVersion, epoch: Int, partition: Int, totalPartitions: Int): Path {
+        validatePartition(partition, totalPartitions)
+        val root = storageRoot(version, epoch)
+        return if (totalPartitions == 1) root else Path.of("parts", partition.toString()).resolve(root)
+    }
+
     /**
      * Represents a factory interface for creating storage instances.
      * The default implementation is [InMemoryStorageFactory] which stores data in memory
@@ -58,6 +90,7 @@ object Storage {
         fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
             dbName: DatabaseName,
+            partition: Int = 0, totalPartitions: Int = 1,
             meterRegistry: MeterRegistry? = null,
             storageVersion: StorageVersion = VERSION,
             remotes: Map<RemoteAlias, Remote> = emptyMap(),
@@ -91,9 +124,15 @@ object Storage {
     data class InMemoryStorageFactory(override var epoch: Int = 0) : Factory {
         override fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
-            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
+            dbName: DatabaseName, partition: Int, totalPartitions: Int,
+            meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
             remotes: Map<RemoteAlias, Remote>,
-        ): BufferPool = MemoryStorage(allocator, epoch)
+        ): BufferPool {
+            // each open() is its own store, so partitions are isolated by construction — only the
+            // index needs validating
+            validatePartition(partition, totalPartitions)
+            return MemoryStorage(allocator, epoch)
+        }
     }
 
     @JvmStatic
@@ -118,12 +157,14 @@ object Storage {
 
         override fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
-            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
+            dbName: DatabaseName, partition: Int, totalPartitions: Int,
+            meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
             remotes: Map<RemoteAlias, Remote>,
         ): BufferPool {
-            val rootPath = path.resolve(storageRoot(storageVersion, epoch)).also { it.createDirectories() }
+            val rootPath = path.resolve(storageRoot(storageVersion, epoch, partition, totalPartitions))
+                .also { it.createDirectories() }
 
-            return LocalStorage(allocator, memoryCache, meterRegistry, epoch, dbName, rootPath)
+            return LocalStorage(allocator, memoryCache, meterRegistry, epoch, dbName, partition, rootPath)
         }
     }
 
@@ -146,13 +187,15 @@ object Storage {
 
         override fun open(
             allocator: BufferAllocator, memoryCache: MemoryCache, diskCache: DiskCache?,
-            dbName: DatabaseName, meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
+            dbName: DatabaseName, partition: Int, totalPartitions: Int,
+            meterRegistry: MeterRegistry?, storageVersion: StorageVersion,
             remotes: Map<RemoteAlias, Remote>,
         ): BufferPool {
             requireNotNull(diskCache) { "diskCache is required for remote storage" }
 
-            return objectStore.openObjectStore(storageRoot(storageVersion, epoch), remotes).closeOnCatch { objectStore ->
-                RemoteBufferPool(allocator, objectStore, memoryCache, diskCache, meterRegistry, epoch, dbName)
+            val objStoreRoot = storageRoot(storageVersion, epoch, partition, totalPartitions)
+            return objectStore.openObjectStore(objStoreRoot, remotes).closeOnCatch { objectStore ->
+                RemoteBufferPool(allocator, objectStore, memoryCache, diskCache, meterRegistry, epoch, dbName, partition)
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -253,9 +253,9 @@ class Database(
             val indexerConfig = base.config.indexer
             val readOnly = dbConfig.isReadOnly
 
-            // Attach-time gate: the type signatures admit N throughout, but per-partition BufferPool
-            // layout (unit 6), TableCatalog wrappers + UNION-at-scan (unit 7) and xt.txs_$partition
-            // naming (unit 8) haven't landed. Lifting this gate is unit 9.
+            // Attach-time gate: the type signatures admit N throughout, but TableCatalog wrappers +
+            // UNION-at-scan (unit 7) and xt.txs_$partition naming (unit 8) haven't landed. Lifting
+            // this gate is unit 9.
             if (dbConfig.partitions > 1)
                 throw Incorrect(
                     "multi-partition external-source databases are not yet enabled " +
@@ -272,7 +272,8 @@ class Database(
             val bufferPool = open {
                 val bp = dbConfig.storage.open(
                     allocator, base.memoryCache, base.diskCache,
-                    dbName, base.meterRegistry, Storage.VERSION,
+                    dbName, 0, dbConfig.partitions,
+                    base.meterRegistry, Storage.VERSION,
                     base.remotes,
                 )
                 if (readOnly) ReadOnlyBufferPool(bp) else bp

--- a/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
@@ -35,6 +35,7 @@ internal class LocalStorage(
     meterRegistry: MeterRegistry? = null,
     override val epoch: StorageEpoch,
     dbName: DatabaseName,
+    partition: Int,
     val rootPath: Path,
 ) : BufferPool, IEvictBufferTest, Closeable {
 
@@ -44,10 +45,10 @@ internal class LocalStorage(
     private val recordBatchRequests: Counter? = meterRegistry?.counter("record-batch-requests")
     private val memCacheMisses: Counter? = meterRegistry?.counter("memory-cache-misses")
 
-    // we partition the cache by dbName as it's shared between multiple databases
+    // we scope the cache keys by dbName/partition as the cache is shared between multiple
+    // databases (and, at N>1, multiple partitions of the same database)
     // the cache itself has no knowledge of this
-    // '0' for partition 0, in advance of multi-partition support
-    private val cacheRootPath = dbName.asPath.resolve("0")
+    private val cacheRootPath = dbName.asPath.resolve(partition.toString())
 
     companion object {
         private fun Path.createTempUploadFile(): Path {

--- a/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
@@ -41,6 +41,7 @@ internal class RemoteBufferPool(
     meterRegistry: MeterRegistry? = null,
     override val epoch: StorageEpoch,
     dbName: DatabaseName,
+    partition: Int,
 ) : BufferPool, IEvictBufferTest, Closeable {
 
     private val allocator = allocator.openChildAllocator("buffer-pool")
@@ -53,10 +54,10 @@ internal class RemoteBufferPool(
     private val networkWrite: Counter? = meterRegistry?.counter("buffer-pool.network.write")
     private val networkRead: Counter? = meterRegistry?.counter("buffer-pool.network.read")
 
-    // we partition the caches by dbName as they're shared between multiple databases
-    // the caches themselves has no knowledge of this
-    // '0' for partition 0, in advance of multi-partition support
-    private val cacheRootPath = dbName.asPath.resolve("0")
+    // we scope the cache keys by dbName/partition as the caches are shared between multiple
+    // databases (and, at N>1, multiple partitions of the same database)
+    // the caches themselves have no knowledge of this
+    private val cacheRootPath = dbName.asPath.resolve(partition.toString())
 
     companion object {
         internal var minMultipartPartSize = 5 * 1024 * 1024

--- a/core/src/test/kotlin/xtdb/api/storage/StorageRootTest.kt
+++ b/core/src/test/kotlin/xtdb/api/storage/StorageRootTest.kt
@@ -1,0 +1,60 @@
+package xtdb.api.storage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import xtdb.api.error.Incorrect
+import xtdb.api.storage.Storage.storageRoot
+import xtdb.util.asPath
+
+/**
+ * Versions are passed literally rather than as [Storage.VERSION] throughout: the subject here is the
+ * rendering of a root, which must stay stable across version bumps, not whatever version is current.
+ */
+class StorageRootTest {
+
+    @Test
+    fun `epoch 0 renders bare`() {
+        assertEquals("v06".asPath, storageRoot(6, 0))
+    }
+
+    @Test
+    fun `non-zero epoch appends a lex-hex suffix`() {
+        assertEquals("v06_e01".asPath, storageRoot(6, 1))
+        assertEquals("v06_e0a".asPath, storageRoot(6, 10))
+    }
+
+    /**
+     * Asserted as equality with the two-arg root rather than against a literal, because the contract is
+     * "indistinguishable from a store written before partitioning existed" — the two-arg form is the
+     * reference for what those stores contain.
+     */
+    @Test
+    fun `single partition is byte-identical to the unpartitioned root`() {
+        for (epoch in listOf(0, 1, 10)) {
+            assertEquals(storageRoot(6, epoch), storageRoot(6, epoch, 0, 1), "epoch $epoch")
+        }
+    }
+
+    @Test
+    fun `multiple partitions nest under a parts marker`() {
+        assertEquals("parts/0/v06".asPath, storageRoot(6, 0, 0, 3))
+        assertEquals("parts/2/v06".asPath, storageRoot(6, 0, 2, 3))
+    }
+
+    /**
+     * Partition-outer, so each partition's subtree holds a complete set of epoch generations — which is
+     * what keeps per-partition epochs open as a future option. The inverted nesting would foreclose it.
+     */
+    @Test
+    fun `the partition marker sits outside the epoch root`() {
+        assertEquals("parts/1/v06_e02".asPath, storageRoot(6, 2, 1, 2))
+    }
+
+    @Test
+    fun `rejects partitions outside the declared range`() {
+        assertThrows(Incorrect::class.java) { storageRoot(6, 0, 2, 2) }
+        assertThrows(Incorrect::class.java) { storageRoot(6, 0, -1, 1) }
+        assertThrows(Incorrect::class.java) { storageRoot(6, 0, 0, 0) }
+    }
+}

--- a/core/src/test/kotlin/xtdb/storage/LocalStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/LocalStorageTest.kt
@@ -5,6 +5,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import xtdb.api.storage.Storage
@@ -13,15 +14,24 @@ import xtdb.util.asPath
 import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.nio.file.Files.createTempDirectory
+import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.readBytes
 
-class LocalStorageTest : StorageTest() {
+class LocalStorageTest : PartitionedStorageTest() {
     private lateinit var allocator: BufferAllocator
     private lateinit var memoryCache: MemoryCache
     private lateinit var localBufferPool: BufferPool
 
+    @TempDir
+    lateinit var partitionedPath: Path
+
     override fun storage(): BufferPool = localBufferPool
+
+    // distinct dbName so the partitioned pools don't alias localBufferPool's namespace in the
+    // shared memoryCache — they're different stores that would otherwise share cache keys
+    override fun openPartitionedStorage(partition: Int, totalPartitions: Int): BufferPool =
+        Storage.local(partitionedPath).open(allocator, memoryCache, null, "parted-db", partition, totalPartitions)
 
     @BeforeEach
     fun setUp() {
@@ -38,6 +48,32 @@ class LocalStorageTest : StorageTest() {
         localBufferPool.close()
         memoryCache.close()
         allocator.close()
+    }
+
+    @Test
+    fun `partitioned pools nest under a parts-N marker on disk`() {
+        openPartitionedStorage(0, 2).use { p0 ->
+            openPartitionedStorage(1, 2).use { p1 ->
+                p0.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(3)))
+                p1.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(7)))
+            }
+        }
+
+        val versionRoot = Storage.storageRoot(Storage.VERSION, 0)
+        assertTrue(partitionedPath.resolve("parts/0").resolve(versionRoot).resolve("blocks/b00.binpb").exists())
+        assertTrue(partitionedPath.resolve("parts/1").resolve(versionRoot).resolve("blocks/b00.binpb").exists())
+    }
+
+    @Test
+    fun `single-partition pool keeps the unmarked on-disk layout`() {
+        openPartitionedStorage(0, 1).use { bp ->
+            bp.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
+        }
+
+        assertTrue(
+            partitionedPath.resolve(Storage.storageRoot(Storage.VERSION, 0))
+                .resolve("blocks/b00.binpb").exists()
+        )
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/storage/MemoryStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/MemoryStorageTest.kt
@@ -4,22 +4,30 @@ import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import xtdb.api.storage.Storage
+import xtdb.cache.MemoryCache
 
 class MemoryStorageTest : StorageTest() {
     override fun storage(): BufferPool = memoryStorage
 
+    override fun openPartitionedStorage(partition: Int, totalPartitions: Int): BufferPool =
+        Storage.inMemory().open(allocator, memoryCache, null, "xtdb", partition, totalPartitions)
+
     private lateinit var allocator: BufferAllocator
+    private lateinit var memoryCache: MemoryCache
     private lateinit var memoryStorage: MemoryStorage
 
     @BeforeEach
     fun setUp() {
         allocator = RootAllocator()
+        memoryCache = MemoryCache.Factory().open(allocator)
         memoryStorage = MemoryStorage(allocator, epoch = 0)
     }
 
     @AfterEach
     fun tearDown() {
         memoryStorage.close()
+        memoryCache.close()
         allocator.close()
     }
 }

--- a/core/src/test/kotlin/xtdb/storage/PartitionedStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/PartitionedStorageTest.kt
@@ -1,0 +1,51 @@
+package xtdb.storage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.api.storage.ObjectStore.StoredObject
+import xtdb.util.StringUtil.asLexHex
+import xtdb.util.asPath
+
+/**
+ * Partition assertions that only mean anything when [openPartitionedStorage] hands back pools over a
+ * shared underlying store, so the isolation below is real path-scoping. MemoryStorage gets a fresh
+ * store per open and so deliberately doesn't extend this — the assertions would hold even if the
+ * partition index were ignored entirely.
+ */
+abstract class PartitionedStorageTest : StorageTest() {
+
+    @Test
+    fun partitionedPoolsAreIsolated() {
+        openPartitionedStorage(0, 2).use { p0 ->
+            openPartitionedStorage(1, 2).use { p1 ->
+                // the same key in both partitions — sizes distinguish who wrote what
+                p0.writeBlock(0, size = 3)
+                p1.writeBlock(0, size = 7)
+                p1.writeBlock(1, size = 7)
+
+                assertEquals(
+                    listOf(StoredObject("blocks/b${0L.asLexHex}.binpb".asPath, 3)),
+                    p0.listAllObjects().toList(),
+                    "partition 0 lists only its own objects"
+                )
+                assertEquals(
+                    listOf(
+                        StoredObject("blocks/b${0L.asLexHex}.binpb".asPath, 7),
+                        StoredObject("blocks/b${1L.asLexHex}.binpb".asPath, 7),
+                    ),
+                    p1.listAllObjects().toList(),
+                    "partition 1 lists only its own objects"
+                )
+
+                assertEquals(0L, p0.latestAvailableBlockIndex(), "block discovery is per-partition")
+                assertEquals(1L, p1.latestAvailableBlockIndex(), "block discovery is per-partition")
+
+                // delete is GC's primitive — a partition's GC must never touch a sibling's files
+                p0.deleteIfExists("blocks/b${0L.asLexHex}.binpb".asPath)
+
+                assertEquals(emptyList<StoredObject>(), p0.listAllObjects().toList())
+                assertEquals(2, p1.listAllObjects().count(), "partition 1 unaffected by partition 0's delete")
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -2,9 +2,6 @@ package xtdb.storage
 
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.Field
-import org.apache.arrow.vector.types.pojo.FieldType
-import org.apache.arrow.vector.types.pojo.Schema
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -18,6 +15,7 @@ import xtdb.api.RemoteAlias
 import xtdb.api.storage.InMemoryBucket
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.PrefixedObjectStore
+import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.remote
 import xtdb.api.storage.StoreOperation.COMPLETE
 import xtdb.api.storage.StoreOperation.UPLOAD
@@ -28,21 +26,26 @@ import xtdb.arrow.schema
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
 import xtdb.test.AllocatorResolver
+import xtdb.util.asPath
+import java.nio.ByteBuffer
 import java.nio.file.Path
 import kotlin.io.path.listDirectoryEntries
 import com.google.protobuf.Any as ProtoAny
 
 @ExtendWith(AllocatorResolver::class)
-class RemoteStorageTest : StorageTest() {
+class RemoteStorageTest : PartitionedStorageTest() {
     override fun storage(): BufferPool = remoteBufferPool
 
+    private lateinit var allocator: BufferAllocator
     private lateinit var memoryCache: MemoryCache
-    private lateinit var sharedBucket: InMemoryBucket
+    private lateinit var diskCache: DiskCache
     private lateinit var remoteBufferPool: RemoteBufferPool
+    private lateinit var xtdbBucket: InMemoryBucket
+    private lateinit var partedBucket: InMemoryBucket
 
-    // hands every open a prefixing view onto the one shared bucket, the way the cloud stores resolve
-    // their prefix over a single durable bucket — so assertions read the pool's real key-space off
-    // `sharedBucket` rather than downcasting the pool's client
+    // hands every open a prefixing view onto one shared bucket, the way the cloud stores resolve their
+    // prefix over a single durable bucket — so assertions read the pool's real key-space off the bucket
+    // rather than downcasting the pool's client
     class PrefixingObjectStoreFactory(val bucket: InMemoryBucket) : ObjectStore.Factory {
         override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): ObjectStore =
             PrefixedObjectStore(storageRoot, bucket)
@@ -51,13 +54,22 @@ class RemoteStorageTest : StorageTest() {
             get() = ProtoAny.newBuilder().build()
     }
 
+    // partitioned pools get their own bucket and a distinct dbName, so they neither alias
+    // remoteBufferPool's namespace in the node-shared caches nor pollute its key-space observations
+    override fun openPartitionedStorage(partition: Int, totalPartitions: Int): BufferPool =
+        remote(PrefixingObjectStoreFactory(partedBucket))
+            .open(allocator, memoryCache, diskCache, "parted-db", partition, totalPartitions)
+
     @BeforeEach
     fun setUp(@TempDir localDiskCachePath: Path, al: BufferAllocator) {
+        allocator = al
         memoryCache = MemoryCache.Factory().open(al)
-        sharedBucket = InMemoryBucket()
+        diskCache = DiskCache.Factory(localDiskCachePath).build()
+        xtdbBucket = InMemoryBucket()
+        partedBucket = InMemoryBucket()
         remoteBufferPool =
-            remote(PrefixingObjectStoreFactory(sharedBucket))
-                .open(al, memoryCache, DiskCache.Factory(localDiskCachePath).build(), "xtdb") as RemoteBufferPool
+            remote(PrefixingObjectStoreFactory(xtdbBucket))
+                .open(al, memoryCache, diskCache, "xtdb") as RemoteBufferPool
 
         // Mocking small value for MIN_MULTIPART_PART_SIZE
         RemoteBufferPool.minMultipartPartSize = 320
@@ -69,6 +81,60 @@ class RemoteStorageTest : StorageTest() {
         memoryCache.close()
     }
 
+    @Test
+    fun `partitioned pools scope object keys under parts-N`() {
+        openPartitionedStorage(0, 2).use { p0 ->
+            openPartitionedStorage(1, 2).use { p1 ->
+                p0.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(3)))
+                p1.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(7)))
+            }
+        }
+
+        val versionRoot = Storage.storageRoot(Storage.VERSION, 0)
+        assertEquals(
+            listOf(
+                "parts/0".asPath.resolve(versionRoot).resolve("blocks/b00.binpb"),
+                "parts/1".asPath.resolve(versionRoot).resolve("blocks/b00.binpb"),
+            ),
+            partedBucket.buffers.keys.toList(),
+            "raw object-store keys carry the partition marker"
+        )
+    }
+
+    @Test
+    fun `single-partition pool keeps the unmarked key-space`() {
+        openPartitionedStorage(0, 1).use { bp ->
+            bp.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
+        }
+
+        assertEquals(
+            listOf(Storage.storageRoot(Storage.VERSION, 0).resolve("blocks/b00.binpb")),
+            partedBucket.buffers.keys.toList(),
+            "no partition marker at partitions = 1"
+        )
+    }
+
+    /**
+     * Lives here rather than in [PartitionedStorageTest] because only the remote backend can express it:
+     * the disk cache is durable, so p0's entry is still there when p1 reads. Local has no disk cache, and
+     * MemoryCache releases an entry once the last reference drops, so p1's read is a fresh miss that
+     * reloads from its own root — the assertion would pass there even with the partition dropped from the
+     * cache key. Verified by reverting `cacheRootPath` to `dbName/0`: this fails, the local sibling didn't.
+     */
+    @Test
+    fun `partitions get their own entries in the node-shared caches`() {
+        openPartitionedStorage(0, 2).use { p0 ->
+            openPartitionedStorage(1, 2).use { p1 ->
+                val key = "blocks/b00.binpb".asPath
+                p0.putObject(key, ByteBuffer.wrap(ByteArray(3)))
+                p1.putObject(key, ByteBuffer.wrap(ByteArray(7)))
+
+                // p0 reads first, seeding the shared cache under this key
+                assertEquals(3, p0.getByteArray(key).size, "partition 0 reads its own bytes")
+                assertEquals(7, p1.getByteArray(key).size, "partition 1 isn't served partition 0's cache entry")
+            }
+        }
+    }
 
     @Test
     fun `openArrowWriter seeds the disk cache under the pool-scoped key`(al: BufferAllocator) {
@@ -83,7 +149,7 @@ class RemoteStorageTest : StorageTest() {
         }
 
         // only the disk cache can serve the read once the store forgets the object
-        sharedBucket.buffers.clear()
+        xtdbBucket.buffers.clear()
         assertNotNull(remoteBufferPool.getFooter(key))
     }
 
@@ -98,7 +164,7 @@ class RemoteStorageTest : StorageTest() {
                 writer.end()
             }
         }
-        assertEquals(listOf(UPLOAD, UPLOAD, COMPLETE), sharedBucket.calls)
+        assertEquals(listOf(UPLOAD, UPLOAD, COMPLETE), xtdbBucket.calls)
 
         remoteBufferPool.getRecordBatch(path, 0).use { rb ->
             val footer = remoteBufferPool.getFooter(path)

--- a/core/src/test/kotlin/xtdb/storage/StorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/StorageTest.kt
@@ -3,7 +3,9 @@ package xtdb.storage
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import xtdb.api.error.Incorrect
 import xtdb.api.storage.ObjectStore.StoredObject
 import xtdb.arrow.IntVector
 import xtdb.arrow.Relation
@@ -13,6 +15,16 @@ import java.nio.ByteBuffer
 
 abstract class StorageTest {
     abstract fun storage(): BufferPool
+
+    /**
+     * A pool for one partition of a multi-partition database.
+     *
+     * Only the factory-level validation below is asserted for every backend. MemoryStorage returns an
+     * independent store per call, so cross-partition isolation is true by construction for it rather
+     * than by path-scoping; backends whose partition pools share one underlying store assert that in
+     * [PartitionedStorageTest].
+     */
+    abstract fun openPartitionedStorage(partition: Int, totalPartitions: Int): BufferPool
 
     @Test
     fun listObjectTests_3545() {
@@ -36,8 +48,8 @@ abstract class StorageTest {
         )
     }
 
-    private fun BufferPool.writeBlock(blockIndex: Long) {
-        putObject("blocks/b${blockIndex.asLexHex}.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
+    protected fun BufferPool.writeBlock(blockIndex: Long, size: Int = 10) {
+        putObject("blocks/b${blockIndex.asLexHex}.binpb".asPath, ByteBuffer.wrap(ByteArray(size)))
     }
 
     @Test
@@ -91,5 +103,12 @@ abstract class StorageTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun rejectsInvalidPartitionIndex() {
+        assertThrows(Incorrect::class.java) { openPartitionedStorage(2, 2) }
+        assertThrows(Incorrect::class.java) { openPartitionedStorage(-1, 1) }
+        assertThrows(Incorrect::class.java) { openPartitionedStorage(0, 0) }
     }
 }

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -42,7 +42,7 @@
              ~@body))))))
 
 (defn- open-storage ^xtdb.storage.BufferPool [^Storage$Factory factory]
-  (.open factory tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))
+  (.open factory tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 nil Storage/VERSION {}))
 
 (t/deftest test-remote-buffer-pool-setup
   (util/with-tmp-dirs #{path}
@@ -95,7 +95,7 @@
   (with-caches {}
     (let [^InMemoryBucket bucket (InMemoryBucket.)]
       (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory bucket))
-                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 nil Storage/VERSION {}))]
         (t/testing "if <= min part size, putObject is used"
           (.putObject bp (util/->path "min-part-put") (utf8-buf "12"))
           (t/is (= [StoreOperation/PUT] (.getCalls bucket)))
@@ -118,7 +118,7 @@
 (t/deftest local-disk-cache-max-size
   (with-caches {:mem-bytes 12, :disk-bytes 10}
     (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (InMemoryBucket.)))
-                       (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
+                       (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 nil Storage/VERSION {}))]
       (t/testing "staying below max size - all elements available"
         (insert-utf8-to-local-cache bp (util/->path "a") 4)
         (insert-utf8-to-local-cache bp (util/->path "b") 4)
@@ -155,7 +155,7 @@
     (with-caches {:mem-bytes 64, :disk-bytes 64}
       ;; Writing files to buffer pool & local-disk-cache
       (with-open [bp (-> (Storage/remote obj-store-factory)
-                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 nil Storage/VERSION {}))]
         (insert-utf8-to-local-cache bp path-a 4)
         (insert-utf8-to-local-cache bp path-b 4)
         (t/is (= {:file-count 2 :file-names #{"a" "b"}} (file-info *disk-cache-dir*))))
@@ -163,7 +163,7 @@
       ;; Starting a new buffer pool - should load buffers correctly from disk (can be sure its grabbed from disk since using a memory cache and memory object store)
       ;; passing a no-op object store to ensure objects are not loaded from object store and instead only the cache is under test.
       (with-open [bp (-> (Storage/remote (no-op-object-store-factory))
-                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 nil Storage/VERSION {}))]
         (t/is (= 0 (util/compare-nio-buffers-unsigned (utf8-buf "aaaa") (ByteBuffer/wrap (.getByteArray bp path-a)))))
         (t/is (= 0 (util/compare-nio-buffers-unsigned (utf8-buf "aaaa") (ByteBuffer/wrap (.getByteArray bp path-b)))))))))
 
@@ -298,7 +298,7 @@
   (let [registry (SimpleMeterRegistry.)]
     (with-caches {}
       (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (InMemoryBucket.)))
-                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" registry Storage/VERSION {}))]
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 registry Storage/VERSION {}))]
         (let [k1 (util/->path "a")
               k2 (util/->path "b")
               ^ByteBuffer v1 (utf8-buf "aaa")

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -96,6 +96,40 @@ class BlockGarbageCollectorTest {
         }
     }
 
+    @Test
+    fun `garbageCollectBlocks only touches its own partition`(@TempDir tempDir: Path, al: BufferAllocator) = runTest {
+        MemoryCache.Factory().open(al).use { memoryCache ->
+            Storage.local(tempDir).open(al, memoryCache, null, "xtdb", 0, 2).use { p0 ->
+                Storage.local(tempDir).open(al, memoryCache, null, "xtdb", 1, 2).use { p1 ->
+                    val blocksPath = "blocks".asPath
+                    val tableBlockPath = "public/foo".tablePath.resolve(blocksPath)
+
+                    for (pool in listOf(p0, p1)) {
+                        (1L..10L).forEach { index ->
+                            writeBlock(pool, index, listOf("public/foo"), listOf(blocksPath, tableBlockPath))
+                        }
+                    }
+
+                    val gc = BlockGarbageCollector(
+                        backgroundScope,
+                        p0, BlockCatalog(p0.latestBlock),
+                        blocksToKeep = 3,
+                        enabled = false,
+                        dbName = "xtdb",
+                    )
+
+                    gc.garbageCollectBlocks()
+
+                    assertBlockCount(p0, blocksPath, 3)
+                    assertBlockCount(p0, tableBlockPath, 3)
+
+                    assertBlockCount(p1, blocksPath, 10)
+                    assertBlockCount(p1, tableBlockPath, 10)
+                }
+            }
+        }
+    }
+
     /*
     TODO: Fix this test - race condition with ListAllObjects
     @Test


### PR DESCRIPTION
Part of #5557 — unit 6 of multi-DB stage 4: a partition's `BufferPool` knows which partition it serves and scopes its key-space accordingly.

## Summary

`Storage.Factory.open` gains `(partition, totalPartitions)`, and a pool's key-space is scoped by those in its root path (local) / object-store prefix (remote). Multi-partition databases remain rejected at `Database.open` — that gate lifts in unit 9 — so at `partitions = 1`, the only reachable shape, everything here is behaviour-preserving, byte-for-byte, including resource open/close ordering. N>1 is reachable only from tests.

## Storage layout

Mirrors unit 5's LocalLog decision — no partition marker at N=1, grouped under one at N>1:

- `partitions == 1`: `<prefix>/<version>_<epoch>/…` — byte-identical to today. This is load-bearing rather than cosmetic: object stores hold durable production data, blob stores have no `mv` primitive, and re-keying a database would mean a full copy-and-delete sweep, so existing stores must keep working unchanged through a rolling upgrade.
- `partitions > 1`: `<prefix>/parts/<partition>/<version>_<epoch>/…` — each partition's subtree is a complete store of the existing shape, so everything downstream of the pool root (block discovery, GC, trie paths) works per-partition without change. `parts/` keeps the subtrees out of the store root's namespace: without it, partition directories would occupy the exact slot the `<version>_<epoch>` roots do, so enumerating partitions degrades to "list the root, keep integer-looking names" and every numeric name at the root is reserved forever. With it, the root holds either a version-epoch root or `parts/`, and that one token identifies the layout. (`LocalLog` reaches the same *shape* at N>1, but its nesting is forced — `LOG` is a file at N=1, so fanning out under a fixed name requires a directory. `parts/` is a discretionary segment and stands on the namespace argument above, not on that precedent.)

The `BufferPool` interface is untouched: keys stay relative to the pool root, and the scoping lives in the root path / object-store prefix. The node-shared memory/disk caches scope entries by `dbName/<partition>` — the slot the pre-existing `'0'` placeholder comment reserved. No collision between the two layout shapes is possible because partition counts are immutable post-attach: a store is one shape or the other for its whole lifetime.

The `parts/<partition>/<version>_<epoch>` nesting — rather than `<version>_<epoch>/parts/<partition>` — is deliberate, not forced by compatibility (N>1 key-spaces are always born fresh, so either order would have been zero-migration). Partition-outer keeps each subtree a complete store, models the stable thing (a partition's identity) outside the transient thing (an epoch bump), and leaves per-partition epochs open as a future feature — partition-scoped recovery for large-N external-source databases where whole-database re-ingestion is expensive. The inverted nesting would foreclose that structurally, buying only single-prefix cleanup of stale generations after a restore.

`Storage.Factory.open` keeps Kotlin defaults (`partition = 0, totalPartitions = 1`) so single-partition call sites don't churn; unit 9 strips them alongside the `Log<M>` ones once multi-partition is live, per the same hack-value argument. Clojure call sites pass the args explicitly, since Kotlin defaults don't cross interop.

The attach-time gate in `Database.open` stays, since units 7 (TableCatalog wrappers + UNION-at-scan) and 8 (`xt.txs_$partition` naming) are still outstanding — but its comment no longer lists unit 6 among the reasons, this being that unit.

## Landed separately

This PR originally carried the `DatabaseStorage`/`DatabaseLogs` split as a first commit. That has since shipped to `main` on its own (`47195175e`), along with the follow-on tidies that renamed `DatabaseStorage` to `PartitionStorage` (`04ffbbb3b`), bound per-partition log operations through `PartitionLog` (`53d925806`), named the consumer handles `partitionStorage` (`cbf3ce339`), and renamed `DatabaseState` to `PartitionState` (`a6a09b904`, `7a372c094`). Two further pieces the pre-PR review surfaced also shipped independently: the disk-cache write-through fix (`98ff788af`) and the object-store test-double refactor (#5818), which split the fused `SimulatedObjectStore` into a `PrefixedObjectStore` client over an `InMemoryBucket` so cross-pool isolation is testable at all.

What's left here is a single commit, rebased on top of all of that, and it consumes both: the partitioned tests build on the upstream `InMemoryBucket` fixture, and the disk-cache write-through fix is what makes the shared-cache scoping assertable at all — at N>1 the old bare-key write-through wouldn't just have been a dead cache entry but a key collision across sibling partitions.

The rebase needed two adaptations beyond replay: `BlockGarbageCollectorTest` moved to the one-arg `BlockCatalog(latestBlock)` constructor, `d2cab3e2c` having dropped `dbName` from it; and the gate comment shed its unit-6 clause as described above.

## Changes

1. `tidy(storage): partition-aware BufferPool construction; storage layout` — the layout and factory widening. N>1 is reachable only from tests.
2. `test(storage): pin storageRoot's rendering of epoch and partition roots` — test-only. Half of it covers the pre-existing `epoch > 0` branch, which had no direct coverage before this PR; the rest covers the partition branch and the combination of the two.

## Test plan

N>1 coverage is a first-class deliverable for this unit — unlike the log layer, where the N-partition delta was mechanical loop-count, storage involves semantic path-scoping with production data in the blast radius.

- `StorageRootTest`: `storageRoot` as a pure case table — the bare renderings at epoch 0 and N=1, the epoch suffix, the `parts/<n>` marker, and the combination of the two. `parts/1/v06_e02` had never been rendered in a test before this: nothing anywhere set a non-zero *storage* epoch, at any partition count (every `:epoch 1` in the suite is a log epoch, which doesn't reach `storageRoot`). The N=1 case is asserted as equality with the two-arg root rather than a literal, since the contract is indistinguishability from a pre-partitioning store.
- `StorageTest` base (all three backends): partition-index validation, asserted on the `Incorrect` anomaly rather than a bare `IllegalArgumentException`.
- `PartitionedStorageTest` (local + remote only): cross-partition isolation of listing, block-index discovery, and deletes — delete being GC's primitive, so a scoping bug there means one partition's GC eating a sibling's files. `MemoryStorage` returns an independent store per open, so it deliberately doesn't extend this — the assertions would hold there even if the partition index were ignored entirely, which read as three backends' worth of coverage where there are two.
- `RemoteStorageTest` only: two partitions of one database get their own entries in the node-shared caches. This is remote-only by necessity, not convenience — the durable disk cache is what keeps partition 0's entry alive for partition 1 to be wrongly served it. Local has no disk cache, and `MemoryCache` releases an entry when the last reference drops, so the sibling read is a fresh miss reloading from its own root.
- Local + remote: physical layout pinned at both N=1 (no marker — the byte-compat regression pin) and N>1 (`parts/<partition>/…`).
- `BlockGarbageCollectorTest`: a partition's GC sweep leaves its sibling's blocks untouched, asserted at the real `BlockGarbageCollector` level.
- Remote tests reuse the `PrefixedObjectStore`/`InMemoryBucket` fixture (#5818): partition pools open prefixing views over one shared `InMemoryBucket`, so cross-partition isolation is a falsifiable claim rather than the vacuous pass a fresh-store-per-open factory would give, and the partition-marked key-space is assertable off the bucket.

The shared-cache assertion is the one that earns its keep, and its placement was settled by experiment rather than inspection. The `dbName/<partition>` prefix is the single behaviour-changing line in the diff, and before this test the whole suite stayed green if it were reverted to the old `dbName/0` — every other test either bypasses the caches or reads through one partition only. Reverting it now fails the remote assertion; a first attempt that also asserted this from the shared base passed for local, which is why the test lives where it does rather than where it looked tidiest.

Full `./gradlew test` is green on the rebased branch against current `main`, with no compilation errors and no reflection or boxed-math warnings.

## Raised, not fixed

- **`Storage.Factory.open` changes shape for JVM callers, and is deliberately left unmarked.** Two ints are inserted mid-signature, and Kotlin defaults on an interface member generate no JVM overloads, so the compiled `Storage$Factory` loses its old 7-arg `open`. All six `buffer_pool_test.clj` call sites had to thread `0 1` positionally, which is precisely the interop break an external caller would hit. It stays a plain `tidy:` rather than `tidy!:` because `Factory` is `sealed`: nothing outside the module can implement it, the only implementations are the three in `Storage.kt`, and storage is configured through node config rather than by calling the factory by hand — so no supported usage breaks. Noted here rather than passed over silently, in case a downstream caller ever does hit it. Retaining the old arity would take a hand-written delegating overload (`@JvmOverloads` isn't valid on abstract interface members) whose entire meaning would be "partition 0 of 1" — the hack value AGENTS.md warns against.
- **The in-memory backend opens a `MemoryCache` purely to fill an argument slot.** `InMemoryStorageFactory.open` discards both caches, so `MemoryStorageTest` allocates one solely to satisfy the shared signature while still exercising factory-level partition validation. Accepted rather than fixed: the alternatives are changing that signature — more churn than the wart is worth — or dropping the in-memory backend's only validation coverage.

A prior revision of this description raised two further hazards — shared-cache keys omitting the storage epoch, and no open-time validation of a store's key-space shape against the declared `totalPartitions`. Both were checked in review and neither is constructible: the partition count is never read from operator-editable config on any path (not node YAML, not `DatabaseCatalog.open`), so the scenario those warnings described can't be reached. They're removed rather than restated to avoid documenting a hazard that isn't one.

Generated with [Claude Code](https://claude.com/claude-code)
