### PR TITLE
tidy(database): get the database name off the per-partition indexing layer

### DIFF
--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -515,7 +515,7 @@
       (let [^IQuerySource$QueryDatabase db db
             ^IQuerySource$QueryCatalog db-cat db-cat
             db-state (.getQueryState db)
-            db-name (.getName db-state)
+            db-name (.getName db)
             table-catalog (.getTableCatalog db-state)
             trie-catalog (.getTrieCatalog db-state)
             schema-info (-> (merge-with merge

--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -67,6 +67,7 @@ class OpenTx
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
     private val dbState: DatabaseState,
+    private val dbName: DatabaseName,
     val txKey: TransactionKey,
     val externalSourceToken: ExternalSourceToken?,
     private val tracer: Tracer? = null,
@@ -144,6 +145,7 @@ class OpenTx
             val liveIndex = dbState.liveIndex
 
             val queryDb = object : IQuerySource.QueryDatabase {
+                override val name get() = dbName
                 override val storage get() = partitionStorage
                 override val queryState get() = dbState
                 // a tx always builds a fresh read-your-writes snapshot; the read basis doesn't apply
@@ -152,8 +154,8 @@ class OpenTx
             }
 
             return object : IQuerySource.QueryCatalog {
-                override val databaseNames: Collection<DatabaseName> get() = setOf(dbState.name)
-                override fun databaseOrNull(dbName: DatabaseName) = queryDb.takeIf { dbName == dbState.name }
+                override val databaseNames: Collection<DatabaseName> get() = setOf(dbName)
+                override fun databaseOrNull(dbName: DatabaseName) = queryDb.takeIf { dbName == this@OpenTx.dbName }
             }
         }
 
@@ -169,7 +171,7 @@ class OpenTx
         val currentTime = opts.currentTime ?: txKey.systemTime
 
         val prepareOpts = PrepareOpts(
-            currentTime = currentTime, defaultTz = opts.defaultTz, defaultDb = dbState.name,
+            currentTime = currentTime, defaultTz = opts.defaultTz, defaultDb = dbName,
         )
 
         return nodeBase.querySource
@@ -191,7 +193,7 @@ class OpenTx
         val qOpts = opts.copy(currentTime = currentTime, tracer = opts.tracer ?: tracer)
 
         val prepareOpts = PrepareOpts(
-            currentTime = currentTime, defaultTz = opts.defaultTz, defaultDb = dbState.name,
+            currentTime = currentTime, defaultTz = opts.defaultTz, defaultDb = dbName,
             argFields = args?.schema?.fields,
         )
 
@@ -304,10 +306,10 @@ class OpenTx
         principal: String?,
         revoke: Boolean
     ) {
-        if (dbState.name != "xtdb")
+        if (dbName != "xtdb")
             throw Incorrect(
                 "Role membership can only be managed on the primary 'xtdb' database.",
-                "xtdb/role-membership-non-primary", mapOf("db" to dbState.name),
+                "xtdb/role-membership-non-primary", mapOf("db" to dbName),
             )
 
         if (principal == null || !nodeBase.config.authn.isSuperuser(principal))
@@ -641,7 +643,7 @@ class OpenTx
             checkNotForbidden(ref)
 
             val prepareOpts = PrepareOpts(
-                currentTime = txKey.systemTime, defaultDb = dbState.name,
+                currentTime = txKey.systemTime, defaultDb = dbName,
                 argFields = docs.schema.fields,
             )
 

--- a/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
@@ -10,7 +10,6 @@ import xtdb.block.proto.block
 import xtdb.block.proto.txKey
 import xtdb.database.proto.DatabaseConfig
 import xtdb.storage.BufferPool
-import xtdb.api.DatabaseName
 import xtdb.api.TableRef
 import xtdb.table.fromSchemaAndTable
 import xtdb.time.InstantUtil.asMicros
@@ -23,7 +22,6 @@ import java.nio.file.Path
 import kotlin.io.path.extension
 
 class BlockCatalog(
-    private val dbName: DatabaseName, 
     @field:Volatile private var latestBlock: Block?
 ) {
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -62,6 +62,7 @@ private val LOG = Database::class.logger
 class Database(
     val allocator: BufferAllocator,
     val config: Config,
+    override val name: DatabaseName,
     val logs: DatabaseLogs,
     val isIndexing: Boolean,
     val partitions: Map<Int, DatabasePartition>,
@@ -78,7 +79,6 @@ class Database(
     // lookup once `partitions > 1` is enabled; for now every Database has exactly one.
     private val partition0: DatabasePartition get() = partitions.getValue(0)
 
-    val name: DatabaseName get() = partition0.state.name
     override val storage: PartitionStorage get() = partition0.storage
     override val queryState: DatabaseState get() = partition0.state
     val watchers: Watchers get() = partition0.watchers
@@ -343,7 +343,7 @@ class Database(
 
                 LogProcessor(
                     allocator, base, crashLogger,
-                    storage, state, watchers, blockUploader,
+                    storage, state, dbName, watchers, blockUploader,
                     compactorForDb, dbCatalog,
                     externalSourceFactory = dbConfig.externalSource,
                     scope = scope,
@@ -390,6 +390,7 @@ class Database(
             val db = Database(
                 allocator = allocator,
                 config = dbConfig,
+                name = dbName,
                 logs = logs,
                 isIndexing = indexerConfig.enabled,
                 partitions = mapOf(0 to partition),

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -281,7 +281,7 @@ class Database(
             val logs = open { DatabaseLogs.open(base, dbConfig) }
 
             val storage = PartitionStorage(logs, bufferPool, metadataManager, partition = 0)
-            val state = open { DatabaseState.open(allocator, storage, dbName, indexerConfig) }
+            val state = open { DatabaseState.open(allocator, storage, indexerConfig) }
             val blockCatalog = state.blockCatalog
             val sourceMsgId = maxOf(
                 blockCatalog.latestProcessedMsgId ?: -1,

--- a/core/src/main/kotlin/xtdb/database/DatabaseState.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseState.kt
@@ -13,7 +13,6 @@ import xtdb.util.requiringResolve
 import xtdb.util.safelyOpening
 
 data class DatabaseState(
-    val name: DatabaseName,
     val blockCatalogOrNull: BlockCatalog?,
     val tableCatalogOrNull: TableCatalog?,
     val trieCatalogOrNull: TrieCatalog?,
@@ -58,7 +57,7 @@ data class DatabaseState(
 
             val liveIndex = open { LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName, indexerConfig) }
 
-            DatabaseState(dbName, blockCatalog, tableCatalog, trieCatalog, liveIndex)
+            DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/database/DatabaseState.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseState.kt
@@ -6,7 +6,6 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.BlockCatalog.Companion.latestBlock
 import xtdb.catalog.TableCatalog
 import xtdb.indexer.LiveIndex
-import xtdb.api.DatabaseName
 import xtdb.api.TableRef
 import xtdb.trie.TrieCatalog
 import xtdb.util.requiringResolve
@@ -36,12 +35,11 @@ data class DatabaseState(
         fun open(
             allocator: BufferAllocator,
             storage: PartitionStorage,
-            dbName: DatabaseName,
             indexerConfig: IndexerConfig = IndexerConfig(),
         ): DatabaseState = safelyOpening {
             val bufferPool = storage.bufferPool
 
-            val blockCatalog = BlockCatalog(dbName, bufferPool.latestBlock)
+            val blockCatalog = BlockCatalog(bufferPool.latestBlock)
 
             val tableCatalog = TableCatalog(bufferPool).also {
                 it.refresh(blockCatalog)
@@ -55,7 +53,7 @@ data class DatabaseState(
 
             val trieCatalog = trieCatalogFactory.open(bufferPool, blockCatalog)
 
-            val liveIndex = open { LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName, indexerConfig) }
+            val liveIndex = open { LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, indexerConfig) }
 
             DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         }

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.selects.select
 import xtdb.catalog.BlockCatalog.Companion.blockFromLatest
+import xtdb.api.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.storage.BufferPool
 import xtdb.api.TableRef
@@ -54,6 +55,7 @@ class TrieGarbageCollector(
     scope: CoroutineScope,
     private val bufferPool: BufferPool,
     dbState: DatabaseState,
+    dbName: DatabaseName,
     /**
      * Publishes a `TriesDeleted` to the replica log AND removes the keys from the local trie catalog — atomically, in a single Persister task on the leader.
      * The Persister channel is the sole ordering point, so no other replica-log write interleaves between the two.
@@ -83,7 +85,7 @@ class TrieGarbageCollector(
     private val deleteTimer: Timer? = meterRegistry?.let {
         Timer.builder("xtdb.gc.tries.delete.timer")
             .publishPercentiles(0.75, 0.95, 0.99)
-            .tag("db", dbState.name)
+            .tag("db", dbName)
             .register(it)
     }
     

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.DatabaseName
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
 import xtdb.api.log.*
@@ -40,6 +41,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     replicaLog: PartitionLog<ReplicaMessage>,
     private val bufferPool: BufferPool,
     private val dbState: DatabaseState,
+    private val dbName: DatabaseName,
     private val compactor: Compactor.ForDatabase,
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
@@ -50,8 +52,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val meterRegistry: MeterRegistry? = null,
     private val maxBufferedRecords: Int = 1024,
 ) : LogProcessor.Processor<ReplicaMessage> {
-
-    private val dbName = dbState.name
 
     private fun processTimer(msgType: String): Timer? = meterRegistry?.let {
         Timer.builder("xtdb.replica.process.timer")

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.selects.selectUnbiased
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
+import xtdb.api.DatabaseName
 import xtdb.api.TransactionResult
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
@@ -39,6 +40,7 @@ internal class LeaderLogProcessor(
     private val partitionStorage: PartitionStorage,
     crashLogger: CrashLogger,
     private val dbState: DatabaseState,
+    private val dbName: DatabaseName,
     private val blockUploader: BlockUploader,
     private val watchers: Watchers,
     private val extSource: ExternalSource?,
@@ -54,12 +56,11 @@ internal class LeaderLogProcessor(
 ) : LogProcessor.Processor<SourceMessage>, TxIndexer {
 
     init {
-        require((dbCatalog != null) == (dbState.name == "xtdb")) {
+        require((dbCatalog != null) == (dbName == "xtdb")) {
             "dbCatalog must be provided iff database is 'xtdb'"
         }
     }
 
-    private val dbName = dbState.name
     private val partition = partitionStorage.partition
     private val sourceLog = partitionStorage.sourceLog
     private val bufferPool = partitionStorage.bufferPool
@@ -72,7 +73,7 @@ internal class LeaderLogProcessor(
     // resolved-but-not-yet-durable tx — until we've committed it into the live index below. Driven only
     // from the persister coroutine, and freed in close() once that job is joined; see TxResolver.
     private val txResolver =
-        TxResolver(allocator, nodeBase, partitionStorage, dbState, crashLogger, skipTxs, instantSource)
+        TxResolver(allocator, nodeBase, partitionStorage, dbState, dbName, crashLogger, skipTxs, instantSource)
 
     var pendingBlock: PendingBlock? = null
         private set
@@ -403,7 +404,7 @@ internal class LeaderLogProcessor(
 
         TrieGarbageCollector(
             gcScope,
-            bufferPool, dbState,
+            bufferPool, dbState, dbName,
             commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
             cfg.enabled,
             nodeBase.meterRegistry,

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -54,7 +54,6 @@ class LiveIndex private constructor(
     private val allocator: BufferAllocator,
     private val tableCatalog: TableCatalog,
     val trieCatalog: TrieCatalog,
-    private val dbName: String,
     @Volatile var latestCompletedTx: TransactionKey?,
     initialBlockIdx: Long,
     indexerConfig: IndexerConfig,
@@ -221,11 +220,11 @@ class LiveIndex private constructor(
         @JvmName("open")
         fun open(
             allocator: BufferAllocator, blockCatalog: BlockCatalog, tableCatalog: TableCatalog,
-            trieCatalog: TrieCatalog, dbName: String, indexerConfig: IndexerConfig = IndexerConfig(),
+            trieCatalog: TrieCatalog, indexerConfig: IndexerConfig = IndexerConfig(),
         ) = safelyOpening {
             LiveIndex(
                 open { allocator.newChildAllocator("live-index", 0, Long.MAX_VALUE) },
-                tableCatalog, trieCatalog, dbName,
+                tableCatalog, trieCatalog,
                 blockCatalog.latestCompletedTx,
                 (blockCatalog.currentBlockIndex ?: -1L) + 1L,
                 indexerConfig,

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -14,6 +14,7 @@ import xtdb.NodeBase
 import xtdb.api.log.*
 import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.compactor.Compactor
+import xtdb.api.DatabaseName
 import xtdb.database.Database
 import xtdb.database.DatabaseState
 import xtdb.database.PartitionStorage
@@ -36,6 +37,7 @@ class LogProcessor(
     private val crashLogger: CrashLogger,
     private val partitionStorage: PartitionStorage,
     private val dbState: DatabaseState,
+    private val dbName: DatabaseName,
     private val watchers: Watchers,
     private val blockUploader: BlockUploader,
     private val compactor: Compactor.ForDatabase,
@@ -51,7 +53,6 @@ class LogProcessor(
         val latestReplicaMsgId: MessageId
     }
 
-    private val dbName = dbState.name
     private val replicaLog = partitionStorage.replicaLog
     private val hasExternalSource = externalSourceFactory != null
 
@@ -90,7 +91,7 @@ class LogProcessor(
     ): LeaderLogProcessor =
         // The leader term owns (and frees) its replica producer and ext source.
         LeaderLogProcessor(
-            allocator, base, partitionStorage, crashLogger, dbState, blockUploader,
+            allocator, base, partitionStorage, crashLogger, dbState, dbName, blockUploader,
             watchers,
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
             replicaProducer, skipTxs, dbCatalog,
@@ -105,7 +106,7 @@ class LogProcessor(
         afterReplicaMsgId: MessageId,
     ): TransitionLogProcessor =
         TransitionLogProcessor(
-            allocator, partitionStorage.bufferPool, dbState, dbState.liveIndex,
+            allocator, partitionStorage.bufferPool, dbState, dbName, dbState.liveIndex,
             blockUploader, replicaProducer, watchers, dbCatalog,
             afterReplicaMsgId,
             hasExternalSource = hasExternalSource,
@@ -116,7 +117,7 @@ class LogProcessor(
         afterReplicaMsgId: MessageId,
     ): FollowerLogProcessor =
         FollowerLogProcessor(
-            allocator, partitionStorage.replicaLog, partitionStorage.bufferPool, dbState, compactor, watchers,
+            allocator, partitionStorage.replicaLog, partitionStorage.bufferPool, dbState, dbName, compactor, watchers,
             dbCatalog, pendingBlock, afterReplicaMsgId, scope,
             hasExternalSource = hasExternalSource,
             meterRegistry = base.meterRegistry,
@@ -146,7 +147,7 @@ class LogProcessor(
         base.meterRegistry?.let { reg ->
             Gauge.builder("xtdb.log.leader", this) { if (it.state is Leading) 1.0 else 0.0 }
                 .description("1 if this node is the log leader, 0 if follower")
-                .tag("db", dbState.name)
+                .tag("db", dbName)
                 .register(reg)
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
@@ -7,6 +7,7 @@ import xtdb.Metrics.withSpan
 import xtdb.NodeBase
 import xtdb.api.TransactionKey
 import xtdb.arrow.*
+import xtdb.api.DatabaseName
 import xtdb.database.DatabaseState
 import xtdb.api.error.Anomaly
 import xtdb.api.error.Anomaly.Companion.wrapAnomaly
@@ -49,6 +50,7 @@ internal class SourceLogTxIndexer(
     private val allocator: BufferAllocator,
     base: NodeBase,
     private val dbState: DatabaseState,
+    private val dbName: DatabaseName,
     private val crashLogger: CrashLogger,
 ) {
 
@@ -252,7 +254,7 @@ internal class SourceLogTxIndexer(
                 tracer.withSpan(
                     "xtdb.transaction.patch-docs",
                     attributes = mapOf(
-                        "db" to dbState.name, "schema" to tableRef.schemaName, "table" to tableRef.tableName,
+                        "db" to dbName, "schema" to tableRef.schemaName, "table" to tableRef.tableName,
                     ),
                 ) {
                     table(tableRef).patchDocs(docs, validFrom, validTo)

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -1,6 +1,7 @@
 package xtdb.indexer
 
 import org.apache.arrow.memory.BufferAllocator
+import xtdb.api.DatabaseName
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
 import xtdb.api.log.DbOp
@@ -26,6 +27,7 @@ class TransitionLogProcessor(
     allocator: BufferAllocator,
     private val bufferPool: BufferPool,
     private val dbState: DatabaseState,
+    private val dbName: DatabaseName,
     private val liveIndex: LiveIndex,
     private val blockUploader: BlockUploader,
     private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
@@ -38,7 +40,6 @@ class TransitionLogProcessor(
     override var latestReplicaMsgId: MessageId = afterReplicaMsgId
         private set
 
-    private val dbName = dbState.name
     private val blockCatalog = dbState.blockCatalog
     private val trieCatalog = dbState.trieCatalog
 

--- a/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CompletableDeferred
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.Metrics.withSpan
 import xtdb.NodeBase
+import xtdb.api.DatabaseName
 import xtdb.api.TransactionKey
 import xtdb.api.TransactionResult
 import xtdb.api.TransactionResult.Aborted
@@ -86,12 +87,12 @@ internal class TxResolver(
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
     private val dbState: DatabaseState,
+    private val dbName: DatabaseName,
     crashLogger: CrashLogger,
     private val skipTxs: Set<MessageId>,
     private val instantSource: InstantSource,
 ) : AutoCloseable {
 
-    private val dbName = dbState.name
     private val bufferPool = partitionStorage.bufferPool
 
     private val allocator = allocator.newChildAllocator("tx-resolver", 0, Long.MAX_VALUE)
@@ -100,7 +101,7 @@ internal class TxResolver(
 
     private val txErrorCounter: Counter? = nodeBase.meterRegistry?.let { Counter.builder("tx.error").register(it) }
 
-    private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, dbState, crashLogger)
+    private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, dbState, dbName, crashLogger)
 
     var latestCompletedTx: TransactionKey? = dbState.liveIndex.latestCompletedTx
         private set
@@ -154,7 +155,7 @@ internal class TxResolver(
     }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
-        OpenTx(allocator, nodeBase, partitionStorage, dbState, txKey, externalSourceToken, tracer, inFlightTxs)
+        OpenTx(allocator, nodeBase, partitionStorage, dbState, dbName, txKey, externalSourceToken, tracer, inFlightTxs)
 
     // Stage a fresh tx committing a single skip / abort / invalid-system-time row. `countError` mirrors the
     // pre-staging behaviour: skipped txs don't count as errors.

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -18,6 +18,7 @@ interface IQuerySource : AutoCloseable {
     }
 
     interface QueryDatabase : DatabaseSnapshot.Source {
+        val name: DatabaseName
         val storage: PartitionStorage
         val queryState: DatabaseState
     }

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -114,7 +114,7 @@ class NodeSimulationTest : SimulationTestBase() {
 
         dbs = List(numberOfSystems) {
             val trieCatalog = createTrieCatalog()
-            val blockCatalog = BlockCatalog("xtdb", sharedBufferPool.latestBlock)
+            val blockCatalog = BlockCatalog(sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
             val partitionStorage = PartitionStorage(DatabaseLogs(null, null), sharedBufferPool, null)
             val dbState = DatabaseState(blockCatalog, null, trieCatalog, null)

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -117,13 +117,13 @@ class NodeSimulationTest : SimulationTestBase() {
             val blockCatalog = BlockCatalog("xtdb", sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
             val partitionStorage = PartitionStorage(DatabaseLogs(null, null), sharedBufferPool, null)
-            val dbState = DatabaseState("xtdb", blockCatalog, null, trieCatalog, null)
+            val dbState = DatabaseState(blockCatalog, null, trieCatalog, null)
             val compactorScope = CoroutineScope(dispatcher)
             val compactorForDb = compactor.openForDatabase(compactorScope, allocator, partitionStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
             val gcScope = CoroutineScope(dispatcher)
             val garbageCollector = TrieGarbageCollector(
                 gcScope,
-                sharedBufferPool, dbState,
+                sharedBufferPool, dbState, "xtdb",
                 commitTriesDeleted = { tableName, trieKeys ->
                     // No replica log in the mock — apply the catalog mutation directly so the
                     // simulation's view of the catalog still converges as the test asserts.

--- a/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
@@ -58,7 +58,7 @@ class ExternalSourceTokenTest {
 
     @Test
     fun `Block proto round-trips external source token`() {
-        val blockCatalog = BlockCatalog("test-db", null)
+        val blockCatalog = BlockCatalog(null)
 
         val block = blockCatalog.buildBlock(
             blockIndex = 0,
@@ -77,7 +77,7 @@ class ExternalSourceTokenTest {
 
     @Test
     fun `BlockCatalog externalSourceToken reads from latest block`() {
-        val blockCatalog = BlockCatalog("test-db", null)
+        val blockCatalog = BlockCatalog(null)
 
         assertNull(blockCatalog.externalSourceToken)
 
@@ -97,7 +97,7 @@ class ExternalSourceTokenTest {
 
     @Test
     fun `BlockCatalog externalSourceToken returns null when no token`() {
-        val blockCatalog = BlockCatalog("test-db", null)
+        val blockCatalog = BlockCatalog(null)
 
         val block = blockCatalog.buildBlock(
             blockIndex = 0,

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -112,7 +112,7 @@ class ExternalSourceTest {
         val blockCatalog = BlockCatalog("test", null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
-        val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
@@ -122,7 +122,7 @@ class ExternalSourceTest {
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, crashLogger,
-            dbState, blockUploader, watchers, extSource, replicaProducer,
+            dbState, "test", blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1, scope = backgroundScope
         ).also(leadersToClose::add)
@@ -395,12 +395,13 @@ class ExternalSourceTest {
         // note: not .use — Database.close() would close `allocator`, which @AfterEach also closes
         val partition = DatabasePartition(
             storage = PartitionStorage(DatabaseLogs(null, null), null, null),
-            state = DatabaseState("cdc", null, null, null, null),
+            state = DatabaseState(null, null, null, null),
             watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         )
         val db = Database(
             allocator = allocator,
             config = config,
+            name = "cdc",
             logs = DatabaseLogs(null, null),
             isIndexing = false,
             partitions = mapOf(0 to partition),

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -56,10 +56,10 @@ class ExternalSourceTest {
         nodeBase = openBase()
         bufferPool = MemoryStorage(allocator, 0)
 
-        val blockCatalog = BlockCatalog("test", null)
+        val blockCatalog = BlockCatalog(null)
         val tableCatalog = TableCatalog(bufferPool).also { it.refresh(blockCatalog) }
         val trieCatalog = createTrieCatalog()
-        liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, "test")
+        liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog)
     }
 
     @AfterEach
@@ -109,7 +109,7 @@ class ExternalSourceTest {
         afterToken: ExternalSourceToken? = null,
         wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
     ): LeaderLogProcessor {
-        val blockCatalog = BlockCatalog("test", null)
+        val blockCatalog = BlockCatalog(null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
         val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -57,7 +57,7 @@ class MockDb(
     val compactor: Compactor,
 ) {
     val partitionStorage: PartitionStorage get() = PartitionStorage(DatabaseLogs(null, null), bufferPool, null)
-    val dbState: DatabaseState get() = DatabaseState(name, null, null, trieCatalog, null)
+    val dbState: DatabaseState get() = DatabaseState(null, null, trieCatalog, null)
 }
 
 private val LOGGER = CompactorMockDriverFactory::class.logger

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -57,7 +57,7 @@ class FollowerLogProcessorTest {
         blockCatalog = BlockCatalog("test", null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
-        dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // The processor self-launches its replica tail; park it so it idles while the test drives
@@ -80,7 +80,7 @@ class FollowerLogProcessorTest {
         meterRegistry: MeterRegistry? = null,
     ) =
         FollowerLogProcessor(
-            allocator, PartitionLog(replicaLog, 0), bufferPool, dbState, compactor,
+            allocator, PartitionLog(replicaLog, 0), bufferPool, dbState, "test", compactor,
             watchers, null, null, afterReplicaMsgId = -1L, backgroundScope,
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,
@@ -126,7 +126,7 @@ class FollowerLogProcessorTest {
         // block catalog starts at block 5 (simulating startup from latest block).
         val startBlock = block { blockIndex = 5 }
         blockCatalog = BlockCatalog("test", startBlock)
-        dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
         val proc = makeProcessor()
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -54,7 +54,7 @@ class FollowerLogProcessorTest {
         bufferPool = mockk(relaxed = true)
         liveIndex = mockk(relaxed = true)
         compactor = mockk(relaxed = true)
-        blockCatalog = BlockCatalog("test", null)
+        blockCatalog = BlockCatalog(null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
         dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
@@ -125,7 +125,7 @@ class FollowerLogProcessorTest {
         // replaying a replica log that has old SW-era messages.
         // block catalog starts at block 5 (simulating startup from latest block).
         val startBlock = block { blockIndex = 5 }
-        blockCatalog = BlockCatalog("test", startBlock)
+        blockCatalog = BlockCatalog(startBlock)
         dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
         val proc = makeProcessor()

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -82,14 +82,14 @@ class LeaderLogProcessorTest {
         wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
-        val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, blockUploader, watchers,
+            dbState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = skipTxs, dbCatalog = null,
             afterReplicaMsgId = -1,
@@ -140,7 +140,7 @@ class LeaderLogProcessorTest {
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
@@ -148,7 +148,7 @@ class LeaderLogProcessorTest {
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, blockUploader, watchers,
+            dbState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1,
@@ -211,7 +211,7 @@ class LeaderLogProcessorTest {
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
         val blockCatalog = BlockCatalog("test", null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
@@ -219,7 +219,7 @@ class LeaderLogProcessorTest {
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, blockUploader, watchers,
+            dbState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1,
@@ -540,14 +540,14 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
-        val dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, blockUploader, watchers,
+            dbState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = setOf(10), dbCatalog = null,
             afterReplicaMsgId = -1,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -74,7 +74,7 @@ class LeaderLogProcessorTest {
         replicaLog: InMemoryLog<ReplicaMessage> = InMemoryLog(InstantSource.system(), 0),
         bufferPool: BufferPool = mockk(relaxed = true) { every { epoch } returns 0 },
         liveIndex: LiveIndex = mockk(relaxed = true),
-        blockCatalog: BlockCatalog = BlockCatalog("test", null),
+        blockCatalog: BlockCatalog = BlockCatalog(null),
         trieCatalog: TrieCatalog = mockk(relaxed = true),
         compactor: Compactor.ForDatabase = mockk(relaxed = true),
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
@@ -138,7 +138,7 @@ class LeaderLogProcessorTest {
         }
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
-        val blockCatalog = BlockCatalog("test", null)
+        val blockCatalog = BlockCatalog(null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
@@ -209,7 +209,7 @@ class LeaderLogProcessorTest {
         }
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
-        val blockCatalog = BlockCatalog("test", null)
+        val blockCatalog = BlockCatalog(null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
@@ -536,7 +536,7 @@ class LeaderLogProcessorTest {
         }
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
-        val blockCatalog = BlockCatalog("test", null)
+        val blockCatalog = BlockCatalog(null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -61,10 +61,10 @@ class LiveIndexTest {
 
     private inner class TestDb(private val dbName: String = "xtdb") : AutoCloseable {
         val bp = MemoryStorage(allocator, epoch = 0)
-        private val blockCatalog = BlockCatalog(dbName, null)
+        private val blockCatalog = BlockCatalog(null)
         private val tableCatalog = TableCatalog(bp)
         val trieCatalog = createTrieCatalog()
-        val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName)
+        val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog)
         private val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         private val partitionStorage = PartitionStorage(
             DatabaseLogs(

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -59,13 +59,13 @@ class LiveIndexTest {
         nodeBase.close()
     }
 
-    private inner class TestDb(dbName: String = "xtdb") : AutoCloseable {
+    private inner class TestDb(private val dbName: String = "xtdb") : AutoCloseable {
         val bp = MemoryStorage(allocator, epoch = 0)
         private val blockCatalog = BlockCatalog(dbName, null)
         private val tableCatalog = TableCatalog(bp)
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName)
-        private val dbState = DatabaseState(dbName, blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        private val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         private val partitionStorage = PartitionStorage(
             DatabaseLogs(
                 InMemoryLog<SourceMessage>(InstantSource.system(), 0),
@@ -75,7 +75,7 @@ class LiveIndexTest {
         )
 
         fun openTx(txId: Long, systemTime: Instant) =
-            OpenTx(allocator, nodeBase, partitionStorage, dbState, TransactionKey(txId, systemTime), null)
+            OpenTx(allocator, nodeBase, partitionStorage, dbState, dbName, TransactionKey(txId, systemTime), null)
 
         fun commitTx(openTx: OpenTx) {
             openTx.writeTxRow(null, null)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -151,7 +151,7 @@ class LogProcessorSimTest : SimulationTestBase() {
     }
 
     private inner class SimNode(
-        dbName: String,
+        private val dbName: String,
         val bp: MemoryStorage,
         indexerConfig: IndexerConfig,
         private val simExtSource: SimExtSource,
@@ -162,7 +162,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName, indexerConfig)
 
-        val dbState = DatabaseState(dbName, blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
 
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
             .also { simExtSource.watch(it) }
@@ -174,7 +174,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         fun openLogProcessor(scope: CoroutineScope) =
             LogProcessor(
                 allocator, nodeBase, crashLogger,
-                partitionStorage, dbState, watchers,
+                partitionStorage, dbState, dbName, watchers,
                 BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, scope, uploadDispatcher = dispatcher),
                 mockk<Compactor.ForDatabase>(relaxed = true), dbCatalog = null,
                 externalSourceFactory = object : ExternalSource.Factory {

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -157,10 +157,10 @@ class LogProcessorSimTest : SimulationTestBase() {
         private val simExtSource: SimExtSource,
     ) : AutoCloseable {
 
-        val blockCatalog = BlockCatalog(dbName, null)
+        val blockCatalog = BlockCatalog(null)
         val tableCatalog = TableCatalog(bp)
         val trieCatalog = createTrieCatalog()
-        val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, dbName, indexerConfig)
+        val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, indexerConfig)
 
         val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -47,7 +47,6 @@ class LogProcessorTest {
 
     private fun dbState(name: String = "test-db", liveIndex: LiveIndex = mockk(relaxed = true)) =
         DatabaseState(
-            name,
             BlockCatalog(name, null),
             mockk<TableCatalog>(relaxed = true),
             mockk<TrieCatalog>(relaxed = true),
@@ -62,7 +61,7 @@ class LogProcessorTest {
         scope: CoroutineScope,
     ) = LogProcessor(
         allocator, nodeBase, mockk(relaxed = true),
-        partitionStorage, dbState, watchers, blockUploader,
+        partitionStorage, dbState, "test-db", watchers, blockUploader,
         mockk<Compactor.ForDatabase>(relaxed = true), dbCatalog = null,
         externalSourceFactory = null,
         scope = scope,

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -47,7 +47,7 @@ class LogProcessorTest {
 
     private fun dbState(name: String = "test-db", liveIndex: LiveIndex = mockk(relaxed = true)) =
         DatabaseState(
-            BlockCatalog(name, null),
+            BlockCatalog(null),
             mockk<TableCatalog>(relaxed = true),
             mockk<TrieCatalog>(relaxed = true),
             liveIndex

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -37,7 +37,7 @@ class TransitionLogProcessorTest {
         liveIndex = mockk(relaxed = true)
         blockUploader = mockk(relaxed = true)
         replicaProducer = mockk(relaxed = true)
-        blockCatalog = BlockCatalog("test", null)
+        blockCatalog = BlockCatalog(null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
         dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -40,7 +40,7 @@ class TransitionLogProcessorTest {
         blockCatalog = BlockCatalog("test", null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
-        dbState = DatabaseState("test", blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         every { bufferPool.epoch } returns 1
@@ -53,7 +53,7 @@ class TransitionLogProcessorTest {
 
     private fun makeProcessor(hasExternalSource: Boolean = false) =
         TransitionLogProcessor(
-            allocator, bufferPool, dbState, liveIndex,
+            allocator, bufferPool, dbState, "test", liveIndex,
             blockUploader, replicaProducer,
             watchers, null, afterReplicaMsgId = -1L,
             hasExternalSource = hasExternalSource,

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -63,7 +63,7 @@ class BlockGarbageCollectorTest {
                 assertBlockCount(bufferPool, table1BlockPath, 10)
                 assertBlockCount(bufferPool, table2BlockPath, 10)
 
-                val blockCat = BlockCatalog("xtdb", bufferPool.latestBlock)
+                val blockCat = BlockCatalog(bufferPool.latestBlock)
 
                 val gc = BlockGarbageCollector(
                     backgroundScope,

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -388,7 +388,7 @@
    (->open-tx (.getAllocator node) node tx-key))
   (^OpenTx [^BufferAllocator allocator node ^TransactionKey tx-key]
    (let [db (db/primary-db node)]
-     (OpenTx. allocator (util/node-base node) (.getStorage db) (.getQueryState db) tx-key nil nil))))
+     (OpenTx. allocator (util/node-base node) (.getStorage db) (.getQueryState db) (.getName db) tx-key nil nil))))
 
 (defn open-put-log-rel
   "Builds a log-data relation of put ops via the public log-data writer - the same relation


### PR DESCRIPTION
Part of #5557 — a two-commit tidy that gets the database name out of a database's per-partition indexing state, where it never belonged.

A `DatabasePartition`'s indexing state — `DatabaseState` and the `BlockCatalog` / `LiveIndex` it holds — is per-partition: one set per partition. But the database *name* is database-level (every partition of a database shares it), and it had leaked into that per-partition layer in two different ways, both left over from earlier refactors:

- `DatabaseState` carried a `name` field that per-partition workers *used* — but they recovered it by reaching into per-partition state (`dbState.name`), and `Database` surfaced its own identity as `partition0.state.name`, reaching through partition 0 for something that isn't partition-scoped.
- `BlockCatalog` and `LiveIndex` carried `dbName` constructor params that nothing *reads* — orphaned when `make TableRef db-relative` (034dc82f3) removed the last uses (they used to stamp the db onto `TableRef`s) but left the params behind.

This moves the name to where it belongs and removes what was dead.

## Changes

1. `tidy(database): lift the database name off per-partition DatabaseState` — remove `name` from `DatabaseState`; put it on `Database` (its db-level owner) and expose it on the db-level `IQuerySource.QueryDatabase` view; hand `dbName` as an explicit constructor input to the per-partition consumers that use it (`LogProcessor`, the leader/follower/transition processors, `OpenTx`, `SourceLogTxIndexer`, `TrieGarbageCollector`). Each site now gets the name from where it belongs — the query path (e.g. `information_schema`) and the white-box `->open-tx` fixture read it from the `QueryDatabase`, not from per-partition state.
2. `tidy(indexer): drop the unused dbName from BlockCatalog and LiveIndex` — remove the write-only `dbName` params from both, and consequently from `DatabaseState.open` (which only threaded it to feed them). Finishes 034dc82f3's "per-db indexing layers simply stop stamping the db on."

## Notes

The name's three real uses are all preserved by commit 1, unchanged: query planning (`OpenTx`'s `defaultDb` and its single-db query catalog), the primary-database guards (`name == "xtdb"`), and observability labels (log prefixes, metric `db` tags, error context).

It's threaded as the bare `DatabaseName` value that already exists rather than a new identity/context type. An abstraction would be premature: the metric `db` tags are set at *meter registration* (construction time), so whatever carries the name has to be a constructor input regardless — an ambient/context mechanism wouldn't be available at that point.

Pure equivalence. Commit 1: the same name reaches the same sites; `Database.name` becomes a stored field instead of a partition-0 delegate. Commit 2: dead-param removal — the fields were write-only (confirmed by the 034dc82f3 history *and* the current source), and no Clojure interop constructs these types, so it's Kotlin-only. Both together also clear one of the `partition0` read-through smells tracked for the stage-4 cleanup.

## Test plan

Local: the affected core suites (`xtdb.indexer.*`, `xtdb.compactor.*`, `xtdb.api.tx.*`, `xtdb.database.*`, `xtdb.api.log.*`); the root-module `BlockGarbageCollectorTest` (the real `BlockCatalog` consumer); and the Clojure paths that exercise the interop surface (`information_schema_test`, `indexer.crash_logger_test`, `indexer.live_index_test` — the latter two drive the `->open-tx` fixture). CI runs the full suite.
