### PR TITLE
test(postgres-source): await the CDC metric counters rather than racing them

### DIFF
--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -370,10 +370,15 @@ class PostgresSourceIntegrationTest {
             fun metric(name: String) =
                 metrics.find(name).tags("db", "cdc", "source", slotName, "source_type", "postgres")
 
-            assertTrue((metric("xtdb.postgres_source.events.total").counter()?.count() ?: 0.0) >= 1.0,
-                "events.total should have counted the streamed row")
-            assertTrue((metric("xtdb.postgres_source.commits.total").counter()?.count() ?: 0.0) >= 1.0,
-                "commits.total should have counted the streamed commit")
+            // The counters are incremented in `promoteDurable`, which the poll loop reaches only
+            // after `settle` has completed the submit handle — and `settle` makes the row queryable
+            // before it does that. So the row being visible above doesn't imply it's been counted.
+            awaitCondition("events.total counted the streamed row") {
+                (metric("xtdb.postgres_source.events.total").counter()?.count() ?: 0.0) >= 1.0
+            }
+            awaitCondition("commits.total counted the streamed commit") {
+                (metric("xtdb.postgres_source.commits.total").counter()?.count() ?: 0.0) >= 1.0
+            }
 
             // Confirms the pg_replication_slots query path works against real Postgres —
             // the gauge pulls on read so this should be populated immediately after streaming.


### PR DESCRIPTION
## Summary

`PostgresSourceIntegrationTest.metrics populate against real Postgres` has been failing intermittently on `main` — three of the seven CI runs on 2026-07-28, always on the same assertion. There's no tracking issue, so the context below stands in for one.

## Symptoms

Failing runs: [30350360296](https://github.com/xtdb/xtdb/actions/runs/30350360296), [30360240677](https://github.com/xtdb/xtdb/actions/runs/30360240677), [30362317589](https://github.com/xtdb/xtdb/actions/runs/30362317589). Each one:

```
org.opentest4j.AssertionFailedError: events.total should have counted the streamed row ==> expected: <true> but was: <false>
```

Never reproduces locally on an idle machine, which is the tell — the test asserts on a value that isn't set yet, and a fast box happens to set it before the assertion is reached.

## Root cause

The test waited for the streamed row to become queryable, then read `xtdb.postgres_source.events.total` immediately. Those two facts are ordered, and not in the direction the test assumed:

```
test thread                                CDC poll loop / persister
───────────                                ─────────────────────────
awaitCondition("streamed row visible")
                                           submitTx(tx) → handle
                                           kickAppend() ──┐ replica-log append, in background
                                                          │
                                           InFlightBatch.settle():
                                             append.await()             ← replica log COMMITTED
                                             liveIndex.commitTx(…)      ← row becomes QUERYABLE
                                             watchers.notifyTx(…)
                                             [maybe finishBlock]        ← object-storage block write
  ← sees the row, stops waiting
assertTrue(events.total >= 1.0)   ✗ 0.0
                                             txs.forEach { pending.complete() }   ← handle completes
                                           …next poll turn:
                                             promoteDurable() → eventsCounter.increment()
```

`settle` commits to the live index before completing the submit handle (`LeaderLogProcessor.kt:124-143`), and `promoteDurable` only counts a tx once that handle has completed. So the condition the test waited on is satisfied strictly before the thing it then asserted on.

Worth being explicit about what that gap is *not*, since it looks like a durability window and isn't one. `settle` opens with `append.await()`, so the fenced replica-log transaction is committed before anything becomes queryable — the leader never exposes a tx the replica log doesn't already carry, and nothing between the live-index commit and the handle completing can walk it back. What actually sits in the gap is the rest of the promote loop, a possible `finishBlock`, and then the handle completion — ordered last on purpose (`:140-142`): signalling per-tx mid-loop lets a caller race ahead of the block cut and ack an LSN whose `BlockBoundary` never landed a `BlockUploaded` (#5783, caught at 15/300 in the sim).

## Why it started failing now

Not the metrics work that landed the same day — [3ac0ea9db](https://github.com/xtdb/xtdb/commit/3ac0ea9db) is `query.timer`/`query.error`/`tx.error` on `Xtdb.Connection` and touches nothing in the `xtdb.postgres_source.*` path, and still exposes `:metrics-registry` as the same `(.getMeterRegistry base)` the test reads. It's just the commit the first failure happened to land on.

The trailing distance grew with [603df7b5c](https://github.com/xtdb/xtdb/commit/603df7b5c) (2026-07-13). Before it the poll loop drove each tx through `executeTx` — `submitTx(...).await()` — so completing the handle resumed the loop's continuation directly and the increment ran on the very next statement. After it nothing wakes the loop: `promoteDurable` discovers completion by polling `isCompleted` on its next turn, behind a `readPending` IO dispatch and a 50ms idle pause every fifth empty poll. Everything up to the handle completing is common to both versions; what changed is that event-driven resumption became polled discovery. CI only ran ~6 times between then and 2026-07-28, which is why it took a fortnight to surface.

## Approach

Recording at promotion is deliberate — it's what stops a tx being counted twice when a stream teardown makes Postgres re-send from the confirmed-flush LSN — so the production code is right and the fix belongs on the test side. The two counter assertions become `awaitCondition` waits.

The predicate is unchanged; only its evaluation schedule is. The point isn't the 10s budget, it's that the wait condition and the assertion are now the same expression, so there's no proxy signal left to drift from what's being checked.

The cost is a slower failure signal: a genuinely uncounted event now surfaces as a 10s timeout naming the metric rather than an immediate expected/actual. Same information, later.

## Out of scope

Two neighbouring problems this PR deliberately leaves alone, recorded here so they're not lost:

1. **The `wal_lag_bytes` assertion below the fix is tautological.** The gauge is registered in `init` so it always resolves, and its lambda null-coalesces a failed `pg_replication_slots` query to `0.0` — which satisfies `>= 0.0`. It cannot fail, despite the comment claiming it proves the query path works against real Postgres.
2. **`source fails when postgres dies during snapshot` (`:464`) fails locally on a fast machine**, on its own precondition `snapshot completed before kill` — it assumes the kill wins a race against the snapshot. It's green in CI, so it's a separate change, but it's the same assume-the-race-goes-my-way shape as the bug fixed here.

## Test plan

- `:modules:xtdb-postgres-source:integration-test` locally: 21 tests, the metrics test green in 2.7s.
- Full CI on the fork: [30376172374](https://github.com/mbutlerw/xtdb/actions/runs/30376172374) — all jobs green, including Integration Test with zero failure annotations. That run predates a comment-only amend to this commit; the code under test is identical.

Neither run proves the race is gone (a passing race still passes), but the failure mode was a missing wait, and the wait is now there.
