### PR TITLE
fix(pgwire): bound connection admission and the pre-auth read

### DIFF
--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -22,14 +22,14 @@
   (:import io.micrometer.core.instrument.Counter
            [java.io Closeable DataInputStream EOFException IOException PushbackInputStream]
            [java.lang Thread$State]
-           [java.net InetAddress ServerSocket Socket SocketException]
+           [java.net InetAddress ServerSocket Socket SocketException SocketTimeoutException]
            [java.nio ByteBuffer]
            [java.nio.charset StandardCharsets]
            [java.nio.channels FileChannel]
            [java.nio.file Path]
            [java.security KeyStore]
            [java.time Clock Duration ZoneId]
-           [java.util.concurrent ExecutorService Executors Future$State FutureTask TimeUnit]
+           [java.util.concurrent ExecutorService Future$State FutureTask LinkedBlockingQueue RejectedExecutionException ThreadPoolExecutor TimeUnit]
            [javax.net.ssl KeyManagerFactory SSLContext]
            (org.apache.arrow.memory BufferAllocator)
            org.apache.arrow.vector.types.pojo.Field
@@ -57,6 +57,8 @@
 (defrecord Server [^BufferAllocator allocator
                    ^InetAddress host
                    port read-only? playground?
+
+                   num-threads authn-timeout-ms
 
                    ^ServerSocket accept-socket
                    ^Thread accept-thread
@@ -409,7 +411,7 @@
           (pgio/cmd-write-msg conn pgio/msg-auth {:result 3})
 
           ;; we go idle until we receive a message
-          (when-let [{:keys [msg-name] :as msg} (pgio/read-client-msg! frontend)]
+          (when-let [{:keys [msg-name] :as msg} (pgio/read-client-msg! frontend pgio/max-startup-packet-length)]
             (if (not= :msg-password msg-name)
               (throw (err-invalid-auth-spec (str "password authentication failed for user: " user)))
 
@@ -437,7 +439,7 @@
           (pgio/cmd-write-msg conn pgio/msg-auth {:result 3})
 
           ;; we go idle until we receive a message
-          (when-let [{:keys [msg-name] :as msg} (pgio/read-client-msg! frontend)]
+          (when-let [{:keys [msg-name] :as msg} (pgio/read-client-msg! frontend pgio/max-startup-packet-length)]
             (if (not= :msg-password msg-name)
               (throw (err-invalid-auth-spec (str "client credentials authentication failed for user: " user)))
 
@@ -495,6 +497,14 @@
       (log/debug e "EOFException during startup")
       (doto conn
         (handle-msg* {:msg-name :msg-terminate})))
+
+    ;; deliberately no send-ex: the client has already proved it isn't reading, and a
+    ;; write to a peer that isn't draining its receive window would block us in turn.
+    (catch SocketTimeoutException _
+      (log/debug "Timed out waiting for the client to authenticate" {:cid (:cid conn)})
+      (doto conn
+        (handle-msg* {:msg-name :msg-terminate})))
+
     (catch Exception e
       (doto conn
         (send-ex e)
@@ -1566,7 +1576,7 @@
 
         ;; go idle until we receive another msg from the client
         :else (do
-                (when-let [msg (pgio/read-client-msg! frontend)]
+                (when-let [msg (pgio/read-client-msg! frontend pgio/max-msg-length)]
                   (handle-msg conn msg))
 
                 (recur))))))
@@ -1578,7 +1588,7 @@
   freed at the end of this function. So the connections lifecycle should be totally enclosed over the lifetime of a connect call.
 
   See comment 'Connection lifecycle'."
-  [{:keys [node, ^Authenticator authn, server-state, port, allocator, tx-error-counter, tx-latency-timer, ^Counter total-connections-counter, ^Counter cancelled-connections-counter, query-tracer] :as server} ^Socket conn-socket]
+  [{:keys [node, ^Authenticator authn, server-state, port, allocator, authn-timeout-ms, tx-error-counter, tx-latency-timer, ^Counter total-connections-counter, ^Counter cancelled-connections-counter, query-tracer] :as server} ^Socket conn-socket]
   (let [close-promise (promise)
         {:keys [cid !closing?] :as conn} (util/with-close-on-catch [_ conn-socket]
                                            (let [cid (:next-cid (swap! server-state update :next-cid (fnil inc 0)))
@@ -1587,6 +1597,13 @@
                                                  !closing? (atom false)]
                                              (log/debug "New connection" {:cid cid})
                                              (try
+                                               ;; A client that completes the TCP handshake and then goes quiet would
+                                               ;; otherwise hold one of the server's finite handler slots for good — see
+                                               ;; #5850. Bound the pre-auth phase, as Postgres does with
+                                               ;; authentication_timeout. An SSL upgrade layers over this same socket,
+                                               ;; so the deadline survives it.
+                                               (.setSoTimeout conn-socket (int authn-timeout-ms))
+
                                                (-> (map->Connection {:cid cid, :node node, :authn authn, :server server,
                                                                      :frontend (pgio/->socket-frontend conn-socket),
                                                                      :!closing? !closing?
@@ -1597,7 +1614,11 @@
                                                  (reset! !closing? true))
                                                (catch Throwable t
                                                  (log/warn t "error on conn startup")
-                                                 (throw t)))))
+                                                 (throw t))
+                                               (finally
+                                                 ;; an authenticated session is entitled to idle for as long as it likes
+                                                 (when-not (.isClosed conn-socket)
+                                                   (.setSoTimeout conn-socket 0))))))
         conn (assoc conn
                     :query-tracer query-tracer
                     :tx-error-counter tx-error-counter
@@ -1657,8 +1678,27 @@
           (try
             (let [conn-socket (.accept accept-socket)]
               (.setTcpNoDelay conn-socket true)
-              ;; TODO fix buffer on tp? q gonna be infinite right now
-              (.submit thread-pool ^Runnable (fn [] (connect server conn-socket))))
+              (try
+                ;; execute, not submit: submit buries an escaping throwable in a Future
+                ;; nobody reads, which is why #5850 produced no logs at all.
+                (.execute thread-pool ^Runnable (fn [] (connect server conn-socket)))
+                (catch RejectedExecutionException _
+                  ;; At capacity. Closing is the only honest answer — a queued socket the
+                  ;; client eventually abandons sits in CLOSE_WAIT forever, holding an fd
+                  ;; nobody will ever read or close (#5850).
+                  ;;
+                  ;; We close rather than write an ErrorResponse because the client may not
+                  ;; have spoken yet: an unsolicited 'E' would be misread as the single-byte
+                  ;; reply to an SSLRequest.
+                  ;; the pool also rejects once it's been shut down, and an accept that
+                  ;; races shutdown is routine — don't report that as saturation
+                  (if @(:!closing? server)
+                    (log/debug "Refusing connection, server closing" {:port (:port server)})
+                    (log/warn "PGwire at capacity, refusing connection"
+                              {:port (:port server), :max-connections (:num-threads server)}))
+                  (when-some [c (:connections-refused-counter server)]
+                    (.increment ^Counter c))
+                  (util/try-close conn-socket))))
             (catch SocketException e
               (when (and (not (.isClosed accept-socket))
                          (not= "Socket closed" (.getMessage e)))
@@ -1682,21 +1722,41 @@
 
   :port (default 0, opening the socket on an unused port).
   :num-threads (bounds the number of client connections, default 42)
+  :authn-timeout-ms (how long a client has to complete the startup handshake, default 60s)
   :playground? (default false) - if true, the server will create a new in-memory database if it doesn't already exist.
   "
   (^Server [node] (serve node {}))
-  (^Server [node {:keys [allocator host port num-threads drain-wait ssl-ctx metrics-registry tracer query-tracing? read-only? playground?]
+  (^Server [node {:keys [allocator host port num-threads authn-timeout-ms drain-wait ssl-ctx metrics-registry tracer query-tracing? read-only? playground?]
                   :or {host (InetAddress/getLoopbackAddress)
                        port 0
                        num-threads 42
+                       authn-timeout-ms 60000
                        drain-wait 5000}}]
    (util/with-close-on-catch [accept-socket (ServerSocket. port 0 host)]
      (let [host (.getInetAddress accept-socket)
-           port (.getLocalPort accept-socket) 
+           port (.getLocalPort accept-socket)
            tx-error-counter (when metrics-registry (metrics/add-counter metrics-registry "tx.error"))
            tx-latency-timer (when metrics-registry (metrics/add-timer metrics-registry "pgwire.tx.latency" {}))
            total-connections-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.total_connections"))
-           cancelled-connections-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.cancelled_connections")) 
+           cancelled-connections-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.cancelled_connections"))
+           connections-refused-counter (when metrics-registry (metrics/add-counter metrics-registry "pgwire.connections_refused"))
+
+           ;; A handler owns its connection for the connection's whole life, so `num-threads`
+           ;; is a ceiling on concurrent clients and the queue only holds accepted-but-not-yet-
+           ;; started sockets. It has to be bounded: an unbounded one converts handler
+           ;; saturation into unbounded fd growth, with every queued client hanging on a
+           ;; handshake that will never come (#5850).
+           ;;
+           ;; Not zero-length, though — a SynchronousQueue refuses whenever no worker is
+           ;; sitting in poll() at that instant, which spuriously rejects under ordinary churn.
+           thread-pool (ThreadPoolExecutor. num-threads num-threads
+                                            0 TimeUnit/MILLISECONDS
+                                            (LinkedBlockingQueue. (int num-threads))
+                                            (-> (Thread/ofVirtual)
+                                                (.name "pgwire-connection-" 0)
+                                                (.uncaughtExceptionHandler util/uncaught-exception-handler)
+                                                (.factory)))
+
            server (map->Server {:allocator allocator
                                 :node node
                                 :authn (authn/<-node node)
@@ -1704,11 +1764,10 @@
                                 :host host
                                 :port port
                                 :read-only? read-only?
+                                :num-threads num-threads
+                                :authn-timeout-ms authn-timeout-ms
                                 :accept-socket accept-socket
-                                :thread-pool (Executors/newFixedThreadPool num-threads (-> (Thread/ofVirtual)
-                                                                                           (.name "pgwire-connection-" 0)
-                                                                                           (.uncaughtExceptionHandler util/uncaught-exception-handler)
-                                                                                           (.factory)))
+                                :thread-pool thread-pool
                                 :!closing? (atom false)
                                 ;;TODO use clock from node or at least take clock as a param for testing
                                 :server-state (atom (let [default-clock (Clock/systemDefaultZone)]
@@ -1733,7 +1792,8 @@
                          :tx-error-counter tx-error-counter
                          :tx-latency-timer tx-latency-timer
                          :total-connections-counter total-connections-counter
-                         :cancelled-connections-counter cancelled-connections-counter)
+                         :cancelled-connections-counter cancelled-connections-counter
+                         :connections-refused-counter connections-refused-counter)
            accept-thread (-> (Thread/ofVirtual)
                              (.name (str "pgwire-server-accept-" port))
                              (.uncaughtExceptionHandler util/uncaught-exception-handler)
@@ -1745,7 +1805,14 @@
        (when metrics-registry
          (metrics/add-gauge metrics-registry "pgwire.active_connections" server
                             (fn [server]
-                              (count (:connections @(:server-state server))))))
+                              (count (:connections @(:server-state server)))))
+
+         ;; the saturation signal. Sustained non-zero here is the endpoint running out of
+         ;; handlers, which is what #5850 looked like from the outside and had no reading at
+         ;; the time. Scrapeable, so it works where taking a thread dump doesn't.
+         (metrics/add-gauge metrics-registry "pgwire.pending_connections" server
+                            (fn [server]
+                              (.size (.getQueue ^ThreadPoolExecutor (:thread-pool server))))))
        (.start accept-thread)
        server))))
 

--- a/core/src/main/clojure/xtdb/pgwire/io.clj
+++ b/core/src/main/clojure/xtdb/pgwire/io.clj
@@ -6,7 +6,7 @@
   (:import [clojure.lang MapEntry]
            [java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream DataInputStream DataOutputStream EOFException IOException InputStream OutputStream]
            [java.lang AutoCloseable]
-           [java.net Socket]
+           [java.net Socket SocketTimeoutException]
            [java.nio.charset StandardCharsets]
            [javax.net.ssl SSLContext SSLSocket]))
 
@@ -15,7 +15,9 @@
     [frontend msg-def]
     [frontend msg-def data])
 
-  (read-client-msg! [frontend])
+  ;; max-length bounds the allocation we size from the client's length prefix. Callers on
+  ;; the pre-auth path MUST pass max-startup-packet-length — see the note by that constant.
+  (read-client-msg! [frontend max-length])
   (host-address [frontend])
 
   (upgrade-to-ssl [frontend ssl-ctx])
@@ -88,14 +90,32 @@
    ;; gssapi encoding is not supported by xt, and we tell the client that
    80877104 :gssenc})
 
-(defn- read-untyped-msg [^DataInputStream in]
-  (let [size (- (.readInt in) 4)
-        barr (byte-array size)
-        _ (.readFully in barr)]
-    (DataInputStream. (ByteArrayInputStream. barr))))
+(defn err-protocol-violation
+  ([msg] (err-protocol-violation msg nil))
+  ([msg cause]
+   (ex-info msg {::pgw/severity :error, ::pgw/error-code "08P01"} cause)))
+
+;; The length prefix is the first thing an unauthenticated client sends, and we size an
+;; allocation from it — so it's bounded before it's believed. Both limits are Postgres':
+;; a startup packet can't exceed 10000 bytes, and no message may reach 1GB.
+;;
+;; The tight bound holds for as long as the client is unauthenticated, which is past the
+;; startup packet itself: the password exchange is read under it too. Only once auth has
+;; succeeded does a client get to declare a large message.
+(def max-startup-packet-length 10000)
+(def max-msg-length 0x3FFFFFFF)
+
+(defn- read-untyped-msg [^DataInputStream in ^long max-length]
+  (let [size (- (.readInt in) 4)]
+    (when (or (neg? size) (> size max-length))
+      (throw (err-protocol-violation (str "Invalid message length: " (+ size 4)))))
+
+    (let [barr (byte-array size)]
+      (.readFully in barr)
+      (DataInputStream. (ByteArrayInputStream. barr)))))
 
 (defn read-version [^DataInputStream in]
-  (let [^DataInputStream msg-in (read-untyped-msg in)
+  (let [^DataInputStream msg-in (read-untyped-msg in max-startup-packet-length)
         version (.readInt msg-in)]
     {:msg-in msg-in
      :version (version-messages version)}))
@@ -107,11 +127,6 @@
     :msg-parameter-status :msg-auth :msg-ready
     :msg-portal-suspended
     :msg-copy-in-response :msg-copy-done})
-
-(defn err-protocol-violation
-  ([msg] (err-protocol-violation msg nil))
-  ([msg cause]
-   (ex-info msg {::pgw/severity :error, ::pgw/error-code "08P01"} cause)))
 
 (defrecord SocketFrontend [^Socket socket, ^DataInputStream in, ^DataOutputStream out]
   Frontend
@@ -135,14 +150,21 @@
       (when (flush-messages (:name msg-def))
         (.flush out))))
 
-  (read-client-msg! [_]
+  (read-client-msg! [_ max-length]
     (try
       (let [type-char (char (.readUnsignedByte in))
             msg-var (or (client-msgs type-char)
                         (throw (err-protocol-violation (str "Unknown client message " type-char))))
             rdr (:read @msg-var)]
-        (-> (rdr (read-untyped-msg in))
+        (-> (rdr (read-untyped-msg in max-length))
             (assoc :msg-name (:name @msg-var))))
+
+      ;; a read deadline expiring isn't the client violating the protocol, and the caller
+      ;; needs to tell the two apart — it must not try to write back to a peer that has
+      ;; already stopped talking to us
+      (catch SocketTimeoutException e
+        (throw e))
+
       (catch IOException e
         (throw (err-protocol-violation (str "Error reading client message " (ex-message e)) e)))))
 

--- a/monitoring/dev-dashboards/xtdb-monitoring.json
+++ b/monitoring/dev-dashboards/xtdb-monitoring.json
@@ -1207,6 +1207,38 @@
           "range": true,
           "refId": "Node Average",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(pgwire_pending_connections)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Cluster Awaiting Handler",
+          "range": true,
+          "refId": "Pending",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "DS_PROMETHEUS"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(rate(pgwire_connections_refused_total[5m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Cluster Refused /sec",
+          "range": true,
+          "refId": "Refused",
+          "useBackend": false
         }
       ],
       "title": "Cluster PGWire Active Connections",

--- a/monitoring/public-dashboards/xtdb-monitoring.json
+++ b/monitoring/public-dashboards/xtdb-monitoring.json
@@ -1256,6 +1256,38 @@
           "range": true,
           "refId": "Node Average",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(pgwire_pending_connections)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Cluster Awaiting Handler",
+          "range": true,
+          "refId": "Pending",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(rate(pgwire_connections_refused_total[5m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Cluster Refused /sec",
+          "range": true,
+          "refId": "Refused",
+          "useBackend": false
         }
       ],
       "title": "Cluster PGWire Active Connections",

--- a/src/test/clojure/xtdb/pgwire_protocol_test.clj
+++ b/src/test/clojure/xtdb/pgwire_protocol_test.clj
@@ -45,7 +45,8 @@
       (swap! !in-msgs conj [(:name msg-def) data]))
     nil)
 
-  (read-client-msg! [_]
+  ;; no wire framing here, so nothing to bound
+  (read-client-msg! [_ _max-length]
     (let [msg (first @!out-msgs)]
       (swap! !out-msgs rest)
       (when-not msg (throw (Exception. "No more messages")))

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -452,6 +452,66 @@
     (.close server)
     (check-server-resources-freed server)))
 
+;;; #5850 — a wedged pgwire endpoint that kept accepting sockets and never closed them.
+;;; These cover the containment: a slot can't be held forever, saturation refuses rather
+;;; than queueing without limit, and a client's length prefix isn't believed before it's
+;;; bounded.
+
+(defn- silent-socket
+  "A client that completes the TCP handshake and then says nothing at all."
+  ^Socket [port]
+  (Socket. (InetAddress/getLoopbackAddress) (int port)))
+
+(defn- hung-up?
+  "Whether the server closes its end within `ms`."
+  [^Socket socket ms]
+  (.setSoTimeout socket (int ms))
+  (try
+    (neg? (.read (.getInputStream socket)))
+    (catch java.net.SocketTimeoutException _ false)
+    (catch java.net.SocketException _ true)))
+
+(deftest silent-client-disconnected-once-authn-times-out-5850
+  (with-open [server (serve {:authn-timeout-ms 100})
+              socket (silent-socket (:port server))]
+    (is (hung-up? socket 10000)
+        "a client that never sends a startup packet doesn't hold its handler forever")))
+
+(deftest connections-beyond-capacity-refused-not-queued-5850
+  ;; num-threads 1 gives one handler plus a queue of one, so silent clients exhaust the
+  ;; server almost immediately. The authn timeout is set high so that it's capacity, and
+  ;; not the timeout, that ends up refusing them.
+  (with-open [server (serve {:num-threads 1, :authn-timeout-ms 600000})]
+    (let [port (:port server)
+          sockets (atom [])]
+      (try
+        (is (some (fn [_]
+                    (let [socket (silent-socket port)]
+                      (swap! sockets conj socket)
+                      (hung-up? socket 500)))
+                  (range 10))
+            "server refuses once handlers and queue are full, rather than accumulating sockets")
+        (finally
+          (run! util/try-close @sockets))))))
+
+(deftest client-declared-message-length-is-bounded-5850
+  ;; one server for both cases — `Server.close` closes the allocator it was given, which
+  ;; here is the shared fixture allocator, so a second server would start out broken
+  (with-open [server (serve)]
+    (letfn [(startup-with-length [len]
+              (with-open [socket (silent-socket (:port server))]
+                (doto (java.io.DataOutputStream. (.getOutputStream socket))
+                  (.writeInt len)
+                  (.flush))
+                (.setSoTimeout socket 10000)
+                (.read (.getInputStream socket))))]
+
+      (testing "a length we'd have to allocate ~2GiB to believe"
+        (is (= (int \E) (startup-with-length Integer/MAX_VALUE))))
+
+      (testing "a length shorter than its own header"
+        (is (= (int \E) (startup-with-length 0)))))))
+
 (defn- get-connections [server]
   (vals (:connections @(:server-state server))))
 


### PR DESCRIPTION
Part of #5850.

## tl;dr

Containment, not a cure — what actually occupied the connection handlers is still unidentified, and this deliberately doesn't guess at it.

- **The accept loop had no admission control**, and that alone reproduces every reported symptom.
- **Nothing on the PGwire path had a read deadline**, so a single silent client held a handler for good.
- **A pre-auth allocation was sized from a client-declared length**, unbounded and with no sign check.
- **Every piece stands on its own merits** whichever root-cause hypothesis eventually wins.
- **Two gaps left open deliberately** — CANCEL under saturation, and `:device-auth`.

## Summary

- **The queue behind the handler pool was unbounded.** `accept-loop` accepted unconditionally and handed each socket to a `newFixedThreadPool`, whose `LinkedBlockingQueue` has no capacity bound. The code already knew — a `TODO fix buffer on tp? q gonna be infinite right now` had been sitting on that line since the original implementation.
- **Saturation therefore turned into unbounded fd growth**, and every reported symptom follows from that one gap with nothing else needing to be true.
  - **TCP connects and probes succeed** — the kernel completes the handshake and the accept loop really does pull the socket. It just never gets serviced.
  - **Startup handshakes time out** — no thread ever writes the auth response.
  - **Sockets sit in `CLOSE_WAIT` forever** — the client gives up and sends FIN, and with nothing there to read or close our end, the fd is never released.
  - **~2 millicores of CPU, nothing in the logs** — everything parked rather than spinning, and nothing ever threw.

## Why this is containment and not a cure

- **The socket census argues against the obvious explanation**, which is what stopped me committing to a root cause.
  - **4 `ESTABLISHED` against 11,331 `CLOSE_WAIT` doesn't fit handlers blocked on their own socket reads** — a peer that has FIN'd delivers EOF to a blocking read, and `connect` catches `EOFException`.
  - **It fits handlers blocked downstream in the node.** Such a thread never notices its client's FIN, so its socket drops into `CLOSE_WAIT` and becomes indistinguishable from the queued ones, leaving only the freshest arrivals `ESTABLISHED`.
- **If that's right, the trigger sits upstream of PGwire entirely**, and PGwire's contribution is converting "the node stalled" into "the endpoint is silently unreachable and leaks 11k fds".
- **Settling it needs a thread dump**, which is why the issue has been unresolvable so far.

## What's fixed

Two distinct defects, in one commit because the arity change ties them — splitting would leave an intermediate that doesn't compile.

- **Admission control.** The queue is bounded at `num-threads`, and a rejected socket is closed rather than parked.
  - **Dispatch moves from `.submit` to `.execute`** — `submit` buries an escaping throwable in a `Future` nobody reads, a good part of why this failure produced no logs at all.
- **A read deadline on the startup handshake.** A client that completed the TCP handshake and then went quiet held a handler indefinitely — a NAT gateway silently expiring a conntrack entry does exactly this, and it needs only 42 of them.
  - **`SO_TIMEOUT` bounds the handshake and is cleared once it completes**, mirroring Postgres' `authentication_timeout`; an authenticated session may still idle as long as it likes.
  - **It's set on the raw socket**, which is also what governs reads once an SSL upgrade layers over it.
- **Client-declared message lengths are bounded before anything is allocated from them.** Found on the way, and on the **pre-authentication** path: `read-untyped-msg` sized a `byte-array` straight from the declared length with no bound and no sign check.
  - **A length near `Integer/MAX_VALUE` provoked a ~2 GiB allocation attempt**; one below 4, a `NegativeArraySizeException`.
  - **Both limits now match Postgres** — 10000 bytes while unauthenticated, 1GB after.

## Decision rationale

- **Refuse by closing, not by writing an `ErrorResponse`.** At refusal time the client may not have spoken yet, and an unsolicited `E` byte would be misread as the single-byte reply to an `SSLRequest`. A socket we hold but will never service is strictly worse than one the client sees fail immediately.
- **Bounded `LinkedBlockingQueue`, not a `SynchronousQueue`.** Zero-length was tempting — it would make `num-threads` mean exactly what its docstring claims — but it refuses whenever no worker happens to be sitting in `poll()` at that instant, which spuriously rejects under ordinary churn.
- **No `send-ex` when the timeout fires.** The client has already demonstrated it isn't reading, and writing to a peer that isn't draining its receive window is a way to block the very handler we're trying to free.
  - **This required `read-client-msg!` to stop wrapping `SocketTimeoutException` as a protocol violation** — it's an `IOException`, so the existing catch was swallowing the distinction.
- **The length bound is a parameter on `read-client-msg!`, not state on the frontend.** The tight bound has to hold past the startup packet, because the password exchange is read while still unauthenticated. Passing it makes each call site declare which phase it's in, rather than the frontend carrying a mutable flag that says so.

## One review finding, checked and rejected

Recorded so nobody re-raises it. A reviewer flagged at high confidence that a TLS handshake timeout would arrive wrapped in an `SSLException`, falling through to the `send-ex` path the timeout branch exists to avoid. It doesn't hold:

- **`readHandshakeRecord` re-throws `InterruptedIOException` unchanged** — *"Don't change exception in case of timeouts or interrupts"* (`SSLSocketImpl.java:1427-1429`).
- **Public `startHandshake()` calls `startHandshake(true)`**, so `resumable` is true and the exception routes to `handleException`.
- **`handleException` re-throws it as-is** — *"Don't close the Socket in case of timeouts or interrupts"* (`:1676-1678`).
- **`SocketTimeoutException extends InterruptedIOException`**, so it arrives at the catch unwrapped.

## Known gaps

Neither is introduced here, but both are worth naming rather than leaving to be discovered.

- **CANCEL can now be refused under saturation.** It arrives as a fresh connection through the same accept loop, so once pool and queue are full it's closed like anything else, where previously it would eventually have been queued. Postgres avoids this by handling cancel requests in the postmaster rather than a backend; matching that is a design change beyond containment.
- **`:device-auth` isn't bounded by the new timeout.** It blocks on `.await` rather than a socket read, so `SO_TIMEOUT` never fires. A handful of concurrent device-auth attempts against a small pool can still exhaust it.

## Out of scope

- **`authn-timeout-ms` is deliberately not exposed through `ServerConfig`**, on the same footing as `drain-wait`. If people turn out to need to tune it, that's a cheap follow-up.

## Observability

- **`pgwire.pending_connections` (queue depth) and `pgwire.connections_refused` are new**, and both are plotted on the existing connections panel in the Grafana dashboards.
- **Sustained non-zero pending is the saturation signal this incident had no reading for** — and being scraped rather than attached to, it works in deployments where taking a thread dump doesn't.

## Test plan

- **Three regression tests in `pgwire_test.clj`**, all named `…-5850`.
  - a silent client is disconnected once the authn timeout expires;
  - connections beyond capacity are refused rather than accumulating;
  - a client-declared message length is bounded, both oversized and shorter-than-its-own-header.
- **Full suite green** — 1,664 tests, no reflection or boxed-math warnings.
