### PR TITLE
test(tx): pin OpenTx's single-db query catalog contract

### DIFF
--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -140,7 +140,9 @@ class OpenTx
     }
 
 
-    private val queryCatalog: IQuerySource.QueryCatalog
+    // `internal` rather than `private` solely so OpenTxTest can assert the single-db contract directly;
+    // no production code outside this file reads it.
+    internal val queryCatalog: IQuerySource.QueryCatalog
         get() {
             val liveIndex = dbState.liveIndex
 

--- a/core/src/test/kotlin/xtdb/api/tx/OpenTxTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/OpenTxTest.kt
@@ -1,0 +1,75 @@
+@file:OptIn(xtdb.InternalApi::class)
+
+package xtdb.api.tx
+
+import org.apache.arrow.memory.BufferAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import xtdb.NodeBase
+import xtdb.NodeBase.Companion.openBase
+import xtdb.SimulationTestUtils.Companion.createTrieCatalog
+import xtdb.api.TransactionKey
+import xtdb.api.log.InMemoryLog
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.SourceMessage
+import xtdb.catalog.BlockCatalog
+import xtdb.catalog.TableCatalog
+import xtdb.database.DatabaseLogs
+import xtdb.database.DatabaseState
+import xtdb.database.PartitionStorage
+import xtdb.indexer.LiveIndex
+import xtdb.storage.MemoryStorage
+import java.time.Instant
+import java.time.InstantSource
+
+class OpenTxTest {
+
+    private lateinit var nodeBase: NodeBase
+    private lateinit var allocator: BufferAllocator
+
+    @BeforeEach
+    fun setUp() {
+        nodeBase = openBase(openMeterRegistry = false)
+        allocator = nodeBase.allocator.newChildAllocator("test", 0, Long.MAX_VALUE)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        allocator.close()
+        nodeBase.close()
+    }
+
+    private fun <R> withOpenTx(dbName: String, f: (OpenTx) -> R): R =
+        MemoryStorage(allocator, epoch = 0).use { bp ->
+            val blockCatalog = BlockCatalog(null)
+            val tableCatalog = TableCatalog(bp)
+            val trieCatalog = createTrieCatalog()
+            val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog)
+
+            DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex).use { dbState ->
+                val storage = PartitionStorage(
+                    DatabaseLogs(
+                        InMemoryLog<SourceMessage>(InstantSource.system(), 0),
+                        InMemoryLog<ReplicaMessage>(InstantSource.system(), 0),
+                    ),
+                    bp, null
+                )
+
+                OpenTx(allocator, nodeBase, storage, dbState, dbName, TransactionKey(0, Instant.EPOCH), null).use(f)
+            }
+        }
+
+    @Test
+    fun `query catalog contains only the tx's own database`() {
+        withOpenTx("my_db") { tx ->
+            val queryCatalog = tx.queryCatalog
+
+            assertEquals(setOf("my_db"), queryCatalog.databaseNames.toSet())
+            assertEquals("my_db", queryCatalog.databaseOrNull("my_db")?.name)
+            assertNull(queryCatalog.databaseOrNull("other_db"))
+        }
+    }
+}


### PR DESCRIPTION
Part of #5557.

#5825 lifted the database name off per-partition `DatabaseState` and threaded it explicitly. Part of that was a `replace_all` of `dbState.name` → `dbName`, and one of the rewritten sites sat inside `override fun databaseOrNull(dbName: DatabaseName)`, whose parameter shadows OpenTx's own field. The comparison silently became `dbName == dbName` — always true, so a transaction's query catalog would have returned its own database under whatever name it was asked for. It compiled clean, no test moved, and it was caught by reading the diff before pushing.

This adds the test that would have caught it. Production behaviour is unchanged: the only edit outside the test is `private` → `internal` on `OpenTx.queryCatalog`.

## Why a unit test rather than a behavioural one

No end-to-end test could have caught this. Table resolution is gated upstream on `databaseNames` — the planner derives `:db-names` from the catalog (`query.clj:345`) and `visitBaseTable` throws `table-not-found` for anything outside that set — so `databaseOrNull` is only ever called with the transaction's own name. The always-true branch was unreachable through the public API.

The nullable return exists for the real `DatabaseCatalog`, which is live: a concurrent detach can drop a database between listing the names and looking one up (see the comment at `Database.kt:557`). A transaction has no such race, so OpenTx's implementation is a trivially-true adapter — which is exactly why only a direct assertion on the catalog can pin it.

## Why `internal`

`queryCatalog` is a private computed property, so there's no handle to assert against. Two alternatives were built and dropped.

Extracting a `QueryDatabase.asCatalog()` extension keeps production visibility untouched, but adds a named abstraction with a single call site purely to give the test somewhere to stand.

Capturing the catalog through a mocked `IQuerySource` at the `prepareQuery` boundary needs no production change at all — the recipient is already injected — but it couples the test to *how* `openQuery` passes the catalog on, and spends six lines of stubbing before the first assertion means anything.

`internal` costs one keyword and joins a band the class already maintains: `table`, `tables`, `sealTables` and `writeTxRow` are all internal, drawing the line between what the indexer may touch and what an external-source writer may. The comment on the property records that no production code outside the file reads it.

## Implementation notes

The fixture uses real objects rather than mocks — `MemoryStorage`, real block/table/trie catalogs, a real `LiveIndex` and `NodeBase` — because `LiveIndexTest` already constructs an OpenTx exactly this way, including the `@file:OptIn(xtdb.InternalApi::class)` convention that keeps the constructor call clean. Nothing needed stubbing.

That does duplicate `LiveIndexTest.TestDb`'s fixture across two test classes in different packages. Sharing it means extracting another test's private inner class, which felt like more churn than the duplication is worth — flagging it rather than doing it.

## Worth knowing before this ages

The assertion `databaseNames == setOf("my_db")` turned out to be more load-bearing than it looks. `dbs-in-xtdb.md:63` documents that *"Transactions are submitted to one database and may only refer to tables within that database"*, and the read half of that guarantee is enforced entirely by which catalog reaches the planner — there is no check anywhere in the DML path asserting it independently. So OpenTx returning a single-entry `databaseNames` **is** the enforcement, and this is the only mechanical statement of it in the repo.

That matters because a plausible follow-up would deliberately change it. Cross-database references inside a transaction currently fail with `Table not found: other_db.bar`, which is untrue and misleading — the table exists, it just isn't reachable from a transaction. Producing a decent error requires the transaction-time planner to know that `other_db` *is* a database, which means widening `databaseNames` while keeping `databaseOrNull` resolving only its own. Anyone doing that will need to update this test, and it should be a considered change rather than a surprise. Tracked separately, with the investigation written up there.

## Test plan

`./gradlew :xtdb-core:test --tests 'xtdb.api.tx.OpenTxTest'` passes, with no reflection or boxed-math warnings. A full `./gradlew test` is running as this goes up; I'll follow up on the PR if it turns anything over.