### PR TITLE
tidy(indexer): a LeaderDriver seam for the leader's external effects

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
@@ -1,5 +1,9 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.SelectClause1
 import xtdb.api.TableRef
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log
@@ -11,6 +15,29 @@ import xtdb.arrow.RelationReader
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.types.MessageId
+
+/** One poll batch inbound from the transport, plus the handle its submitter awaits. */
+internal class SourceBatch(val records: List<Log.Record<SourceMessage>>) {
+    val onComplete = CompletableDeferred<Unit>()
+}
+
+/**
+ * The inbound source-log pipe — the one edge that runs the other way, so the persister *pulls*
+ * batches through a select clause rather than being pushed at.
+ *
+ * One owned object rather than three members on [LeaderDriver]: submitting, selecting and shutting
+ * down are the three ends of a single pipe, and keeping them together is what stops them drifting.
+ */
+internal interface SourceBatches {
+    /** Armed by the persister's select, alongside its own channels. */
+    val onBatch: SelectClause1<SourceBatch>
+
+    /** Hand a batch to the persister; the returned handle completes once it has been processed. */
+    suspend fun submit(records: List<Log.Record<SourceMessage>>): Deferred<Unit>
+
+    /** Term teardown: no batch will be processed after this, and a later [submit] throws [cause]. */
+    fun shutdown(cause: Throwable?)
+}
 
 /**
  * The leader term's observable external effects, behind one seam.
@@ -26,6 +53,8 @@ import xtdb.types.MessageId
  * those reads stay consistent with what the driver has applied.
  */
 internal interface LeaderDriver : AutoCloseable {
+
+    val sourceBatches: SourceBatches
 
     /**
      * Append [msgs] to the replica log as one atomic unit, in order, and await their positions.
@@ -63,6 +92,22 @@ internal class RealLeaderDriver(
 
     private val sourceLog = partitionStorage.sourceLog
     private val liveIndex = partitionState.liveIndex
+
+    // capacity 1: the poll thread can deposit one batch ahead and read the next while the persister
+    // works, bounding lookahead to ~2 batches. Backpressure falls out of a full channel suspending
+    // the send.
+    override val sourceBatches = object : SourceBatches {
+        private val ch = Channel<SourceBatch>(capacity = 1, onUndeliveredElement = { it.onComplete.cancel() })
+
+        override val onBatch get() = ch.onReceive
+
+        override suspend fun submit(records: List<Log.Record<SourceMessage>>): Deferred<Unit> =
+            SourceBatch(records).also { ch.send(it) }.onComplete
+
+        override fun shutdown(cause: Throwable?) {
+            ch.close(cause)
+        }
+    }
 
     override suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> =
         replicaProducer.withTx { tx -> msgs.map { tx.appendMessage(it) }.toList() }.map { it.await() }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
@@ -1,0 +1,80 @@
+package xtdb.indexer
+
+import xtdb.api.TableRef
+import xtdb.api.TransactionKey
+import xtdb.api.log.Log
+import xtdb.api.log.Log.AtomicProducer.Companion.withTx
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.ReplicaMessage.BlockBoundary
+import xtdb.api.log.SourceMessage
+import xtdb.arrow.RelationReader
+import xtdb.database.PartitionState
+import xtdb.database.PartitionStorage
+import xtdb.types.MessageId
+
+/**
+ * The leader term's observable external effects, behind one seam.
+ *
+ * The [LeaderLogProcessor] keeps the concurrency that drives these — the persister select loop, the
+ * background append, the staging resolver — and reaches the outside world only through here. That
+ * makes the leader simulable: a mock driver can model transactional-producer fencing, stall an
+ * upload, or fail an append, none of which the real logs express in memory.
+ *
+ * Deliberately narrow. In-memory state mutations that happen to sit on the leader's path —
+ * `trieCatalog`, `dbCatalog`, `watchers`, the GC signals — stay on the processor, as do all *reads*
+ * (`liveIndex.isFull()`, `blockCatalog.currentBlockIndex`). A mock holds real state objects, so
+ * those reads stay consistent with what the driver has applied.
+ */
+internal interface LeaderDriver : AutoCloseable {
+
+    /**
+     * Append [msgs] to the replica log as one atomic unit, in order, and await their positions.
+     *
+     * [msgs] is consumed *inside* the append's atomic unit, so a caller may serialize each message
+     * lazily rather than materialising a whole batch's worth of Arrow bytes up front — a sealed
+     * batch can run to a full block (`rowsPerBlock`, 100k rows by default).
+     */
+    suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata>
+
+    /** Commit a resolved tx's writes into the durable live index. */
+    suspend fun applyTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>)
+
+    /**
+     * Snapshot the live index into block files, append the [BlockBoundary]'s matching `BlockUploaded`,
+     * and roll the index. Returns the `BlockUploaded`'s replica-log position.
+     */
+    suspend fun uploadBlock(boundaryMsgId: MessageId, boundary: BlockBoundary): MessageId
+
+    /** Ask the source log to cut a block, on the flush-timeout path. Returns the message's position. */
+    suspend fun requestFlushBlock(expectedBlockIdx: Long): MessageId
+}
+
+/**
+ * Owns the leader term's replica producer — the only place besides `LogProcessor.openLeader` that
+ * names one. The producer is term-scoped and opened by the transition (which needs it for its own
+ * replay-target probe), so it arrives already open and is closed here when the term ends.
+ */
+internal class RealLeaderDriver(
+    private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
+    partitionStorage: PartitionStorage,
+    partitionState: PartitionState,
+    private val blockUploader: BlockUploader,
+) : LeaderDriver {
+
+    private val sourceLog = partitionStorage.sourceLog
+    private val liveIndex = partitionState.liveIndex
+
+    override suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> =
+        replicaProducer.withTx { tx -> msgs.map { tx.appendMessage(it) }.toList() }.map { it.await() }
+
+    override suspend fun applyTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>) =
+        liveIndex.commitTx(txKey, tables)
+
+    override suspend fun uploadBlock(boundaryMsgId: MessageId, boundary: BlockBoundary): MessageId =
+        blockUploader.uploadBlock(replicaProducer, boundaryMsgId, boundary)
+
+    override suspend fun requestFlushBlock(expectedBlockIdx: Long): MessageId =
+        sourceLog.appendMessage(SourceMessage.FlushBlock(expectedBlockIdx)).msgId
+
+    override fun close() = replicaProducer.close()
+}

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -10,7 +10,6 @@ import xtdb.NodeBase
 import xtdb.api.DatabaseName
 import xtdb.api.TransactionResult
 import xtdb.api.log.*
-import xtdb.api.log.Log.AtomicProducer.Companion.withTx
 import xtdb.api.log.ReplicaMessage.BlockBoundary
 import xtdb.api.log.ReplicaMessage.TriesAdded
 import xtdb.api.storage.Storage
@@ -41,10 +40,9 @@ internal class LeaderLogProcessor(
     crashLogger: CrashLogger,
     private val partitionState: PartitionState,
     private val dbName: DatabaseName,
-    private val blockUploader: BlockUploader,
+    private val driver: LeaderDriver,
     private val watchers: Watchers,
     private val extSource: ExternalSource?,
-    private val replicaProducer: Log.AtomicProducer<ReplicaMessage>,
     skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
     afterReplicaMsgId: MessageId,
@@ -62,7 +60,6 @@ internal class LeaderLogProcessor(
     }
 
     private val partition = partitionStorage.partition
-    private val sourceLog = partitionStorage.sourceLog
     private val bufferPool = partitionStorage.bufferPool
     private val liveIndex = partitionState.liveIndex
 
@@ -106,13 +103,13 @@ internal class LeaderLogProcessor(
         val txs = txResolver.seal() ?: return
 
         inFlight = appendScope.async {
-            txs.zip(appendToReplica(txs.asSequence().map { it.toReplicaMessage() }))
+            txs.zip(driver.appendToReplica(txs.asSequence().map { it.toReplicaMessage() }))
         }
     }
 
     private suspend fun settle(appended: List<Pair<ResolvedTx, Log.MessageMetadata>>) {
         for ((resolvedTx, metadata) in appended) {
-            liveIndex.commitTx(resolvedTx.txKey, resolvedTx.allTables.associate { it.ref to it.relation })
+            driver.applyTx(resolvedTx.txKey, resolvedTx.allTables.associate { it.ref to it.relation })
             latestReplicaMsgId = metadata.msgId
             watchers.notifyTx(resolvedTx.txResult, resolvedTx.srcMsgId, resolvedTx.externalSourceToken)
         }
@@ -541,24 +538,12 @@ internal class LeaderLogProcessor(
     }
 
     private suspend fun maybeFlushBlock() {
-        if (blockFlusher.checkBlockTimeout(blockCatalog, liveIndex)) {
-            val flushMessage = SourceMessage.FlushBlock(blockCatalog.currentBlockIndex ?: -1)
-            blockFlusher.flushedTxId = sourceLog.appendMessage(flushMessage).msgId
-        }
+        if (blockFlusher.checkBlockTimeout(blockCatalog, liveIndex))
+            blockFlusher.flushedTxId = driver.requestFlushBlock(blockCatalog.currentBlockIndex ?: -1)
     }
 
-    /**
-     * Append [msgs] to the replica log as one atomic unit, in order, and await their positions.
-     *
-     * [msgs] is consumed *inside* the producer transaction, so a caller may serialize each message
-     * lazily rather than materialising a whole batch's worth of Arrow bytes up front — a sealed batch
-     * can run to a full block (`rowsPerBlock`, 100k rows by default).
-     */
-    private suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> =
-        replicaProducer.withTx { tx -> msgs.map { tx.appendMessage(it) }.toList() }.map { it.await() }
-
     private suspend fun appendToReplica(message: ReplicaMessage): Log.MessageMetadata =
-        appendToReplica(sequenceOf(message)).single()
+        driver.appendToReplica(sequenceOf(message)).single()
             .also { latestReplicaMsgId = it.msgId }
 
     private suspend fun finishBlock(latestProcessedMsgId: MessageId, externalSourceToken: ExternalSourceToken?) {
@@ -570,7 +555,7 @@ internal class LeaderLogProcessor(
 
         pendingBlock = PendingBlock(boundaryMsgId, boundaryMsg)
 
-        latestReplicaMsgId = blockUploader.uploadBlock(replicaProducer, boundaryMsgId, boundaryMsg)
+        latestReplicaMsgId = driver.uploadBlock(boundaryMsgId, boundaryMsg)
         pendingBlock = null
 
         // Safe to call from inside a Persister task: signal() just enqueues a cycle on the GC's
@@ -597,7 +582,7 @@ internal class LeaderLogProcessor(
 
     override fun close() {
         extSource?.close()
-        replicaProducer.close()
+        driver.close()
         // Frees every resolved-but-not-applied tx, including a batch whose settle never completed
         // (fault / teardown) — safe now that cancelAndJoin has joined the persister and the append.
         txResolver.close()

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -106,11 +106,7 @@ internal class LeaderLogProcessor(
         val txs = txResolver.seal() ?: return
 
         inFlight = appendScope.async {
-            replicaProducer
-                .withTx { tx ->
-                    txs.map { it to tx.appendMessage(it.toReplicaMessage()) }
-                }
-                .map { it.first to it.second.await() }
+            txs.zip(appendToReplica(txs.asSequence().map { it.toReplicaMessage() }))
         }
     }
 
@@ -551,8 +547,18 @@ internal class LeaderLogProcessor(
         }
     }
 
+    /**
+     * Append [msgs] to the replica log as one atomic unit, in order, and await their positions.
+     *
+     * [msgs] is consumed *inside* the producer transaction, so a caller may serialize each message
+     * lazily rather than materialising a whole batch's worth of Arrow bytes up front — a sealed batch
+     * can run to a full block (`rowsPerBlock`, 100k rows by default).
+     */
+    private suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> =
+        replicaProducer.withTx { tx -> msgs.map { tx.appendMessage(it) }.toList() }.map { it.await() }
+
     private suspend fun appendToReplica(message: ReplicaMessage): Log.MessageMetadata =
-        replicaProducer.withTx { tx -> tx.appendMessage(message) }.await()
+        appendToReplica(sequenceOf(message)).single()
             .also { latestReplicaMsgId = it.msgId }
 
     private suspend fun finishBlock(latestProcessedMsgId: MessageId, externalSourceToken: ExternalSourceToken?) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -157,22 +157,15 @@ internal class LeaderLogProcessor(
     }
 
 
-    // What the persister wakes up for: a task from one of the channels, or the in-flight append
-    // completing (Settle). Settle is select-driven — with ext-source handlers no longer draining,
-    // this arm is what promotes their batches even when no task is queued.
+    // What the persister wakes up for: a source batch pulled from the driver, a task from one of the
+    // channels, or the in-flight append completing (Settle). Settle is select-driven — with ext-source
+    // handlers no longer draining, this arm is what promotes their batches even when no task is queued.
     private sealed interface PersisterWork
     private data object Settle : PersisterWork
+    private class SourceWork(val batch: SourceBatch) : PersisterWork
 
     private sealed interface PersisterTask : PersisterWork {
         val onComplete: CompletableDeferred<Unit>
-    }
-
-    private sealed interface SourceLogTask : PersisterTask {
-        // One task per poll batch; the persister resolves + imports the records in order.
-        // onComplete is required by PersisterTask but unused here — processRecords fires and returns.
-        data class Batch(val records: List<Log.Record<SourceMessage>>) : SourceLogTask {
-            override val onComplete = CompletableDeferred<Unit>()
-        }
     }
 
     private sealed interface ExtSourceTask : PersisterTask {
@@ -186,11 +179,6 @@ internal class LeaderLogProcessor(
             override val onComplete = CompletableDeferred<Unit>()
         }
     }
-
-    // capacity 1: the poll thread can deposit one batch ahead and read the next while the persister
-    // works, bounding lookahead to ~2 batches. Backpressure falls out of a full channel suspending the send.
-    private val sourceLogCh =
-        Channel<SourceLogTask>(capacity = 1, onUndeliveredElement = { it.onComplete.cancel() })
 
     // capacity 1 so a fire-and-forget `submitTx` caller can queue one tx ahead while the persister works the
     // current one (bounding lookahead to ~2). `executeTx` still blocks on the result regardless of capacity.
@@ -333,12 +321,35 @@ internal class LeaderLogProcessor(
         trieCatalog.deleteTries(task.tableName, task.trieKeys)
     }
 
+    // Run one unit of persister work, routing any failure onto its completion handle so no caller is
+    // left awaiting a term that has gone. Interrupts and cancellation are shutdown signals rather than
+    // ingestion faults, so only a genuine fault reaches the watchers. Every failure still propagates:
+    // the persister exits, and its `finally` sweeps whatever is left.
+    private suspend inline fun guarded(onComplete: CompletableDeferred<Unit>, block: () -> Unit) {
+        try {
+            block()
+            onComplete.complete(Unit)
+        } catch (e: CancellationException) {
+            onComplete.cancel(e)
+            throw e
+        } catch (e: InterruptedException) {
+            onComplete.completeExceptionally(e)
+            throw e
+        } catch (e: Interrupted) {
+            onComplete.completeExceptionally(e)
+            throw e
+        } catch (e: Throwable) {
+            watchers.notifyError(e)
+            onComplete.completeExceptionally(e)
+            throw e
+        }
+    }
+
     // Hand the task to the persister and return its completion handle. The caller decides whether to
-    // await it: `executeTx`, GC and `processRecords` await (they need the work done before returning);
-    // `submitTx` doesn't (fire-and-forget). Suspends only on the channel send (backpressure).
+    // await it: `executeTx` and GC await (they need the work done before returning); `submitTx`
+    // doesn't (fire-and-forget). Suspends only on the channel send (backpressure).
     private suspend fun enqueue(task: PersisterTask): Deferred<Unit> {
         when (task) {
-            is SourceLogTask -> sourceLogCh.send(task)
             is ExtSourceTask -> extSourceCh.send(task)
             is GcTask -> gcCh.send(task)
         }
@@ -428,13 +439,13 @@ internal class LeaderLogProcessor(
                             // onJoin, not onAwait: join fires on failure too, and settleAppend's own await
                             // rethrows the fault inside the try below, routing it through notifyError.
                             inFlight?.let { append -> append.onJoin { Settle } }
-                            sourceLogCh.onReceive { it }
+                            driver.sourceBatches.onBatch { SourceWork(it) }
                             extSourceCh.onReceive { it }
                             gcCh.onReceive { it }
                         }
 
                         when (work) {
-                            // Mirrors the task catches below: interrupts are shutdown signals, not
+                            // Mirrors the guarded handlers: interrupts are shutdown signals, not
                             // ingestion faults — they mustn't poison the watchers on their way out.
                             Settle ->
                                 try {
@@ -450,30 +461,16 @@ internal class LeaderLogProcessor(
                                     throw e
                                 }
 
-                            is PersisterTask -> {
-                                val task = work
-                                try {
-                                    when (task) {
-                                        is SourceLogTask.Batch -> handleSourceLogBatch(task.records)
+                            is SourceWork ->
+                                guarded(work.batch.onComplete) { handleSourceLogBatch(work.batch.records) }
+
+                            is PersisterTask ->
+                                guarded(work.onComplete) {
+                                    when (val task = work) {
                                         is ExtSourceTask.IndexTx -> handleIndexTx(task)
                                         is GcTask.TriesDeleted -> handleTriesDeleted(task)
                                     }
-                                    task.onComplete.complete(Unit)
-                                } catch (e: CancellationException) {
-                                    task.onComplete.cancel(e)
-                                    throw e
-                                } catch (e: InterruptedException) {
-                                    task.onComplete.completeExceptionally(e)
-                                    throw e
-                                } catch (e: Interrupted) {
-                                    task.onComplete.completeExceptionally(e)
-                                    throw e
-                                } catch (e: Throwable) {
-                                    watchers.notifyError(e)
-                                    task.onComplete.completeExceptionally(e)
-                                    throw e
                                 }
-                            }
                         }
                     }
                 } catch (_: CancellationException) {
@@ -496,7 +493,7 @@ internal class LeaderLogProcessor(
                         if (task is ExtSourceTask.IndexTx) task.msg.pending.completeExceptionally(pendingCause)
                     }
 
-                    sourceLogCh.close(cause)
+                    driver.sourceBatches.shutdown(cause)
                     extSourceCh.close(cause)
                     gcCh.close(cause)
                 }
@@ -575,7 +572,7 @@ internal class LeaderLogProcessor(
         // run a leader/follower transition under `runBlocking` — the persister is quiescent, so a
         // concurrent DETACH/shutdown that must cancel-join the term doesn't wedge against in-flight
         // import work on a starved dispatcher (#5741).
-        if (records.isNotEmpty()) enqueue(SourceLogTask.Batch(records)).await()
+        if (records.isNotEmpty()) driver.sourceBatches.submit(records).await()
     }
 
     suspend fun cancelAndJoin() = termJob.cancelAndJoin()

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -89,12 +89,14 @@ class LogProcessor(
         replicaProducer: Log.AtomicProducer<ReplicaMessage>,
         afterReplicaMsgId: MessageId,
     ): LeaderLogProcessor =
-        // The leader term owns (and frees) its replica producer and ext source.
+        // The leader term owns (and frees) its driver — and through it the replica producer — and its
+        // ext source.
         LeaderLogProcessor(
-            allocator, base, partitionStorage, crashLogger, partitionState, dbName, blockUploader,
+            allocator, base, partitionStorage, crashLogger, partitionState, dbName,
+            RealLeaderDriver(replicaProducer, partitionStorage, partitionState, blockUploader),
             watchers,
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
-            replicaProducer, skipTxs, dbCatalog,
+            skipTxs, dbCatalog,
             afterReplicaMsgId,
             flushTimeout = flushTimeout,
             scope = scope,

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -30,8 +30,10 @@ import xtdb.database.PartitionStorage
 import xtdb.api.error.Incorrect
 import xtdb.indexer.BlockUploader
 import xtdb.indexer.CrashLogger
+import xtdb.indexer.LeaderDriver
 import xtdb.indexer.LeaderLogProcessor
 import xtdb.indexer.LiveIndex
+import xtdb.indexer.RealLeaderDriver
 import xtdb.storage.MemoryStorage
 import xtdb.tx.TxOpts
 import xtdb.util.closeAll
@@ -107,22 +109,26 @@ class ExternalSourceTest {
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         extSource: ExternalSource = InMemoryExternalSource(),
         afterToken: ExternalSourceToken? = null,
-        wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
+        wrapDriver: (LeaderDriver) -> LeaderDriver = { it },
     ): LeaderLogProcessor {
         val blockCatalog = BlockCatalog(null)
         val trieCatalog = mockk<xtdb.trie.TrieCatalog>(relaxed = true)
         val tableCatalog = mockk<xtdb.catalog.TableCatalog>(relaxed = true)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope)
+        val driver = wrapDriver(
+            RealLeaderDriver(
+                replicaLog.openAtomicProducer("test-leader", 0), partitionStorage, partitionState, blockUploader
+            )
+        )
 
         val crashLogger = mockk<CrashLogger>(relaxed = true)
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, crashLogger,
-            partitionState, "test", blockUploader, watchers, extSource, replicaProducer,
+            partitionState, "test", driver, watchers, extSource,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1, scope = backgroundScope
         ).also(leadersToClose::add)
@@ -346,16 +352,10 @@ class ExternalSourceTest {
 
     @Test
     fun `a replica-log commit fault in the background append surfaces through executeTx`() = runTest {
-        val failingProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
-            object : Log.AtomicProducer<ReplicaMessage> {
-                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
-                    val tx = inner.openTx()
-                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
-                        override fun commit() = throw RuntimeException("replica-log commit fault")
-                    }
-                }
-
-                override fun close() = inner.close()
+        val failingDriver = { inner: LeaderDriver ->
+            object : LeaderDriver by inner {
+                override suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>) =
+                    throw RuntimeException("replica-log commit fault")
             }
         }
 
@@ -377,7 +377,7 @@ class ExternalSourceTest {
             override fun close() {}
         }
 
-        leaderProc(watchers = watchers, extSource = extSource, wrapProducer = failingProducer)
+        leaderProc(watchers = watchers, extSource = extSource, wrapDriver = failingDriver)
 
         val e = thrown.await()
         assertEquals(

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -1,0 +1,344 @@
+package xtdb.indexer
+
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.apache.arrow.memory.BufferAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import xtdb.NodeBase
+import xtdb.NodeBase.Companion.openBase
+import xtdb.RepeatableSimulationTest
+import xtdb.SimulationTestBase
+import xtdb.SimulationTestUtils.Companion.createTrieCatalog
+import xtdb.api.IndexerConfig
+import xtdb.api.TableRef
+import xtdb.api.TransactionResult
+import xtdb.api.log.InMemoryLog
+import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.ReplicaMessage.BlockBoundary
+import xtdb.api.log.SourceMessage
+import xtdb.api.log.Watchers
+import xtdb.api.tx.TxIndexer.TxResult
+import xtdb.catalog.BlockCatalog
+import xtdb.catalog.TableCatalog
+import xtdb.compactor.Compactor
+import xtdb.database.DatabaseLogs
+import xtdb.database.PartitionState
+import xtdb.database.PartitionStorage
+import xtdb.storage.MemoryStorage
+import xtdb.types.MessageId
+import xtdb.util.closeAll
+import java.time.InstantSource
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Kafka's transactional-id fencing, modelled in memory: claiming the id supersedes every earlier
+ * claimant, and a superseded producer's commit is rejected by the coordinator — so the appends
+ * buffered in that transaction never reach the log.
+ *
+ * Neither [InMemoryLog] nor `SimLog` models this: both hand out independent producers that append
+ * happily alongside each other. Fencing is the *only* thing standing between two nodes that each
+ * believe they lead and a corrupted replica log, so without a model of it that guard is untested.
+ */
+private class ReplicaLogFence {
+    private var latest = 0
+
+    fun claim() = ++latest
+
+    fun isFenced(generation: Int) = generation != latest
+}
+
+private class ProducerFenced(generation: Int) :
+    RuntimeException("replica producer generation $generation was fenced by a newer leader")
+
+private fun Log.AtomicProducer<ReplicaMessage>.fencedAt(generation: Int, fence: ReplicaLogFence) =
+    object : Log.AtomicProducer<ReplicaMessage> {
+        override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
+            val tx = this@fencedAt.openTx()
+            return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
+                override fun commit() {
+                    if (fence.isFenced(generation)) throw ProducerFenced(generation)
+                    tx.commit()
+                }
+            }
+        }
+
+        override fun close() = this@fencedAt.close()
+    }
+
+/**
+ * Two `LeaderLogProcessor`s, each believing it leads the same database, against one shared replica
+ * log and one shared object store.
+ *
+ * This is what the [LeaderDriver] seam bought: a leader can be built and fed without a transport, so
+ * a test can hold two of them live at once — something no rebalance-driven harness can produce,
+ * because a rebalance demotes the old leader before promoting the new one.
+ */
+@Tag("property")
+class LeaderDriverSimTest : SimulationTestBase() {
+
+    private lateinit var nodeBase: NodeBase
+    private lateinit var allocator: BufferAllocator
+    private lateinit var bufferPool: MemoryStorage
+    private lateinit var sourceLog: InMemoryLog<SourceMessage>
+    private lateinit var replicaLog: InMemoryLog<ReplicaMessage>
+    private lateinit var fence: ReplicaLogFence
+
+    private val leaders = mutableListOf<SimLeader>()
+
+    /** Every *successful* block upload across both leaders, as (blockIndex, boundaryMsgId). */
+    private val blockUploads = mutableListOf<Pair<Long, MessageId>>()
+
+    private val docsTable = TableRef("public", "docs")
+
+    @BeforeEach
+    fun setUp() {
+        nodeBase = openBase(openMeterRegistry = false)
+        allocator = nodeBase.allocator.newChildAllocator("test", 0, Long.MAX_VALUE)
+        bufferPool = MemoryStorage(allocator, epoch = 0)
+        sourceLog = InMemoryLog(InstantSource.system(), 0)
+        replicaLog = InMemoryLog(InstantSource.system(), 0)
+        fence = ReplicaLogFence()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        leaders.closeAll()
+        bufferPool.close()
+        allocator.close()
+        nodeBase.close()
+    }
+
+    /**
+     * One node's whole leader-side world: its own catalogs and live index (nothing is shared between
+     * leaders except the replica log and the object store, which is the point).
+     */
+    private inner class SimLeader(
+        name: String, rowsPerBlock: Long, scope: CoroutineScope,
+        wrapDriver: (LeaderDriver) -> LeaderDriver = { it },
+    ) : AutoCloseable {
+        val generation = fence.claim()
+
+        val blockCatalog = BlockCatalog(null)
+        val tableCatalog = TableCatalog(bufferPool)
+        val trieCatalog = createTrieCatalog()
+        val liveIndex =
+            LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, IndexerConfig(rowsPerBlock = rowsPerBlock))
+
+        val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        val proc = LeaderLogProcessor(
+            allocator, nodeBase, partitionStorage, CrashLogger(allocator, bufferPool, "sim-$name"),
+            partitionState, "test-db",
+            wrapDriver(
+                RecordingDriver(
+                    RealLeaderDriver(
+                        replicaLog.openAtomicProducer("test-db-leader", 0).fencedAt(generation, fence),
+                        partitionStorage, partitionState,
+                        BlockUploader(
+                            partitionStorage, partitionState, mockk<Compactor.ForDatabase>(relaxed = true),
+                            null, null, scope, uploadDispatcher = dispatcher
+                        )
+                    )
+                )
+            ),
+            watchers, extSource = null, skipTxs = emptySet(), dbCatalog = null,
+            afterReplicaMsgId = -1, scope = scope, gcDispatcher = dispatcher,
+        )
+
+        /** Fire-and-forget: the returned handle completes only once the tx is durably replicated. */
+        suspend fun submitRows(rows: List<UUID>): Deferred<TransactionResult> =
+            proc.submitTx(null) { openTx ->
+                val table = openTx.table(docsTable)
+                for (id in rows) table.writePut(mapOf("_id" to id, "tx_id" to openTx.txKey.txId))
+                TxResult.Committed()
+            }
+
+        /**
+         * Submit and wait, yielding the acked tx-id or null if it never became durable.
+         *
+         * Both halves can throw once this leader has been fenced, and which one does is a race:
+         * `submitTx` itself throws if the term's channels have already been closed with the fault
+         * (the documented early-exit signal), otherwise the handle fails at settle. For these tests
+         * the only distinction that matters is acked vs not.
+         */
+        suspend fun trySubmitRows(rows: List<UUID>): Long? =
+            runCatching { submitRows(rows).await() }.getOrNull()
+                .let { (it as? TransactionResult.Committed)?.txKey?.txId }
+
+        override fun close() {
+            proc.close()
+            partitionState.close()
+        }
+    }
+
+    /** Records the boundary each block was actually uploaded for — see [assertBlockCutsAgree]. */
+    private inner class RecordingDriver(private val inner: LeaderDriver) : LeaderDriver by inner {
+        override suspend fun uploadBlock(boundaryMsgId: MessageId, boundary: BlockBoundary) =
+            inner.uploadBlock(boundaryMsgId, boundary)
+                .also { blockUploads += boundary.blockIndex to boundaryMsgId }
+    }
+
+    private fun openLeader(
+        name: String, rowsPerBlock: Long, scope: CoroutineScope,
+        wrapDriver: (LeaderDriver) -> LeaderDriver = { it },
+    ) = SimLeader(name, rowsPerBlock, scope, wrapDriver).also { leaders += it }
+
+    // ---- observations of the shared replica log ----
+
+    private fun replicaMessages(): List<ReplicaMessage> =
+        replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1).map { it.message }.toList()
+
+    private fun replicaTxIds() = replicaMessages().filterIsInstance<ReplicaMessage.ResolvedTx>().map { it.txId }
+
+    /**
+     * Two leaders uploading the same block index is *fine* — the upload is deterministic from the
+     * boundary, so a redundant one is the same coordination-free idempotency the compactor relies on.
+     * What must not happen is two leaders disagreeing about *which* cut block N is: a block is
+     * identified by the replica-log position of its `BlockBoundary`, so every upload of index N must
+     * name the same `boundaryMsgId`. Two uploads of N from different boundaries means two different
+     * snapshots writing the same object-store paths.
+     */
+    private fun assertBlockCutsAgree() {
+        for ((blockIndex, boundaryMsgIds) in blockUploads.groupBy({ it.first }, { it.second })) {
+            assertEquals(
+                1, boundaryMsgIds.distinct().size,
+                "block b$blockIndex was uploaded for more than one boundary: " +
+                        "${boundaryMsgIds.distinct()} (seed=$currentSeed)"
+            )
+        }
+    }
+
+    /**
+     * The dangerous direction: a leader must never tell a caller its tx is durable unless the tx
+     * actually reached the log. Falsely failing an appended tx is survivable (the caller retries);
+     * falsely acking a lost one is not.
+     */
+    private fun assertNoPhantomAcks(acked: List<Long>) {
+        val onLog = replicaTxIds().toSet()
+        val phantom = acked.filterNot { it in onLog }
+        assertTrue(
+            phantom.isEmpty(),
+            "acked txs that never reached the replica log: $phantom (seed=$currentSeed)"
+        )
+    }
+
+    private suspend fun Deferred<TransactionResult>.ackedTxIdOrNull(): Long? =
+        runCatching { (await() as TransactionResult.Committed).txKey.txId }.getOrNull()
+
+    /**
+     * Where the leaders' coroutines live: `backgroundScope` so `runTest` cancels them when the body
+     * finishes without waiting for them, on the seeded dispatcher so the simulation stays
+     * deterministic.
+     *
+     * A leader's term job runs its persister forever, so it must NOT be a child of anything the test
+     * joins — otherwise the join waits on a coroutine that only the join's completion would cancel.
+     */
+    private val TestScope.leaderScope get() = CoroutineScope(backgroundScope.coroutineContext + dispatcher)
+
+    private val randomRows get() = List(rand.nextInt(1, 4)) { UUID(rand.nextLong(), rand.nextLong()) }
+
+    @RepeatableSimulationTest
+    fun `a superseded leader is fenced, fails its term, and acks nothing it lost`() =
+        runTest(timeout = 10.seconds) {
+            val beforeCount = rand.nextInt(1, 5)
+            val afterCount = rand.nextInt(1, 5)
+            val scope = leaderScope
+
+            val a = openLeader("A", rowsPerBlock = 10_000, scope = scope)
+
+            // A leads alone: everything it submits here should land. Asserted, not assumed — without
+            // this the fencing assertions below would pass just as happily against a leader that
+            // never worked at all.
+            val beforeAcked = List(beforeCount) { a.trySubmitRows(randomRows) }.filterNotNull()
+            assertEquals(
+                beforeCount, beforeAcked.size,
+                "the sole leader must ack everything it submits before anyone supersedes it"
+            )
+
+            // B claims the transactional id — A is a zombie now, though it doesn't know yet.
+            val b = openLeader("B", rowsPerBlock = 10_000, scope = scope)
+
+            val afterAcked = List(afterCount) { a.trySubmitRows(randomRows) }.filterNotNull()
+
+            assertEquals(
+                emptyList<Long>(), afterAcked,
+                "a fenced leader must not ack anything it submitted after being superseded"
+            )
+            // The fence specifically, not merely "something went wrong" — `notifyError` wraps the
+            // cause in an IngestionStoppedException, so an unrelated fault would otherwise satisfy
+            // a bare non-null check and quietly pass this off as the fencing behaviour.
+            assertInstanceOf(
+                ProducerFenced::class.java, a.watchers.exception?.cause,
+                "the fence must fail A's term rather than leave it silently wedged"
+            )
+            assertNoPhantomAcks(beforeAcked + afterAcked)
+
+            // B is unaffected and can still write.
+            val bAcked = b.trySubmitRows(randomRows)
+            assertNotNull(bAcked, "the surviving leader must still be able to write")
+            assertNoPhantomAcks(beforeAcked + afterAcked + listOfNotNull(bAcked))
+        }
+
+    /**
+     * The one interleaving where two leaders really are concurrent. Fencing bites at commit, so a
+     * younger leader kills an older one the instant it claims — the only way to have both live at
+     * once is to catch the older one with work already in flight. Here A is held inside
+     * `uploadBlock`, having already appended its `BlockBoundary`, when B supersedes it.
+     */
+    @Test
+    fun `a leader fenced mid-upload announces no block`() = runTest(timeout = 10.seconds) {
+        val atUpload = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val scope = leaderScope
+
+        val a = openLeader("A", rowsPerBlock = 2, scope = scope) { inner ->
+            object : LeaderDriver by inner {
+                override suspend fun uploadBlock(boundaryMsgId: MessageId, boundary: BlockBoundary): MessageId {
+                    atUpload.complete(Unit)
+                    release.await()
+                    return inner.uploadBlock(boundaryMsgId, boundary)
+                }
+            }
+        }
+
+        // Two rows fills the block, so settling this tx cuts a boundary and enters uploadBlock.
+        val handle = a.submitRows(listOf(UUID(1, 1), UUID(2, 2)))
+
+        atUpload.await()
+        openLeader("B", rowsPerBlock = 2, scope = scope)
+        release.complete(Unit)
+
+        val acked = listOfNotNull(handle.ackedTxIdOrNull())
+
+        // The scenario actually happened: A got its boundary onto the log (it wasn't yet fenced) and
+        // was then inside uploadBlock when B superseded it. Without this the next assertion would
+        // hold trivially for a leader that never cut a block at all.
+        assertEquals(
+            listOf(0L), replicaMessages().filterIsInstance<BlockBoundary>().map { it.blockIndex },
+            "A should have announced block b0's boundary before being fenced"
+        )
+
+        assertEquals(
+            emptyList<Long>(),
+            replicaMessages().filterIsInstance<ReplicaMessage.BlockUploaded>().map { it.blockIndex },
+            "a leader fenced mid-upload must not get its BlockUploaded onto the log"
+        )
+        assertNoPhantomAcks(acked)
+        assertBlockCutsAgree()
+    }
+}

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -79,18 +79,22 @@ class LeaderLogProcessorTest {
         compactor: Compactor.ForDatabase = mockk(relaxed = true),
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1),
         skipTxs: Set<MessageId> = emptySet(),
-        wrapProducer: (Log.AtomicProducer<ReplicaMessage>) -> Log.AtomicProducer<ReplicaMessage> = { it },
+        wrapDriver: (LeaderDriver) -> LeaderDriver = { it },
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val replicaProducer = wrapProducer(replicaLog.openAtomicProducer("test-leader", 0))
         val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, uploadDispatcher)
+        val driver = wrapDriver(
+            RealLeaderDriver(
+                replicaLog.openAtomicProducer("test-leader", 0), partitionStorage, partitionState, blockUploader
+            )
+        )
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", blockUploader, watchers,
-            extSource = null, replicaProducer = replicaProducer,
+            partitionState, "test", driver, watchers,
+            extSource = null,
             skipTxs = skipTxs, dbCatalog = null,
             afterReplicaMsgId = -1,
             scope = backgroundScope,
@@ -142,14 +146,16 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val driver = RealLeaderDriver(
+            replicaLog.openAtomicProducer("test-leader", 0), partitionStorage, partitionState, blockUploader
+        )
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", blockUploader, watchers,
-            extSource = null, replicaProducer = replicaProducer,
+            partitionState, "test", driver, watchers,
+            extSource = null,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1,
             scope = backgroundScope,
@@ -213,14 +219,16 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val driver = RealLeaderDriver(
+            replicaLog.openAtomicProducer("test-leader", 0), partitionStorage, partitionState, blockUploader
+        )
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", blockUploader, watchers,
-            extSource = null, replicaProducer = replicaProducer,
+            partitionState, "test", driver, watchers,
+            extSource = null,
             skipTxs = emptySet(), dbCatalog = null,
             afterReplicaMsgId = -1,
             scope = backgroundScope,
@@ -258,33 +266,19 @@ class LeaderLogProcessorTest {
 
         val gate = CompletableDeferred<Unit>()
         val appendStarted = CompletableDeferred<Unit>()
-        val producerBatchSizes = mutableListOf<Int>()
+        val appendBatchSizes = mutableListOf<Int>()
 
-        // Counts each producer transaction's size, and gates every append handle so the first batch's
-        // settle stalls on the gate (a slow commit-ack) without blocking any thread.
-        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
-            object : Log.AtomicProducer<ReplicaMessage> {
-                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
-                    val tx = inner.openTx()
-                    var count = 0
-                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
-                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
-                            count++
-                            val real = tx.appendMessage(message)
-                            appendStarted.complete(Unit)
-                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
-                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
-                            }
-                        }
-
-                        override fun commit() {
-                            tx.commit()
-                            producerBatchSizes += count
-                        }
-                    }
+        // Records each append's batch size, and stalls the first one on the gate (a slow commit-ack)
+        // without blocking any thread — so the rest of the poll batch resolves behind it.
+        val wrapDriver = { inner: LeaderDriver ->
+            object : LeaderDriver by inner {
+                override suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> {
+                    val batch = msgs.toList()
+                    appendBatchSizes += batch.size
+                    appendStarted.complete(Unit)
+                    gate.await()
+                    return inner.appendToReplica(batch.asSequence())
                 }
-
-                override fun close() = inner.close()
             }
         }
 
@@ -292,7 +286,7 @@ class LeaderLogProcessorTest {
         val n = 5L
         val lp = leaderProc(
             StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
-            skipTxs = (0 until n).toSet(), wrapProducer = wrapProducer,
+            skipTxs = (0 until n).toSet(), wrapDriver = wrapDriver,
         )
 
         val now = Instant.now()
@@ -307,8 +301,8 @@ class LeaderLogProcessorTest {
         batchJob.join()
 
         assertEquals(
-            listOf(1, 4), producerBatchSizes,
-            "record 0 kicked its append alone; 1-4 resolved behind it and rode the next producer transaction"
+            listOf(1, 4), appendBatchSizes,
+            "record 0 kicked its append alone; 1-4 resolved behind it and rode the next append"
         )
 
         val resolvedTxs = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
@@ -324,28 +318,19 @@ class LeaderLogProcessorTest {
         val gate = CompletableDeferred<Unit>()
         val appendStarted = CompletableDeferred<Unit>()
 
-        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
-            object : Log.AtomicProducer<ReplicaMessage> {
-                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
-                    val tx = inner.openTx()
-                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
-                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
-                            val real = tx.appendMessage(message)
-                            appendStarted.complete(Unit)
-                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
-                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
-                            }
-                        }
-                    }
+        val wrapDriver = { inner: LeaderDriver ->
+            object : LeaderDriver by inner {
+                override suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> {
+                    appendStarted.complete(Unit)
+                    gate.await()
+                    return inner.appendToReplica(msgs)
                 }
-
-                override fun close() = inner.close()
             }
         }
 
         val lp = leaderProc(
             StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
-            wrapProducer = wrapProducer,
+            wrapDriver = wrapDriver,
         )
 
         // launch the executeTx so we can observe its completion state without blocking the test
@@ -370,28 +355,19 @@ class LeaderLogProcessorTest {
         val gate = CompletableDeferred<Unit>()
         val appendStarted = CompletableDeferred<Unit>()
 
-        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
-            object : Log.AtomicProducer<ReplicaMessage> {
-                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
-                    val tx = inner.openTx()
-                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
-                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
-                            val real = tx.appendMessage(message)
-                            appendStarted.complete(Unit)
-                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
-                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
-                            }
-                        }
-                    }
+        val wrapDriver = { inner: LeaderDriver ->
+            object : LeaderDriver by inner {
+                override suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> {
+                    appendStarted.complete(Unit)
+                    gate.await()
+                    return inner.appendToReplica(msgs)
                 }
-
-                override fun close() = inner.close()
             }
         }
 
         val lp = leaderProc(
             StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
-            wrapProducer = wrapProducer,
+            wrapDriver = wrapDriver,
         )
 
         // Capture the executeTx failure; the runTest timeout guards against a hang if it never completes.
@@ -448,33 +424,19 @@ class LeaderLogProcessorTest {
 
         val gate = CompletableDeferred<Unit>()
         val appendStarted = CompletableDeferred<Unit>()
-        val producerBatchSizes = mutableListOf<Int>()
+        val appendBatchSizes = mutableListOf<Int>()
 
-        // Counts each producer transaction's size, and gates every append handle so the first batch's
-        // settle stalls on the gate (a slow commit-ack) without blocking any thread.
-        val wrapProducer = { inner: Log.AtomicProducer<ReplicaMessage> ->
-            object : Log.AtomicProducer<ReplicaMessage> {
-                override fun openTx(): Log.AtomicProducer.Tx<ReplicaMessage> {
-                    val tx = inner.openTx()
-                    var count = 0
-                    return object : Log.AtomicProducer.Tx<ReplicaMessage> by tx {
-                        override fun appendMessage(message: ReplicaMessage): CompletableDeferred<Log.MessageMetadata> {
-                            count++
-                            val real = tx.appendMessage(message)
-                            appendStarted.complete(Unit)
-                            return CompletableDeferred<Log.MessageMetadata>().also { gated ->
-                                backgroundScope.launch { gate.await(); gated.complete(real.await()) }
-                            }
-                        }
-
-                        override fun commit() {
-                            tx.commit()
-                            producerBatchSizes += count
-                        }
-                    }
+        // Records each append's batch size, and stalls the first one on the gate (a slow commit-ack)
+        // without blocking any thread.
+        val wrapDriver = { inner: LeaderDriver ->
+            object : LeaderDriver by inner {
+                override suspend fun appendToReplica(msgs: Sequence<ReplicaMessage>): List<Log.MessageMetadata> {
+                    val batch = msgs.toList()
+                    appendBatchSizes += batch.size
+                    appendStarted.complete(Unit)
+                    gate.await()
+                    return inner.appendToReplica(batch.asSequence())
                 }
-
-                override fun close() = inner.close()
             }
         }
 
@@ -483,7 +445,7 @@ class LeaderLogProcessorTest {
             // Explicit null head: the relaxed default returns a mock TransactionKey whose txId is 0,
             // which would seed the staging index at 0 and shift the ext-source txIds to 1..5.
             liveIndex = mockk(relaxed = true) { every { latestCompletedTx } returns null },
-            wrapProducer = wrapProducer,
+            wrapDriver = wrapDriver,
         )
 
         // tx 0: stages an ext-source tx and kicks the gated append
@@ -508,8 +470,8 @@ class LeaderLogProcessorTest {
         // txs 1-4 (staging crosses launch → channel → persister, unlike a source-log poll batch),
         // so assert correctness-under-accumulation and leave the coalescing factor to the
         // kafka-source benchmark. tx 0 always seals alone — nothing else was staged when it kicked.
-        assertEquals(1, producerBatchSizes.first(), "tx 0 kicked its append alone")
-        assertEquals(5, producerBatchSizes.sum(), "every tx reached the replica log exactly once")
+        assertEquals(1, appendBatchSizes.first(), "tx 0 kicked its append alone")
+        assertEquals(5, appendBatchSizes.sum(), "every tx reached the replica log exactly once")
 
         val resolvedTxs = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
             .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
@@ -542,13 +504,15 @@ class LeaderLogProcessorTest {
 
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val replicaProducer = replicaLog.openAtomicProducer("test-leader", 0)
         val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val driver = RealLeaderDriver(
+            replicaLog.openAtomicProducer("test-leader", 0), partitionStorage, partitionState, blockUploader
+        )
 
         val lp = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", blockUploader, watchers,
-            extSource = null, replicaProducer = replicaProducer,
+            partitionState, "test", driver, watchers,
+            extSource = null,
             skipTxs = setOf(10), dbCatalog = null,
             afterReplicaMsgId = -1,
             scope = backgroundScope,


### PR DESCRIPTION
## Summary

Extracts a `LeaderDriver` seam covering the leader's observable external effects, then uses it to simulate something no existing harness can produce: two `LeaderLogProcessor`s that each believe they lead the same database.

The first three commits are strictly behaviour-preserving. The fourth adds the test.

## Context

`LeaderLogProcessor` reaches a `Log.AtomicProducer`, a `LiveIndex`, a `BlockUploader` and the source log directly, so the only way to exercise it is against real components — and the real components can't express the failures worth testing.

Most pointedly, split-brain. Transactional-producer fencing is the sole guard against two nodes both believing they lead, and neither `InMemoryLog` nor `SimLog` models fencing at all: a second `openAtomicProducer` on the same transactional id just appends happily alongside the first. So the one thing standing between a split-brain cluster and a corrupted replica log had no in-memory coverage whatsoever.

Every existing harness is also rebalance-driven, and a rebalance demotes the old leader before promoting the new one — structurally unable to produce two live leaders.

## The seam

`LeaderDriver` carries five things: an atomic batch append to the replica log, the live-index commit, the block upload, the source-log flush request, and the inbound source-batch pipe.

The concurrency stays where it is. The persister select loop, the background append, the staging resolver are the code we want *under* test, not the code we want to stub — the driver is only their edge.

It's deliberately narrow. In-memory state mutations that happen to sit on the leader's path — `trieCatalog`, `dbCatalog`, `watchers`, the GC signals — stay on the processor, as do all reads (`liveIndex.isFull()`, `blockCatalog.currentBlockIndex`). Faking those in every mock would buy nothing, and a mock holding real state objects keeps the reads consistent with what the driver has applied.

## Decisions

**No factory**, unlike `Compactor.Driver`. That one earns its keep because `Compactor.Impl.openForDatabase` builds a driver per database at runtime; here the sole construction site already holds every piece, so the processor just takes a `LeaderDriver`. Its constructor gets *smaller* as a result — `blockUploader` was only ever there to be handed to `uploadBlock`, and `replicaProducer` only to be appended to.

**The producer's lifetime** was the one thing needing care. It's term-scoped, and the transition opens it for its own replay-target probe before any leader exists; a driver that opened its own would be a second producer on the same transactional id, fencing the transition's. So it arrives already open and the driver closes it when the term ends. `AtomicProducer` now appears in exactly two places — the `openLeader` wiring line and `RealLeaderDriver` — and nowhere in the processor.

**The batch append takes a `Sequence`**, which is load-bearing rather than stylistic. `kickAppend` serialises each `ResolvedTx` to Arrow bytes as it appends, inside the producer transaction, and a sealed batch runs to `rowsPerBlock` — 100k rows by default. A `List` parameter would have materialised a block's worth of serialised relations before the transaction even opened, alongside the live relations the resolver is still holding.

## What the test pins

Fencing is modelled where Kafka puts it — at commit, so a superseded producer's whole transaction is discarded rather than half-applied.

A superseded leader acks nothing it lost. Whether the failure surfaces synchronously from `submitTx` (the term's channels already closed with the fault) or later from the durability handle is a scheduling race, and both count as "not acked".

And the one interleaving where two leaders are genuinely concurrent: under commit-time fencing a younger leader kills an older one instantly, so the older has to be caught with work already in flight. There, A is held inside `uploadBlock` with its `BlockBoundary` already on the log when B supersedes it.

Both tests assert the scenario actually *happened* — that the sole leader acked all its pre-fence txs, that A's boundary really did reach the log — because without those the fencing assertions would pass just as happily against a leader that never did anything.

## Out of scope

`assertBlockCutsAgree` encodes the invariant that matters for blocks: two leaders uploading the same index is fine, since the upload is deterministic from the boundary and redundancy is the same coordination-free idempotency the compactor relies on. What must not happen is two uploads of index N naming different `boundaryMsgId`s, which would mean two different snapshots writing the same object-store paths. It is not exercised yet — the fenced leader's upload never completes, so nothing is recorded. Exercising it needs a successor leader that replayed the log first, which is the transition path rather than the fencing path.

Separately, and deliberately left alone: the term-teardown sweep drains buffered `extSourceCh` elements but not buffered source batches, because `Channel.close()` doesn't visit a channel's buffer — only `cancel()` does. A batch sitting in the buffer when the persister exits leaves its submitter awaiting. That's pre-existing behaviour, preserved exactly; fixing it isn't an equivalence change and doesn't belong in this series.

## Test plan

Full suite green: 1,661 unit tests, 27 property tests, no compiler warnings on the touched files and no reflection or boxed-math warnings.

Each of the three tidy commits was verified independently before landing — the Kotlin indexer and tx suites plus 300 iterations of `LogProcessorSimTest`, which is the closest existing coverage of the append/settle path. The new `LeaderDriverSimTest` runs 101 iterations.

Not run: `integration-test` and `kafka-test`, which need docker. CI covers those.
