### PR TITLE
tidy(storage): name the consumers' storage handles partitionStorage

### DIFF
--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -65,7 +65,7 @@ class OpenTx
 @JvmOverloads constructor(
     private val allocator: BufferAllocator,
     private val nodeBase: NodeBase,
-    private val dbStorage: PartitionStorage,
+    private val partitionStorage: PartitionStorage,
     private val dbState: DatabaseState,
     val txKey: TransactionKey,
     val externalSourceToken: ExternalSourceToken?,
@@ -144,7 +144,7 @@ class OpenTx
             val liveIndex = dbState.liveIndex
 
             val queryDb = object : IQuerySource.QueryDatabase {
-                override val storage get() = dbStorage
+                override val storage get() = partitionStorage
                 override val queryState get() = dbState
                 // a tx always builds a fresh read-your-writes snapshot; the read basis doesn't apply
                 override fun openSnapshot(minBasis: List<Instant?>?) =

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -62,25 +62,25 @@ interface Compactor : AutoCloseable {
         }
     }
 
-    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): ForDatabase
+    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): ForDatabase
 
     interface Driver : AutoCloseable {
         suspend fun executeJob(job: Job): TriesAdded
         suspend fun publishTries(triesAdded: TriesAdded)
 
         interface Factory {
-            fun create(allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver
+            fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver
         }
 
         companion object {
             @JvmStatic
             fun real(pageSize: Int, recencyPartition: RecencyPartition?) =
                 object : Factory {
-                    override fun create(allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : Driver {
+                    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : Driver {
                         private val al = allocator.openChildAllocator("compactor")
-                        private val log = dbStorage.sourceLog
-                        private val bp = dbStorage.bufferPool
-                        private val mm = dbStorage.metadataManager
+                        private val log = partitionStorage.sourceLog
+                        private val bp = partitionStorage.bufferPool
+                        private val mm = partitionStorage.metadataManager
 
                         private val trieWriter = PageTrieWriter(al, bp, calculateBlooms = true)
                         private val segMerge = SegmentMerge(al)
@@ -166,12 +166,12 @@ interface Compactor : AutoCloseable {
         private val jobsDispatcher = dispatcher.limitedParallelism(threadCount, "compactor")
         private val jobsSemaphore = Semaphore(threadCount)
 
-        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
 
             private val trieCatalog = dbState.trieCatalog
             private val liveIndex = dbState.liveIndexOrNull
 
-            val driver = driverFactory.create(allocator, dbStorage, dbState, watchers)
+            val driver = driverFactory.create(allocator, partitionStorage, dbState, watchers)
 
             @Volatile
             private var availableJobs = emptyMap<JobKey, Job>()
@@ -284,7 +284,7 @@ interface Compactor : AutoCloseable {
     companion object {
         @JvmField
         val NOOP = object : Compactor {
-            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
                 override fun signalBlock() = Unit
                 override suspend fun compactAll() = Unit
                 override fun close() = Unit

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -37,7 +37,7 @@ private const val MAX_CONCURRENT_BLOCK_UPLOADS = 16
 private val defaultBlockUploadDispatcher = IO.limitedParallelism(MAX_CONCURRENT_BLOCK_UPLOADS, "block-upload")
 
 class BlockUploader(
-    dbStorage: PartitionStorage,
+    partitionStorage: PartitionStorage,
     dbState: DatabaseState,
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,
@@ -45,8 +45,8 @@ class BlockUploader(
     private val scope: CoroutineScope,
     private val uploadDispatcher: CoroutineDispatcher = defaultBlockUploadDispatcher,
 ) {
-    private val sourceLog = dbStorage.sourceLog
-    private val bufferPool = dbStorage.bufferPool
+    private val sourceLog = partitionStorage.sourceLog
+    private val bufferPool = partitionStorage.bufferPool
     private val liveIndex = dbState.liveIndex
     private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -53,7 +53,7 @@ private val LOG = LeaderLogProcessor::class.logger
 internal class LeaderLogProcessor(
     allocator: BufferAllocator,
     private val nodeBase: NodeBase,
-    private val dbStorage: PartitionStorage,
+    private val partitionStorage: PartitionStorage,
     crashLogger: CrashLogger,
     private val dbState: DatabaseState,
     private val blockUploader: BlockUploader,
@@ -77,9 +77,9 @@ internal class LeaderLogProcessor(
     }
 
     private val dbName = dbState.name
-    private val partition = dbStorage.partition
-    private val sourceLog = dbStorage.sourceLog
-    private val bufferPool = dbStorage.bufferPool
+    private val partition = partitionStorage.partition
+    private val sourceLog = partitionStorage.sourceLog
+    private val bufferPool = partitionStorage.bufferPool
     private val liveIndex = dbState.liveIndex
 
     private val blockCatalog = dbState.blockCatalog
@@ -627,7 +627,7 @@ internal class LeaderLogProcessor(
     }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
-        OpenTx(allocator, nodeBase, dbStorage, dbState, txKey, externalSourceToken, tracer, resolvedTxs)
+        OpenTx(allocator, nodeBase, partitionStorage, dbState, txKey, externalSourceToken, tracer, resolvedTxs)
 
     override suspend fun executeTx(
         externalSourceToken: ExternalSourceToken?, systemTime: Instant?,

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -34,7 +34,7 @@ class LogProcessor(
     private val allocator: BufferAllocator,
     private val base: NodeBase,
     private val crashLogger: CrashLogger,
-    private val dbStorage: PartitionStorage,
+    private val partitionStorage: PartitionStorage,
     private val dbState: DatabaseState,
     private val watchers: Watchers,
     private val blockUploader: BlockUploader,
@@ -52,7 +52,7 @@ class LogProcessor(
     }
 
     private val dbName = dbState.name
-    private val replicaLog = dbStorage.replicaLog
+    private val replicaLog = partitionStorage.replicaLog
     private val hasExternalSource = externalSourceFactory != null
 
     // `close` MUST follow a returned `cancelAndJoin`. See dev/doc/coroutines.adoc.
@@ -90,7 +90,7 @@ class LogProcessor(
     ): LeaderLogProcessor =
         // The leader term owns (and frees) its replica producer and ext source.
         LeaderLogProcessor(
-            allocator, base, dbStorage, crashLogger, dbState, blockUploader,
+            allocator, base, partitionStorage, crashLogger, dbState, blockUploader,
             watchers,
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
             replicaProducer, skipTxs, dbCatalog,
@@ -105,7 +105,7 @@ class LogProcessor(
         afterReplicaMsgId: MessageId,
     ): TransitionLogProcessor =
         TransitionLogProcessor(
-            allocator, dbStorage.bufferPool, dbState, dbState.liveIndex,
+            allocator, partitionStorage.bufferPool, dbState, dbState.liveIndex,
             blockUploader, replicaProducer, watchers, dbCatalog,
             afterReplicaMsgId,
             hasExternalSource = hasExternalSource,
@@ -116,7 +116,7 @@ class LogProcessor(
         afterReplicaMsgId: MessageId,
     ): FollowerLogProcessor =
         FollowerLogProcessor(
-            allocator, dbStorage.replicaLog, dbStorage.bufferPool, dbState, compactor, watchers,
+            allocator, partitionStorage.replicaLog, partitionStorage.bufferPool, dbState, compactor, watchers,
             dbCatalog, pendingBlock, afterReplicaMsgId, scope,
             hasExternalSource = hasExternalSource,
             meterRegistry = base.meterRegistry,

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -116,10 +116,10 @@ class NodeSimulationTest : SimulationTestBase() {
             val trieCatalog = createTrieCatalog()
             val blockCatalog = BlockCatalog("xtdb", sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
-            val dbStorage = PartitionStorage(DatabaseLogs(null, null), sharedBufferPool, null)
+            val partitionStorage = PartitionStorage(DatabaseLogs(null, null), sharedBufferPool, null)
             val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
             val compactorScope = CoroutineScope(dispatcher)
-            val compactorForDb = compactor.openForDatabase(compactorScope, allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            val compactorForDb = compactor.openForDatabase(compactorScope, allocator, partitionStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
             val gcScope = CoroutineScope(dispatcher)
             val garbageCollector = TrieGarbageCollector(
                 gcScope,

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -113,15 +113,15 @@ class ExternalSourceTest {
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope)
 
         val crashLogger = mockk<CrashLogger>(relaxed = true)
 
         return LeaderLogProcessor(
-            allocator, nodeBase, dbStorage, crashLogger,
+            allocator, nodeBase, partitionStorage, crashLogger,
             dbState, blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1, scope = backgroundScope

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -56,7 +56,7 @@ class MockDb(
     val bufferPool: BufferPool,
     val compactor: Compactor,
 ) {
-    val dbStorage: PartitionStorage get() = PartitionStorage(DatabaseLogs(null, null), bufferPool, null)
+    val partitionStorage: PartitionStorage get() = PartitionStorage(DatabaseLogs(null, null), bufferPool, null)
     val dbState: DatabaseState get() = DatabaseState(name, null, null, trieCatalog, null)
 }
 
@@ -98,14 +98,14 @@ class CompactorMockDriverFactory(
     // system's listener failing doesn't cancel the others.
     val scope = CoroutineScope(dispatcher + SupervisorJob())
 
-    override fun create(allocator: BufferAllocator, dbStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver {
+    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver {
         val systemId = nextSystemId++
-        return CompactorMockDriver(dbStorage, dbState, systemId)
+        return CompactorMockDriver(partitionStorage, dbState, systemId)
     }
 
-    private inner class CompactorMockDriver(val dbStorage: PartitionStorage, val dbState: DatabaseState, val systemId: Int) : Driver {
+    private inner class CompactorMockDriver(val partitionStorage: PartitionStorage, val dbState: DatabaseState, val systemId: Int) : Driver {
         val trieCatalog = dbState.trieCatalog
-        val bufferPool = dbStorage.bufferPool
+        val bufferPool = partitionStorage.bufferPool
 
         init {
             scope.launch {
@@ -332,7 +332,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     // ForDatabase to free the driver.
     private fun MockDb.withCompactor(block: (Compactor.ForDatabase) -> Unit) {
         val scope = CoroutineScope(dispatcher)
-        val forDb = compactor.openForDatabase(scope, allocator, dbStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+        val forDb = compactor.openForDatabase(scope, allocator, partitionStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
         try {
             block(forDb)
         } finally {
@@ -344,7 +344,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     private fun withCompactors(dbs: List<MockDb>, block: (List<Compactor.ForDatabase>) -> Unit) {
         val scopes = dbs.map { CoroutineScope(dispatcher) }
         val forDbs = dbs.zip(scopes).map { (db, scope) ->
-            db.compactor.openForDatabase(scope, allocator, db.dbStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            db.compactor.openForDatabase(scope, allocator, db.partitionStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
         }
         try {
             block(forDbs)

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -83,12 +83,12 @@ class LeaderLogProcessorTest {
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
+        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
 
         return LeaderLogProcessor(
-            allocator, nodeBase, dbStorage, mockk(relaxed = true),
+            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = skipTxs, dbCatalog = null,
@@ -141,13 +141,13 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val lp = LeaderLogProcessor(
-            allocator, nodeBase, dbStorage, mockk(relaxed = true),
+            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
@@ -212,13 +212,13 @@ class LeaderLogProcessorTest {
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val lp = LeaderLogProcessor(
-            allocator, nodeBase, dbStorage, mockk(relaxed = true),
+            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
@@ -541,12 +541,12 @@ class LeaderLogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
-        val blockUploader = BlockUploader(dbStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
 
         val lp = LeaderLogProcessor(
-            allocator, nodeBase, dbStorage, mockk(relaxed = true),
+            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
             dbState, blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = setOf(10), dbCatalog = null,

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -66,7 +66,7 @@ class LiveIndexTest {
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName)
         private val dbState = DatabaseState(dbName, blockCatalog, tableCatalog, trieCatalog, liveIndex)
-        private val dbStorage = PartitionStorage(
+        private val partitionStorage = PartitionStorage(
             DatabaseLogs(
                 InMemoryLog<SourceMessage>(InstantSource.system(), 0),
                 InMemoryLog<ReplicaMessage>(InstantSource.system(), 0),
@@ -75,7 +75,7 @@ class LiveIndexTest {
         )
 
         fun openTx(txId: Long, systemTime: Instant) =
-            OpenTx(allocator, nodeBase, dbStorage, dbState, TransactionKey(txId, systemTime), null)
+            OpenTx(allocator, nodeBase, partitionStorage, dbState, TransactionKey(txId, systemTime), null)
 
         fun commitTx(openTx: OpenTx) {
             openTx.writeTxRow(null, null)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -166,7 +166,7 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
             .also { simExtSource.watch(it) }
-        val dbStorage = PartitionStorage(DatabaseLogs(srcLog, replicaLog), bp, null)
+        val partitionStorage = PartitionStorage(DatabaseLogs(srcLog, replicaLog), bp, null)
         val crashLogger = CrashLogger(allocator, bp, "sim-node")
 
         private var logProcessor: LogProcessor? = null
@@ -174,8 +174,8 @@ class LogProcessorSimTest : SimulationTestBase() {
         fun openLogProcessor(scope: CoroutineScope) =
             LogProcessor(
                 allocator, nodeBase, crashLogger,
-                dbStorage, dbState, watchers,
-                BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, scope, uploadDispatcher = dispatcher),
+                partitionStorage, dbState, watchers,
+                BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, scope, uploadDispatcher = dispatcher),
                 mockk<Compactor.ForDatabase>(relaxed = true), dbCatalog = null,
                 externalSourceFactory = object : ExternalSource.Factory {
                     override fun open(

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -55,14 +55,14 @@ class LogProcessorTest {
         )
 
     private fun logProcessor(
-        dbStorage: PartitionStorage,
+        partitionStorage: PartitionStorage,
         dbState: DatabaseState,
         watchers: Watchers,
         blockUploader: BlockUploader,
         scope: CoroutineScope,
     ) = LogProcessor(
         allocator, nodeBase, mockk(relaxed = true),
-        dbStorage, dbState, watchers, blockUploader,
+        partitionStorage, dbState, watchers, blockUploader,
         mockk<Compactor.ForDatabase>(relaxed = true), dbCatalog = null,
         externalSourceFactory = null,
         scope = scope,
@@ -74,12 +74,12 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
         val dbState = dbState()
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(dbStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 
@@ -96,12 +96,12 @@ class LogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
         val dbState = dbState()
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(dbStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 
@@ -121,8 +121,8 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log with a transaction
@@ -131,7 +131,7 @@ class LogProcessorTest {
         replicaProducer.close()
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(dbStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 
@@ -156,15 +156,15 @@ class LogProcessorTest {
             every { latestCompletedTx } returns null
         }
         val dbState = dbState(liveIndex = liveIndex)
-        val dbStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(dbStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log
         replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(dbStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 


### PR DESCRIPTION
Part of #5557 — a small follow-up tidy to the levels reshape (#5822).

#5822 renamed the *type* `DatabaseStorage → PartitionStorage` as a pure token swap and deliberately left the *identifiers* for a follow-up so its rename commit stayed a trivially-reviewable type-only diff. This is that follow-up.

The storage-facing consumers (`LogProcessor`, `LeaderLogProcessor`, `BlockUploader`, the compactor driver, `OpenTx`) and their tests held `dbStorage: PartitionStorage`. The `db-` prefix asserts database scope on what is a partition-level handle — the same mislabelling the type rename set out to fix.

## Why `partitionStorage`, not a bare `storage`

The obvious target was `storage` (the name already used on `DatabasePartition.storage` / `QueryDatabase.storage`), leaning on the type annotation to say "which storage". But that only reads at the *declaration*. At a *pass-through* call site — `LeaderLogProcessor` handing its storage to `OpenTx`, `LogProcessor` handing it to `LeaderLogProcessor` — there's no type in view, and a bare `storage` argument makes the reader trace it back to the field to learn what it is. `partitionStorage` self-documents at those sites and states the correct scope, where `dbStorage` stated the wrong one.

The bare `storage` name is kept where the receiver is itself the partition — `DatabasePartition.storage`, `IQuerySource.QueryDatabase.storage` — since `partition.storage` reads correctly and needs no scope in the identifier. The principle: the name carries more where the call site carries less.

Identifier-only; pure equivalence.

## Left alone

- `MinioTest`'s `xtdbStorage` is an `xt`-prefixed `Storage.Factory`, not a `db-` handle — its name is already correct, and a substring rename would have corrupted it. Untouched.
- `dbState` / `DatabaseState` is a separate question: per-partition under the stage-4 design but still carrying the `Database` name, and `dbState` can't simply become `state` because `LogProcessor` already has a role-machine `state` field. That's a larger type+identifier rename to weigh on its own, not folded in here.

## Test plan

Affected core suites — `xtdb.indexer.*`, `xtdb.compactor.*`, `xtdb.api.tx.*`, `xtdb.database.*` — pass locally (full core-module Kotlin compile + 60 tests). CI runs the full suite.
