### PR TITLE
tidy(database): rename DatabaseState to PartitionState

### DIFF
--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -13,7 +13,7 @@ import xtdb.arrow.VectorType.Companion.INSTANT
 import xtdb.arrow.VectorType.Companion.TRANSIT
 import xtdb.authz.RoleMembership
 import xtdb.database.DatabaseName
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.api.error.Conflict
 import xtdb.api.error.Incorrect
@@ -66,7 +66,7 @@ class OpenTx
     private val allocator: BufferAllocator,
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
-    private val dbState: DatabaseState,
+    private val dbState: PartitionState,
     private val dbName: DatabaseName,
     val txKey: TransactionKey,
     val externalSourceToken: ExternalSourceToken?,

--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -66,7 +66,7 @@ class OpenTx
     private val allocator: BufferAllocator,
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
-    private val dbState: PartitionState,
+    private val partitionState: PartitionState,
     private val dbName: DatabaseName,
     val txKey: TransactionKey,
     val externalSourceToken: ExternalSourceToken?,
@@ -144,12 +144,12 @@ class OpenTx
     // no production code outside this file reads it.
     internal val queryCatalog: IQuerySource.QueryCatalog
         get() {
-            val liveIndex = dbState.liveIndex
+            val liveIndex = partitionState.liveIndex
 
             val queryDb = object : IQuerySource.QueryDatabase {
                 override val name get() = dbName
                 override val storage get() = partitionStorage
-                override val queryState get() = dbState
+                override val queryState get() = partitionState
                 // a tx always builds a fresh read-your-writes snapshot; the read basis doesn't apply
                 override fun openSnapshot(minBasis: List<Instant?>?) =
                     DatabaseSnapshot(listOf(liveIndex.openSnapshot(resolvedTxs, this@OpenTx)))

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -62,21 +62,21 @@ interface Compactor : AutoCloseable {
         }
     }
 
-    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers): ForDatabase
+    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, partitionState: PartitionState, watchers: Watchers): ForDatabase
 
     interface Driver : AutoCloseable {
         suspend fun executeJob(job: Job): TriesAdded
         suspend fun publishTries(triesAdded: TriesAdded)
 
         interface Factory {
-            fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers): Driver
+            fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, partitionState: PartitionState, watchers: Watchers): Driver
         }
 
         companion object {
             @JvmStatic
             fun real(pageSize: Int, recencyPartition: RecencyPartition?) =
                 object : Factory {
-                    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers) = object : Driver {
+                    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, partitionState: PartitionState, watchers: Watchers) = object : Driver {
                         private val al = allocator.openChildAllocator("compactor")
                         private val log = partitionStorage.sourceLog
                         private val bp = partitionStorage.bufferPool
@@ -166,12 +166,12 @@ interface Compactor : AutoCloseable {
         private val jobsDispatcher = dispatcher.limitedParallelism(threadCount, "compactor")
         private val jobsSemaphore = Semaphore(threadCount)
 
-        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers) = object : ForDatabase {
+        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, partitionState: PartitionState, watchers: Watchers) = object : ForDatabase {
 
-            private val trieCatalog = dbState.trieCatalog
-            private val liveIndex = dbState.liveIndexOrNull
+            private val trieCatalog = partitionState.trieCatalog
+            private val liveIndex = partitionState.liveIndexOrNull
 
-            val driver = driverFactory.create(allocator, partitionStorage, dbState, watchers)
+            val driver = driverFactory.create(allocator, partitionStorage, partitionState, watchers)
 
             @Volatile
             private var availableJobs = emptyMap<JobKey, Job>()
@@ -284,7 +284,7 @@ interface Compactor : AutoCloseable {
     companion object {
         @JvmField
         val NOOP = object : Compactor {
-            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers) = object : ForDatabase {
+            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, partitionState: PartitionState, watchers: Watchers) = object : ForDatabase {
                 override fun signalBlock() = Unit
                 override suspend fun compactAll() = Unit
                 override fun close() = Unit

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -16,7 +16,7 @@ import xtdb.api.storage.Storage
 import xtdb.arrow.Relation
 import xtdb.compactor.PageTree.Companion.asTree
 import org.apache.arrow.memory.BufferAllocator
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.TrieMetadata
@@ -62,21 +62,21 @@ interface Compactor : AutoCloseable {
         }
     }
 
-    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): ForDatabase
+    fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers): ForDatabase
 
     interface Driver : AutoCloseable {
         suspend fun executeJob(job: Job): TriesAdded
         suspend fun publishTries(triesAdded: TriesAdded)
 
         interface Factory {
-            fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver
+            fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers): Driver
         }
 
         companion object {
             @JvmStatic
             fun real(pageSize: Int, recencyPartition: RecencyPartition?) =
                 object : Factory {
-                    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : Driver {
+                    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers) = object : Driver {
                         private val al = allocator.openChildAllocator("compactor")
                         private val log = partitionStorage.sourceLog
                         private val bp = partitionStorage.bufferPool
@@ -166,7 +166,7 @@ interface Compactor : AutoCloseable {
         private val jobsDispatcher = dispatcher.limitedParallelism(threadCount, "compactor")
         private val jobsSemaphore = Semaphore(threadCount)
 
-        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+        override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers) = object : ForDatabase {
 
             private val trieCatalog = dbState.trieCatalog
             private val liveIndex = dbState.liveIndexOrNull
@@ -284,7 +284,7 @@ interface Compactor : AutoCloseable {
     companion object {
         @JvmField
         val NOOP = object : Compactor {
-            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers) = object : ForDatabase {
+            override fun openForDatabase(scope: CoroutineScope, allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers) = object : ForDatabase {
                 override fun signalBlock() = Unit
                 override suspend fun compactAll() = Unit
                 override fun close() = Unit

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -80,7 +80,7 @@ class Database(
     private val partition0: DatabasePartition get() = partitions.getValue(0)
 
     override val storage: PartitionStorage get() = partition0.storage
-    override val queryState: DatabaseState get() = partition0.state
+    override val queryState: PartitionState get() = partition0.state
     val watchers: Watchers get() = partition0.watchers
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
 
@@ -281,7 +281,7 @@ class Database(
             val logs = open { DatabaseLogs.open(base, dbConfig) }
 
             val storage = PartitionStorage(logs, bufferPool, metadataManager, partition = 0)
-            val state = open { DatabaseState.open(allocator, storage, indexerConfig) }
+            val state = open { PartitionState.open(allocator, storage, indexerConfig) }
             val blockCatalog = state.blockCatalog
             val sourceMsgId = maxOf(
                 blockCatalog.latestProcessedMsgId ?: -1,

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -14,7 +14,7 @@ import java.time.Instant
 
 class DatabasePartition(
     val storage: PartitionStorage,
-    val state: DatabaseState,
+    val state: PartitionState,
     val watchers: Watchers,
     val compactorOrNull: Compactor.ForDatabase? = null,
     val logProcessor: LogProcessor? = null,

--- a/core/src/main/kotlin/xtdb/database/PartitionState.kt
+++ b/core/src/main/kotlin/xtdb/database/PartitionState.kt
@@ -11,7 +11,7 @@ import xtdb.trie.TrieCatalog
 import xtdb.util.requiringResolve
 import xtdb.util.safelyOpening
 
-data class DatabaseState(
+class PartitionState(
     val blockCatalogOrNull: BlockCatalog?,
     val tableCatalogOrNull: TableCatalog?,
     val trieCatalogOrNull: TrieCatalog?,
@@ -36,7 +36,7 @@ data class DatabaseState(
             allocator: BufferAllocator,
             storage: PartitionStorage,
             indexerConfig: IndexerConfig = IndexerConfig(),
-        ): DatabaseState = safelyOpening {
+        ): PartitionState = safelyOpening {
             val bufferPool = storage.bufferPool
 
             val blockCatalog = BlockCatalog(bufferPool.latestBlock)
@@ -55,7 +55,7 @@ data class DatabaseState(
 
             val liveIndex = open { LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, indexerConfig) }
 
-            DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+            PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -54,7 +54,7 @@ class TrieGarbageCollector(
     /** The owner's scope: supplies this collector's lifetime and the thread its loop runs on. Cancelling it stops the loop. */
     scope: CoroutineScope,
     private val bufferPool: BufferPool,
-    dbState: PartitionState,
+    partitionState: PartitionState,
     dbName: DatabaseName,
     /**
      * Publishes a `TriesDeleted` to the replica log AND removes the keys from the local trie catalog — atomically, in a single Persister task on the leader.
@@ -72,8 +72,8 @@ class TrieGarbageCollector(
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
-    private val blockCatalog = dbState.blockCatalog
-    private val trieCatalog = dbState.trieCatalog
+    private val blockCatalog = partitionState.blockCatalog
+    private val trieCatalog = partitionState.trieCatalog
 
     // [signal] is fire-and-forget; bursts coalesce into one upcoming cycle.
     private val signalCh = Channel<Unit>(CONFLATED)

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.selects.select
 import xtdb.catalog.BlockCatalog.Companion.blockFromLatest
 import xtdb.api.DatabaseName
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.storage.BufferPool
 import xtdb.api.TableRef
 import xtdb.time.microsAsInstant
@@ -54,7 +54,7 @@ class TrieGarbageCollector(
     /** The owner's scope: supplies this collector's lifetime and the thread its loop runs on. Cancelling it stops the loop. */
     scope: CoroutineScope,
     private val bufferPool: BufferPool,
-    dbState: DatabaseState,
+    dbState: PartitionState,
     dbName: DatabaseName,
     /**
      * Publishes a `TriesDeleted` to the replica log AND removes the keys from the local trie catalog — atomically, in a single Persister task on the leader.

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -38,7 +38,7 @@ private val defaultBlockUploadDispatcher = IO.limitedParallelism(MAX_CONCURRENT_
 
 class BlockUploader(
     partitionStorage: PartitionStorage,
-    dbState: PartitionState,
+    partitionState: PartitionState,
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,
     private val meterRegistry: MeterRegistry?,
@@ -47,10 +47,10 @@ class BlockUploader(
 ) {
     private val sourceLog = partitionStorage.sourceLog
     private val bufferPool = partitionStorage.bufferPool
-    private val liveIndex = dbState.liveIndex
-    private val blockCatalog = dbState.blockCatalog
-    private val trieCatalog = dbState.trieCatalog
-    private val tableCatalog = dbState.tableCatalog
+    private val liveIndex = partitionState.liveIndex
+    private val blockCatalog = partitionState.blockCatalog
+    private val trieCatalog = partitionState.trieCatalog
+    private val tableCatalog = partitionState.tableCatalog
     private val blockUploadTimer: Timer? = meterRegistry?.let {
         Timer.builder("block.upload.timer")
             .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -21,7 +21,7 @@ import xtdb.api.storage.Storage
 import xtdb.catalog.BlockCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.Database
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.util.StringUtil.asLexHex
@@ -38,7 +38,7 @@ private val defaultBlockUploadDispatcher = IO.limitedParallelism(MAX_CONCURRENT_
 
 class BlockUploader(
     partitionStorage: PartitionStorage,
-    dbState: DatabaseState,
+    dbState: PartitionState,
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,
     private val meterRegistry: MeterRegistry?,

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -40,7 +40,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     allocator: BufferAllocator,
     replicaLog: PartitionLog<ReplicaMessage>,
     private val bufferPool: BufferPool,
-    private val dbState: PartitionState,
+    private val partitionState: PartitionState,
     private val dbName: DatabaseName,
     private val compactor: Compactor.ForDatabase,
     private val watchers: Watchers,
@@ -116,10 +116,10 @@ class FollowerLogProcessor @JvmOverloads constructor(
             is ReplicaState.Failed -> s.msgId
         }
 
-    private val blockCatalog = dbState.blockCatalog
-    private val tableCatalog = dbState.tableCatalog
-    private val trieCatalog = dbState.trieCatalog
-    private val liveIndex = dbState.liveIndex
+    private val blockCatalog = partitionState.blockCatalog
+    private val tableCatalog = partitionState.tableCatalog
+    private val trieCatalog = partitionState.trieCatalog
+    private val liveIndex = partitionState.liveIndex
 
     private val allocator = allocator.newChildAllocator("follower-log-processor", 0, Long.MAX_VALUE)
 

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -19,7 +19,7 @@ import xtdb.block.proto.Block.parseFrom
 import xtdb.catalog.BlockCatalog.Companion.blockFilePath
 import xtdb.compactor.Compactor
 import xtdb.database.Database
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.api.error.Anomaly
 import xtdb.api.error.Interrupted
 import xtdb.types.LogTimestamp
@@ -40,7 +40,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     allocator: BufferAllocator,
     replicaLog: PartitionLog<ReplicaMessage>,
     private val bufferPool: BufferPool,
-    private val dbState: DatabaseState,
+    private val dbState: PartitionState,
     private val dbName: DatabaseName,
     private val compactor: Compactor.ForDatabase,
     private val watchers: Watchers,

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -39,7 +39,7 @@ internal class LeaderLogProcessor(
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
     crashLogger: CrashLogger,
-    private val dbState: PartitionState,
+    private val partitionState: PartitionState,
     private val dbName: DatabaseName,
     private val blockUploader: BlockUploader,
     private val watchers: Watchers,
@@ -64,16 +64,16 @@ internal class LeaderLogProcessor(
     private val partition = partitionStorage.partition
     private val sourceLog = partitionStorage.sourceLog
     private val bufferPool = partitionStorage.bufferPool
-    private val liveIndex = dbState.liveIndex
+    private val liveIndex = partitionState.liveIndex
 
-    private val blockCatalog = dbState.blockCatalog
-    private val trieCatalog = dbState.trieCatalog
+    private val blockCatalog = partitionState.blockCatalog
+    private val trieCatalog = partitionState.trieCatalog
 
     // Resolves each source-log / attach-detach / ext-source tx and holds it — with every other
     // resolved-but-not-yet-durable tx — until we've committed it into the live index below. Driven only
     // from the persister coroutine, and freed in close() once that job is joined; see TxResolver.
     private val txResolver =
-        TxResolver(allocator, nodeBase, partitionStorage, dbState, dbName, crashLogger, skipTxs, instantSource)
+        TxResolver(allocator, nodeBase, partitionStorage, partitionState, dbName, crashLogger, skipTxs, instantSource)
 
     var pendingBlock: PendingBlock? = null
         private set
@@ -404,7 +404,7 @@ internal class LeaderLogProcessor(
 
         TrieGarbageCollector(
             gcScope,
-            bufferPool, dbState, dbName,
+            bufferPool, partitionState, dbName,
             commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
             cfg.enabled,
             nodeBase.meterRegistry,

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -39,7 +39,7 @@ internal class LeaderLogProcessor(
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
     crashLogger: CrashLogger,
-    private val dbState: DatabaseState,
+    private val dbState: PartitionState,
     private val dbName: DatabaseName,
     private val blockUploader: BlockUploader,
     private val watchers: Watchers,

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -16,7 +16,7 @@ import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.compactor.Compactor
 import xtdb.api.DatabaseName
 import xtdb.database.Database
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.api.tx.ExternalSource
 import xtdb.api.error.Fault
@@ -36,7 +36,7 @@ class LogProcessor(
     private val base: NodeBase,
     private val crashLogger: CrashLogger,
     private val partitionStorage: PartitionStorage,
-    private val dbState: DatabaseState,
+    private val dbState: PartitionState,
     private val dbName: DatabaseName,
     private val watchers: Watchers,
     private val blockUploader: BlockUploader,

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -36,7 +36,7 @@ class LogProcessor(
     private val base: NodeBase,
     private val crashLogger: CrashLogger,
     private val partitionStorage: PartitionStorage,
-    private val dbState: PartitionState,
+    private val partitionState: PartitionState,
     private val dbName: DatabaseName,
     private val watchers: Watchers,
     private val blockUploader: BlockUploader,
@@ -91,7 +91,7 @@ class LogProcessor(
     ): LeaderLogProcessor =
         // The leader term owns (and frees) its replica producer and ext source.
         LeaderLogProcessor(
-            allocator, base, partitionStorage, crashLogger, dbState, dbName, blockUploader,
+            allocator, base, partitionStorage, crashLogger, partitionState, dbName, blockUploader,
             watchers,
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
             replicaProducer, skipTxs, dbCatalog,
@@ -106,7 +106,7 @@ class LogProcessor(
         afterReplicaMsgId: MessageId,
     ): TransitionLogProcessor =
         TransitionLogProcessor(
-            allocator, partitionStorage.bufferPool, dbState, dbName, dbState.liveIndex,
+            allocator, partitionStorage.bufferPool, partitionState, dbName, partitionState.liveIndex,
             blockUploader, replicaProducer, watchers, dbCatalog,
             afterReplicaMsgId,
             hasExternalSource = hasExternalSource,
@@ -117,7 +117,7 @@ class LogProcessor(
         afterReplicaMsgId: MessageId,
     ): FollowerLogProcessor =
         FollowerLogProcessor(
-            allocator, partitionStorage.replicaLog, partitionStorage.bufferPool, dbState, dbName, compactor, watchers,
+            allocator, partitionStorage.replicaLog, partitionStorage.bufferPool, partitionState, dbName, compactor, watchers,
             dbCatalog, pendingBlock, afterReplicaMsgId, scope,
             hasExternalSource = hasExternalSource,
             meterRegistry = base.meterRegistry,
@@ -141,7 +141,7 @@ class LogProcessor(
 
     @Volatile
     private var state: State =
-        Following(openFollowerSystem(dbState.blockCatalog.boundaryReplicaMsgId ?: -1))
+        Following(openFollowerSystem(partitionState.blockCatalog.boundaryReplicaMsgId ?: -1))
 
     init {
         base.meterRegistry?.let { reg ->

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
@@ -49,12 +49,12 @@ private fun assertTimestampColType(rdr: VectorReader) {
 internal class SourceLogTxIndexer(
     private val allocator: BufferAllocator,
     base: NodeBase,
-    private val dbState: PartitionState,
+    private val partitionState: PartitionState,
     private val dbName: DatabaseName,
     private val crashLogger: CrashLogger,
 ) {
 
-    private val liveIndex = dbState.liveIndex
+    private val liveIndex = partitionState.liveIndex
 
     private val tracer: Tracer? =
         if (base.config.tracer.transactionTracing) base.tracer else null

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
@@ -8,7 +8,7 @@ import xtdb.NodeBase
 import xtdb.api.TransactionKey
 import xtdb.arrow.*
 import xtdb.api.DatabaseName
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.api.error.Anomaly
 import xtdb.api.error.Anomaly.Companion.wrapAnomaly
 import xtdb.api.error.Fault
@@ -49,7 +49,7 @@ private fun assertTimestampColType(rdr: VectorReader) {
 internal class SourceLogTxIndexer(
     private val allocator: BufferAllocator,
     base: NodeBase,
-    private val dbState: DatabaseState,
+    private val dbState: PartitionState,
     private val dbName: DatabaseName,
     private val crashLogger: CrashLogger,
 ) {

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -26,7 +26,7 @@ private val LOG = TransitionLogProcessor::class.logger
 class TransitionLogProcessor(
     allocator: BufferAllocator,
     private val bufferPool: BufferPool,
-    private val dbState: PartitionState,
+    private val partitionState: PartitionState,
     private val dbName: DatabaseName,
     private val liveIndex: LiveIndex,
     private val blockUploader: BlockUploader,
@@ -40,8 +40,8 @@ class TransitionLogProcessor(
     override var latestReplicaMsgId: MessageId = afterReplicaMsgId
         private set
 
-    private val blockCatalog = dbState.blockCatalog
-    private val trieCatalog = dbState.trieCatalog
+    private val blockCatalog = partitionState.blockCatalog
+    private val trieCatalog = partitionState.trieCatalog
 
     private val allocator = allocator.newChildAllocator("transition-log-processor", 0, Long.MAX_VALUE)
 

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -13,7 +13,7 @@ import xtdb.api.storage.Storage
 import xtdb.api.error.Anomaly
 import xtdb.api.error.Interrupted
 import xtdb.database.Database
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.storage.BufferPool
 import xtdb.table.fromSchemaAndTable
 import xtdb.util.*
@@ -26,7 +26,7 @@ private val LOG = TransitionLogProcessor::class.logger
 class TransitionLogProcessor(
     allocator: BufferAllocator,
     private val bufferPool: BufferPool,
-    private val dbState: DatabaseState,
+    private val dbState: PartitionState,
     private val dbName: DatabaseName,
     private val liveIndex: LiveIndex,
     private val blockUploader: BlockUploader,

--- a/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
@@ -86,7 +86,7 @@ internal class TxResolver(
     allocator: BufferAllocator,
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
-    private val dbState: PartitionState,
+    private val partitionState: PartitionState,
     private val dbName: DatabaseName,
     crashLogger: CrashLogger,
     private val skipTxs: Set<MessageId>,
@@ -101,9 +101,9 @@ internal class TxResolver(
 
     private val txErrorCounter: Counter? = nodeBase.meterRegistry?.let { Counter.builder("tx.error").register(it) }
 
-    private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, dbState, dbName, crashLogger)
+    private val sourceLogTxIndexer = SourceLogTxIndexer(this.allocator, nodeBase, partitionState, dbName, crashLogger)
 
-    var latestCompletedTx: TransactionKey? = dbState.liveIndex.latestCompletedTx
+    var latestCompletedTx: TransactionKey? = partitionState.liveIndex.latestCompletedTx
         private set
 
     private var sealedBatch: List<ResolvedTx> = emptyList()
@@ -155,7 +155,7 @@ internal class TxResolver(
     }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
-        OpenTx(allocator, nodeBase, partitionStorage, dbState, dbName, txKey, externalSourceToken, tracer, inFlightTxs)
+        OpenTx(allocator, nodeBase, partitionStorage, partitionState, dbName, txKey, externalSourceToken, tracer, inFlightTxs)
 
     // Stage a fresh tx committing a single skip / abort / invalid-system-time row. `countError` mirrors the
     // pre-staging behaviour: skipped txs don't count as errors.

--- a/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
@@ -23,7 +23,7 @@ import xtdb.api.tx.TxIndexer.TxResult
 import xtdb.arrow.Relation
 import xtdb.arrow.VectorReader
 import xtdb.arrow.asChannel
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.time.InstantUtil.asMicros
 import xtdb.time.InstantUtil.fromMicros
@@ -86,7 +86,7 @@ internal class TxResolver(
     allocator: BufferAllocator,
     private val nodeBase: NodeBase,
     private val partitionStorage: PartitionStorage,
-    private val dbState: DatabaseState,
+    private val dbState: PartitionState,
     private val dbName: DatabaseName,
     crashLogger: CrashLogger,
     private val skipTxs: Set<MessageId>,

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -4,7 +4,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.query.PrepareOpts
 import xtdb.database.DatabaseName
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.indexer.DatabaseSnapshot
 import xtdb.api.TableRef
@@ -20,7 +20,7 @@ interface IQuerySource : AutoCloseable {
     interface QueryDatabase : DatabaseSnapshot.Source {
         val name: DatabaseName
         val storage: PartitionStorage
-        val queryState: DatabaseState
+        val queryState: PartitionState
     }
 
     fun prepareQuery(query: ParsedStatement, dbs: QueryCatalog, opts: PrepareOpts): PreparedQuery

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -117,13 +117,13 @@ class NodeSimulationTest : SimulationTestBase() {
             val blockCatalog = BlockCatalog(sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
             val partitionStorage = PartitionStorage(DatabaseLogs(null, null), sharedBufferPool, null)
-            val dbState = PartitionState(blockCatalog, null, trieCatalog, null)
+            val partitionState = PartitionState(blockCatalog, null, trieCatalog, null)
             val compactorScope = CoroutineScope(dispatcher)
-            val compactorForDb = compactor.openForDatabase(compactorScope, allocator, partitionStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            val compactorForDb = compactor.openForDatabase(compactorScope, allocator, partitionStorage, partitionState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
             val gcScope = CoroutineScope(dispatcher)
             val garbageCollector = TrieGarbageCollector(
                 gcScope,
-                sharedBufferPool, dbState, "xtdb",
+                sharedBufferPool, partitionState, "xtdb",
                 commitTriesDeleted = { tableName, trieKeys ->
                     // No replica log in the mock — apply the catalog mutation directly so the
                     // simulation's view of the catalog still converges as the test asserts.

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -27,7 +27,7 @@ import xtdb.SimulationTestUtils.Companion.L0TrieKeys
 import xtdb.SimulationTestUtils.Companion.L3TrieKeys
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseName
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.garbage_collector.TrieGarbageCollector
 import xtdb.log.proto.TrieDetails
@@ -117,7 +117,7 @@ class NodeSimulationTest : SimulationTestBase() {
             val blockCatalog = BlockCatalog(sharedBufferPool.latestBlock)
             val compactor = Compactor.Impl(compactorDriverFactory, null, jobCalculator, false, 2, dispatcher)
             val partitionStorage = PartitionStorage(DatabaseLogs(null, null), sharedBufferPool, null)
-            val dbState = DatabaseState(blockCatalog, null, trieCatalog, null)
+            val dbState = PartitionState(blockCatalog, null, trieCatalog, null)
             val compactorScope = CoroutineScope(dispatcher)
             val compactorForDb = compactor.openForDatabase(compactorScope, allocator, partitionStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
             val gcScope = CoroutineScope(dispatcher)

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -25,7 +25,7 @@ import xtdb.compactor.Compactor
 import xtdb.database.Database
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabasePartition
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.api.error.Incorrect
 import xtdb.indexer.BlockUploader
@@ -112,7 +112,7 @@ class ExternalSourceTest {
         val blockCatalog = BlockCatalog(null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
-        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
@@ -395,7 +395,7 @@ class ExternalSourceTest {
         // note: not .use — Database.close() would close `allocator`, which @AfterEach also closes
         val partition = DatabasePartition(
             storage = PartitionStorage(DatabaseLogs(null, null), null, null),
-            state = DatabaseState(null, null, null, null),
+            state = PartitionState(null, null, null, null),
             watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         )
         val db = Database(

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -112,17 +112,17 @@ class ExternalSourceTest {
         val blockCatalog = BlockCatalog(null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
-        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
-        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope)
 
         val crashLogger = mockk<CrashLogger>(relaxed = true)
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, crashLogger,
-            dbState, "test", blockUploader, watchers, extSource, replicaProducer,
+            partitionState, "test", blockUploader, watchers, extSource, replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1, scope = backgroundScope
         ).also(leadersToClose::add)

--- a/core/src/test/kotlin/xtdb/api/tx/OpenTxTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/OpenTxTest.kt
@@ -18,7 +18,7 @@ import xtdb.api.log.SourceMessage
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.database.DatabaseLogs
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.indexer.LiveIndex
 import xtdb.storage.MemoryStorage
@@ -49,7 +49,7 @@ class OpenTxTest {
             val trieCatalog = createTrieCatalog()
             val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog)
 
-            DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex).use { dbState ->
+            PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex).use { dbState ->
                 val storage = PartitionStorage(
                     DatabaseLogs(
                         InMemoryLog<SourceMessage>(InstantSource.system(), 0),

--- a/core/src/test/kotlin/xtdb/api/tx/OpenTxTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/OpenTxTest.kt
@@ -49,7 +49,7 @@ class OpenTxTest {
             val trieCatalog = createTrieCatalog()
             val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog)
 
-            PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex).use { dbState ->
+            PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex).use { partitionState ->
                 val storage = PartitionStorage(
                     DatabaseLogs(
                         InMemoryLog<SourceMessage>(InstantSource.system(), 0),
@@ -58,7 +58,7 @@ class OpenTxTest {
                     bp, null
                 )
 
-                OpenTx(allocator, nodeBase, storage, dbState, dbName, TransactionKey(0, Instant.EPOCH), null).use(f)
+                OpenTx(allocator, nodeBase, storage, partitionState, dbName, TransactionKey(0, Instant.EPOCH), null).use(f)
             }
         }
 

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -57,7 +57,7 @@ class MockDb(
     val compactor: Compactor,
 ) {
     val partitionStorage: PartitionStorage get() = PartitionStorage(DatabaseLogs(null, null), bufferPool, null)
-    val dbState: PartitionState get() = PartitionState(null, null, trieCatalog, null)
+    val partitionState: PartitionState get() = PartitionState(null, null, trieCatalog, null)
 }
 
 private val LOGGER = CompactorMockDriverFactory::class.logger
@@ -98,13 +98,13 @@ class CompactorMockDriverFactory(
     // system's listener failing doesn't cancel the others.
     val scope = CoroutineScope(dispatcher + SupervisorJob())
 
-    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers): Driver {
+    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, partitionState: PartitionState, watchers: Watchers): Driver {
         val systemId = nextSystemId++
-        return CompactorMockDriver(partitionStorage, dbState, systemId)
+        return CompactorMockDriver(partitionStorage, partitionState, systemId)
     }
 
-    private inner class CompactorMockDriver(val partitionStorage: PartitionStorage, val dbState: PartitionState, val systemId: Int) : Driver {
-        val trieCatalog = dbState.trieCatalog
+    private inner class CompactorMockDriver(val partitionStorage: PartitionStorage, val partitionState: PartitionState, val systemId: Int) : Driver {
+        val trieCatalog = partitionState.trieCatalog
         val bufferPool = partitionStorage.bufferPool
 
         init {
@@ -332,7 +332,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     // ForDatabase to free the driver.
     private fun MockDb.withCompactor(block: (Compactor.ForDatabase) -> Unit) {
         val scope = CoroutineScope(dispatcher)
-        val forDb = compactor.openForDatabase(scope, allocator, partitionStorage, dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+        val forDb = compactor.openForDatabase(scope, allocator, partitionStorage, partitionState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
         try {
             block(forDb)
         } finally {
@@ -344,7 +344,7 @@ class CompactorSimulationTest : SimulationTestBase() {
     private fun withCompactors(dbs: List<MockDb>, block: (List<Compactor.ForDatabase>) -> Unit) {
         val scopes = dbs.map { CoroutineScope(dispatcher) }
         val forDbs = dbs.zip(scopes).map { (db, scope) ->
-            db.compactor.openForDatabase(scope, allocator, db.partitionStorage, db.dbState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
+            db.compactor.openForDatabase(scope, allocator, db.partitionStorage, db.partitionState, Watchers(latestTxId = -1, latestSourceMsgId = -1))
         }
         try {
             block(forDbs)

--- a/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/compactor/CompactorSimulationTest.kt
@@ -30,7 +30,7 @@ import xtdb.compactor.RecencyPartition.WEEK
 import xtdb.compactor.TemporalSplitting.*
 import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseName
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.BufferPool
@@ -57,7 +57,7 @@ class MockDb(
     val compactor: Compactor,
 ) {
     val partitionStorage: PartitionStorage get() = PartitionStorage(DatabaseLogs(null, null), bufferPool, null)
-    val dbState: DatabaseState get() = DatabaseState(null, null, trieCatalog, null)
+    val dbState: PartitionState get() = PartitionState(null, null, trieCatalog, null)
 }
 
 private val LOGGER = CompactorMockDriverFactory::class.logger
@@ -98,12 +98,12 @@ class CompactorMockDriverFactory(
     // system's listener failing doesn't cancel the others.
     val scope = CoroutineScope(dispatcher + SupervisorJob())
 
-    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: DatabaseState, watchers: Watchers): Driver {
+    override fun create(allocator: BufferAllocator, partitionStorage: PartitionStorage, dbState: PartitionState, watchers: Watchers): Driver {
         val systemId = nextSystemId++
         return CompactorMockDriver(partitionStorage, dbState, systemId)
     }
 
-    private inner class CompactorMockDriver(val partitionStorage: PartitionStorage, val dbState: DatabaseState, val systemId: Int) : Driver {
+    private inner class CompactorMockDriver(val partitionStorage: PartitionStorage, val dbState: PartitionState, val systemId: Int) : Driver {
         val trieCatalog = dbState.trieCatalog
         val bufferPool = partitionStorage.bufferPool
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -24,7 +24,7 @@ import xtdb.block.proto.block
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.api.error.Fault
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
@@ -41,7 +41,7 @@ class FollowerLogProcessorTest {
     private lateinit var blockCatalog: BlockCatalog
     private lateinit var tableCatalog: TableCatalog
     private lateinit var trieCatalog: TrieCatalog
-    private lateinit var dbState: DatabaseState
+    private lateinit var dbState: PartitionState
     private lateinit var replicaLog: Log<ReplicaMessage>
 
     // runTest cancels and joins backgroundScope before tearDown, so the followers are quiescent here
@@ -57,7 +57,7 @@ class FollowerLogProcessorTest {
         blockCatalog = BlockCatalog(null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
-        dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // The processor self-launches its replica tail; park it so it idles while the test drives
@@ -126,7 +126,7 @@ class FollowerLogProcessorTest {
         // block catalog starts at block 5 (simulating startup from latest block).
         val startBlock = block { blockIndex = 5 }
         blockCatalog = BlockCatalog(startBlock)
-        dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
         val proc = makeProcessor()
 

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -41,7 +41,7 @@ class FollowerLogProcessorTest {
     private lateinit var blockCatalog: BlockCatalog
     private lateinit var tableCatalog: TableCatalog
     private lateinit var trieCatalog: TrieCatalog
-    private lateinit var dbState: PartitionState
+    private lateinit var partitionState: PartitionState
     private lateinit var replicaLog: Log<ReplicaMessage>
 
     // runTest cancels and joins backgroundScope before tearDown, so the followers are quiescent here
@@ -57,7 +57,7 @@ class FollowerLogProcessorTest {
         blockCatalog = BlockCatalog(null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
-        dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // The processor self-launches its replica tail; park it so it idles while the test drives
@@ -80,7 +80,7 @@ class FollowerLogProcessorTest {
         meterRegistry: MeterRegistry? = null,
     ) =
         FollowerLogProcessor(
-            allocator, PartitionLog(replicaLog, 0), bufferPool, dbState, "test", compactor,
+            allocator, PartitionLog(replicaLog, 0), bufferPool, partitionState, "test", compactor,
             watchers, null, null, afterReplicaMsgId = -1L, backgroundScope,
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,
@@ -126,7 +126,7 @@ class FollowerLogProcessorTest {
         // block catalog starts at block 5 (simulating startup from latest block).
         val startBlock = block { blockIndex = 5 }
         blockCatalog = BlockCatalog(startBlock)
-        dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
         val proc = makeProcessor()
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -82,14 +82,14 @@ class LeaderLogProcessorTest {
         wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
-        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
-        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, uploadDispatcher)
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, "test", blockUploader, watchers,
+            partitionState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = skipTxs, dbCatalog = null,
             afterReplicaMsgId = -1,
@@ -140,15 +140,15 @@ class LeaderLogProcessorTest {
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
         val blockCatalog = BlockCatalog(null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
-        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, "test", blockUploader, watchers,
+            partitionState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1,
@@ -211,15 +211,15 @@ class LeaderLogProcessorTest {
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
         val blockCatalog = BlockCatalog(null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
-        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, "test", blockUploader, watchers,
+            partitionState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1,
@@ -540,14 +540,14 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
-        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
-        val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            dbState, "test", blockUploader, watchers,
+            partitionState, "test", blockUploader, watchers,
             extSource = null, replicaProducer = replicaProducer,
             skipTxs = setOf(10), dbCatalog = null,
             afterReplicaMsgId = -1,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -31,7 +31,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.trieMetadata
@@ -82,7 +82,7 @@ class LeaderLogProcessorTest {
         wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
-        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, uploadDispatcher)
@@ -140,7 +140,7 @@ class LeaderLogProcessorTest {
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
         val blockCatalog = BlockCatalog(null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
@@ -211,7 +211,7 @@ class LeaderLogProcessorTest {
         val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
         val blockCatalog = BlockCatalog(null)
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
@@ -540,7 +540,7 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
-        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, dbState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -24,7 +24,7 @@ import xtdb.api.log.SourceMessage
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.database.DatabaseLogs
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.MemoryStorage
@@ -65,7 +65,7 @@ class LiveIndexTest {
         private val tableCatalog = TableCatalog(bp)
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog)
-        private val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        private val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         private val partitionStorage = PartitionStorage(
             DatabaseLogs(
                 InMemoryLog<SourceMessage>(InstantSource.system(), 0),

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -65,7 +65,7 @@ class LiveIndexTest {
         private val tableCatalog = TableCatalog(bp)
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog)
-        private val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        private val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         private val partitionStorage = PartitionStorage(
             DatabaseLogs(
                 InMemoryLog<SourceMessage>(InstantSource.system(), 0),
@@ -75,7 +75,7 @@ class LiveIndexTest {
         )
 
         fun openTx(txId: Long, systemTime: Instant) =
-            OpenTx(allocator, nodeBase, partitionStorage, dbState, dbName, TransactionKey(txId, systemTime), null)
+            OpenTx(allocator, nodeBase, partitionStorage, partitionState, dbName, TransactionKey(txId, systemTime), null)
 
         fun commitTx(openTx: OpenTx) {
             openTx.writeTxRow(null, null)
@@ -83,7 +83,7 @@ class LiveIndexTest {
         }
 
         override fun close() {
-            dbState.close()
+            partitionState.close()
             bp.close()
         }
     }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -25,7 +25,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.api.tx.ExternalSource
 import xtdb.api.tx.ExternalSourceToken
@@ -162,7 +162,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, indexerConfig)
 
-        val dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
 
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
             .also { simExtSource.watch(it) }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -162,7 +162,7 @@ class LogProcessorSimTest : SimulationTestBase() {
         val trieCatalog = createTrieCatalog()
         val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, indexerConfig)
 
-        val dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
 
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
             .also { simExtSource.watch(it) }
@@ -174,8 +174,8 @@ class LogProcessorSimTest : SimulationTestBase() {
         fun openLogProcessor(scope: CoroutineScope) =
             LogProcessor(
                 allocator, nodeBase, crashLogger,
-                partitionStorage, dbState, dbName, watchers,
-                BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, scope, uploadDispatcher = dispatcher),
+                partitionStorage, partitionState, dbName, watchers,
+                BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, scope, uploadDispatcher = dispatcher),
                 mockk<Compactor.ForDatabase>(relaxed = true), dbCatalog = null,
                 externalSourceFactory = object : ExternalSource.Factory {
                     override fun open(
@@ -190,7 +190,7 @@ class LogProcessorSimTest : SimulationTestBase() {
 
         override fun close() {
             logProcessor?.close()
-            dbState.close()
+            partitionState.close()
         }
     }
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -17,7 +17,7 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
@@ -46,7 +46,7 @@ class LogProcessorTest {
         mockk<BufferPool>(relaxed = true) { every { this@mockk.epoch } returns epoch }
 
     private fun dbState(name: String = "test-db", liveIndex: LiveIndex = mockk(relaxed = true)) =
-        DatabaseState(
+        PartitionState(
             BlockCatalog(null),
             mockk<TableCatalog>(relaxed = true),
             mockk<TrieCatalog>(relaxed = true),
@@ -55,7 +55,7 @@ class LogProcessorTest {
 
     private fun logProcessor(
         partitionStorage: PartitionStorage,
-        dbState: DatabaseState,
+        dbState: PartitionState,
         watchers: Watchers,
         blockUploader: BlockUploader,
         scope: CoroutineScope,

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -45,7 +45,7 @@ class LogProcessorTest {
     private fun mockBufferPool(epoch: Int = 0) =
         mockk<BufferPool>(relaxed = true) { every { this@mockk.epoch } returns epoch }
 
-    private fun dbState(name: String = "test-db", liveIndex: LiveIndex = mockk(relaxed = true)) =
+    private fun newPartitionState(name: String = "test-db", liveIndex: LiveIndex = mockk(relaxed = true)) =
         PartitionState(
             BlockCatalog(null),
             mockk<TableCatalog>(relaxed = true),
@@ -55,13 +55,13 @@ class LogProcessorTest {
 
     private fun logProcessor(
         partitionStorage: PartitionStorage,
-        dbState: PartitionState,
+        partitionState: PartitionState,
         watchers: Watchers,
         blockUploader: BlockUploader,
         scope: CoroutineScope,
     ) = LogProcessor(
         allocator, nodeBase, mockk(relaxed = true),
-        partitionStorage, dbState, "test-db", watchers, blockUploader,
+        partitionStorage, partitionState, "test-db", watchers, blockUploader,
         mockk<Compactor.ForDatabase>(relaxed = true), dbCatalog = null,
         externalSourceFactory = null,
         scope = scope,
@@ -72,13 +72,13 @@ class LogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
-        val dbState = dbState()
+        val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 
@@ -94,13 +94,13 @@ class LogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 1)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
-        val dbState = dbState()
+        val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 
@@ -119,9 +119,9 @@ class LogProcessorTest {
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
             every { latestCompletedTx } returns null
         }
-        val dbState = dbState(liveIndex = liveIndex)
+        val partitionState = newPartitionState(liveIndex = liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log with a transaction
@@ -130,7 +130,7 @@ class LogProcessorTest {
         replicaProducer.close()
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 
@@ -154,16 +154,16 @@ class LogProcessorTest {
         val liveIndex = mockk<LiveIndex>(relaxed = true) {
             every { latestCompletedTx } returns null
         }
-        val dbState = dbState(liveIndex = liveIndex)
+        val partitionState = newPartitionState(liveIndex = liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, dbState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log
         replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
 
         val scope = CoroutineScope(SupervisorJob())
-        val logProc = logProcessor(partitionStorage, dbState, watchers, blockUploader, scope)
+        val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
 
         scope.launch { sourceLog.openGroupSubscription(logProc) }
 

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -12,7 +12,7 @@ import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.Watchers
 import xtdb.catalog.BlockCatalog
 import xtdb.catalog.TableCatalog
-import xtdb.database.DatabaseState
+import xtdb.database.PartitionState
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
 import java.time.Instant
@@ -28,7 +28,7 @@ class TransitionLogProcessorTest {
     private lateinit var blockCatalog: BlockCatalog
     private lateinit var tableCatalog: TableCatalog
     private lateinit var trieCatalog: TrieCatalog
-    private lateinit var dbState: DatabaseState
+    private lateinit var dbState: PartitionState
 
     @BeforeEach
     fun setUp() {
@@ -40,7 +40,7 @@ class TransitionLogProcessorTest {
         blockCatalog = BlockCatalog(null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
-        dbState = DatabaseState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         every { bufferPool.epoch } returns 1

--- a/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TransitionLogProcessorTest.kt
@@ -28,7 +28,7 @@ class TransitionLogProcessorTest {
     private lateinit var blockCatalog: BlockCatalog
     private lateinit var tableCatalog: TableCatalog
     private lateinit var trieCatalog: TrieCatalog
-    private lateinit var dbState: PartitionState
+    private lateinit var partitionState: PartitionState
 
     @BeforeEach
     fun setUp() {
@@ -40,7 +40,7 @@ class TransitionLogProcessorTest {
         blockCatalog = BlockCatalog(null)
         tableCatalog = mockk(relaxed = true)
         trieCatalog = mockk(relaxed = true)
-        dbState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         every { bufferPool.epoch } returns 1
@@ -53,7 +53,7 @@ class TransitionLogProcessorTest {
 
     private fun makeProcessor(hasExternalSource: Boolean = false) =
         TransitionLogProcessor(
-            allocator, bufferPool, dbState, "test", liveIndex,
+            allocator, bufferPool, partitionState, "test", liveIndex,
             blockUploader, replicaProducer,
             watchers, null, afterReplicaMsgId = -1L,
             hasExternalSource = hasExternalSource,


### PR DESCRIPTION
Part of #5557.

Two behaviour-preserving commits renaming `DatabaseState` to `PartitionState` and bringing its identifiers into line. Nothing changes at runtime — the only hunk that isn't a token swap is dropping the `data` modifier, covered below.

## Why

The type has been per-partition since the `DatabasePartition` split: it's built from a `PartitionStorage`, one instance hangs off each `DatabasePartition`, and `Database.currentBasis()` already walks the partition map reading one `liveIndex` per partition. The `Database` prefix therefore asserts the wrong scope — harmless while every database has exactly one partition, actively misleading once the multi-partition gate lifts, at which point one database owns N of these and the name identifies none of them.

The name came from the storage/state/services split in b4fb0b6bf, where it was named for the thing that owned it. A partition owns it now, so `PartitionState` is the faithful update of the same scheme, and it pairs with its sibling `PartitionStorage` — following the precedent #5822 set for `DatabaseStorage → PartitionStorage`.

## Changes

1. `tidy(database): rename DatabaseState to PartitionState` — type-only token swap, plus the `data` drop. Identifiers are deliberately left alone so this commit stays a pure type rename.
2. `tidy(database): de-prefix dbState to partitionState` — the identifiers, at both owner and consumer sites.

## Implementation notes

**Dropping `data`.** It was fair enough when the class landed in b4fb0b6bf — a bundle of borrowed references that owned nothing — but d4b441da4 made it `AutoCloseable`, with a `close()` that frees the live index and an `open()` that constructs one. From that point `copy()` was a trap: it hands out a second `PartitionState` sharing one `LiveIndex`, leaving two owners each entitled to `close()` it, and structural equality compares things whose identity has become load-bearing. Nothing used `copy`, destructuring, equality, or the type as a map key, and the Clojure side only reaches it through plain getters, so removal is invisible.

**Naming rule.** Qualified at consumer sites, bare at owner sites — matching how `PartitionStorage` was handled. This isn't purely stylistic: `LogProcessor` holds both a `PartitionState` and its own sealed `State` role, so a bare `state` there would have been a hard redeclaration.

**Substring hazard.** `SqlParser.kt`'s `visitAttachDatabaseStatement` / `visitDetachDatabaseStatement` and their `...StatementContext` types contain `DatabaseState` as a substring. A rename that isn't word-boundary aware rewrites them into nonsense. That file holds no reference to the type and is untouched here.

**No clash with the log partition state.** `InMemoryLog` and `LocalLog` each have a `private inner class PartitionState` for a log partition's bookkeeping. Both are private to their file and neither imports this one, so they keep their names for now; a follow-up may prefix them `LogPartitionState` to keep the term unambiguous in conversation.

## Out of scope

De-nulling `PartitionState`'s four nullable components. `Compactor` reads `liveIndexOrNull`, and `ExternalSourceTest` builds a hollow partition with all-null state, so the nullability is a live simulation affordance rather than dead code. `PartitionStorage` carries the identical pattern, and the two should be addressed together.

Also left alone: renaming the log impls' `private inner class PartitionState`; `LogProcessor.state` → `role` (which would need its Allium spec updated alongside); and the `queryState` accessor on `IQuerySource.QueryDatabase`, which reaches four Clojure call sites.

## Test plan

Behaviour-preserving, so existing coverage is the check rather than new tests.

`:xtdb-core:compileTestKotlin` is green with no warnings, and `git grep DatabaseState` across the repo returns only the two `SqlParser.kt` substring matches noted above. A `/code-review medium` pass over the diff returned no findings.

I have not run the full suite locally — CI is the gate for that.
