### PR TITLE
tidy(scan): groundwork for the partition-aware read path

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -27,6 +27,7 @@
            (xtdb Bytes)
            (xtdb.api ICursor)
            (xtdb.indexer DatabaseSnapshot Snapshot Snapshot$Source TableSnapshot)
+           (xtdb.database PartitionStorage)
            (xtdb.metadata MetadataPredicate PageMetadata)
            (xtdb.operator.scan MultiIidSelector ScanCursor ScanMetrics SingleIidSelector)
            xtdb.query.IQuerySource$QueryCatalog
@@ -198,6 +199,47 @@
         (test [_ path]
           (not (.isEmpty (.filterIidsForPath bucketer iid-set path))))))))
 
+(defn- ->partition-scan-cursor
+  "Everything partition-specific arrives as an argument, so this knows nothing about which partition
+   it's been given or how many exist."
+  ^ICursor [{:keys [allocator ^TableRef table col-names col-preds iid-set metadata-pred scan-opts
+                    schema args ^ScanMetrics metrics]}
+            ^PartitionStorage storage ^Snapshot snapshot ^TemporalBounds temporal-bounds]
+
+  (let [metadata-mgr (.getMetadataManager storage)
+        buffer-pool (.getBufferPool storage)]
+
+    (util/with-close-on-catch [!segments (LinkedList.)]
+      (let [filter-opts {:query-bounds temporal-bounds
+                         :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
+                         :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
+            current-tries (cat/current-tries (.trieTableState snapshot table))
+            filtered-tries (cat/filter-tries current-tries filter-opts)]
+
+        (.addFiles metrics
+                   (long (- (count current-tries) (count filtered-tries)))
+                   (long (count filtered-tries)))
+
+        (doseq [{:keys [^String trie-key]} filtered-tries]
+          (.add !segments (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
+
+        (doseq [^TableSnapshot live-table-snap (.table snapshot table)]
+          (.add !segments (.getSegment live-table-snap)))
+
+        (let [count-pages (fn [pages]
+                            (let [survivors (trie/filter-pages pages filter-opts)]
+                              (.addPages metrics
+                                         (long (- (count pages) (count survivors)))
+                                         (long (count survivors)))
+                              survivors))
+              merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) count-pages)]
+
+          (ScanCursor. allocator (vec col-names) col-preds
+                       temporal-bounds (boolean (:clamp-valid-time? scan-opts))
+                       !segments (.iterator ^Iterable merge-tasks)
+                       schema args
+                       metrics))))))
+
 (defn scan-vec-types [^IQuerySource$QueryCatalog db-catalog, snaps, scan-cols]
   (letfn [(->vec-type [[db-name ^TableRef table col-name]]
             (let [col-name (str col-name)]
@@ -222,8 +264,6 @@
             db (.databaseOrNull db-cat db-name)
             storage (.getStorage db)
             state (.getQueryState db)
-            metadata-mgr (.getMetadataManager storage)
-            buffer-pool (.getBufferPool storage)
             table-catalog (.getTableCatalog state)
             col-names (->> columns
                            (into #{} (map (fn [[col-type arg]]
@@ -308,60 +348,43 @@
                                              (update :for-valid-time
                                                      (fn [fvt]
                                                        (or fvt [:at [:now]]))))
-                               live-table-snaps (.table snapshot table)
-                               ;; TODO (#5835) each branch takes its own partition's basis slot. Wrong
-                               ;; rather than absent at N>1: every branch would apply partition 0's
+
+                               ;; EXPLAIN ANALYZE reports one set of counters per operator, and these
+                               ;; are keyed by (db, scan source) — operator identity. Built here so
+                               ;; that stays true however many cursors the operator ends up building.
+                               ^ScanMetrics metrics (ScanMetrics. db-name
+                                                                  (str (.getSchemaName table) "." (.getTableName table)))
+
+                               ;; TODO (#5835) each partition takes its own basis slot. Wrong rather
+                               ;; than absent at N>1: every partition would apply partition 0's
                                ;; temporal bound, so the scan returns wrong rows rather than failing.
                                temporal-bounds (->temporal-bounds allocator args scan-opts
                                                                   (-> (basis/<-time-basis-str snapshot-token)
-                                                                      (get-in [db-name 0])))]
+                                                                      (get-in [db-name 0])))
 
-                           (util/with-close-on-catch [!segments (LinkedList.)]
+                               trace? (or explain-analyze? (and tracer query-span))
+                               trace-attrs (when trace?
+                                             (not-empty
+                                              (merge-with merge
+                                                          (when pushdown-blooms
+                                                            (update-keys (update-vals pushdown-blooms (fn [b] {:bloom-filter b}))
+                                                                         str))
+                                                          (update-keys (update-vals (into {} (filter val) (or pushdown-iids {}))
+                                                                                    (fn [s] {:iids s}))
+                                                                       str))))]
 
-                             (let [filter-opts {:query-bounds temporal-bounds
-                                                :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
-                                                :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
-                                   ^ScanMetrics metrics (ScanMetrics. db-name
-                                                                      (str (.getSchemaName table) "." (.getTableName table)))
-                                   current-tries (cat/current-tries (.trieTableState snapshot table))
-                                   filtered-tries (cat/filter-tries current-tries filter-opts)]
-
-                               (.addFiles metrics
-                                          (long (- (count current-tries) (count filtered-tries)))
-                                          (long (count filtered-tries)))
-
-                               (doseq [{:keys [^String trie-key]} filtered-tries]
-                                 (.add !segments
-                                       (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
-
-                               (doseq [^TableSnapshot live-table-snap live-table-snaps]
-                                 (.add !segments (.getSegment live-table-snap)))
-
-                               (let [count-pages (fn [pages]
-                                                   (let [survivors (trie/filter-pages pages filter-opts)]
-                                                     (.addPages metrics
-                                                                (long (- (count pages) (count survivors)))
-                                                                (long (count survivors)))
-                                                     survivors))
-                                     merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) count-pages)]
-                               (cond-> (ScanCursor. allocator (vec col-names) col-preds
-                                                    temporal-bounds (boolean (:clamp-valid-time? scan-opts))
-                                                    !segments (.iterator ^Iterable merge-tasks)
-                                                    schema args
-                                                    metrics)
-                                 (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer
-                                                                                                    query-span
-                                                                                                    (format "query.cursor.scan.%s" (.getTableName table))
-                                                                                                    (not-empty
-                                                                                                     (merge-with merge
-                                                                                                                 (when pushdown-blooms
-                                                                                                                   (update-keys
-                                                                                                                    (update-vals pushdown-blooms (fn [b] {:bloom-filter b}))
-                                                                                                                    str))
-                                                                                                                 (update-keys
-                                                                                                                  (update-vals (into {} (filter val) (or pushdown-iids {}))
-                                                                                                                               (fn [s] {:iids s}))
-                                                                                                                  str))))))))))))}))))
+                           ;; the cursor owns its segments from the moment it's built, and the tracing
+                           ;; wrap takes that ownership over — so it has to happen under a scope that
+                           ;; closes the cursor if the wrap itself throws.
+                           (util/with-close-on-catch [cursor (->partition-scan-cursor
+                                                              {:allocator allocator, :table table, :col-names col-names,
+                                                               :col-preds col-preds, :iid-set iid-set, :metadata-pred metadata-pred,
+                                                               :scan-opts scan-opts, :schema schema, :args args, :metrics metrics}
+                                                              storage snapshot temporal-bounds)]
+                             (cond-> cursor
+                               trace? (ICursor/wrapTracing tracer query-span
+                                                           (format "query.cursor.scan.%s" (.getTableName table))
+                                                           trace-attrs)))))))}))))
 
 (defmethod lp/emit-expr :scan [scan-expr {:keys [^IScanEmitter scan-emitter db-cat scan-vec-types, param-types]}]
   (assert db-cat)

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -350,17 +350,25 @@
                 ;; when people have 'proper' multi-tenancy, this will be a problem
                 ;; thankfully we can probably figure out what databases may be relevant to the query at parse-time
                 (util/with-close-on-catch [!snaps (HashMap.)]
-                  (doseq [db-name (.getDatabaseNames db-cat)]
-                    (.put !snaps db-name (.openSnapshot (.databaseOrNull db-cat db-name) (get min-basis db-name))))
+                  ;; `getDatabaseNames` and `databaseOrNull` are separate reads, so a concurrent
+                  ;; DETACH can drop a database between them — skip it, as Database.Catalog's own
+                  ;; iterators do. We open a snapshot for every attached database, so a query that
+                  ;; never mentions the detached one would otherwise die on its NPE.
+                  (doseq [db-name (.getDatabaseNames db-cat)
+                          :let [db (.databaseOrNull db-cat db-name)]
+                          :when db]
+                    (.put !snaps db-name (.openSnapshot db (get min-basis db-name))))
                   (into {} !snaps)))
 
               (->table-info [min-basis]
                 ;; TODO this, too, gets the schema for *every* db in the catalog
                 (->> (.getDatabaseNames db-cat)
                      (into {} (mapcat (fn [db-name]
-                                        (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat db-name) (get min-basis db-name))]
-                                          (->> (.tableInfo snap)
-                                               (map (fn [[table-ref cols]] [[db-name table-ref] (set cols)])))))))))
+                                        ;; same detach race as open-snaps above
+                                        (when-let [db (.databaseOrNull db-cat db-name)]
+                                          (util/with-open [^DatabaseSnapshot snap (.openSnapshot db (get min-basis db-name))]
+                                            (->> (.tableInfo snap)
+                                                 (map (fn [[table-ref cols]] [[db-name table-ref] (set cols)]))))))))))
 
               (plan-query* [table-info]
                 (-plan-query this parsed-query query-opts table-info))]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -898,7 +898,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     dbCat.awaitAll(awaitToken, awaitTimeout)
                     dbCat.databaseNames.flatMap { dbName ->
                         val db = dbCat.databaseOrNull(dbName) ?: return@flatMap emptyList()
-                        db.partitions.toSortedMap().map { (part, partition) ->
+                        db.partitions.mapIndexed { part, partition ->
                             mapOf("db_name" to dbName, "part" to part) + read(db, partition)
                         }
                     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -65,7 +65,7 @@ class Database(
     override val name: DatabaseName,
     val logs: DatabaseLogs,
     val isIndexing: Boolean,
-    val partitions: Map<Int, DatabasePartition>,
+    val partitions: List<DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
     private val job: Job? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
@@ -73,11 +73,18 @@ class Database(
 
     init {
         require(partitions.isNotEmpty()) { "Database must have at least one partition" }
+
+        // List position *is* the partition index. The basis-token codec is positional — slot N of a
+        // database's vector is partition N — so `openSnapshot`, `currentBasis`, `latestCompletedTxs`
+        // and `awaitAll` all index partitions and basis slots against one another.
+        partitions.forEachIndexed { idx, part ->
+            require(part.partition == idx) { "partition ${part.partition} at index $idx" }
+        }
     }
 
     // Single-partition delegate. Per the stage-4 design, this becomes a per-partition
     // lookup once `partitions > 1` is enabled; for now every Database has exactly one.
-    private val partition0: DatabasePartition get() = partitions.getValue(0)
+    private val partition0: DatabasePartition get() = partitions[0]
 
     override val storage: PartitionStorage get() = partition0.storage
     override val queryState: PartitionState get() = partition0.state
@@ -85,14 +92,10 @@ class Database(
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
 
     override fun openSnapshot(minBasis: List<Instant?>?): DatabaseSnapshot =
-        // Index minBasis by sorted position, matching how `currentBasis`/`snapshotToken` pack it and how
-        // `txBasis`/`validate-basis-not-before` read it back — slot N is the Nth partition in key order.
-        DatabaseSnapshot(partitions.entries.sortedBy { it.key }
-            .mapIndexed { idx, e -> e.value.openSnapshot(minBasis?.getOrNull(idx)) })
+        DatabaseSnapshot(partitions.mapIndexed { idx, part -> part.openSnapshot(minBasis?.getOrNull(idx)) })
 
     /** This database's read basis right now — latest-completed system-time per partition, in partition-index order. */
-    fun currentBasis(): List<Instant?> =
-        partitions.entries.sortedBy { it.key }.map { it.value.liveIndex.latestCompletedTx?.systemTime }
+    fun currentBasis(): List<Instant?> = partitions.map { it.liveIndex.latestCompletedTx?.systemTime }
 
     val blockCatalog: BlockCatalog get() = partition0.blockCatalog
     val tableCatalog: TableCatalog get() = partition0.tableCatalog
@@ -151,7 +154,7 @@ class Database(
         // Phase 2: the job tree has already been cancel-joined (by `cancelAndJoin` above, or by the
         // owner cancelling the catalog root). Free state, children before the database allocator.
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
-        (partitions.values + listOf(logs, allocator)).closeAll()
+        (partitions + listOf(logs, allocator)).closeAll()
     }
 
     fun submitTxBlocking(ops: List<TxOp>, opts: TxOpts): Xtdb.SubmittedTx {
@@ -193,7 +196,7 @@ class Database(
      * Intended for tests and manual admin pokes; bypasses the `enabled` flag.
      */
     fun gcAll() {
-        partitions.values.forEach { it.logProcessor?.gcAll() }
+        partitions.forEach { it.logProcessor?.gcAll() }
     }
 
     companion object {
@@ -394,7 +397,7 @@ class Database(
                 name = dbName,
                 logs = logs,
                 isIndexing = indexerConfig.enabled,
-                partitions = mapOf(0 to partition),
+                partitions = listOf(partition),
                 meterRegistry = meterRegistry,
                 job = job,
                 registeredGauges = gauges,
@@ -403,13 +406,13 @@ class Database(
             if (indexerConfig.enabled && !readOnly) {
                 val listener = object : Log.SubscriptionListener<SourceMessage> {
                     override fun launchTransition(partition: Int, termId: Long) =
-                        db.partitions.getValue(partition).logProcessor!!.launchTransition(partition, termId)
+                        db.partitions[partition].logProcessor!!.launchTransition(partition, termId)
 
                     override fun commitLeader(partition: Int) =
-                        db.partitions.getValue(partition).logProcessor!!.commitLeader(partition)
+                        db.partitions[partition].logProcessor!!.commitLeader(partition)
 
                     override suspend fun demoteLeader(partition: Int) {
-                        db.partitions[partition]?.logProcessor?.demoteLeader(partition)
+                        db.partitions.getOrNull(partition)?.logProcessor?.demoteLeader(partition)
                     }
                 }
                 scope.launch { logs.sourceLog.openGroupSubscription(listener) }
@@ -505,10 +508,9 @@ class Database(
                     .map { db ->
                         launch {
                             val basisVec = basis[db.name] ?: return@launch
-                            db.partitions.entries.sortedBy { it.key }
-                                .forEach { (partIdx, part) ->
-                                    basisVec.getOrNull(partIdx)?.let { part.watchers.awaitSource(it) }
-                                }
+                            db.partitions.forEachIndexed { partIdx, part ->
+                                basisVec.getOrNull(partIdx)?.let { part.watchers.awaitSource(it) }
+                            }
                         }
                     }
                     .joinAll()
@@ -551,22 +553,21 @@ class Database(
                 .encodeTimeBasisToken()
 
         // each database's latest-completed tx per partition, surfaced through Xtdb.latestCompletedTxs and
-        // pgwire's `SHOW LATEST_COMPLETED_TXS`. Partition order is positional (sorted by partition key),
-        // so it lines up with the basis-token codec.
+        // pgwire's `SHOW LATEST_COMPLETED_TXS`. Partition order is positional, so it lines up with the
+        // basis-token codec.
         fun latestCompletedTxs(): Map<DatabaseName, List<TransactionKey?>> =
             databaseNames.mapNotNull { dbName ->
                 // databaseNames and databaseOrNull are read separately, so a concurrent detach can drop a db
                 // between them — skip it, as the sibling awaitAll0/syncAll0 do, rather than NPE.
                 databaseOrNull(dbName)?.let { db ->
-                    dbName to db.partitions.entries.sortedBy { it.key }
-                        .map { it.value.liveIndex.latestCompletedTx }
+                    dbName to db.partitions.map { it.liveIndex.latestCompletedTx }
                 }
             }.toMap()
 
         fun latestSubmittedMsgIds(): Map<DatabaseName, List<MessageId>> =
             databaseNames.mapNotNull { dbName ->
                 databaseOrNull(dbName)?.let { db ->
-                    dbName to db.partitions.keys.sorted().map { db.sourceLog.latestSubmittedMsgId(it) }
+                    dbName to db.partitions.indices.map { db.sourceLog.latestSubmittedMsgId(it) }
                 }
             }.toMap()
 

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -404,7 +404,7 @@ class ExternalSourceTest {
             name = "cdc",
             logs = DatabaseLogs(null, null),
             isIndexing = false,
-            partitions = mapOf(0 to partition),
+            partitions = listOf(partition),
             meterRegistry = null,
         )
 

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -337,23 +337,37 @@
                                     :for-valid-time :all-time, :columns [_id version]}]
                            {:node tu/*node*}))))))
 
+(defn- ->xt-docs-col-type [col]
+  (:types
+   (tu/query-ra `[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [~col]}]
+                {:node tu/*node*, :with-types? true})))
+
 (t/deftest test-scan-col-types
-  (letfn [(->col-type [col]
-            (:types
-             (tu/query-ra `[:scan {:db-name "xtdb", :table #xt/table xt_docs, :columns [~col]}]
-                          {:node tu/*node*, :with-types? true})))]
+  (xt/execute-tx tu/*node* [[:put-docs :xt_docs {:xt/id :doc}]])
 
-    (xt/execute-tx tu/*node* [[:put-docs :xt_docs {:xt/id :doc}]])
+  (tu/flush-block! tu/*node*)
 
-    (tu/flush-block! tu/*node*)
+  (t/is (= '{_id #xt/type :keyword}
+           (->xt-docs-col-type '_id)))
 
-    (t/is (= '{_id #xt/type :keyword}
-             (->col-type '_id)))
+  (xt/submit-tx tu/*node* [[:put-docs :xt_docs {:xt/id "foo"}]])
 
-    (xt/submit-tx tu/*node* [[:put-docs :xt_docs {:xt/id "foo"}]])
+  (t/is (= '{_id #xt/type #{:keyword :utf8}}
+           (->xt-docs-col-type '_id))))
 
-    (t/is (= '{_id #xt/type #{:keyword :utf8}}
-             (->col-type '_id)))))
+(t/deftest scan-col-type-widens-for-column-absent-from-the-live-table
+  (xt/execute-tx tu/*node* [[:put-docs :xt_docs {:xt/id 1, :v 1}]])
+  (tu/flush-block! tu/*node*)
+
+  (t/is (= '{v #xt/type :i64} (->xt-docs-col-type 'v))
+        "baseline: every row has a `v`, so it isn't nullable yet")
+
+  (xt/execute-tx tu/*node* [[:put-docs :xt_docs {:xt/id 2}]])
+
+  ;; the live table now has the table but no `v` vector, so its rows *are* null for `v` — distinct
+  ;; from the live index having nothing to say about the table, and only this case widens the type.
+  (t/is (= '{v #xt/type [:? :i64]} (->xt-docs-col-type 'v))
+        "a live row without `v` widens it to nullable"))
 
 (t/deftest test-content-pred
   (xt/submit-tx tu/*node* [[:put-docs :xt_docs {:xt/id :ivan, :first-name "Ivan", :last-name "Ivanov"}]


### PR DESCRIPTION
Groundwork for #5835, landed separately. Nothing here is partition-aware.

## Context

Unit 7 of stage 4 (#5835) makes the query read path partition-aware. Written in one go it came out at ~600 lines, most of it inside a `:->cursor` closure that had grown to ~100 lines nested four deep in a `reify`, with its innermost code at column 128. Two review passes over that branch found a confirmed correctness regression in it — a semantics change that rode along unnoticed inside a diff that read as mechanical.

So the groundwork is coming out first, as four steps that each stand on their own. The partition change then lands on top as the small thing it should have been.

## Changes

1. `test(scan)` — pins that a column present historically but absent from the *live* table is declared nullable.
2. `fix(query)` — skip databases detached mid-query rather than NPEing.
3. `tidy(database)` — `Database.partitions` from a `Map<Int, _>` to a `List` indexed by partition.
4. `tidy(scan)` — lift a table's cursor construction out of the emitter.

## Notes

**The test is first on purpose.** It's a characterisation test, verified green on `main` and red against the branch that regressed this exact property — so it guards the refactor in commit 4 rather than merely accompanying it.

It also has two assertions where one would do. `scan-vec-types` merges a column's historical type with its live type, and the live side answers three questions that are easy to collapse into two: no live table at all (contributes nothing), the column present (contributes its type), and the table present *without* the column (contributes `Null`, widening to nullable). The pair pins that adding a row without the column is what widens it; a single assertion couldn't distinguish that from a system that declared everything nullable.

**The detach fix is partial, deliberately.** `open-snaps` and `->table-info` each read the catalog twice — `getDatabaseNames`, then `databaseOrNull` — and a DETACH landing between the two made the second return null. Since `open-snaps` opens a snapshot for *every* attached database (per the TODO above it), detaching one database could take down concurrent queries that never referenced it. That case is gone.

What remains is the query that *does* reference the detached database: `scan-vec-types` dereferences `databaseOrNull` unguarded too, so it now fails there instead, still as an NPE. Turning that into a proper anomaly means choosing what a mid-flight detach should surface as, which is a behaviour decision rather than a tidy. The commit body says so rather than implying the race is fully handled.

**`Map` → `List` rests on an invariant worth stating.** The basis-token codec is positional — slot N of a database's vector is partition N — so `openSnapshot`, `currentBasis`, `latestCompletedTxs`, `latestSubmittedMsgIds` and `awaitAll` all index partitions and basis slots against one another. With a map, each re-established the ordering for itself with `entries.sortedBy`. The list states it once and the constructor asserts each partition's storage handle agrees with its position.

That's safe because every node holds every partition — it simply isn't leader for all of them — so the index range is contiguous. If partitions ever become per-node-assigned rather than all-N, this is the commit to revisit.

**The scan extraction changes no calls, only where they live.** `->partition-scan-cursor` takes the three things that determine what it reads — storage, snapshot, temporal bound — plus a bundle of the per-query values it applies. `metadata-mgr` and `buffer-pool` are derived inside it from the storage handle rather than bound two scopes up. `->cursor` goes from 98 lines to 77, deepest column 128 to 85.

Two smaller things came with it. The `wrapTracing` attribute map — pure data construction, unrelated to cursors — moves to a named binding; it was contributing most of the remaining indentation. And `ScanMetrics` moves up to the emitter, because EXPLAIN ANALYZE reports one set of counters per operator and they're keyed by (db, scan source), i.e. operator identity.

One subtlety the review caught: the tracing wrap takes ownership of the cursor, and the segments' close scope now ends inside the helper. So the `cond->` is wrapped in `with-close-on-catch` on the returned cursor — otherwise a throw between the helper returning and the wrap succeeding would strand the segments.

## Review

Two passes. `/code-review med` over commits 1–4 found the ownership gap above. `/code-review high` then found the test's first assertion claiming a snapshot-eviction fact it couldn't observe (reworded to state the baseline it does establish), a duplicated `->col-type` letfn (lifted to a shared fn), and two comments restating their code rather than carrying rationale (trimmed). It also raised the unguarded `scan-vec-types` read, which is the deliberate omission described above.

## Follow-ups, not in scope

- **Resolve query inputs once per execution.** `databaseOrNull` is called five times per query and the basis is encoded and re-decoded to reach the scan. Threading one resolved catalog and one decoded basis would remove both, give the `scan-vec-types` NPE a single place to be handled, and drop a guard the partition work would otherwise need.
- **Result-shape validation lives in pgwire.** The advertised-schema-vs-resolved-types check sits above the shared `Xtdb.Statement`, so Flight SQL and direct ADBC callers use the same `executeSchema` and don't get it.

## Test plan

- [x] `./gradlew test` green (2046) after each of the four commits
- [x] The new test verified green on `main` and red against the branch that regressed it