### PR TITLE
test(storage): separate the remote-store test double into client + bucket

### DIFF
--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.io.TempDir
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
 import xtdb.api.storage.ObjectStore
+import xtdb.api.storage.PrefixedObjectStore
 import xtdb.api.storage.SimulatedObjectStore
 import xtdb.api.storage.Storage.remote
 import xtdb.api.storage.StoreOperation.COMPLETE
@@ -36,10 +37,15 @@ class RemoteStorageTest : StorageTest() {
     override fun storage(): BufferPool = remoteBufferPool
 
     private lateinit var memoryCache: MemoryCache
+    private lateinit var sharedBucket: SimulatedObjectStore
     private lateinit var remoteBufferPool: RemoteBufferPool
 
-    object SimulatedObjectStoreFactory : ObjectStore.Factory {
-        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): ObjectStore = SimulatedObjectStore()
+    // hands every open a prefixing view onto the one shared bucket, the way the cloud stores resolve
+    // their prefix over a single durable bucket — so assertions read the pool's real key-space off
+    // `sharedBucket` rather than downcasting the pool's client
+    class PrefixingObjectStoreFactory(val bucket: SimulatedObjectStore) : ObjectStore.Factory {
+        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): ObjectStore =
+            PrefixedObjectStore(storageRoot, bucket)
 
         override val configProto: ProtoAny
             get() = ProtoAny.newBuilder().build()
@@ -48,8 +54,9 @@ class RemoteStorageTest : StorageTest() {
     @BeforeEach
     fun setUp(@TempDir localDiskCachePath: Path, al: BufferAllocator) {
         memoryCache = MemoryCache.Factory().open(al)
+        sharedBucket = SimulatedObjectStore()
         remoteBufferPool =
-            remote(SimulatedObjectStoreFactory)
+            remote(PrefixingObjectStoreFactory(sharedBucket))
                 .open(al, memoryCache, DiskCache.Factory(localDiskCachePath).build(), "xtdb") as RemoteBufferPool
 
         // Mocking small value for MIN_MULTIPART_PART_SIZE
@@ -76,7 +83,7 @@ class RemoteStorageTest : StorageTest() {
         }
 
         // only the disk cache can serve the read once the store forgets the object
-        (remoteBufferPool.objectStore as SimulatedObjectStore).buffers.clear()
+        sharedBucket.buffers.clear()
         assertNotNull(remoteBufferPool.getFooter(key))
     }
 
@@ -91,7 +98,7 @@ class RemoteStorageTest : StorageTest() {
                 writer.end()
             }
         }
-        assertEquals(listOf(UPLOAD, UPLOAD, COMPLETE), (remoteBufferPool.objectStore as SimulatedObjectStore).calls)
+        assertEquals(listOf(UPLOAD, UPLOAD, COMPLETE), sharedBucket.calls)
 
         remoteBufferPool.getRecordBatch(path, 0).use { rb ->
             val footer = remoteBufferPool.getFooter(path)

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
+import xtdb.api.storage.InMemoryBucket
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.PrefixedObjectStore
-import xtdb.api.storage.SimulatedObjectStore
 import xtdb.api.storage.Storage.remote
 import xtdb.api.storage.StoreOperation.COMPLETE
 import xtdb.api.storage.StoreOperation.UPLOAD
@@ -37,13 +37,13 @@ class RemoteStorageTest : StorageTest() {
     override fun storage(): BufferPool = remoteBufferPool
 
     private lateinit var memoryCache: MemoryCache
-    private lateinit var sharedBucket: SimulatedObjectStore
+    private lateinit var sharedBucket: InMemoryBucket
     private lateinit var remoteBufferPool: RemoteBufferPool
 
     // hands every open a prefixing view onto the one shared bucket, the way the cloud stores resolve
     // their prefix over a single durable bucket — so assertions read the pool's real key-space off
     // `sharedBucket` rather than downcasting the pool's client
-    class PrefixingObjectStoreFactory(val bucket: SimulatedObjectStore) : ObjectStore.Factory {
+    class PrefixingObjectStoreFactory(val bucket: InMemoryBucket) : ObjectStore.Factory {
         override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): ObjectStore =
             PrefixedObjectStore(storageRoot, bucket)
 
@@ -54,7 +54,7 @@ class RemoteStorageTest : StorageTest() {
     @BeforeEach
     fun setUp(@TempDir localDiskCachePath: Path, al: BufferAllocator) {
         memoryCache = MemoryCache.Factory().open(al)
-        sharedBucket = SimulatedObjectStore()
+        sharedBucket = InMemoryBucket()
         remoteBufferPool =
             remote(PrefixingObjectStoreFactory(sharedBucket))
                 .open(al, memoryCache, DiskCache.Factory(localDiskCachePath).build(), "xtdb") as RemoteBufferPool

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -16,7 +16,7 @@
            (java.nio.file Path)
            (org.apache.arrow.vector.types.pojo Schema)
            (xtdb.api.storage ObjectStore ObjectStore$Factory Storage Storage$Factory)
-           (xtdb.api.storage PrefixedObjectStore SimulatedObjectStore StoreOperation)
+           (xtdb.api.storage PrefixedObjectStore InMemoryBucket StoreOperation)
            xtdb.arrow.Relation
            (xtdb.cache DiskCache MemoryCache)
            (xtdb.storage BufferPool BufferPoolKt RemoteBufferPool)))
@@ -86,14 +86,14 @@
         ;; Will fetch from object store again
         (t/is (= 0 (util/compare-nio-buffers-unsigned expected (ByteBuffer/wrap (.getByteArray bp k)))))))))
 
-(defn prefixing-obj-store-factory [^SimulatedObjectStore bucket]
+(defn prefixing-obj-store-factory [^InMemoryBucket bucket]
   (reify ObjectStore$Factory
     (openObjectStore [_ storage-root _remotes]
       (PrefixedObjectStore. storage-root bucket))))
 
 (t/deftest below-min-size-put-test
   (with-caches {}
-    (let [^SimulatedObjectStore bucket (SimulatedObjectStore.)]
+    (let [^InMemoryBucket bucket (InMemoryBucket.)]
       (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory bucket))
                          (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
         (t/testing "if <= min part size, putObject is used"
@@ -117,7 +117,7 @@
 
 (t/deftest local-disk-cache-max-size
   (with-caches {:mem-bytes 12, :disk-bytes 10}
-    (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (SimulatedObjectStore.)))
+    (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (InMemoryBucket.)))
                        (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
       (t/testing "staying below max size - all elements available"
         (insert-utf8-to-local-cache bp (util/->path "a") 4)
@@ -149,7 +149,7 @@
         (deleteIfExists [_ _k] (throw (UnsupportedOperationException. "foo")))))))
 
 (t/deftest local-disk-cache-with-previous-values
-  (let [obj-store-factory (prefixing-obj-store-factory (SimulatedObjectStore.))
+  (let [obj-store-factory (prefixing-obj-store-factory (InMemoryBucket.))
         path-a (util/->path "a")
         path-b (util/->path "b")]
     (with-caches {:mem-bytes 64, :disk-bytes 64}
@@ -297,7 +297,7 @@
 (t/deftest network-counter-test
   (let [registry (SimpleMeterRegistry.)]
     (with-caches {}
-      (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (SimulatedObjectStore.)))
+      (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (InMemoryBucket.)))
                          (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" registry Storage/VERSION {}))]
         (let [k1 (util/->path "a")
               k2 (util/->path "b")

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -16,7 +16,7 @@
            (java.nio.file Path)
            (org.apache.arrow.vector.types.pojo Schema)
            (xtdb.api.storage ObjectStore ObjectStore$Factory Storage Storage$Factory)
-           (xtdb.api.storage SimulatedObjectStore StoreOperation)
+           (xtdb.api.storage PrefixedObjectStore SimulatedObjectStore StoreOperation)
            xtdb.arrow.Relation
            (xtdb.cache DiskCache MemoryCache)
            (xtdb.storage BufferPool BufferPoolKt RemoteBufferPool)))
@@ -86,22 +86,20 @@
         ;; Will fetch from object store again
         (t/is (= 0 (util/compare-nio-buffers-unsigned expected (ByteBuffer/wrap (.getByteArray bp k)))))))))
 
-(defn simulated-obj-store-factory []
+(defn prefixing-obj-store-factory [^SimulatedObjectStore bucket]
   (reify ObjectStore$Factory
-    (openObjectStore [_ _storage-root _remotes]
-      (SimulatedObjectStore.))))
-
-(defn get-remote-calls [^RemoteBufferPool test-bp]
-  (.getCalls ^SimulatedObjectStore (.getObjectStore test-bp)))
+    (openObjectStore [_ storage-root _remotes]
+      (PrefixedObjectStore. storage-root bucket))))
 
 (t/deftest below-min-size-put-test
   (with-caches {}
-    (with-open [bp (-> (Storage/remote (simulated-obj-store-factory))
-                       (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
-      (t/testing "if <= min part size, putObject is used"
-        (.putObject bp (util/->path "min-part-put") (utf8-buf "12"))
-        (t/is (= [StoreOperation/PUT] (get-remote-calls bp)))
-        (test-get-object bp (util/->path "min-part-put") (utf8-buf "12"))))))
+    (let [^SimulatedObjectStore bucket (SimulatedObjectStore.)]
+      (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory bucket))
+                         (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
+        (t/testing "if <= min part size, putObject is used"
+          (.putObject bp (util/->path "min-part-put") (utf8-buf "12"))
+          (t/is (= [StoreOperation/PUT] (.getCalls bucket)))
+          (test-get-object bp (util/->path "min-part-put") (utf8-buf "12")))))))
 
 (defn open-mem-cache-entry [^BufferPool bp k len]
   (let [^ByteBuffer buf (utf8-buf (apply str (repeat len "a")))]
@@ -119,7 +117,7 @@
 
 (t/deftest local-disk-cache-max-size
   (with-caches {:mem-bytes 12, :disk-bytes 10}
-    (with-open [bp (-> (Storage/remote (simulated-obj-store-factory))
+    (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (SimulatedObjectStore.)))
                        (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" nil Storage/VERSION {}))]
       (t/testing "staying below max size - all elements available"
         (insert-utf8-to-local-cache bp (util/->path "a") 4)
@@ -151,7 +149,7 @@
         (deleteIfExists [_ _k] (throw (UnsupportedOperationException. "foo")))))))
 
 (t/deftest local-disk-cache-with-previous-values
-  (let [obj-store-factory (simulated-obj-store-factory)
+  (let [obj-store-factory (prefixing-obj-store-factory (SimulatedObjectStore.))
         path-a (util/->path "a")
         path-b (util/->path "b")]
     (with-caches {:mem-bytes 64, :disk-bytes 64}
@@ -299,7 +297,7 @@
 (t/deftest network-counter-test
   (let [registry (SimpleMeterRegistry.)]
     (with-caches {}
-      (with-open [bp (-> (Storage/remote (simulated-obj-store-factory))
+      (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory (SimulatedObjectStore.)))
                          (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" registry Storage/VERSION {}))]
         (let [k1 (util/->path "a")
               k2 (util/->path "b")

--- a/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
@@ -2,7 +2,6 @@ package xtdb.api.storage
 
 import xtdb.api.storage.ObjectStore.StoredObject
 import xtdb.multipart.IMultipartUpload
-import xtdb.multipart.SupportsMultipart
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.util.*
@@ -14,12 +13,18 @@ enum class StoreOperation {
     PUT, UPLOAD, COMPLETE, ABORT
 }
 
-class SimulatedObjectStore(
+/**
+ * The durable-bucket half of the remote-storage test doubles: a keyed blob map plus an operation
+ * journal. Deliberately NOT an [ObjectStore] — that is the client role, played by [PrefixedObjectStore]
+ * over this. Keeping the bucket off the client interface makes "wire a pool straight to the bucket,
+ * skipping the prefix" a compile error rather than a silent vacuous pass.
+ */
+class InMemoryBucket(
     // Synchronized: uploadMultipartBuffers calls uploadPart from concurrent coroutines (up to
     // MAX_CONCURRENT_PART_UPLOADS), so a plain ArrayList races on add and intermittently throws AIOOBE.
     val calls: MutableList<StoreOperation> = Collections.synchronizedList(mutableListOf()),
     val buffers: NavigableMap<Path, ByteBuffer> = TreeMap()
-) : ObjectStore, SupportsMultipart<ByteBuffer> {
+) {
 
     private fun copyByteBuffer(buffer: ByteBuffer) =
         ByteBuffer.allocate(buffer.remaining()).put(buffer.duplicate()).flip()
@@ -31,10 +36,10 @@ class SimulatedObjectStore(
         return buffer.flip()
     }
 
-    override fun getObject(k: Path): CompletableFuture<ByteBuffer> =
+    fun getObject(k: Path): CompletableFuture<ByteBuffer> =
         completedFuture(buffers[k])
 
-    override fun getObject(k: Path, outPath: Path): CompletableFuture<Path> =
+    fun getObject(k: Path, outPath: Path): CompletableFuture<Path> =
         buffers[k]?.let { buffer ->
             val bytes = ByteArray(buffer.remaining())
             buffer.duplicate().get(bytes)
@@ -42,36 +47,36 @@ class SimulatedObjectStore(
             completedFuture(outPath)
         } ?: failedFuture(IllegalStateException("Object $k doesn't exist"))
 
-    override fun putObject(k: Path, buf: ByteBuffer): CompletableFuture<Unit> {
+    fun putObject(k: Path, buf: ByteBuffer): CompletableFuture<Unit> {
         buffers[k] = buf
         calls.add(StoreOperation.PUT)
         return completedFuture(Unit)
     }
 
-    override fun listAllObjects() = buffers.map { (key, buffer) -> StoredObject(key, buffer.capacity().toLong()) }
+    fun listAllObjects() = buffers.map { (key, buffer) -> StoredObject(key, buffer.capacity().toLong()) }
 
-    override fun listAllObjects(dir: Path): List<StoredObject> =
+    fun listAllObjects(dir: Path): List<StoredObject> =
         buffers.tailMap(dir).entries
             .takeWhile { it.key.startsWith(dir) }
             .map { (key, buffer) -> StoredObject(key, buffer.capacity().toLong()) }
 
-    override fun listAfter(dir: Path, afterKey: Path): List<StoredObject> =
+    fun listAfter(dir: Path, afterKey: Path): List<StoredObject> =
         buffers.tailMap(afterKey, false).entries
             .takeWhile { it.key.startsWith(dir) }
             .map { (key, buffer) -> StoredObject(key, buffer.capacity().toLong()) }
 
-    override fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> {
+    fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> {
         val srcBuffer = buffers[src] ?: return failedFuture(IllegalStateException("Object $src doesn't exist"))
         buffers[dest] = copyByteBuffer(srcBuffer)
         return completedFuture(Unit)
     }
 
-    override fun deleteIfExists(k: Path): CompletableFuture<Unit> {
+    fun deleteIfExists(k: Path): CompletableFuture<Unit> {
         buffers.remove(k)
         return completedFuture(Unit)
     }
 
-    override fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<ByteBuffer>> {
+    fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<ByteBuffer>> {
         val upload = object : IMultipartUpload<ByteBuffer> {
             override fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<ByteBuffer> {
                 calls.add(StoreOperation.UPLOAD)

--- a/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.CompletableFuture.completedFuture
 import java.util.concurrent.CompletableFuture.failedFuture
 
@@ -23,7 +24,9 @@ class InMemoryBucket(
     // Synchronized: uploadMultipartBuffers calls uploadPart from concurrent coroutines (up to
     // MAX_CONCURRENT_PART_UPLOADS), so a plain ArrayList races on add and intermittently throws AIOOBE.
     val calls: MutableList<StoreOperation> = Collections.synchronizedList(mutableListOf()),
-    val buffers: NavigableMap<Path, ByteBuffer> = TreeMap()
+    // Concurrent: one bucket backs several pools that may write at once (e.g. per-partition pools),
+    // so a plain TreeMap would corrupt under concurrent mutation — the same reason `calls` is synchronized.
+    val buffers: NavigableMap<Path, ByteBuffer> = ConcurrentSkipListMap()
 ) {
 
     private fun copyByteBuffer(buffer: ByteBuffer) =

--- a/src/testFixtures/kotlin/xtdb/api/storage/PrefixedObjectStore.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/PrefixedObjectStore.kt
@@ -1,0 +1,55 @@
+package xtdb.api.storage
+
+import xtdb.api.storage.ObjectStore.StoredObject
+import xtdb.multipart.IMultipartUpload
+import xtdb.multipart.SupportsMultipart
+import java.nio.ByteBuffer
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+
+/**
+ * The test-fixture analogue of a production [ObjectStore] client (`xtdb.aws.S3` et al): it resolves
+ * pool-relative keys under [prefix] on the way in and relativizes them back out, exactly as the
+ * cloud stores do internally with their configured prefix + storage root. The [delegate] plays the
+ * durable bucket behind it.
+ *
+ * The point of the split is that one [delegate] can back several pools opened at different prefixes
+ * (per-partition pools, or successive opens of the same store), so a test that shares one bucket can
+ * assert cross-pool isolation and read the bucket's raw key-space — neither of which is observable
+ * when a pool talks straight to a bucket.
+ *
+ * Closing is a no-op: the delegate is shared, owned by whoever created it, and outlives any one pool.
+ */
+class PrefixedObjectStore(
+    private val prefix: Path, private val delegate: SimulatedObjectStore,
+) : SupportsMultipart<ByteBuffer> {
+
+    private fun StoredObject.relativized() = StoredObject(prefix.relativize(key), size)
+
+    override fun getObject(k: Path): CompletableFuture<ByteBuffer> = delegate.getObject(prefix.resolve(k))
+
+    override fun getObject(k: Path, outPath: Path): CompletableFuture<Path> =
+        delegate.getObject(prefix.resolve(k), outPath)
+
+    override fun putObject(k: Path, buf: ByteBuffer): CompletableFuture<Unit> =
+        delegate.putObject(prefix.resolve(k), buf)
+
+    override fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<ByteBuffer>> =
+        delegate.startMultipart(prefix.resolve(k))
+
+    override fun listAllObjects(): Iterable<StoredObject> =
+        delegate.listAllObjects(prefix).map { it.relativized() }
+
+    override fun listAllObjects(dir: Path): Iterable<StoredObject> =
+        delegate.listAllObjects(prefix.resolve(dir)).map { it.relativized() }
+
+    override fun listAfter(dir: Path, afterKey: Path): Iterable<StoredObject> =
+        delegate.listAfter(prefix.resolve(dir), prefix.resolve(afterKey)).map { it.relativized() }
+
+    override fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> =
+        delegate.copyObject(prefix.resolve(src), prefix.resolve(dest))
+
+    override fun deleteIfExists(k: Path): CompletableFuture<Unit> = delegate.deleteIfExists(prefix.resolve(k))
+
+    override fun close() {}
+}

--- a/src/testFixtures/kotlin/xtdb/api/storage/PrefixedObjectStore.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/PrefixedObjectStore.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture
  * Closing is a no-op: the delegate is shared, owned by whoever created it, and outlives any one pool.
  */
 class PrefixedObjectStore(
-    private val prefix: Path, private val delegate: SimulatedObjectStore,
+    private val prefix: Path, private val delegate: InMemoryBucket,
 ) : SupportsMultipart<ByteBuffer> {
 
     private fun StoredObject.relativized() = StoredObject(prefix.relativize(key), size)


### PR DESCRIPTION
Standalone test-fixture tidy, behaviour-preserving. Groundwork ahead of the per-partition `BufferPool` work (#5557), pulled out so that PR can stay focused on the storage layout itself.

## Summary

The remote-storage tests used a single `SimulatedObjectStore` as both the client a `RemoteBufferPool` talks to *and* the durable bucket behind it, then reached back into it by downcasting the pool's `objectStore` field. This separates those two roles: a `PrefixedObjectStore` client resolves pool-relative keys under a prefix over an `InMemoryBucket`, mirroring how the production stores (S3/Azure/GCS) resolve their configured prefix over one bucket. Tests now drive the pool through the client and observe the bucket at a first-class handle they hold directly.

## Why

`ObjectStore` is the client SPI — `xtdb.aws.S3` and friends implement it, each scoping keys under a prefix over a remote bucket. The test double collapsed that into one object: the factory ignored the storage root and handed the pool the bare store, so "the store the pool talks to" and "the bucket" were identical, and `remoteBufferPool.objectStore as SimulatedObjectStore` type-checked only because of that identity.

That conflation is a latent hazard the moment a test's meaning depends on cross-open shared state. A fresh-store-per-open factory makes "these two pools don't see each other's objects" vacuously true — two separate maps can't collide regardless of whether the key-scoping under test works at all. The per-partition pools in #5557 need exactly that assertion (plus assertions on the raw object-store key-space), so the fixture has to model the production shape first: one shared bucket, a prefixing client per open.

## Changes

1. `test(storage): back remote-pool tests with a shared bucket via PrefixedObjectStore` — introduce the `PrefixedObjectStore` fixture and migrate both the Kotlin (`RemoteStorageTest`) and Clojure (`buffer-pool-test`) suites off the bare store and the downcasts, holding the bucket directly to read `calls` / `buffers`. Behaviour-preserving; `SimulatedObjectStore` is still an `ObjectStore` at this point.

2. `tidy(storage): make the bucket double a plain InMemoryBucket, not an ObjectStore` — sever the interface and rename to `InMemoryBucket`, so the type names its role. With the bucket off the client interface, wiring a pool straight to it (skipping the prefix — the shape that made isolation vacuous) no longer type-checks: a factory hands out an `ObjectStore`, and `InMemoryBucket` isn't one. The misuse becomes a compile error rather than a convention.

3. `tidy(storage): make InMemoryBucket's backing map thread-safe` — swap the bucket's `TreeMap` for a `ConcurrentSkipListMap`. Now that one bucket backs several pools, concurrent writes to it are possible; this is a drop-in (identical `NavigableMap` semantics and sorted ordering, and the bucket never stores nulls) that makes the shared fixture safe by construction rather than waiting for the first concurrent-writer test to flake.

## Test plan

`./gradlew :xtdb-core:test --tests 'xtdb.storage.*' :test --tests 'xtdb.buffer_pool_test*'` — 13 Kotlin storage tests + 10 Clojure buffer-pool tests, all green, no reflection or compilation warnings. No production code changes; the diff is confined to `testFixtures` and the two test files.
