### PR TITLE
docs: point the stage-4 markers at their sub-issues, and pin the reasoning at its call sites (#5557)

### DIFF
--- a/core/src/main/clojure/xtdb/export.clj
+++ b/core/src/main/clojure/xtdb/export.clj
@@ -59,6 +59,10 @@
                                   (log/warn "No completed blocks found - aborting."))]
 
            (let [export-dir (export-dir-path block-idx start-time)
+                 ;; Deliberately the unmarked two-arg root: a snapshot is a fresh single-partition
+                 ;; store, whatever it was exported from. Don't sweep this to the partition-aware
+                 ;; form — that would key every export under parts/N/ and break restore. The input
+                 ;; side is the open question (#5838), not this.
                  export-root (.resolve export-dir (Storage/storageRoot Storage/VERSION 0))
                  tables (.getTables trie-cat)]
 

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -309,6 +309,9 @@
                                                      (fn [fvt]
                                                        (or fvt [:at [:now]]))))
                                live-table-snaps (.table snapshot table)
+                               ;; TODO (#5835) each branch takes its own partition's basis slot. Wrong
+                               ;; rather than absent at N>1: every branch would apply partition 0's
+                               ;; temporal bound, so the scan returns wrong rows rather than failing.
                                temporal-bounds (->temporal-bounds allocator args scan-opts
                                                                   (-> (basis/<-time-basis-str snapshot-token)
                                                                       (get-in [db-name 0])))]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -207,7 +207,7 @@
                   (let [state (.getQueryState (.databaseOrNull db-catalog db-name))
                         table-catalog (.getTableCatalog state)
                         ^DatabaseSnapshot db-snap (get snaps db-name)
-                        ;; TODO (#5557 unit 7) reduce types/merge-types over per-partition live
+                        ;; TODO (#5835) reduce types/merge-types over per-partition live
                         ;; types here; for now we only allow single-partition databases.
                         ^Snapshot snap (first (.getPartitions db-snap))]
                     (types/merge-types (.getType table-catalog table col-name)
@@ -270,7 +270,7 @@
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, query-source, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
                      (let [^DatabaseSnapshot db-snapshot (get snaps db-name)
-                           ;; TODO (#5557 unit 7) walk every partition's Snapshot and UNION at scan,
+                           ;; TODO (#5835) walk every partition's Snapshot and UNION at scan,
                            ;; instead of picking the only partition.
                            ^Snapshot snapshot (first (.getPartitions db-snapshot))
                            derived-table-schema (info-schema/derived-table table)]

--- a/core/src/main/kotlin/xtdb/api/storage/Storage.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/Storage.kt
@@ -63,12 +63,22 @@ object Storage {
     }
 
     /**
-     * At `totalPartitions == 1` this is byte-identical to the single-partition layout, so existing
-     * object stores and local directories keep working without a key-space migration — load-bearing
-     * for rolling upgrades, since blob stores have no `mv` primitive and re-keying a database would
-     * mean a full copy-and-delete sweep. Only at N > 1 does the `parts/<partition>/` grouping appear.
-     * Partition counts are immutable post-attach, so a store is one shape or the other for its whole
-     * lifetime and the two never collide.
+     * The `totalPartitions == 1` branch produces the same key-space as the pre-multi-partition layout,
+     * and must keep doing so — do not unify the two branches. An older version resolves against the
+     * unmarked root, so a single-partition database writing under `parts/0/` would leave a rollback with
+     * nothing to read and a data migration to run at the worst possible moment. Avoiding a re-key of
+     * existing stores is the secondary benefit — blob stores have no `mv` primitive, so that means a full
+     * copy-and-delete sweep — but reversibility is the sharper reason. Only at N > 1 does the
+     * `parts/<partition>/` grouping appear, and partition counts are immutable post-attach, so a store is
+     * one shape or the other for its whole lifetime and the two never collide.
+     *
+     * The nesting is deliberately partition-outer rather than epoch-outer. That was a free choice —
+     * multi-partition key-spaces are always born fresh — and it buys three things: each partition
+     * subtree is a complete store of the single-partition shape, so anything defined against a store
+     * root works per-partition verbatim; a partition is a stable identity where an epoch is a
+     * transient recovery event, and the stable thing belongs outer; and it leaves room for
+     * partition-scoped epochs, recovering one partition of a large external-source database without
+     * re-ingesting the whole thing. Epoch-outer would foreclose that structurally.
      */
     @JvmStatic
     fun storageRoot(version: StorageVersion, epoch: Int, partition: Int, totalPartitions: Int): Path {

--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -142,6 +142,13 @@ class OpenTx
 
     // `internal` rather than `private` solely so OpenTxTest can assert the single-db contract directly;
     // no production code outside this file reads it.
+    // Both narrowings below — one database, one partition — are load-bearing rather than incidental, and
+    // the single-element snapshot is the one to leave alone. Unioning the partitions would make a writer's
+    // output depend on sibling partitions' log positions, which vary by node, so a new leader re-resolving
+    // its slice after a transition would emit different rows from the original leader and diverge the
+    // replica logs. Pinning a per-partition basis in the resolved tx restores determinism only by making
+    // every partition wait on every other, which is the independence the throughput scaling is built on.
+    // #5843 covers the separate question of whether the narrowing should be visible in the method names.
     internal val queryCatalog: IQuerySource.QueryCatalog
         get() {
             val liveIndex = partitionState.liveIndex
@@ -168,6 +175,10 @@ class OpenTx
      * matched to the query's `?` placeholders by ordinal position. The columns must be supplied unnamed or
      * named `$1..$N` in order (see [withPositionalParamNames]); mis-ordered names are rejected rather than
      * silently rebound. Defaults for [opts] are derived from the tx's system-time and the database's default timezone.
+     *
+     * Reads are scoped to this transaction's own database — narrower than the same SQL run from a
+     * connection, which resolves a two-part name against every attached database. A table in another
+     * database is not reachable from here, and referring to one reports that the table was not found.
      */
     fun openQuery(sql: String, args: RelationReader? = null, opts: QueryOpts = QueryOpts()): ResultCursor {
         val currentTime = opts.currentTime ?: txKey.systemTime
@@ -187,6 +198,9 @@ class OpenTx
      * [openQuery] — unnamed or named `$1..$N` in order.
      *
      * DML writes to forbidden schemas (`xt`, `information_schema`, `pg_catalog`) will throw.
+     *
+     * The scope narrowing documented on [openQuery] applies to any read this performs — including an
+     * `INSERT … SELECT` source.
      */
     @JvmOverloads
     fun executeSql(sql: String, args: RelationReader? = null, opts: QueryOpts = QueryOpts(), user: String? = null) {

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -99,7 +99,7 @@ class Database(
 
     internal fun getColumnTypes(table: TableRef): Map<ColumnName, VectorType>? {
         val historical = tableCatalog.getTypes(table)
-        // TODO (#5557 unit 7) iterate the snapshot's partitions and merge per-partition live types;
+        // TODO (#5835) iterate the snapshot's partitions and merge per-partition live types;
         // for now single-partition is the only allowed shape, so pick the only Snapshot.
         // gate on the current basis so a just-committed table's columns are visible (getTableSchema awaits first).
         val live = openSnapshot(currentBasis()).use { it.partitions.first().allColumnTypes[table] }
@@ -254,8 +254,8 @@ class Database(
             val readOnly = dbConfig.isReadOnly
 
             // Attach-time gate: the type signatures admit N throughout, but TableCatalog wrappers +
-            // UNION-at-scan (unit 7) and xt.txs_$partition naming (unit 8) haven't landed. Lifting
-            // this gate is unit 9.
+            // UNION-at-scan (#5835) and xt.txs_$partition naming (#5836) haven't landed. Lifting
+            // this gate is #5837.
             if (dbConfig.partitions > 1)
                 throw Incorrect(
                     "multi-partition external-source databases are not yet enabled " +

--- a/core/src/main/kotlin/xtdb/database/PartitionStorage.kt
+++ b/core/src/main/kotlin/xtdb/database/PartitionStorage.kt
@@ -19,7 +19,7 @@ class PartitionStorage(
     val bufferPoolOrNull: BufferPool?,
     val metadataManagerOrNull: PageMetadata.Factory?,
     // The partition this view serves; drives the PartitionLog binding below. Defaulted to 0 because
-    // single-partition is the only shape reachable until the multi-partition gate lifts (#5557 unit 9).
+    // single-partition is the only shape reachable until the multi-partition gate lifts (#5837).
     val partition: Int = 0,
 ) : AutoCloseable {
     val sourceLog: PartitionLog<SourceMessage> get() = PartitionLog(logs.sourceLog, partition)

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -190,7 +190,8 @@ class KafkaCluster(
             private val completion = CompletableDeferred<Unit>()
             private var listenerState: ListenerState<M> = Following()
 
-            // expecting a load of change here for multi-part.
+            // #5841: listenerState becomes one entry per assigned partition, and the callbacks below
+            // fan out over the collection Kafka hands them instead of collapsing it with single().
 
             fun onPartitionsAssigned(partitions: Collection<TopicPartition>) {
                 val tp = partitions.single()


### PR DESCRIPTION
Part of #5557.

**Comment-only — no behaviour change.** Every hunk is a Kotlin kdoc block, a Kotlin `//` comment, or a Clojure `;;` comment. Nothing else moved.

## Context

Stage 4's remaining work moved out of checklist lines on the epic and into nine sub-issues, several of which exist specifically to hold design reasoning that had been living in planning notes outside the repo. Two consequences for the code.

The in-code markers for deliberately-deferred work addressed it as "#5557 unit N", which was the only scheme available while the units were checklist items. Each unit now has an issue, so a marker can land the reader on the scoped work item — with its own state, open questions and blocked-by edges — instead of on an epic they then have to search.

And four sites carry a decision that reads like an oversight, or like a simplification waiting to happen. Those are the ones where a well-intentioned change does real damage, and the reasoning for each existed nowhere a future reader would find it.

## Changes

1. `tidy:` — re-point the five markers. Four were indirect; the fifth, in `KafkaCluster`, carried no reference at all, so a reader could tell neither what change was expected, nor how large, nor whether the comment was still live. Its placement was already good — it sits between the single `listenerState` field and the `partitions.single()` collapse, which are exactly what the rebalance rework changes — so it now says that, rather than describing the size of the change.

2. `docs:` — record the reasoning at four call sites.

## Implementation notes

**`storageRoot`'s branch is what makes a release reversible.** An older version resolves against the unmarked root, so a single-partition database writing under `parts/0/` would leave a rollback with nothing to read and a data migration to run at the worst possible moment. The comment says not to unify the branches, and why. This also merges a pre-existing paragraph that argued for the same asymmetry on re-keying-cost grounds — two adjacent overlapping arguments on a four-line function — and demotes cost to secondary, because reversibility is the sharper reason. It drops "byte-identical" for "the same key-space": accurate in that narrow context, but byte-identity isn't the requirement, and unit 5 already shifted the golden block file by two bytes harmlessly when the `partitions` proto field started being emitted unconditionally.

The same kdoc now records why the nesting is partition-outer rather than the more obvious epoch-outer: each partition subtree stays a complete store of the single-partition shape, a partition is a stable identity where an epoch is a transient recovery event, and it leaves partition-scoped epochs available rather than foreclosing them.

**`OpenTx` splits by audience.** The public kdoc on `openQuery` gets only what a source-connector author can act on: reads resolve against this transaction's own database, so a table in another database reports as not found — which is observable in 2.2 today, and is the confusion #5831 describes. The maintainer argument moved to `queryCatalog`, where the narrowing is actually constructed (`databaseNames` of one, a single-element snapshot) and therefore where someone would go to widen it: unioning the partitions would make a writer's output depend on sibling partitions' log positions, which vary by node, so a new leader re-resolving its slice would diverge from the original leader's replica log; pinning a per-partition basis fixes determinism only by coupling every partition's progress to every other's.

An earlier revision of this branch put the partition half of that on the public kdoc. It came off deliberately: multi-partition is gated in 2.2, so it described a distinction the reader cannot observe and cannot resolve. The public statement follows when the gate lifts, alongside the other user-facing documentation tracked on #5837.

**`export.clj`'s unmarked root is deliberate.** It builds its output root from the two-arg form, which reads like a site missed when the partition-aware form arrived. An exported snapshot is a fresh single-partition store regardless of what it came from, so sweeping it to the four-arg form would key every export under a partition prefix and break restore. The input side is the open question — #5838 — not this.

**The scan's temporal-bounds lookup gets a marker it never had.** Unlike its two neighbours it is wrong rather than merely incomplete above one partition: every branch would apply partition 0's bound, so the scan returns wrong rows instead of failing. That absence of a marker is part of why the site went unnoticed while the design notes were being written.

## Scope

Grepping the codebase for `5557` no longer finds these sites. Discovery runs the other way now — the epic lists its sub-issues, and each marker names the one that owns it.

Nothing user-facing is documented here. The public statement of partition scope, the `dev/doc` tour paragraph and the Allium spec refresh all wait until multi-partition is reachable, tracked on #5837.

## Test plan

`./gradlew :test --tests 'xtdb.operator.scan_test*' --tests 'xtdb.export_test*'` — 33 tests, all passing. The point was to confirm the two edited Clojure namespaces still read and load; Kotlin compilation covers the two kdoc files.