### PR TITLE
fix(storage): disk-cache write-through used an unscoped key, so every arrow write missed the cache

### DIFF
--- a/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
@@ -178,7 +178,7 @@ internal class RemoteBufferPool(
                             objectStore.uploadArrowFile(key, tmpPath)
                             networkWrite?.increment(size.toDouble())
 
-                            diskCache.put(key, tmpPath)
+                            diskCache.put(cacheRootPath.resolve(key), tmpPath)
                             return size
                         }
 

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -7,6 +7,7 @@ import org.apache.arrow.vector.types.pojo.FieldType
 import org.apache.arrow.vector.types.pojo.Schema
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -61,6 +62,23 @@ class RemoteStorageTest : StorageTest() {
         memoryCache.close()
     }
 
+
+    @Test
+    fun `openArrowWriter seeds the disk cache under the pool-scoped key`(al: BufferAllocator) {
+        val key = Path.of("aw")
+        Relation(al, "a" ofType I32).use { relation ->
+            remoteBufferPool.openArrowWriter(key, relation).use { writer ->
+                val v = relation["a"]
+                for (i in 0 until 10) v.writeInt(i)
+                writer.writePage()
+                writer.end()
+            }
+        }
+
+        // only the disk cache can serve the read once the store forgets the object
+        (remoteBufferPool.objectStore as SimulatedObjectStore).buffers.clear()
+        assertNotNull(remoteBufferPool.getFooter(key))
+    }
 
     @Test
     fun arrowIpcTest(al: BufferAllocator) = runTest {


### PR DESCRIPTION
## Summary

Every disk-cache *read* in `RemoteBufferPool` resolves its key under `cacheRootPath` — the dbName-scoped namespace the pool's entries occupy in the node-shared disk cache — but the write-through in `openArrowWriter.end()` used the bare key. The seeded entry was dead on arrival: reads look up `xtdb/0/<key>`, the file sat at `<key>`, and the first read after every arrow write missed the cache and re-downloaded the file the node had just uploaded. One-line fix plus a regression test.

## Impact

The arrow-writer path is the block flush (every table's live trie at each block boundary) and the compactor's outputs — and the compaction ladder reads back everything it writes on the same node, each level's outputs becoming the next level's inputs. So on a remote-storage leader, redundant object-store GETs track total bytes written multiplied by compaction's write amplification: download latency inside compaction, plus egress, for bytes that were local moments earlier. The dead entries also weren't free — \`put\` moves the file into the cache directory and registers it against the byte budget, so hot files sat on local disk twice (one unreachable copy, one re-downloaded) until eviction.

Nothing ever returned wrong bytes — the object store is the source of truth and the read path transparently re-fetches — which is why this survived unnoticed: it shows up only as unexplained disk-cache misses and network reads immediately after writes.

## Root cause

The read paths gained the \`cacheRootPath\` scoping when the caches became shared between databases (4c36a34c9); this write path was missed then. Surfaced by the review pass on the multi-partition storage layout work (#5815), where sibling partitions writing the same relative keys would additionally have collided on the bare key. That PR currently carries this same fix as its final commit and will be rebased to drop it once this merges.

## Why making the seeded entries live is safe

\`put\`-created entries start unpinned (\`refCount = 0\`, correctly weighed against the cache budget), and "a \`get\` returns a directly-inserted entry, then releases it" is the shape every warm restart already exercises: \`DiskCache\`'s startup scan re-registers surviving files the same way, and post-restart reads pin/release them through the same accounting.

## Test plan

Test-first: the regression test writes an arrow file through the pool, wipes the simulated backing store, and asserts \`getFooter\` still succeeds — post-wipe, only the disk cache can serve it. Verified red against the unfixed line (fails with \`Object aw doesn't exist\`), green with the fix.

Full \`./gradlew test\` green. \`./gradlew integration-test\` green apart from one intermittent teardown-watchdog timeout in \`KafkaConnectSourceIntegrationTest\` (\`database catalog did not shut down in time\`) that is unrelated to this diff: the affected tests use in-memory storage (no \`RemoteBufferPool\` constructed), the failure moves between tests across runs and passes on re-run, and the same class passed with this fix included in an earlier run today. Worth tracking as a flake independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)