### PR TITLE
tidy(storage): correct the per-partition storage & log levels

### DIFF
--- a/core/src/main/clojure/xtdb/log.clj
+++ b/core/src/main/clojure/xtdb/log.clj
@@ -12,7 +12,7 @@
            java.util.concurrent.TimeUnit
            (xtdb.api TransactionKey Xtdb$Config)
            (xtdb.api.log Log Log$Factory)
-           (xtdb.database Database DatabaseStorage Database$Config)
+           (xtdb.database Database PartitionStorage Database$Config)
            xtdb.api.TableRef
            (xtdb.util MsgIdUtil)))
 

--- a/core/src/main/kotlin/xtdb/api/log/PartitionLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/PartitionLog.kt
@@ -1,0 +1,21 @@
+package xtdb.api.log
+
+import xtdb.types.MessageId
+
+/**
+ * A [Log] view bound to a single [partition]: the partition-indexed operations with the index pre-applied,
+ * so a per-partition consumer holds its slice of the log without threading the partition through every call.
+ *
+ * Deliberately not the whole [Log] surface — the database-level operations ([Log.openGroupSubscription],
+ * one consumer-group membership per database, and [Log.epoch]) belong to the shared log, reached through
+ * DatabaseLogs, not to a single partition's view.
+ */
+class PartitionLog<M>(private val log: Log<M>, val partition: Int) {
+    suspend fun appendMessage(message: M): Log.MessageMetadata = log.appendMessage(message, partition)
+
+    fun openAtomicProducer(transactionalId: String): Log.AtomicProducer<M> =
+        log.openAtomicProducer(transactionalId, partition)
+
+    suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) =
+        log.tailAll(partition, afterMsgId, processor)
+}

--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -14,7 +14,7 @@ import xtdb.arrow.VectorType.Companion.TRANSIT
 import xtdb.authz.RoleMembership
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.api.error.Conflict
 import xtdb.api.error.Incorrect
 import xtdb.indexer.DatabaseSnapshot
@@ -65,7 +65,7 @@ class OpenTx
 @JvmOverloads constructor(
     private val allocator: BufferAllocator,
     private val nodeBase: NodeBase,
-    private val dbStorage: DatabaseStorage,
+    private val dbStorage: PartitionStorage,
     private val dbState: DatabaseState,
     val txKey: TransactionKey,
     val externalSourceToken: ExternalSourceToken?,

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -17,7 +17,7 @@ import xtdb.arrow.Relation
 import xtdb.compactor.PageTree.Companion.asTree
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.TrieMetadata
 import xtdb.segment.BufferPoolSegment
@@ -62,21 +62,21 @@ interface Compactor : AutoCloseable {
         }
     }
 
-    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers): ForDatabase
+    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): ForDatabase
 
     interface Driver : AutoCloseable {
         suspend fun executeJob(job: Job): TriesAdded
         suspend fun publishTries(triesAdded: TriesAdded)
 
         interface Factory {
-            fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers): Driver
+            fun create(allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver
         }
 
         companion object {
             @JvmStatic
             fun real(pageSize: Int, recencyPartition: RecencyPartition?) =
                 object : Factory {
-                    override fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : Driver {
+                    override fun create(allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : Driver {
                         private val al = allocator.openChildAllocator("compactor")
                         private val log = dbStorage.sourceLog
                         private val bp = dbStorage.bufferPool
@@ -166,7 +166,7 @@ interface Compactor : AutoCloseable {
         private val jobsDispatcher = dispatcher.limitedParallelism(threadCount, "compactor")
         private val jobsSemaphore = Semaphore(threadCount)
 
-        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
 
             private val trieCatalog = dbState.trieCatalog
             private val liveIndex = dbState.liveIndexOrNull
@@ -284,7 +284,7 @@ interface Compactor : AutoCloseable {
     companion object {
         @JvmField
         val NOOP = object : Compactor {
-            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
                 override fun signalBlock() = Unit
                 override suspend fun compactAll() = Unit
                 override fun close() = Unit

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -34,6 +34,7 @@ import xtdb.indexer.*
 import xtdb.metadata.PageMetadata
 import xtdb.query.IQuerySource
 import xtdb.storage.BufferPool
+import xtdb.storage.ReadOnlyBufferPool
 import xtdb.api.DatabaseName
 import xtdb.api.TableRef
 import xtdb.trie.ColumnName
@@ -61,7 +62,7 @@ private val LOG = Database::class.logger
 class Database(
     val allocator: BufferAllocator,
     val config: Config,
-    override val storage: DatabaseStorage,
+    val logs: DatabaseLogs,
     val isIndexing: Boolean,
     val partitions: Map<Int, DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
@@ -78,6 +79,7 @@ class Database(
     private val partition0: DatabasePartition get() = partitions.getValue(0)
 
     val name: DatabaseName get() = partition0.state.name
+    override val storage: DatabaseStorage get() = partition0.storage
     override val queryState: DatabaseState get() = partition0.state
     val watchers: Watchers get() = partition0.watchers
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
@@ -107,10 +109,10 @@ class Database(
     val trieCatalog: TrieCatalog get() = partition0.trieCatalog
     val liveIndex: LiveIndex get() = partition0.liveIndex
 
-    val sourceLog: Log<SourceMessage> get() = storage.sourceLog
-    val replicaLog: Log<ReplicaMessage> get() = storage.replicaLog
-    val bufferPool: BufferPool get() = storage.bufferPool
-    val metadataManager: PageMetadata.Factory get() = storage.metadataManager
+    val sourceLog: Log<SourceMessage> get() = logs.sourceLog
+    val replicaLog: Log<ReplicaMessage> get() = logs.replicaLog
+    val bufferPool: BufferPool get() = partition0.bufferPool
+    val metadataManager: PageMetadata.Factory get() = partition0.metadataManager
 
     val compactor: Compactor.ForDatabase get() = partition0.compactor
 
@@ -149,7 +151,7 @@ class Database(
         // Phase 2: the job tree has already been cancel-joined (by `cancelAndJoin` above, or by the
         // owner cancelling the catalog root). Free state, children before the database allocator.
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
-        (partitions.values + listOf(storage, allocator)).closeAll()
+        (partitions.values + listOf(logs, allocator)).closeAll()
     }
 
     fun submitTxBlocking(ops: List<TxOp>, opts: TxOpts): Xtdb.SubmittedTx {
@@ -263,12 +265,27 @@ class Database(
                 )
 
             val allocator = open { base.allocator.newChildAllocator("database/$dbName", 0, Long.MAX_VALUE) }
-            val storage = open { DatabaseStorage.open(allocator, base, dbName, dbConfig) }
+
+            // buffer pool + metadata manager open before the logs, preserving the pre-split failure
+            // order: a storage misconfig must surface before any log/broker interaction (opening a
+            // Kafka log can create topics and consumer-group state as a side effect).
+            val bufferPool = open {
+                val bp = dbConfig.storage.open(
+                    allocator, base.memoryCache, base.diskCache,
+                    dbName, base.meterRegistry, Storage.VERSION,
+                    base.remotes,
+                )
+                if (readOnly) ReadOnlyBufferPool(bp) else bp
+            }
+            val metadataManager = open { PageMetadata.factory(allocator, bufferPool) }
+            val logs = open { DatabaseLogs.open(base, dbConfig) }
+
+            val storage = DatabaseStorage(logs, bufferPool, metadataManager)
             val state = open { DatabaseState.open(allocator, storage, dbName, indexerConfig) }
             val blockCatalog = state.blockCatalog
             val sourceMsgId = maxOf(
                 blockCatalog.latestProcessedMsgId ?: -1,
-                offsetToMsgId(storage.sourceLog.epoch, -1)
+                offsetToMsgId(logs.sourceLog.epoch, -1)
             )
             // tx-id and source-msg-id can diverge under ext-source — seed them independently:
             // tx-id from the live-index's last committed tx, source-msg-id from the persisted
@@ -277,7 +294,7 @@ class Database(
 
             // Catch log/storage divergence (rotated/truncated/wrong topic) before we wire up
             // the indexer — see /ops/backup-and-restore/out-of-sync-log.
-            validateOffsets(dbName, storage.sourceLog, blockCatalog.latestProcessedMsgId)
+            validateOffsets(dbName, logs.sourceLog, blockCatalog.latestProcessedMsgId)
 
             val watchers = Watchers(
                 latestTxId = txId,
@@ -351,19 +368,20 @@ class Database(
                         (state.liveIndex.latestCompletedTx?.txId ?: -1).toDouble()
                     },
                     gauge("node.tx.latestSubmittedMsgId") {
-                        storage.sourceLog.latestSubmittedMsgId().toDouble()
+                        logs.sourceLog.latestSubmittedMsgId().toDouble()
                     },
                     gauge("node.tx.latestProcessedMsgId") {
                         watchers.latestSourceMsgId.toDouble()
                     },
                     gauge("node.tx.lag.MsgId") {
-                        maxOf(storage.sourceLog.latestSubmittedMsgId() - watchers.latestSourceMsgId, 0).toDouble()
+                        maxOf(logs.sourceLog.latestSubmittedMsgId() - watchers.latestSourceMsgId, 0).toDouble()
                     },
                 )
             } ?: emptyList()
 
             val partition = DatabasePartition(
                 partition = 0,
+                storage = storage,
                 state = state,
                 watchers = watchers,
                 compactorOrNull = compactorForDb,
@@ -373,7 +391,7 @@ class Database(
             val db = Database(
                 allocator = allocator,
                 config = dbConfig,
-                storage = storage,
+                logs = logs,
                 isIndexing = indexerConfig.enabled,
                 partitions = mapOf(0 to partition),
                 meterRegistry = meterRegistry,
@@ -393,7 +411,7 @@ class Database(
                         db.partitions[partition]?.logProcessor?.demoteLeader(partition)
                     }
                 }
-                scope.launch { storage.sourceLog.openGroupSubscription(listener) }
+                scope.launch { logs.sourceLog.openGroupSubscription(listener) }
             }
 
             db

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -280,7 +280,7 @@ class Database(
             val metadataManager = open { PageMetadata.factory(allocator, bufferPool) }
             val logs = open { DatabaseLogs.open(base, dbConfig) }
 
-            val storage = PartitionStorage(logs, bufferPool, metadataManager)
+            val storage = PartitionStorage(logs, bufferPool, metadataManager, partition = 0)
             val state = open { DatabaseState.open(allocator, storage, dbName, indexerConfig) }
             val blockCatalog = state.blockCatalog
             val sourceMsgId = maxOf(
@@ -380,7 +380,6 @@ class Database(
             } ?: emptyList()
 
             val partition = DatabasePartition(
-                partition = 0,
                 storage = storage,
                 state = state,
                 watchers = watchers,

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -79,7 +79,7 @@ class Database(
     private val partition0: DatabasePartition get() = partitions.getValue(0)
 
     val name: DatabaseName get() = partition0.state.name
-    override val storage: DatabaseStorage get() = partition0.storage
+    override val storage: PartitionStorage get() = partition0.storage
     override val queryState: DatabaseState get() = partition0.state
     val watchers: Watchers get() = partition0.watchers
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
@@ -280,7 +280,7 @@ class Database(
             val metadataManager = open { PageMetadata.factory(allocator, bufferPool) }
             val logs = open { DatabaseLogs.open(base, dbConfig) }
 
-            val storage = DatabaseStorage(logs, bufferPool, metadataManager)
+            val storage = PartitionStorage(logs, bufferPool, metadataManager)
             val state = open { DatabaseState.open(allocator, storage, dbName, indexerConfig) }
             val blockCatalog = state.blockCatalog
             val sourceMsgId = maxOf(

--- a/core/src/main/kotlin/xtdb/database/DatabaseLogs.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseLogs.kt
@@ -1,0 +1,45 @@
+package xtdb.database
+
+import xtdb.NodeBase
+import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.SourceMessage
+import xtdb.util.closeAll
+import xtdb.util.safelyOpening
+
+/**
+ * The database's source/replica log pair — shared by every [DatabasePartition]
+ * (a single [Log] serves all partitions), so owned and closed at the [Database] level,
+ * after the partitions that consume it.
+ */
+class DatabaseLogs(
+    val sourceLogOrNull: Log<SourceMessage>?,
+    val replicaLogOrNull: Log<ReplicaMessage>?,
+) : AutoCloseable {
+    val sourceLog: Log<SourceMessage> get() = sourceLogOrNull ?: error("no source-log")
+    val replicaLog: Log<ReplicaMessage> get() = replicaLogOrNull ?: error("no replica-log")
+
+    override fun close() {
+        listOf(replicaLogOrNull, sourceLogOrNull).closeAll()
+    }
+
+    companion object {
+        @JvmStatic
+        fun open(base: NodeBase, dbConfig: Database.Config): DatabaseLogs = safelyOpening {
+            val readOnly = dbConfig.isReadOnly
+            val remotes = base.remotes
+
+            val sourceLog = open {
+                if (readOnly) dbConfig.log.openReadOnlySourceLog(remotes, dbConfig.partitions)
+                else dbConfig.log.openSourceLog(remotes, dbConfig.partitions)
+            }
+
+            val replicaLog = open {
+                if (readOnly) dbConfig.log.openReadOnlyReplicaLog(remotes, dbConfig.partitions)
+                else dbConfig.log.openReplicaLog(remotes, dbConfig.partitions)
+            }
+
+            DatabaseLogs(sourceLog, replicaLog)
+        }
+    }
+}

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -7,11 +7,14 @@ import xtdb.compactor.Compactor
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.LogProcessor
 import xtdb.indexer.Snapshot
+import xtdb.metadata.PageMetadata
+import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
 import java.time.Instant
 
 class DatabasePartition(
     val partition: Int,
+    val storage: DatabaseStorage,
     val state: DatabaseState,
     val watchers: Watchers,
     val compactorOrNull: Compactor.ForDatabase? = null,
@@ -22,6 +25,8 @@ class DatabasePartition(
     val tableCatalog: TableCatalog get() = state.tableCatalog
     val trieCatalog: TrieCatalog get() = state.trieCatalog
     val liveIndex: LiveIndex get() = state.liveIndex
+    val bufferPool: BufferPool get() = storage.bufferPool
+    val metadataManager: PageMetadata.Factory get() = storage.metadataManager
 
     val compactor: Compactor.ForDatabase
         get() = compactorOrNull ?: error("compactor not initialised")
@@ -32,5 +37,6 @@ class DatabasePartition(
         logProcessor?.close()
         compactorOrNull?.close()
         state.close()
+        storage.close()
     }
 }

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -14,7 +14,7 @@ import java.time.Instant
 
 class DatabasePartition(
     val partition: Int,
-    val storage: DatabaseStorage,
+    val storage: PartitionStorage,
     val state: DatabaseState,
     val watchers: Watchers,
     val compactorOrNull: Compactor.ForDatabase? = null,

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -13,13 +13,15 @@ import xtdb.trie.TrieCatalog
 import java.time.Instant
 
 class DatabasePartition(
-    val partition: Int,
     val storage: PartitionStorage,
     val state: DatabaseState,
     val watchers: Watchers,
     val compactorOrNull: Compactor.ForDatabase? = null,
     val logProcessor: LogProcessor? = null,
 ) : AutoCloseable {
+
+    // the storage view owns the partition index; delegate rather than store a second copy so the two can't disagree
+    val partition: Int get() = storage.partition
 
     val blockCatalog: BlockCatalog get() = state.blockCatalog
     val tableCatalog: TableCatalog get() = state.tableCatalog

--- a/core/src/main/kotlin/xtdb/database/DatabaseState.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseState.kt
@@ -36,7 +36,7 @@ data class DatabaseState(
         @JvmOverloads
         fun open(
             allocator: BufferAllocator,
-            storage: DatabaseStorage,
+            storage: PartitionStorage,
             dbName: DatabaseName,
             indexerConfig: IndexerConfig = IndexerConfig(),
         ): DatabaseState = safelyOpening {

--- a/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseStorage.kt
@@ -1,66 +1,30 @@
 package xtdb.database
 
-import org.apache.arrow.memory.BufferAllocator
-import xtdb.NodeBase
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
-import xtdb.api.storage.Storage
 import xtdb.metadata.PageMetadata
 import xtdb.storage.BufferPool
-import xtdb.storage.ReadOnlyBufferPool
-import xtdb.api.DatabaseName
 import xtdb.util.closeAll
-import xtdb.util.safelyOpening
 
+/**
+ * A partition's view of the database's storage: the shared source/replica [logs]
+ * plus the partition's own [BufferPool] and metadata manager.
+ *
+ * Closing frees only the per-partition state — the logs are owned by the [Database]
+ * and outlive every partition.
+ */
 class DatabaseStorage(
-    val sourceLogOrNull: Log<SourceMessage>?,
-    val replicaLogOrNull: Log<ReplicaMessage>?,
+    val logs: DatabaseLogs,
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,
 ) : AutoCloseable {
-    val sourceLog: Log<SourceMessage> get() = sourceLogOrNull ?: error("no source-log")
-    val replicaLog: Log<ReplicaMessage> get() = replicaLogOrNull ?: error("no replica-log")
+    val sourceLog: Log<SourceMessage> get() = logs.sourceLog
+    val replicaLog: Log<ReplicaMessage> get() = logs.replicaLog
     val bufferPool: BufferPool get() = bufferPoolOrNull ?: error("no buffer-pool")
     val metadataManager: PageMetadata.Factory get() = metadataManagerOrNull ?: error("no metadata-manager")
 
     override fun close() {
-        listOf(metadataManagerOrNull, bufferPoolOrNull, replicaLogOrNull, sourceLogOrNull).closeAll()
-    }
-
-    companion object {
-        @JvmStatic
-        fun open(
-            allocator: BufferAllocator,
-            base: NodeBase,
-            dbName: DatabaseName,
-            dbConfig: Database.Config,
-        ): DatabaseStorage = safelyOpening {
-            val readOnly = dbConfig.isReadOnly
-            val remotes = base.remotes
-
-            val bufferPool = open {
-                val bp = dbConfig.storage.open(
-                    allocator, base.memoryCache, base.diskCache,
-                    dbName, base.meterRegistry, Storage.VERSION,
-                    base.remotes,
-                )
-                if (readOnly) ReadOnlyBufferPool(bp) else bp
-            }
-
-            val metadataManager = open { PageMetadata.factory(allocator, bufferPool) }
-
-            val sourceLog = open {
-                if (readOnly) dbConfig.log.openReadOnlySourceLog(remotes, dbConfig.partitions)
-                else dbConfig.log.openSourceLog(remotes, dbConfig.partitions)
-            }
-
-            val replicaLog = open {
-                if (readOnly) dbConfig.log.openReadOnlyReplicaLog(remotes, dbConfig.partitions)
-                else dbConfig.log.openReplicaLog(remotes, dbConfig.partitions)
-            }
-
-            DatabaseStorage(sourceLog, replicaLog, bufferPool, metadataManager)
-        }
+        listOf(metadataManagerOrNull, bufferPoolOrNull).closeAll()
     }
 }

--- a/core/src/main/kotlin/xtdb/database/PartitionStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/PartitionStorage.kt
@@ -14,7 +14,7 @@ import xtdb.util.closeAll
  * Closing frees only the per-partition state — the logs are owned by the [Database]
  * and outlive every partition.
  */
-class DatabaseStorage(
+class PartitionStorage(
     val logs: DatabaseLogs,
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,

--- a/core/src/main/kotlin/xtdb/database/PartitionStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/PartitionStorage.kt
@@ -1,6 +1,6 @@
 package xtdb.database
 
-import xtdb.api.log.Log
+import xtdb.api.log.PartitionLog
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
 import xtdb.metadata.PageMetadata
@@ -8,19 +8,22 @@ import xtdb.storage.BufferPool
 import xtdb.util.closeAll
 
 /**
- * A partition's view of the database's storage: the shared source/replica [logs]
- * plus the partition's own [BufferPool] and metadata manager.
+ * A single [partition]'s view of the database's storage: the shared source/replica logs, each bound to
+ * this partition as a [PartitionLog], plus the partition's own [BufferPool] and metadata manager.
  *
- * Closing frees only the per-partition state — the logs are owned by the [Database]
- * and outlive every partition.
+ * Closing frees only the per-partition state — the logs are owned by the [Database] and outlive every
+ * partition.
  */
 class PartitionStorage(
     val logs: DatabaseLogs,
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,
+    // The partition this view serves; drives the PartitionLog binding below. Defaulted to 0 because
+    // single-partition is the only shape reachable until the multi-partition gate lifts (#5557 unit 9).
+    val partition: Int = 0,
 ) : AutoCloseable {
-    val sourceLog: Log<SourceMessage> get() = logs.sourceLog
-    val replicaLog: Log<ReplicaMessage> get() = logs.replicaLog
+    val sourceLog: PartitionLog<SourceMessage> get() = PartitionLog(logs.sourceLog, partition)
+    val replicaLog: PartitionLog<ReplicaMessage> get() = PartitionLog(logs.replicaLog, partition)
     val bufferPool: BufferPool get() = bufferPoolOrNull ?: error("no buffer-pool")
     val metadataManager: PageMetadata.Factory get() = metadataManagerOrNull ?: error("no metadata-manager")
 

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -22,7 +22,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.Database
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.util.StringUtil.asLexHex
 import xtdb.util.debug
@@ -37,7 +37,7 @@ private const val MAX_CONCURRENT_BLOCK_UPLOADS = 16
 private val defaultBlockUploadDispatcher = IO.limitedParallelism(MAX_CONCURRENT_BLOCK_UPLOADS, "block-upload")
 
 class BlockUploader(
-    dbStorage: DatabaseStorage,
+    dbStorage: PartitionStorage,
     dbState: DatabaseState,
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -37,7 +37,7 @@ private val LOG = FollowerLogProcessor::class.logger
 
 class FollowerLogProcessor @JvmOverloads constructor(
     allocator: BufferAllocator,
-    replicaLog: Log<ReplicaMessage>,
+    replicaLog: PartitionLog<ReplicaMessage>,
     private val bufferPool: BufferPool,
     private val dbState: DatabaseState,
     private val compactor: Compactor.ForDatabase,
@@ -293,7 +293,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     // Launched last so every field the tail touches is initialised before the first record.
     private val job = scope.launch {
         try {
-            replicaLog.tailAll(partition = 0, afterReplicaMsgId, this@FollowerLogProcessor)
+            replicaLog.tailAll(afterReplicaMsgId, this@FollowerLogProcessor)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -53,7 +53,7 @@ private val LOG = LeaderLogProcessor::class.logger
 internal class LeaderLogProcessor(
     allocator: BufferAllocator,
     private val nodeBase: NodeBase,
-    private val dbStorage: DatabaseStorage,
+    private val dbStorage: PartitionStorage,
     crashLogger: CrashLogger,
     private val dbState: DatabaseState,
     private val blockUploader: BlockUploader,

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -62,7 +62,6 @@ internal class LeaderLogProcessor(
     private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
     private val skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
-    partition: Int,
     afterReplicaMsgId: MessageId,
     private val instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration = Duration.ofMinutes(5),
@@ -78,6 +77,7 @@ internal class LeaderLogProcessor(
     }
 
     private val dbName = dbState.name
+    private val partition = dbStorage.partition
     private val sourceLog = dbStorage.sourceLog
     private val bufferPool = dbStorage.bufferPool
     private val liveIndex = dbState.liveIndex

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -94,7 +94,7 @@ class LogProcessor(
             watchers,
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
             replicaProducer, skipTxs, dbCatalog,
-            partition = 0, afterReplicaMsgId,
+            afterReplicaMsgId,
             flushTimeout = flushTimeout,
             scope = scope,
             gcDispatcher = gcDispatcher,
@@ -165,7 +165,7 @@ class LogProcessor(
 
     private suspend fun runTransition(followerSys: FollowerSystem) {
         try {
-            replicaLog.openAtomicProducer("$dbName-leader", partition = 0).closeOnCatch { replicaProducer ->
+            replicaLog.openAtomicProducer("$dbName-leader").closeOnCatch { replicaProducer ->
                 val followerProc = followerSys.proc
 
                 // NoOp to get a known msgId we can await — latestSubmittedMsgId won't do, because Kafka's

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -16,7 +16,7 @@ import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.compactor.Compactor
 import xtdb.database.Database
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.api.tx.ExternalSource
 import xtdb.api.error.Fault
 import xtdb.api.error.Interrupted
@@ -34,7 +34,7 @@ class LogProcessor(
     private val allocator: BufferAllocator,
     private val base: NodeBase,
     private val crashLogger: CrashLogger,
-    private val dbStorage: DatabaseStorage,
+    private val dbStorage: PartitionStorage,
     private val dbState: DatabaseState,
     private val watchers: Watchers,
     private val blockUploader: BlockUploader,

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -5,7 +5,7 @@ import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.query.PrepareOpts
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.indexer.DatabaseSnapshot
 import xtdb.api.TableRef
 import java.time.Instant
@@ -18,7 +18,7 @@ interface IQuerySource : AutoCloseable {
     }
 
     interface QueryDatabase : DatabaseSnapshot.Source {
-        val storage: DatabaseStorage
+        val storage: PartitionStorage
         val queryState: DatabaseState
     }
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import xtdb.SimulationTestUtils.Companion.L0TrieKeys
 import xtdb.SimulationTestUtils.Companion.L3TrieKeys
+import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
@@ -115,7 +116,7 @@ class NodeSimulationTest : SimulationTestBase() {
             val trieCatalog = createTrieCatalog()
             val blockCatalog = BlockCatalog("xtdb", sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
-            val dbStorage = DatabaseStorage(null, null, sharedBufferPool, null)
+            val dbStorage = DatabaseStorage(DatabaseLogs(null, null), sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorScope = CoroutineScope(dispatcher)
             val compactorForDb = compactor.openForDatabase(compactorScope, allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -28,7 +28,7 @@ import xtdb.SimulationTestUtils.Companion.L3TrieKeys
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.garbage_collector.TrieGarbageCollector
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.BufferPool
@@ -116,7 +116,7 @@ class NodeSimulationTest : SimulationTestBase() {
             val trieCatalog = createTrieCatalog()
             val blockCatalog = BlockCatalog("xtdb", sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
-            val dbStorage = DatabaseStorage(DatabaseLogs(null, null), sharedBufferPool, null)
+            val dbStorage = PartitionStorage(DatabaseLogs(null, null), sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorScope = CoroutineScope(dispatcher)
             val compactorForDb = compactor.openForDatabase(compactorScope, allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -23,6 +23,7 @@ import xtdb.catalog.TableCatalog
 import xtdb.api.tx.TxIndexer.TxResult
 import xtdb.compactor.Compactor
 import xtdb.database.Database
+import xtdb.database.DatabaseLogs
 import xtdb.database.DatabasePartition
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
@@ -112,7 +113,7 @@ class ExternalSourceTest {
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope)
@@ -394,13 +395,14 @@ class ExternalSourceTest {
         // note: not .use — Database.close() would close `allocator`, which @AfterEach also closes
         val partition = DatabasePartition(
             partition = 0,
+            storage = DatabaseStorage(DatabaseLogs(null, null), null, null),
             state = DatabaseState("cdc", null, null, null, null),
             watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         )
         val db = Database(
             allocator = allocator,
             config = config,
-            storage = DatabaseStorage(null, null, null, null),
+            logs = DatabaseLogs(null, null),
             isIndexing = false,
             partitions = mapOf(0 to partition),
             meterRegistry = null,

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -124,7 +124,7 @@ class ExternalSourceTest {
             allocator, nodeBase, dbStorage, crashLogger,
             dbState, blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1, scope = backgroundScope
+            afterReplicaMsgId = -1, scope = backgroundScope
         ).also(leadersToClose::add)
     }
 
@@ -394,7 +394,6 @@ class ExternalSourceTest {
 
         // note: not .use — Database.close() would close `allocator`, which @AfterEach also closes
         val partition = DatabasePartition(
-            partition = 0,
             storage = PartitionStorage(DatabaseLogs(null, null), null, null),
             state = DatabaseState("cdc", null, null, null, null),
             watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -26,7 +26,7 @@ import xtdb.database.Database
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabasePartition
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.api.error.Incorrect
 import xtdb.indexer.BlockUploader
 import xtdb.indexer.CrashLogger
@@ -113,7 +113,7 @@ class ExternalSourceTest {
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope)
@@ -395,7 +395,7 @@ class ExternalSourceTest {
         // note: not .use — Database.close() would close `allocator`, which @AfterEach also closes
         val partition = DatabasePartition(
             partition = 0,
-            storage = DatabaseStorage(DatabaseLogs(null, null), null, null),
+            storage = PartitionStorage(DatabaseLogs(null, null), null, null),
             state = DatabaseState("cdc", null, null, null, null),
             watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         )

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -28,6 +28,7 @@ import xtdb.compactor.Compactor.Driver.Factory
 import xtdb.compactor.Compactor.Job
 import xtdb.compactor.RecencyPartition.WEEK
 import xtdb.compactor.TemporalSplitting.*
+import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
@@ -55,7 +56,7 @@ class MockDb(
     val bufferPool: BufferPool,
     val compactor: Compactor,
 ) {
-    val dbStorage: DatabaseStorage get() = DatabaseStorage(null, null, bufferPool, null)
+    val dbStorage: DatabaseStorage get() = DatabaseStorage(DatabaseLogs(null, null), bufferPool, null)
     val dbState: DatabaseState get() = DatabaseState(name, null, null, trieCatalog, null)
 }
 

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -31,7 +31,7 @@ import xtdb.compactor.TemporalSplitting.*
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseName
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.BufferPool
 import xtdb.storage.MemoryStorage
@@ -56,7 +56,7 @@ class MockDb(
     val bufferPool: BufferPool,
     val compactor: Compactor,
 ) {
-    val dbStorage: DatabaseStorage get() = DatabaseStorage(DatabaseLogs(null, null), bufferPool, null)
+    val dbStorage: PartitionStorage get() = PartitionStorage(DatabaseLogs(null, null), bufferPool, null)
     val dbState: DatabaseState get() = DatabaseState(name, null, null, trieCatalog, null)
 }
 
@@ -98,12 +98,12 @@ class CompactorMockDriverFactory(
     // system's listener failing doesn't cancel the others.
     val scope = CoroutineScope(dispatcher + SupervisorJob())
 
-    override fun create(allocator: BufferAllocator, dbStorage: DatabaseStorage, dbState: DatabaseState, watchers: Watchers): Driver {
+    override fun create(allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver {
         val systemId = nextSystemId++
         return CompactorMockDriver(dbStorage, dbState, systemId)
     }
 
-    private inner class CompactorMockDriver(val dbStorage: DatabaseStorage, val dbState: DatabaseState, val systemId: Int) : Driver {
+    private inner class CompactorMockDriver(val dbStorage: PartitionStorage, val dbState: DatabaseState, val systemId: Int) : Driver {
         val trieCatalog = dbState.trieCatalog
         val bufferPool = dbStorage.bufferPool
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import xtdb.api.log.Log
+import xtdb.api.log.PartitionLog
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
@@ -79,7 +80,7 @@ class FollowerLogProcessorTest {
         meterRegistry: MeterRegistry? = null,
     ) =
         FollowerLogProcessor(
-            allocator, replicaLog, bufferPool, dbState, compactor,
+            allocator, PartitionLog(replicaLog, 0), bufferPool, dbState, compactor,
             watchers, null, null, afterReplicaMsgId = -1L, backgroundScope,
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -30,6 +30,7 @@ import xtdb.block.proto.TableBlock
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
+import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.log.proto.TrieDetails
@@ -82,7 +83,7 @@ class LeaderLogProcessorTest {
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
 
@@ -140,7 +141,7 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
@@ -211,7 +212,7 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
@@ -540,7 +541,7 @@ class LeaderLogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -32,7 +32,7 @@ import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.trieMetadata
 import xtdb.storage.BufferPool
@@ -83,7 +83,7 @@ class LeaderLogProcessorTest {
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
 
@@ -141,7 +141,7 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
@@ -212,7 +212,7 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
@@ -541,7 +541,7 @@ class LeaderLogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -92,7 +92,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = skipTxs, dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1,
+            afterReplicaMsgId = -1,
             scope = backgroundScope,
         ).also(leadersToClose::add)
     }
@@ -151,7 +151,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1,
+            afterReplicaMsgId = -1,
             scope = backgroundScope,
         ).also(leadersToClose::add)
 
@@ -222,7 +222,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1,
+            afterReplicaMsgId = -1,
             scope = backgroundScope,
         ).also(leadersToClose::add)
 
@@ -550,7 +550,7 @@ class LeaderLogProcessorTest {
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = setOf(10), dbCatalog = null,
-            partition = 0, afterReplicaMsgId = -1,
+            afterReplicaMsgId = -1,
             scope = backgroundScope,
         ).also(leadersToClose::add)
 

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -23,6 +23,7 @@ import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
+import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.log.proto.TrieDetails
@@ -66,8 +67,10 @@ class LiveIndexTest {
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName)
         private val dbState = DatabaseState(dbName, blockCatalog, tableCatalog, trieCatalog, liveIndex)
         private val dbStorage = DatabaseStorage(
-            InMemoryLog<SourceMessage>(InstantSource.system(), 0),
-            InMemoryLog<ReplicaMessage>(InstantSource.system(), 0),
+            DatabaseLogs(
+                InMemoryLog<SourceMessage>(InstantSource.system(), 0),
+                InMemoryLog<ReplicaMessage>(InstantSource.system(), 0),
+            ),
             bp, null
         )
 

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -25,7 +25,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.MemoryStorage
 import xtdb.api.TableRef
@@ -66,7 +66,7 @@ class LiveIndexTest {
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName)
         private val dbState = DatabaseState(dbName, blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        private val dbStorage = DatabaseStorage(
+        private val dbStorage = PartitionStorage(
             DatabaseLogs(
                 InMemoryLog<SourceMessage>(InstantSource.system(), 0),
                 InMemoryLog<ReplicaMessage>(InstantSource.system(), 0),

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -24,6 +24,7 @@ import xtdb.api.log.*
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
+import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.api.tx.ExternalSource
@@ -165,7 +166,7 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
             .also { simExtSource.watch(it) }
-        val dbStorage = DatabaseStorage(srcLog, replicaLog, bp, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(srcLog, replicaLog), bp, null)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
 
         private var logProcessor: LogProcessor? = null

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -26,7 +26,7 @@ import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.api.tx.ExternalSource
 import xtdb.api.tx.ExternalSourceToken
 import xtdb.api.error.Incorrect
@@ -166,7 +166,7 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
             .also { simExtSource.watch(it) }
-        val dbStorage = DatabaseStorage(DatabaseLogs(srcLog, replicaLog), bp, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(srcLog, replicaLog), bp, null)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
 
         private var logProcessor: LogProcessor? = null

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -16,6 +16,7 @@ import xtdb.api.log.*
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
+import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
 import xtdb.database.DatabaseStorage
 import xtdb.storage.BufferPool
@@ -73,7 +74,7 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
         val dbState = dbState()
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -95,7 +96,7 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
         val dbState = dbState()
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -120,7 +121,7 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -155,7 +156,7 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = DatabaseStorage(sourceLog, replicaLog, bufferPool, null)
+        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -18,7 +18,7 @@ import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseState
-import xtdb.database.DatabaseStorage
+import xtdb.database.PartitionStorage
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
 import java.time.InstantSource
@@ -55,7 +55,7 @@ class LogProcessorTest {
         )
 
     private fun logProcessor(
-        dbStorage: DatabaseStorage,
+        dbStorage: PartitionStorage,
         dbState: DatabaseState,
         watchers: Watchers,
         blockUploader: BlockUploader,
@@ -74,7 +74,7 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
         val dbState = dbState()
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -96,7 +96,7 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
         val dbState = dbState()
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -121,7 +121,7 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
@@ -156,7 +156,7 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = DatabaseStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 


### PR DESCRIPTION
Part of #5557 — multi-DB stage 4. This is pure-equivalence pre-work that sits *under* unit 6 (PR #5815): it reshapes the storage and log resource types so that their scope — database-level versus partition-level — is expressed in the type system, before the per-partition `BufferPool` layout and, later, the per-partition indexing rework build on top of them. Nothing here changes runtime behaviour at `partitions = 1`, which is the only shape `Database.open` admits until unit 9.

## Why

The storage types conflated two different scopes. A database's source and replica logs are shared by every partition — one `Log` object serves them all — whereas the buffer pool and metadata manager are per-partition. The old `DatabaseStorage` aggregated all four, so there was nowhere for a per-partition buffer pool to stand without dragging the shared logs along with it.

At the same time, the per-partition log *consumers* — the block uploader, the leader and follower processors, the compactor driver — reached the shared `Log` directly and threaded a hardcoded `partition = 0` through every partition-indexed call. The partition a consumer serves is fixed for its whole life, so passing it call-by-call is the "pass a constant to satisfy a parameter that doesn't vary here" smell, and at N>1 it's a latent bug waiting for someone to forget one.

## The levels, corrected

Three types now name the two scopes cleanly:

- `DatabaseLogs` — the database-level owner of the shared source/replica log pair, closed at the `Database` level after the partitions that consume it.
- `PartitionStorage` (was `DatabaseStorage`) — a single partition's view of storage: its own buffer pool and metadata manager, plus the shared logs bound to *this* partition. It carries the partition index it serves.
- `PartitionLog<M>` — a `Log` view bound to one partition, exposing just the partition-indexed operations (append, open-atomic-producer, tail) with the index pre-applied. The database-level operations stay off it deliberately: `openGroupSubscription` (one consumer-group membership per database) and `epoch` belong to the whole-database `Log`, reached through `DatabaseLogs`.

A consumer that reads `dbStorage.sourceLog` now gets its slice already scoped and never sees the index; `LeaderLogProcessor` likewise drops its own `partition` constructor argument and reads it from the storage view, so there's a single source of truth for which partition a term serves.

## Changes (reading order)

1. `make DatabaseStorage per-partition; split out DatabaseLogs` — the structural split. Pure equivalence: the log pair moves to `DatabaseLogs`, `DatabaseStorage` keeps the per-partition pool + metadata, and open/close ordering is preserved (buffer pool + metadata still open before the logs, so a storage misconfig surfaces before any Kafka interaction). Still named `DatabaseStorage` at this point.
2. `rename DatabaseStorage to PartitionStorage` — mechanical token rename now that the type is unambiguously a partition's view.
3. `bind per-partition log operations through PartitionLog` — introduce `PartitionLog`, have `PartitionStorage` hand out bound source/replica logs, and drop the `partition = 0` constants from the consumers.

## Equivalence

At `partitions = 1` every binding is partition 0, so the append/tail/produce paths are byte-for-byte what they were, and the resource open/close order is unchanged. `PartitionStorage.partition` defaults to 0 — following the same reasoning as the `Storage.Factory.open` / `Log` partition defaults on the feature branch — so single-partition sites and every test construct it unchanged; the sole production call site (`Database.open`) passes it explicitly.

## Out of scope

- Per-partition `BufferPool` construction and the `parts/<n>/…` storage layout — those stay in unit 6 (#5815), which rebases on top of this.
- The per-partition `LogProcessor` rework (one processor per partition, behind the thin database-level subscription dispatcher that already exists in `Database.open`) — that's the first behaviour-advancing multi-partition step and lands separately, ahead of unit 7.
- `KafkaCluster`'s `TopicSubscription` still assumes one partition per topic (`partitions.single()`, a single leader-election state). Teaching it per-Kafka-partition state is its own unit and a prerequisite before the `Database.open` multi-partition gate lifts in unit 9. It doesn't block anything here: N=1 uses `.single()` correctly, and multi-partition indexing is exercised against the in-memory/local logs, which already drive per-partition leadership.

## Test plan

The affected core suites — `xtdb.indexer.*`, `xtdb.compactor.*`, `xtdb.api.tx.*`, `xtdb.database.*` — pass locally (full core-module Kotlin compile, ~1m10s), along with the `LogProcessorSimTest` property test at 25 iterations. CI runs the full suite.
