### PR TITLE
feat(query): partition-aware read path (#5835)

### DIFF
--- a/core/src/main/clojure/xtdb/block_tables.clj
+++ b/core/src/main/clojure/xtdb/block_tables.clj
@@ -128,6 +128,11 @@
     (catch Exception _e
       nil)))
 
+;; The three cursors below read `Database.bufferPool`, which is partition 0's. Above one partition
+;; that's ambiguous rather than merely incomplete: these tables are addressed by block index, and
+;; block N exists in every partition with different contents, so unioning them would read as
+;; duplicates of one block. Deciding how a partition is addressed here is #5849.
+
 (defn- ->block-files-cursor
   [^Database db ^BufferAllocator allocator col-names col-preds selects schema args]
   (let [derived-table-schema (get block-tables 'xt/block_files)

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -20,9 +20,9 @@
            xtdb.authz.RoleMembership
            (xtdb.arrow Relation RelationReader VectorType VectorReader)
            xtdb.pgwire.PgType
-           (xtdb.indexer Snapshot TableSnapshot)
+           (xtdb.indexer DatabaseSnapshot Snapshot TableSnapshot)
            xtdb.operator.SelectionSpec
-           (xtdb.query IQuerySource IQuerySource$QueryCatalog IQuerySource$QueryDatabase)
+           (xtdb.query IQuerySource IQuerySource$QueryCatalog IQuerySource$QueryDatabase IQuerySource$QueryPartition)
            xtdb.api.TableRef
            xtdb.trie.TrieCatalog))
 
@@ -421,14 +421,25 @@
      :trie-key trie-key, :level (int level), :recency recency, :data-file-size data-file-size
      :trie-state (name state), :row-count row-count, :temporal-metadata (some-> trie-meta (dissoc :row-count))}))
 
-(defn live-tables [^Snapshot snap]
-  (for [^TableRef table (.getTables snap)]
-    {:schema-name (.getSchemaName table)
-     :table-name (.getTableName table)
-     :row-count (long (transduce (map (fn [^TableSnapshot ts]
-                                        (.getRowCount (.getRelation ts))))
-                                 + 0
-                                 (.table snap table)))}))
+;; a table's live rows are spread across its database's partitions, so this sums over them the same
+;; way it already sums over a partition's individual live-table slots.
+;; rows come out in first-encounter order rather than the sum map's: at one partition that's the
+;; per-snapshot order this has always emitted, and a Clojure map stops preserving insertion order
+;; past eight entries.
+(defn live-tables [part-snaps]
+  (let [row-counts (reduce (fn [acc [table row-count]]
+                             (update acc table (fnil + 0) row-count))
+                           {}
+                           (for [^Snapshot snap part-snaps
+                                 ^TableRef table (.getTables snap)]
+                             [table (long (transduce (map (fn [^TableSnapshot ts]
+                                                            (.getRowCount (.getRelation ts))))
+                                                     + 0
+                                                     (.table snap table)))]))]
+    (for [^TableRef table (distinct (mapcat #(.getTables ^Snapshot %) part-snaps))]
+      {:schema-name (.getSchemaName table)
+       :table-name (.getTableName table)
+       :row-count (get row-counts table)})))
 
 (defn live-columns [^Snapshot snap]
   (for [^TableRef table (.getTables snap)
@@ -501,26 +512,29 @@
     (some-> out-rel util/close)))
 
 (defprotocol InfoSchema
-  (->cursor [info-schema allocator db db-cat query-source snapshot derived-table-schema
+  (->cursor [info-schema allocator db db-cat query-source db-snap derived-table-schema
              table col-names col-preds
              schema params]))
 
 (defn ->info-schema [_allocator metrics-registry ^Authenticator$Factory authn]
   (reify InfoSchema
-    (->cursor [_ allocator db db-cat query-source snap derived-table-schema
+    (->cursor [_ allocator db db-cat query-source db-snap derived-table-schema
                table col-names col-preds
                schema params]
       ;; TODO should use the schema passed to it, but also regular merge is insufficient here for colFields
       ;; should be types/merge-types as per scan-vec-types
       (let [^IQuerySource$QueryDatabase db db
             ^IQuerySource$QueryCatalog db-cat db-cat
-            db-state (.getQueryState db)
+            ^DatabaseSnapshot db-snap db-snap
             db-name (.getName db)
-            table-catalog (.getTableCatalog db-state)
-            trie-catalog (.getTrieCatalog db-state)
+            table-catalog (.getTableCatalog db)
+            ;; these two lists come from different objects but describe the same partitions, in the
+            ;; same order — the scan checks their lengths agree before dispatching here
+            part-snaps (.getPartitions db-snap)
+            trie-catalogs (map #(.getTrieCatalog (.getState ^IQuerySource$QueryPartition %)) (.getPartitions db))
             schema-info (-> (merge-with merge
                                         (update-vals (into {} (.getTypes table-catalog)) #(into {} %))
-                                        (.getAllColumnTypes ^Snapshot snap))
+                                        (.getAllColumnTypes db-snap))
                             (merge meta-table-schemas)
                             (update-keys (fn [k]
                                            (cond
@@ -559,9 +573,12 @@
                                      pg_catalog/pg_user (pg-user authn)
                                      pg_catalog/pg_roles (pg-roles authn query-source db-cat)
                                      pg_catalog/pg_auth_members (pg-auth-members query-source db-cat)
-                                     xt/trie_stats (trie-stats trie-catalog)
-                                     xt/live_tables (live-tables snap)
-                                     xt/live_columns (live-columns snap)
+                                     ;; a trie key is only unique within its partition, so above one
+                                     ;; partition these rows need a `partition` column to be told
+                                     ;; apart — #5849
+                                     xt/trie_stats (mapcat trie-stats trie-catalogs)
+                                     xt/live_tables (live-tables part-snaps)
+                                     xt/live_columns (mapcat live-columns part-snaps)
                                      xt/metrics_timers (metrics-timers metrics-registry)
                                      xt/metrics_gauges (metrics-gauges metrics-registry)
                                      xt/metrics_counters (metrics-counters metrics-registry)

--- a/core/src/main/clojure/xtdb/log_tables.clj
+++ b/core/src/main/clojure/xtdb/log_tables.clj
@@ -241,6 +241,10 @@
                               (case lower-op :>= v, :> (inc v))))
           to-msg-id (long (let [v (long upper-val)]
                             (case upper-op :<= (inc v), :< v)))
+          ;; hardcoded partition 0. `msg_id` encodes an offset within one partition, so above one
+          ;; partition the required msg_id bounds are ambiguous rather than merely partial — the
+          ;; same addressing problem `xt.block_files` has, and sharper here, because the replica log
+          ;; is what you read to work out why a particular partition is stuck. #5849
           record-seq (.readRecords log 0 from-msg-id to-msg-id)
           record-iter (.iterator record-seq)
           decode-tx-ops? (and source? (contains? col-names "tx_ops"))]

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -2,6 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [xtdb.basis :as basis]
+            [xtdb.error :as err]
             [xtdb.expression :as expr]
             [xtdb.expression.metadata :as expr.meta]
             [xtdb.information-schema :as info-schema]
@@ -28,8 +29,8 @@
            (xtdb.api ICursor)
            (xtdb.indexer DatabaseSnapshot Snapshot Snapshot$Source TableSnapshot)
            (xtdb.metadata MetadataPredicate PageMetadata)
-           (xtdb.operator.scan MultiIidSelector ScanCursor ScanMetrics SingleIidSelector)
-           xtdb.query.IQuerySource$QueryCatalog
+           (xtdb.operator.scan MultiIidSelector PartitionedScanCursor ScanCursor ScanMetrics SingleIidSelector)
+           (xtdb.query IQuerySource$QueryCatalog IQuerySource$QueryPartition)
            (xtdb.segment BufferPoolSegment MergePlanner)
            xtdb.api.TableRef
            (xtdb.trie Bucketer)
@@ -204,14 +205,10 @@
               (or (types/temporal-vec-types col-name)
                   (-> (info-schema/derived-table table)
                       (get (symbol col-name)))
-                  (let [state (.getQueryState (.databaseOrNull db-catalog db-name))
-                        table-catalog (.getTableCatalog state)
-                        ^DatabaseSnapshot db-snap (get snaps db-name)
-                        ;; TODO (#5835) reduce types/merge-types over per-partition live
-                        ;; types here; for now we only allow single-partition databases.
-                        ^Snapshot snap (first (.getPartitions db-snap))]
+                  (let [table-catalog (.getTableCatalog (.databaseOrNull db-catalog db-name))
+                        ^DatabaseSnapshot db-snap (get snaps db-name)]
                     (types/merge-types (.getType table-catalog table col-name)
-                                       (.columnType snap table col-name))))))]
+                                       (.columnType db-snap table col-name))))))]
     (->> scan-cols
          (into {} (map (juxt identity ->vec-type))))))
 
@@ -220,11 +217,7 @@
     (emitScan [_ db-cat {:keys [opts]} scan-vec-types param-types]
       (let [{:keys [db-name ^TableRef table columns] :as scan-opts} opts
             db (.databaseOrNull db-cat db-name)
-            storage (.getStorage db)
-            state (.getQueryState db)
-            metadata-mgr (.getMetadataManager storage)
-            buffer-pool (.getBufferPool storage)
-            table-catalog (.getTableCatalog state)
+            table-catalog (.getTableCatalog db)
             col-names (->> columns
                            (into #{} (map (fn [[col-type arg]]
                                             (case col-type
@@ -270,10 +263,24 @@
          :stats {:row-count row-count}
          :->cursor (fn [{:keys [allocator, query-source, snaps, snapshot-token, schema, args pushdown-blooms pushdown-iids explain-analyze? tracer query-span] :as opts}]
                      (let [^DatabaseSnapshot db-snapshot (get snaps db-name)
-                           ;; TODO (#5835) walk every partition's Snapshot and UNION at scan,
-                           ;; instead of picking the only partition.
-                           ^Snapshot snapshot (first (.getPartitions db-snapshot))
-                           derived-table-schema (info-schema/derived-table table)]
+                           derived-table-schema (info-schema/derived-table table)
+                           query-parts (.getPartitions db)
+                           part-snaps (.getPartitions db-snapshot)
+                           basis (basis/<-time-basis-str snapshot-token)]
+
+                       ;; the snapshot slots and basis slots are read positionally against the partition
+                       ;; list, so a short one drops a partition's rows or silently unpins its temporal
+                       ;; bound rather than failing. Checked ahead of the branch split because the
+                       ;; info_schema cursor reads both lists too.
+                       (letfn [(check-length [what n]
+                                 (when-not (= n (count query-parts))
+                                   (throw (err/fault ::partition-slot-mismatch
+                                                     (format "%s doesn't cover every partition of the database" what)
+                                                     {:db-name db-name, :partitions (count query-parts), what n}))))]
+                         (check-length :snapshots (count part-snaps))
+                         (when-let [db-basis (get basis db-name)]
+                           (check-length :basis-slots (count db-basis))))
+
                        (cond
                          (log-tables/log-table table)
                          (log-tables/->cursor db allocator table col-names col-preds selects schema args)
@@ -282,7 +289,7 @@
                          (block-tables/->cursor db allocator table col-names col-preds selects schema args)
 
                          derived-table-schema
-                         (info-schema/->cursor info-schema allocator db db-cat query-source snapshot derived-table-schema table col-names col-preds schema args)
+                         (info-schema/->cursor info-schema allocator db db-cat query-source db-snapshot derived-table-schema table col-names col-preds schema args)
 
                          :else
 
@@ -308,60 +315,77 @@
                                              (update :for-valid-time
                                                      (fn [fvt]
                                                        (or fvt [:at [:now]]))))
-                               live-table-snaps (.table snapshot table)
-                               ;; TODO (#5835) each branch takes its own partition's basis slot. Wrong
-                               ;; rather than absent at N>1: every branch would apply partition 0's
-                               ;; temporal bound, so the scan returns wrong rows rather than failing.
-                               temporal-bounds (->temporal-bounds allocator args scan-opts
-                                                                  (-> (basis/<-time-basis-str snapshot-token)
-                                                                      (get-in [db-name 0])))]
+                               ;; shared across the branches: partition count is a physical property of
+                               ;; the database, so the operator reports one aggregate set of counters
+                               ;; however many branches it fans out to.
+                               ^ScanMetrics metrics (ScanMetrics. db-name
+                                                                  (str (.getSchemaName table) "." (.getTableName table)))
 
-                           (util/with-close-on-catch [!segments (LinkedList.)]
+                               ->partition-cursor
+                               (fn [part-idx ^IQuerySource$QueryPartition query-part ^Snapshot snapshot]
+                                 (let [storage (.getStorage query-part)
+                                       metadata-mgr (.getMetadataManager storage)
+                                       buffer-pool (.getBufferPool storage)
+                                       temporal-bounds (->temporal-bounds allocator args scan-opts
+                                                                          (get-in basis [db-name part-idx]))]
 
-                             (let [filter-opts {:query-bounds temporal-bounds
-                                                :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
-                                                :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
-                                   ^ScanMetrics metrics (ScanMetrics. db-name
-                                                                      (str (.getSchemaName table) "." (.getTableName table)))
-                                   current-tries (cat/current-tries (.trieTableState snapshot table))
-                                   filtered-tries (cat/filter-tries current-tries filter-opts)]
+                                   (util/with-close-on-catch [!segments (LinkedList.)]
 
-                               (.addFiles metrics
-                                          (long (- (count current-tries) (count filtered-tries)))
-                                          (long (count filtered-tries)))
+                                     (let [filter-opts {:query-bounds temporal-bounds
+                                                        :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
+                                                        :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
+                                           current-tries (cat/current-tries (.trieTableState snapshot table))
+                                           filtered-tries (cat/filter-tries current-tries filter-opts)]
 
-                               (doseq [{:keys [^String trie-key]} filtered-tries]
-                                 (.add !segments
-                                       (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
+                                       (.addFiles metrics
+                                                  (long (- (count current-tries) (count filtered-tries)))
+                                                  (long (count filtered-tries)))
 
-                               (doseq [^TableSnapshot live-table-snap live-table-snaps]
-                                 (.add !segments (.getSegment live-table-snap)))
+                                       (doseq [{:keys [^String trie-key]} filtered-tries]
+                                         (.add !segments
+                                               (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
 
-                               (let [count-pages (fn [pages]
-                                                   (let [survivors (trie/filter-pages pages filter-opts)]
-                                                     (.addPages metrics
-                                                                (long (- (count pages) (count survivors)))
-                                                                (long (count survivors)))
-                                                     survivors))
-                                     merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) count-pages)]
-                               (cond-> (ScanCursor. allocator (vec col-names) col-preds
-                                                    temporal-bounds (boolean (:clamp-valid-time? scan-opts))
-                                                    !segments (.iterator ^Iterable merge-tasks)
-                                                    schema args
-                                                    metrics)
-                                 (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer
-                                                                                                    query-span
-                                                                                                    (format "query.cursor.scan.%s" (.getTableName table))
-                                                                                                    (not-empty
-                                                                                                     (merge-with merge
-                                                                                                                 (when pushdown-blooms
-                                                                                                                   (update-keys
-                                                                                                                    (update-vals pushdown-blooms (fn [b] {:bloom-filter b}))
-                                                                                                                    str))
+                                       (doseq [^TableSnapshot live-table-snap (.table snapshot table)]
+                                         (.add !segments (.getSegment live-table-snap)))
+
+                                       (let [count-pages (fn [pages]
+                                                           (let [survivors (trie/filter-pages pages filter-opts)]
+                                                             (.addPages metrics
+                                                                        (long (- (count pages) (count survivors)))
+                                                                        (long (count survivors)))
+                                                             survivors))
+                                             merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) count-pages)]
+                                         (ScanCursor. allocator (vec col-names) col-preds
+                                                      temporal-bounds (boolean (:clamp-valid-time? scan-opts))
+                                                      !segments (.iterator ^Iterable merge-tasks)
+                                                      schema args
+                                                      metrics))))))]
+
+                           ;; the tracing wrap stays inside the close-on-catch: it takes ownership of the
+                           ;; cursors, so anything it throws on the way (building the attribute map, say)
+                           ;; would otherwise strand them with their segments open.
+                           (util/with-close-on-catch [!cursors (LinkedList.)]
+                             (dorun (map-indexed (fn [part-idx [query-part snapshot]]
+                                                   (.add !cursors (->partition-cursor part-idx query-part snapshot)))
+                                                 (map vector query-parts part-snaps)))
+
+                             (cond-> (if (= 1 (.size !cursors))
+                                       (.getFirst !cursors)
+                                       (PartitionedScanCursor. (vec !cursors) metrics))
+
+                               (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer
+                                                                                                  query-span
+                                                                                                  (format "query.cursor.scan.%s" (.getTableName table))
+                                                                                                  (not-empty
+                                                                                                   (merge-with merge
+                                                                                                               (when pushdown-blooms
                                                                                                                  (update-keys
-                                                                                                                  (update-vals (into {} (filter val) (or pushdown-iids {}))
-                                                                                                                               (fn [s] {:iids s}))
-                                                                                                                  str))))))))))))}))))
+                                                                                                                  (update-vals pushdown-blooms (fn [b] {:bloom-filter b}))
+                                                                                                                  str))
+                                                                                                               (update-keys
+                                                                                                                (update-vals (into {} (filter val) (or pushdown-iids {}))
+                                                                                                                             (fn [s] {:iids s}))
+                                                                                                                str))))))))))}))))
 
 (defmethod lp/emit-expr :scan [scan-expr {:keys [^IScanEmitter scan-emitter db-cat scan-vec-types, param-types]}]
   (assert db-cat)

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -51,7 +51,7 @@
            (xtdb.indexer DatabaseSnapshot Snapshot)
            xtdb.NodeBase
            xtdb.operator.scan.IScanEmitter
-           (xtdb.query IQuerySource IQuerySource$Factory ParsedStatement PreparedQuery SqlStatement$Assert SqlStatement$CreateTable SqlStatement$Delete SqlStatement$Erase SqlStatement$GrantRole SqlStatement$Patch SqlStatement$Put SqlStatement$RevokeRole)
+           (xtdb.query IQuerySource IQuerySource$Factory IQuerySource$QueryCatalog IQuerySource$QueryPartition ParsedStatement PreparedQuery SqlStatement$Assert SqlStatement$CreateTable SqlStatement$Delete SqlStatement$Erase SqlStatement$GrantRole SqlStatement$Patch SqlStatement$Put SqlStatement$RevokeRole)
            xtdb.util.RefCounter))
 
 (defn- wrap-result-types [^ICursor cursor, result-types]
@@ -183,14 +183,19 @@
     conformed-plan))
 
 (defn- emit-query [{:keys [conformed-plan scan-cols col-names ^Cache emit-cache, explain-analyze?]},
-                   scan-emitter, db-cat, snaps
+                   scan-emitter, ^IQuerySource$QueryCatalog db-cat, snaps
                    param-types, {:keys [default-tz]}]
   (.get emit-cache {:scan-vec-types (scan/scan-vec-types db-cat snaps scan-cols)
 
                     ;; this one is just to reset the cache for up-to-date stats
                     ;; probably over-zealous
+                    ;; every partition's block index: a scan's stats and its emitted branches both
+                    ;; depend on all of them, so a block landing in any partition must invalidate.
                     :last-known-blocks (->> (for [db-name (.getDatabaseNames db-cat)]
-                                              [db-name (some-> (.databaseOrNull db-cat db-name) .getQueryState .getBlockCatalog .getCurrentBlockIndex)]))
+                                              [db-name (some->> (.databaseOrNull db-cat db-name)
+                                                                (.getPartitions)
+                                                                (mapv (fn [^IQuerySource$QueryPartition part]
+                                                                        (.getCurrentBlockIndex (.getBlockCatalog (.getState part))))))]))
 
                     :default-tz default-tz
                     :param-types param-types

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -898,7 +898,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     dbCat.awaitAll(awaitToken, awaitTimeout)
                     dbCat.databaseNames.flatMap { dbName ->
                         val db = dbCat.databaseOrNull(dbName) ?: return@flatMap emptyList()
-                        db.partitions.toSortedMap().map { (part, partition) ->
+                        db.partitions.mapIndexed { part, partition ->
                             mapOf("db_name" to dbName, "part" to part) + read(db, partition)
                         }
                     }

--- a/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/OpenTx.kt
@@ -12,6 +12,7 @@ import xtdb.arrow.VectorType.Companion.I64
 import xtdb.arrow.VectorType.Companion.INSTANT
 import xtdb.arrow.VectorType.Companion.TRANSIT
 import xtdb.authz.RoleMembership
+import xtdb.catalog.DatabaseTableCatalog
 import xtdb.database.DatabaseName
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
@@ -153,10 +154,15 @@ class OpenTx
         get() {
             val liveIndex = partitionState.liveIndex
 
+            val queryPartition = object : IQuerySource.QueryPartition {
+                override val storage get() = partitionStorage
+                override val state get() = partitionState
+            }
+
             val queryDb = object : IQuerySource.QueryDatabase {
                 override val name get() = dbName
-                override val storage get() = partitionStorage
-                override val queryState get() = partitionState
+                override val partitions = listOf(queryPartition)
+                override val tableCatalog = DatabaseTableCatalog(listOf(partitionState.tableCatalog))
                 // a tx always builds a fresh read-your-writes snapshot; the read basis doesn't apply
                 override fun openSnapshot(minBasis: List<Instant?>?) =
                     DatabaseSnapshot(listOf(liveIndex.openSnapshot(resolvedTxs, this@OpenTx)))

--- a/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
+++ b/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
@@ -45,7 +45,7 @@ object RoleMembership {
         val primary = dbCat.databaseOrNull(PRIMARY_DB) ?: return emptyList()
         val tableRef = TableRef("xt", "role_membership")
 
-        val exists = primary.queryState.tableCatalog.getTypes(tableRef) != null ||
+        val exists = primary.tableCatalog.getTypes(tableRef) != null ||
                 primary.openSnapshot(null).use { it.tableInfo().containsKey(tableRef) }
         if (!exists) return emptyList()
 

--- a/core/src/main/kotlin/xtdb/catalog/DatabaseTableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/DatabaseTableCatalog.kt
@@ -1,0 +1,35 @@
+package xtdb.catalog
+
+import xtdb.api.TableRef
+import xtdb.arrow.VectorType
+import xtdb.catalog.TableCatalog.Companion.mergeTypeMaps
+import xtdb.catalog.TableCatalog.Companion.mergeTypesByTable
+import xtdb.trie.ColumnName
+
+/**
+ * Read-only database-level view of the historical table metadata, merging each partition's own
+ * [TableCatalog].
+ *
+ * Read-only is the point: writes go through the owning partition's indexer, which is the only
+ * writer to that partition's catalog, so there is no database-level write to express. `null`
+ * means "no partition has this table", not "empty".
+ *
+ * The type merge is associative and commutative, so the reduction is well-defined whatever order
+ * the partitions arrive in.
+ */
+class DatabaseTableCatalog(private val partitions: List<TableCatalog>) {
+
+    // via [getTypes] rather than reducing each partition's `getType`, so the two can't disagree.
+    // Reducing `getType` would drop a partition that has the table but not the column, where the
+    // merge has to see that partition's absent column as `Null` and make the merged type nullable.
+    fun getType(table: TableRef, columnName: ColumnName): VectorType? = getTypes(table)?.get(columnName)
+
+    fun getTypes(table: TableRef): Map<ColumnName, VectorType>? =
+        mergeTypeMaps(partitions.map { it.getTypes(table) })
+
+    fun rowCount(table: TableRef): Long? =
+        partitions.mapNotNull { it.rowCount(table) }.reduceOrNull(Long::plus)
+
+    val types: Map<TableRef, Map<ColumnName, VectorType>>
+        get() = mergeTypesByTable(partitions.map { it.types })
+}

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -148,6 +148,23 @@ class TableCatalog(
                 }
             }
 
+        /**
+         * Merges one table's column types across a database's partitions; null if no partition has
+         * the table. A null entry is "this partition doesn't have the table" — distinct from an
+         * empty map, and distinct again from a partition that has the table without some column,
+         * which [mergeVecTypes] widens to nullable.
+         */
+        internal fun mergeTypeMaps(perPartition: List<Map<ColumnName, VectorType>?>) =
+            perPartition.filterNotNull().reduceOrNull { l, r -> mergeVecTypes(l, r) }
+
+        /** As [mergeTypeMaps], across every table each partition knows about. */
+        internal fun mergeTypesByTable(perPartition: List<Map<TableRef, Map<ColumnName, VectorType>>>) =
+            buildMap {
+                for (partition in perPartition)
+                    for ((table, types) in partition)
+                        put(table, mergeVecTypes(get(table), types))
+            }
+
         internal fun mergeHlls(old: Map<ColumnName, HLL>?, new: Map<ColumnName, HLL>?): Map<ColumnName, HLL> =
             when {
                 old == null -> new.orEmpty()

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -65,7 +65,7 @@ class Database(
     override val name: DatabaseName,
     val logs: DatabaseLogs,
     val isIndexing: Boolean,
-    val partitions: Map<Int, DatabasePartition>,
+    val partitions: List<DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
     private val job: Job? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
@@ -73,11 +73,17 @@ class Database(
 
     init {
         require(partitions.isNotEmpty()) { "Database must have at least one partition" }
+
+        // List position *is* the partition index — that's what lets snapshot slots, basis slots and
+        // partitions be zipped positionally throughout the read path.
+        partitions.forEachIndexed { idx, part ->
+            require(part.partition == idx) { "partition ${part.partition} at index $idx" }
+        }
     }
 
     // Single-partition delegate. Per the stage-4 design, this becomes a per-partition
     // lookup once `partitions > 1` is enabled; for now every Database has exactly one.
-    private val partition0: DatabasePartition get() = partitions.getValue(0)
+    private val partition0: DatabasePartition get() = partitions[0]
 
     override val storage: PartitionStorage get() = partition0.storage
     override val queryState: PartitionState get() = partition0.state
@@ -85,14 +91,10 @@ class Database(
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
 
     override fun openSnapshot(minBasis: List<Instant?>?): DatabaseSnapshot =
-        // Index minBasis by sorted position, matching how `currentBasis`/`snapshotToken` pack it and how
-        // `txBasis`/`validate-basis-not-before` read it back — slot N is the Nth partition in key order.
-        DatabaseSnapshot(partitions.entries.sortedBy { it.key }
-            .mapIndexed { idx, e -> e.value.openSnapshot(minBasis?.getOrNull(idx)) })
+        DatabaseSnapshot(partitions.mapIndexed { idx, part -> part.openSnapshot(minBasis?.getOrNull(idx)) })
 
     /** This database's read basis right now — latest-completed system-time per partition, in partition-index order. */
-    fun currentBasis(): List<Instant?> =
-        partitions.entries.sortedBy { it.key }.map { it.value.liveIndex.latestCompletedTx?.systemTime }
+    fun currentBasis(): List<Instant?> = partitions.map { it.liveIndex.latestCompletedTx?.systemTime }
 
     val blockCatalog: BlockCatalog get() = partition0.blockCatalog
     val tableCatalog: TableCatalog get() = partition0.tableCatalog
@@ -151,7 +153,7 @@ class Database(
         // Phase 2: the job tree has already been cancel-joined (by `cancelAndJoin` above, or by the
         // owner cancelling the catalog root). Free state, children before the database allocator.
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
-        (partitions.values + listOf(logs, allocator)).closeAll()
+        (partitions + listOf(logs, allocator)).closeAll()
     }
 
     fun submitTxBlocking(ops: List<TxOp>, opts: TxOpts): Xtdb.SubmittedTx {
@@ -193,7 +195,7 @@ class Database(
      * Intended for tests and manual admin pokes; bypasses the `enabled` flag.
      */
     fun gcAll() {
-        partitions.values.forEach { it.logProcessor?.gcAll() }
+        partitions.forEach { it.logProcessor?.gcAll() }
     }
 
     companion object {
@@ -394,7 +396,7 @@ class Database(
                 name = dbName,
                 logs = logs,
                 isIndexing = indexerConfig.enabled,
-                partitions = mapOf(0 to partition),
+                partitions = listOf(partition),
                 meterRegistry = meterRegistry,
                 job = job,
                 registeredGauges = gauges,
@@ -403,13 +405,13 @@ class Database(
             if (indexerConfig.enabled && !readOnly) {
                 val listener = object : Log.SubscriptionListener<SourceMessage> {
                     override fun launchTransition(partition: Int, termId: Long) =
-                        db.partitions.getValue(partition).logProcessor!!.launchTransition(partition, termId)
+                        db.partitions[partition].logProcessor!!.launchTransition(partition, termId)
 
                     override fun commitLeader(partition: Int) =
-                        db.partitions.getValue(partition).logProcessor!!.commitLeader(partition)
+                        db.partitions[partition].logProcessor!!.commitLeader(partition)
 
                     override suspend fun demoteLeader(partition: Int) {
-                        db.partitions[partition]?.logProcessor?.demoteLeader(partition)
+                        db.partitions.getOrNull(partition)?.logProcessor?.demoteLeader(partition)
                     }
                 }
                 scope.launch { logs.sourceLog.openGroupSubscription(listener) }
@@ -505,10 +507,9 @@ class Database(
                     .map { db ->
                         launch {
                             val basisVec = basis[db.name] ?: return@launch
-                            db.partitions.entries.sortedBy { it.key }
-                                .forEach { (partIdx, part) ->
-                                    basisVec.getOrNull(partIdx)?.let { part.watchers.awaitSource(it) }
-                                }
+                            db.partitions.forEachIndexed { partIdx, part ->
+                                basisVec.getOrNull(partIdx)?.let { part.watchers.awaitSource(it) }
+                            }
                         }
                     }
                     .joinAll()
@@ -551,22 +552,21 @@ class Database(
                 .encodeTimeBasisToken()
 
         // each database's latest-completed tx per partition, surfaced through Xtdb.latestCompletedTxs and
-        // pgwire's `SHOW LATEST_COMPLETED_TXS`. Partition order is positional (sorted by partition key),
-        // so it lines up with the basis-token codec.
+        // pgwire's `SHOW LATEST_COMPLETED_TXS`. Partition order is positional, so it lines up with the
+        // basis-token codec.
         fun latestCompletedTxs(): Map<DatabaseName, List<TransactionKey?>> =
             databaseNames.mapNotNull { dbName ->
                 // databaseNames and databaseOrNull are read separately, so a concurrent detach can drop a db
                 // between them — skip it, as the sibling awaitAll0/syncAll0 do, rather than NPE.
                 databaseOrNull(dbName)?.let { db ->
-                    dbName to db.partitions.entries.sortedBy { it.key }
-                        .map { it.value.liveIndex.latestCompletedTx }
+                    dbName to db.partitions.map { it.liveIndex.latestCompletedTx }
                 }
             }.toMap()
 
         fun latestSubmittedMsgIds(): Map<DatabaseName, List<MessageId>> =
             databaseNames.mapNotNull { dbName ->
                 databaseOrNull(dbName)?.let { db ->
-                    dbName to db.partitions.keys.sorted().map { db.sourceLog.latestSubmittedMsgId(it) }
+                    dbName to db.partitions.indices.map { db.sourceLog.latestSubmittedMsgId(it) }
                 }
             }.toMap()
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -25,7 +25,7 @@ import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.applyStorage
 import xtdb.arrow.VectorType
 import xtdb.catalog.BlockCatalog
-import xtdb.catalog.TableCatalog
+import xtdb.catalog.DatabaseTableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.proto.DatabaseConfig
 import xtdb.database.proto.DatabaseMode
@@ -48,6 +48,7 @@ import xtdb.util.MsgIdUtil.msgIdToOffset
 import xtdb.util.MsgIdUtil.offsetToMsgId
 import xtdb.util.closeAll
 import xtdb.util.info
+import xtdb.util.safeMapIndexed
 import xtdb.util.safelyOpening
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
@@ -65,7 +66,7 @@ class Database(
     override val name: DatabaseName,
     val logs: DatabaseLogs,
     val isIndexing: Boolean,
-    val partitions: List<DatabasePartition>,
+    override val partitions: List<DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
     private val job: Job? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
@@ -85,26 +86,25 @@ class Database(
     // lookup once `partitions > 1` is enabled; for now every Database has exactly one.
     private val partition0: DatabasePartition get() = partitions[0]
 
-    override val storage: PartitionStorage get() = partition0.storage
-    override val queryState: PartitionState get() = partition0.state
     val watchers: Watchers get() = partition0.watchers
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
 
     override fun openSnapshot(minBasis: List<Instant?>?): DatabaseSnapshot =
-        DatabaseSnapshot(partitions.mapIndexed { idx, part -> part.openSnapshot(minBasis?.getOrNull(idx)) })
+        // safeMapIndexed, not mapIndexed: a partition failing to open would otherwise strand its
+        // predecessors' snapshots with a live retain on the shared live-index snap.
+        DatabaseSnapshot(partitions.safeMapIndexed { idx, part -> part.openSnapshot(minBasis?.getOrNull(idx)) })
 
     /** This database's read basis right now — latest-completed system-time per partition, in partition-index order. */
     fun currentBasis(): List<Instant?> = partitions.map { it.liveIndex.latestCompletedTx?.systemTime }
 
     val blockCatalog: BlockCatalog get() = partition0.blockCatalog
-    val tableCatalog: TableCatalog get() = partition0.tableCatalog
+
+    override val tableCatalog: DatabaseTableCatalog by lazy { DatabaseTableCatalog(partitions.map { it.tableCatalog }) }
 
     internal fun getColumnTypes(table: TableRef): Map<ColumnName, VectorType>? {
         val historical = tableCatalog.getTypes(table)
-        // TODO (#5835) iterate the snapshot's partitions and merge per-partition live types;
-        // for now single-partition is the only allowed shape, so pick the only Snapshot.
         // gate on the current basis so a just-committed table's columns are visible (getTableSchema awaits first).
-        val live = openSnapshot(currentBasis()).use { it.partitions.first().allColumnTypes[table] }
+        val live = openSnapshot(currentBasis()).use { it.columnTypes(table) }
         return if (historical == null && live == null) null
         else (historical ?: emptyMap()) + (live ?: emptyMap())
     }

--- a/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabasePartition.kt
@@ -8,17 +8,18 @@ import xtdb.indexer.LiveIndex
 import xtdb.indexer.LogProcessor
 import xtdb.indexer.Snapshot
 import xtdb.metadata.PageMetadata
+import xtdb.query.IQuerySource
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
 import java.time.Instant
 
 class DatabasePartition(
-    val storage: PartitionStorage,
-    val state: PartitionState,
+    override val storage: PartitionStorage,
+    override val state: PartitionState,
     val watchers: Watchers,
     val compactorOrNull: Compactor.ForDatabase? = null,
     val logProcessor: LogProcessor? = null,
-) : AutoCloseable {
+) : IQuerySource.QueryPartition, AutoCloseable {
 
     // the storage view owns the partition index; delegate rather than store a second copy so the two can't disagree
     val partition: Int get() = storage.partition

--- a/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
@@ -2,6 +2,9 @@ package xtdb.indexer
 
 import xtdb.api.TransactionKey
 import xtdb.api.TableRef
+import xtdb.arrow.VectorType
+import xtdb.catalog.TableCatalog.Companion.mergeTypeMaps
+import xtdb.catalog.TableCatalog.Companion.mergeTypesByTable
 import xtdb.trie.ColumnName
 import xtdb.util.closeAll
 import java.time.Instant
@@ -34,6 +37,23 @@ class DatabaseSnapshot(val partitions: List<Snapshot>) : AutoCloseable {
                 a + (table to (a[table].orEmpty() + cols))
             }
         }
+
+    /**
+     * Live type of [column] in [table], merged across [partitions]; null if no partition has it.
+     *
+     * Via [columnTypes] rather than reducing each partition's `columnType`, so the two can't
+     * disagree — a partition that has the table but not the column has to widen the merged type
+     * to nullable rather than drop out of it.
+     */
+    fun columnType(table: TableRef, column: ColumnName): VectorType? = columnTypes(table)?.get(column)
+
+    /** Live `{column → type}` for [table], merged across [partitions]; null if no partition has it. */
+    fun columnTypes(table: TableRef): Map<ColumnName, VectorType>? =
+        mergeTypeMaps(partitions.map { it.allColumnTypes[table] })
+
+    /** Live `{table → {column → type}}` merged across [partitions]. */
+    val allColumnTypes: Map<TableRef, Map<ColumnName, VectorType>>
+        get() = mergeTypesByTable(partitions.map { it.allColumnTypes })
 
     /** One [TransactionKey] per partition, in partition-index order. */
     val txBasis: List<TransactionKey?> get() = partitions.map { it.txBasis }

--- a/core/src/main/kotlin/xtdb/operator/scan/PartitionedScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/PartitionedScanCursor.kt
@@ -1,0 +1,40 @@
+package xtdb.operator.scan
+
+import xtdb.api.ICursor
+import xtdb.arrow.RelationReader
+import xtdb.util.closeAll
+import java.util.function.Consumer
+
+/**
+ * Emits each partition's [ScanCursor] back-to-back.
+ *
+ * Concatenation rather than a merge: partitions carry disjoint `_id`s under the upstream routing
+ * contract (#5557), so there's no version of a row to resolve across them and no order key between
+ * them to merge on. Each branch has already resolved its own bitemporal versions.
+ *
+ * Presents as a single `scan` with the branches' shared [metrics], so a partitioned scan reads in
+ * EXPLAIN ANALYZE exactly as an unpartitioned one does — partition count is a physical property of
+ * the database, not something the plan chose.
+ */
+class PartitionedScanCursor(
+    private val cursors: List<ICursor>,
+    private val metrics: ScanMetrics
+) : ICursor {
+
+    override val cursorType get() = "scan"
+    override val childCursors get() = emptyList<ICursor>()
+    override val cursorAttributes get() = metrics.toMap()
+
+    private var idx = 0
+
+    override fun tryAdvance(c: Consumer<in RelationReader>): Boolean {
+        while (idx < cursors.size) {
+            if (cursors[idx].tryAdvance(c)) return true
+            idx++
+        }
+
+        return false
+    }
+
+    override fun close() = cursors.closeAll()
+}

--- a/core/src/main/kotlin/xtdb/query/IQuerySource.kt
+++ b/core/src/main/kotlin/xtdb/query/IQuerySource.kt
@@ -3,6 +3,7 @@ package xtdb.query
 import io.micrometer.core.instrument.MeterRegistry
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.query.PrepareOpts
+import xtdb.catalog.DatabaseTableCatalog
 import xtdb.database.DatabaseName
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
@@ -17,10 +18,24 @@ interface IQuerySource : AutoCloseable {
         fun databaseOrNull(dbName: DatabaseName): QueryDatabase?
     }
 
+    /** One partition's read-side state — what a single scan branch reads from. */
+    interface QueryPartition {
+        val storage: PartitionStorage
+        val state: PartitionState
+    }
+
     interface QueryDatabase : DatabaseSnapshot.Source {
         val name: DatabaseName
-        val storage: PartitionStorage
-        val queryState: PartitionState
+
+        /**
+         * In partition-index order. Slot `i` here, slot `i` of the [DatabaseSnapshot] this database
+         * opens, and slot `i` of its basis vector are the same partition — the read path zips the
+         * three positionally.
+         */
+        val partitions: List<QueryPartition>
+
+        /** Historical table metadata across every partition — the planner's database-level view. */
+        val tableCatalog: DatabaseTableCatalog
     }
 
     fun prepareQuery(query: ParsedStatement, dbs: QueryCatalog, opts: PrepareOpts): PreparedQuery

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -404,7 +404,7 @@ class ExternalSourceTest {
             name = "cdc",
             logs = DatabaseLogs(null, null),
             isIndexing = false,
-            partitions = mapOf(0 to partition),
+            partitions = listOf(partition),
             meterRegistry = null,
         )
 

--- a/core/src/test/kotlin/xtdb/catalog/DatabaseTableCatalogTest.kt
+++ b/core/src/test/kotlin/xtdb/catalog/DatabaseTableCatalogTest.kt
@@ -1,0 +1,58 @@
+package xtdb.catalog
+
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import xtdb.api.TableRef
+import xtdb.storage.MemoryStorage
+
+class DatabaseTableCatalogTest {
+
+    private lateinit var allocator: RootAllocator
+
+    @BeforeEach
+    fun setUp() { allocator = RootAllocator() }
+
+    @AfterEach
+    fun tearDown() { allocator.close() }
+
+    private val foo = TableRef("public", "foo")
+    private val bar = TableRef("public", "bar")
+
+    private fun tableCatalog(vararg tables: Pair<TableRef, List<String>>) =
+        TableCatalog(MemoryStorage(allocator, epoch = 0))
+            .also { cat -> tables.forEach { (table, cols) -> cat.seedTable(table, cols) } }
+
+    @Test
+    fun `getType agrees with getTypes for a column only one partition has`() {
+        val cat = DatabaseTableCatalog(
+            listOf(
+                tableCatalog(foo to listOf("_id", "v")),
+                tableCatalog(foo to listOf("_id")),
+            )
+        )
+
+        // the whole point: partition 1 has the table but not the column, so it has to contribute an
+        // absent `v` to the merge rather than drop out of it. Reducing each partition's `getType`
+        // can't see the difference between "no table here" and "no such column here".
+        assertEquals(
+            cat.getTypes(foo)?.get("v"), cat.getType(foo, "v"),
+            "getType and getTypes agree about the same column"
+        )
+
+        assertNull(cat.getType(foo, "no_such_col"), "a column no partition has is absent, not Null")
+        assertNull(cat.getTypes(bar), "a table no partition has is absent, not empty")
+        assertNull(cat.rowCount(bar))
+    }
+
+    @Test
+    fun `a table only one partition has still resolves`() {
+        val cat = DatabaseTableCatalog(listOf(tableCatalog(foo to listOf("_id")), tableCatalog()))
+
+        assertEquals(setOf("_id"), cat.getTypes(foo)?.keys)
+        assertEquals(setOf(foo), cat.types.keys)
+    }
+}

--- a/src/test/clojure/xtdb/multi_partition_scan_test.clj
+++ b/src/test/clojure/xtdb/multi_partition_scan_test.clj
@@ -1,0 +1,150 @@
+(ns xtdb.multi-partition-scan-test
+  (:require [clojure.test :as t]
+            [next.jdbc :as jdbc]
+            [xtdb.api :as xt]
+            [xtdb.basis :as basis]
+            [xtdb.db-catalog :as db]
+            [xtdb.log :as xt-log]
+            [xtdb.node :as xtn]
+            [xtdb.test-util :as tu]
+            [xtdb.util :as util]
+            [xtdb.vector.writer :as vw])
+  (:import (xtdb.api TransactionKey)
+           (xtdb.api.query PrepareOpts QueryOpts)
+           (xtdb.catalog DatabaseTableCatalog)
+           (xtdb.database Database Database$Catalog DatabasePartition)
+           (xtdb.indexer DatabaseSnapshot)
+           (xtdb.query IQuerySource IQuerySource$QueryCatalog IQuerySource$QueryDatabase PreparedQuery)))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-allocator)
+
+;; Multi-partition `Database`s aren't constructible yet — `Database.open` builds partition 0 and the
+;; attach-time gate rejects anything else until #5837. Two attached databases on one node stand in:
+;; each contributes a partition's worth of real storage, live index and trie catalog, written to
+;; through the public API, and the two share the node's root allocator (which two nodes wouldn't —
+;; the scan transfers page ownership, and Arrow refuses that across roots).
+;;
+;; The scan can't tell the difference: everything it reads hangs off the QueryPartition and the
+;; DatabaseSnapshot slot beside it.
+(defn- ->partitioned-db-cat ^IQuerySource$QueryCatalog [node db-names]
+  (let [^Database$Catalog db-cat (db/<-node node)
+        parts (mapv #(first (.getPartitions ^Database (.databaseOrNull db-cat %))) db-names)
+        table-cat (DatabaseTableCatalog. (mapv #(.getTableCatalog ^DatabasePartition %) parts))
+        qdb (reify IQuerySource$QueryDatabase
+              (getName [_] "xtdb")
+              (getPartitions [_] parts)
+              (getTableCatalog [_] table-cat)
+              (openSnapshot [_ min-basis]
+                (DatabaseSnapshot. (into [] (map-indexed (fn [idx ^DatabasePartition part]
+                                                           (.openSnapshot part (when min-basis (nth min-basis idx nil)))))
+                                         parts))))]
+    (reify IQuerySource$QueryCatalog
+      (getDatabaseNames [_] ["xtdb"])
+      (databaseOrNull [_ n] (when (= n "xtdb") qdb)))))
+
+;; each partition's latest-completed system time, as the read basis the presented database would
+;; publish. Without it the live index serves its cached snapshot, which predates the writes.
+(defn- ->snapshot-token [node db-names]
+  (let [^Database$Catalog db-cat (db/<-node node)]
+    (basis/->time-basis-str
+     {"xtdb" (mapv #(first (.currentBasis ^Database (.databaseOrNull db-cat %))) db-names)})))
+
+;; `prepareRa` directly, rather than `tu/query-ra`, because the catalog isn't the node's own — hence
+;; also the explicit sync and basis resolution, which `tu/query-ra` would otherwise do for us.
+(defn- query-ra
+  ([node db-names plan] (query-ra node db-names plan nil))
+  ([node db-names plan snapshot-token]
+   (xt-log/sync-node node #xt/duration "PT5S")
+
+   (let [snapshot-token (or snapshot-token (->snapshot-token node db-names))
+         ^IQuerySource q-src (.getQuerySource (util/node-base node))
+         ^PreparedQuery pq (.prepareRa q-src plan (->partitioned-db-cat node db-names)
+                                       (PrepareOpts. nil nil "xtdb" nil false false snapshot-token))]
+     (util/with-open [args (.openSlice vw/empty-args tu/*allocator*)
+                      res (.openQuery pq args (QueryOpts. nil nil snapshot-token nil))]
+       (into [] cat (tu/<-cursor res))))))
+
+(def ^:private db-names ["xtdb" "part1"])
+
+(defn- start-node ^xtdb.api.Xtdb []
+  (doto (xtn/start-node tu/*node-opts*)
+    (jdbc/execute! ["ATTACH DATABASE part1"])))
+
+(t/deftest scan-unions-every-partition
+  (with-open [node (start-node)]
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :a, :v 1}]])
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :b, :v 2}]
+                         [:put-docs :xt_docs {:xt/id :c, :v 3}]]
+                   {:database :part1})
+
+    (t/is (= #{{:xt/id :a, :v 1} {:xt/id :b, :v 2} {:xt/id :c, :v 3}}
+             (set (query-ra node db-names '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id v]}]))))))
+
+(t/deftest scan-unions-historical-and-live-across-partitions
+  (with-open [node (start-node)]
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :flushed, :v 1}]])
+    (tu/flush-block! node)
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :live, :v 2}]] {:database :part1})
+
+    (t/is (= #{{:xt/id :flushed, :v 1} {:xt/id :live, :v 2}}
+             (set (query-ra node db-names '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id v]}])))
+          "one partition's tries and another's live index both reach the same scan")))
+
+(t/deftest column-types-merge-across-partitions
+  (with-open [node (start-node)]
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id 0, :v 1}]])
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id 1, :v "foo"}]] {:database :part1})
+
+    (t/testing "live types, merged off the partitions' snapshots"
+      (t/is (= #{{:v 1} {:v "foo"}}
+               (set (query-ra node db-names '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [v]}])))
+            "an i64 in one partition and a utf8 in another widen to their union rather than one losing rows"))
+
+    (t/testing "historical types, merged off the partitions' table catalogs"
+      (tu/flush-block! node)
+
+      (t/is (= #{{:v 1} {:v "foo"}}
+               (set (query-ra node db-names '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [v]}])))))))
+
+(t/deftest column-absent-from-one-partition-widens-to-nullable
+  (with-open [node (start-node)]
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id 0, :v 1}]])
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id 1}]] {:database :part1})
+    (tu/flush-block! node)
+
+    (t/is (= #{{:xt/id 0, :v 1} {:xt/id 1}}
+             (set (query-ra node db-names '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id v]}])))
+          "a partition that has the table but not the column contributes an absent `v`, not nothing")))
+
+(t/deftest each-partition-applies-its-own-temporal-bound
+  (with-open [node (start-node)]
+    (let [scan '[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [_id]}]
+          put (fn [id & {:as opts}]
+                (.getSystemTime ^TransactionKey (xt/execute-tx node [[:put-docs :xt_docs {:xt/id id}]] opts)))
+
+          ;; interleaved, so each partition's later tx lands inside the *other* partition's span: a
+          ;; scan that read partition 0's basis slot for every branch would let "1-late" through
+          _0-early (put "0-early")
+          t1-early (put "1-early" {:database :part1})
+          _1-late (put "1-late" {:database :part1})
+          t0-late (put "0-late")]
+
+      (t/is (= #{"0-early" "0-late" "1-early" "1-late"} (set (map :xt/id (query-ra node db-names scan))))
+            "sanity: every tx of both partitions is visible with no basis pinned")
+
+      (t/is (= #{"0-early" "0-late" "1-early"}
+               (set (map :xt/id (query-ra node db-names scan
+                                          (basis/->time-basis-str {"xtdb" [t0-late t1-early]})))))
+            "partition 1 reads its own earlier basis slot, so its later tx is excluded while partition 0's is not"))))
+
+(t/deftest live-tables-sums-row-counts-across-partitions
+  (with-open [node (start-node)]
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :a}]])
+    (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :b}]
+                         [:put-docs :xt_docs {:xt/id :c}]]
+                   {:database :part1})
+
+    (t/is (= [{:schema-name "public", :table-name "xt_docs", :row-count 3}]
+             (->> (query-ra node db-names '[:scan {:db-name "xtdb", :table #xt/table xt/live_tables
+                                                   :columns [schema_name table_name row_count]}])
+                  (filter (comp #{"xt_docs"} :table-name)))))))

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -35,7 +35,7 @@
            (xtdb.test.log RecordingLog$Factory)
            xtdb.api.query.IKeyFn
            (xtdb.arrow Relation RelationReader Vector VectorReader VectorType)
-           [xtdb.database Database Database$Catalog]
+           [xtdb.database Database Database$Catalog DatabasePartition]
            xtdb.database.Database$Catalog
            (xtdb.api.tx OpenTx)
            (xtdb.indexer LiveTable)
@@ -387,8 +387,10 @@
   (^OpenTx [^xtdb.api.Xtdb node ^TransactionKey tx-key]
    (->open-tx (.getAllocator node) node tx-key))
   (^OpenTx [^BufferAllocator allocator node ^TransactionKey tx-key]
-   (let [db (db/primary-db node)]
-     (OpenTx. allocator (util/node-base node) (.getStorage db) (.getQueryState db) (.getName db) tx-key nil nil))))
+   (let [db (db/primary-db node)
+         ;; a tx is always scoped to one partition — see OpenTx.queryCatalog
+         ^DatabasePartition part (first (.getPartitions db))]
+     (OpenTx. allocator (util/node-base node) (.getStorage part) (.getState part) (.getName db) tx-key nil nil))))
 
 (defn open-put-log-rel
   "Builds a log-data relation of put ops via the public log-data writer - the same relation


### PR DESCRIPTION
Part of #5557. Resolves #5835.

## Context

Stage 4 unit 7. Every partition-scoped read still resolved through partition 0: the scan took `first(snapshot.partitions)` and read that partition's storage, `scan-vec-types` and `Database.getColumnTypes` took the same slot, and info_schema read its catalogs off `queryState`.

Most of those were *incomplete* above one partition. One was *wrong*: the temporal-bounds lookup in `scan.clj` indexed the basis at a hardcoded `0`, so at more than one partition every branch would apply partition 0's bound and the scan would return the wrong rows rather than fail. That site is the reason this unit exists.

Single-partition behaviour is preserved exactly — at one partition the database-level catalog view is a passthrough, and the scan emits the same single cursor it does today.

## Changes

1. `tidy(database): index Database.partitions by list position` — `Map<Int, DatabasePartition>` becomes a `List` whose position *is* the partition index. Behaviour-preserving.
2. `feat(query): partition-aware read path` — the substance.

## The aggregation points

`IQuerySource.QueryDatabase` no longer exposes a `PartitionStorage`/`PartitionState` pair. It exposes `partitions: List<QueryPartition>` in index order, plus a `DatabaseTableCatalog`.

`DatabaseTableCatalog` is a read-only database-level view over the per-partition `TableCatalog`s. `getType` and `getTypes` reduce the type merge across partitions, `rowCount` sums, and `null` keeps meaning "no partition has this table". Writes are unrepresentable there on purpose: each partition's indexer is the sole writer to its own catalog, so there's no database-level write to express. `DatabaseSnapshot` grew the matching merges over its per-partition `Snapshot`s.

Everything else stays per-partition, as the issue's call-site walk predicted. `TrieCatalog` reads route through the snapshot's trie-table state at scan runtime, so each branch reads its own partition's tries and no wrapper earns its keep. `BlockCatalog`'s only database-level read is the emit cache's `last-known-blocks`, which becomes a tuple over partitions rather than a merge — a block landing in any partition changes what a scan's branches and stats see.

## The positional invariant

Slot `i` of the partition list, slot `i` of the `DatabaseSnapshot`, and slot `i` of the basis vector are the same partition, and the scan zips all three.

That's stated on `QueryDatabase`, asserted in `Database`'s constructor (each partition's storage handle must agree with its list position), and checked in the scan before it dispatches on table kind. The check isn't belt-and-braces: a short snapshot list makes `map vector` truncate and drop a partition's rows, and a short basis vector makes `get-in` return nil and silently unpin that partition's temporal bound — both the exact failure mode this unit is here to remove. It sits above the `cond` rather than in the `:else` arm because the info_schema cursor reads both lists too.

The single-column merges derive from their map-level siblings — `getType` from `getTypes`, `columnType` from `columnTypes`. Reducing each partition's own `getType` can't tell "this partition doesn't have the table" from "this partition has the table but not this column", and the second has to widen the merged type to nullable rather than drop out of the merge. Deriving makes them consistent by construction, and the reductions are shared with `mergeVecTypes` so the historical and live sides can't drift — `scan-vec-types` reads them side by side.

The `Map` → `List` tidy in commit 1 exists to state that invariant in the type rather than re-deriving it with `entries.sortedBy { it.key }` at each of the five call sites that needed partition order.

## Decision: scan-internal fan-out, not a UNION operator

The open question on the issue. The catalog story is identical either way; the choice is whether the planner sees N branches.

Scan-internal, for three reasons:

- **Partitions are physical, not logical.** The scan already hides multiple physical segments — a live index plus N trie files — behind one operator. Partition fan-out is the same kind of thing. Emitting it into the plan leaks the storage layout into the logical plan for a distinction the reader can't act on.
- **EXPLAIN and costing stay put.** A real UNION would change EXPLAIN output and give the planner N row-count estimates to cost, which can reorder joins. That's a behaviour change for single-partition users the moment the shape generalises.
- **No special case at N=1.** A UNION emitter would need "don't wrap when there's one branch" to preserve today's output. Here the wrapper is simply elided.

So the branches share one `ScanMetrics` and present as a single `scan` cursor — a partitioned scan reads in EXPLAIN ANALYZE exactly as an unpartitioned one does.

`PartitionedScanCursor` concatenates rather than merges. Partitions carry disjoint `_id`s under the upstream routing contract, so there's no version of a row to resolve across them and no order key to merge on; each branch has already resolved its own bitemporal versions.

## info_schema

The issue flagged that info_schema aggregation doesn't fall out for free, and it didn't. The synthetic-table cursor now takes the `DatabaseSnapshot` and reads its catalogs through the database-level view, so `information_schema.columns`, `pg_class` and friends aggregate for free from there.

The `xt.*` observability tables needed a per-table decision:

- `xt.live_tables` sums its row counts across partitions — the same thing it already does across a partition's individual live-table slots.
- `xt.trie_stats` and `xt.live_columns` union theirs. A trie key is only unique within its partition, so above one partition those rows want a `partition` column to be told apart. That's #5849's job; union is at least complete, where partition-0-only would silently drop data.

## Testing

Multi-partition `Database`s aren't constructible yet — `Database.open` builds partition 0 and the attach-time gate rejects anything else until #5837. So the read-path tests present **two attached databases on one node** as the two partitions of one logical database, via a `QueryCatalog` reify. Data goes in through the public API; storage, live index and trie catalog are all real.

Two nodes was the first attempt and doesn't work: the scan transfers page ownership from the live index, and Arrow refuses that between allocators that don't share a root. Two databases on one node do share one.

Reverting the per-branch basis slot to the hardcoded `0` fails four of those tests, including the temporal-bounds one specifically.

The cross-partition type merge is pinned by a Kotlin unit test rather than an end-to-end one, deliberately: at the scan, the live-index half of `scan-vec-types` masks an error in the historical half, so an end-to-end test passes either way. `DatabaseTableCatalogTest` asserts the contract directly.

## Dropped from this PR

#5835's checklist carried "concurrent-write non-collision assertion, carried over from unit 6". I wrote it, then talked myself out of it on review, and it isn't here.

Partition isolation in the buffer pool is path construction — partition 0 writes `parts/0/…`, partition 1 writes `parts/1/…`, different strings. Concurrency can't break that, and the two threads never interact, so there's no interleaving window in which a bug could manifest deterministically. A real defect would have shown up probabilistically, i.e. as flake. `partitionedPoolsAreIsolated` already asserts the same properties sequentially and more precisely, including GC delete isolation.

I initially justified the deletion by pointing at a supposed gap in the shared `memoryCache`/`diskCache` the fixtures hand both pools. That was wrong: `LocalStorage` scopes its cache keys by `dbName/partition` already, with a comment saying so, so there is no cross-partition collision to catch. (#5833 is about those keys omitting the *storage root*, which is an epoch concern, not a partition one.) The deletion stands on its own reasoning above; there's no substitute test I've identified.

## Out of scope

- **The `partition0` delegate survives**, per the issue — `watchers`, `blockCatalog`, `trieCatalog`, `bufferPool` and friends still serve the snapshot export (#5838) and healthz. `storage` and `queryState` are gone from it, since the read path was their only caller.
- **`xt.block_files` / `xt.table_block_files`** still read partition 0's buffer pool, and now carry a marker saying why they can't simply follow `xt.trie_stats` into a union: they're addressed by block index, and block N exists in every partition with different contents, so unioning reads as duplicates of one block rather than as more rows. That's an addressing decision, not a labelling one — raised as #5849 along with the trie-stats column and the rest of stage 4's unit 10, which had been a bare checklist line on #5557 with nowhere to hang either.
- **Partition labelling** on the `xt.*` observability tables, as above.

Two properties of the fan-out are worth naming here rather than leaving for whoever lifts the gate, since both are baked into this design and go live with #5837:

- **Duplicate `_id`s across partitions surface as duplicate rows.** Concatenation gives up the "one resolved version per `_iid`" property a single-branch `MergePlanner` had structurally. That's the documented consequence of the `_id`-stable partitioner contract in #5557, not a new gap — enforcing it would need a cross-partition iid merge, which is the coupling the throughput scaling exists to avoid. Nothing in the read path checks it.
- **All N branch cursors are built eagerly and held to query end.** `MergePlanner/planSync` runs per branch at construction and `PartitionedScanCursor` only closes on its own close, so peak allocator usage is N× a single-partition scan's for the whole query rather than one partition at a time. Closing each branch as it drains is the obvious mitigation; #5557 defers per-node resource work as measure-then-optimise, so it's flagged rather than done.

## One thing to flag

`xtdb.read-only-node-test/read-only-node-sees-data-after-block-flush` failed once in five full-suite runs on this branch, with row `b` present but its `y` column missing. It doesn't reproduce in isolation, didn't recur in the four other full runs (including the final `cleanTest test`), and I couldn't tie it to anything in the diff — the read path doesn't touch the follower's block-application path or `sync-node`, and `sync-node` returning doesn't guarantee the follower has applied the block (the sibling test at line 88 documents exactly that gap). Recording it rather than dropping it; worth a look if it shows up in CI.

## Review

A `/code-review high` pass over the branch raised ten findings; six are fixed in the commits above, three are the deferred items named under Out of scope, and one applied to a test that has since been dropped (see below). The two that mattered were an exception-safety regression in the scan (the tracing wrap had drifted outside its `with-close-on-catch`) and the `getType` inconsistency described under the positional invariant.

## Test plan

- [x] `./gradlew test` — green (2053 tests)
- [x] `./gradlew :xtdb-core:test` — green
- [x] New: `xtdb.multi-partition-scan-test`, 5 tests over a genuinely two-partition read path
- [x] Mutation check: reverting the per-branch basis slot fails 4 of the 5 new tests

Ship/Show/Ask: **Show**.