### PR TITLE
feat(bench): food-prices, a bitemporal delta-ingestion benchmark over ADBC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -879,6 +879,8 @@ createBench(
 
 createBench("ts-devices", mapOf("size" to "--size"))
 
+createBench("food-prices", mapOf("size" to "--size", "dropout" to "--dropout"))
+
 dokka {
     moduleName.set("")
     moduleVersion.set("2.x-SNAPSHOT")

--- a/modules/bench/README.adoc
+++ b/modules/bench/README.adoc
@@ -27,6 +27,16 @@ The node config (registering the docker-compose broker as the `kafkaCluster` rem
 On the benchmark cluster, run it via the 'Nightly Benchmark Kafka Source' workflow dispatch (or `./cloud/run-bench.sh azure kafka-source`).
 
 
+Food Prices::
+`./gradlew food-prices -Psize=small`
++
+Bitemporal delta ingestion over ADBC, ported from https://github.com/jr200-labs/polars-hist-db[jr200-labs/polars-hist-db].
+Ingests a monthly price series a partition at a time, and for each one binds the batch's keys as a list, `UNNEST`s them to find which rows actually moved, resolves the foreign keys the same way, and writes the survivors back under an explicit `SYSTEM_TIME` - so most of what it measures is the keyed temporal join, not the write.
+Sizes are `tiny`, `small` (default), `med` and `big`; `-Pdropout=true` additionally closes out rows the incoming batch no longer mentions.
++
+The dataset is not checked in - the benchmark syncs it from `s3://xtdb-datasets/food-prices/` on its `download` stage, so you need credentials for that bucket (or a local copy under `modules/bench/dataset-downloads/food-prices/<size>/`).
+To refresh or regenerate it, see `modules/bench/mirrors/food-prices/`.
+
 TSBS IoT::
 `XTDB_LOGGING_LEVEL_BENCH_TSBS=debug ./gradlew :tsbs-iot -Pfile=/path/to/txs.transit.json`
 +
@@ -90,6 +100,12 @@ Readings::
 docker run --rm ghcr.io/xtdb/xtdb-bench:nightly readings \
   --devices 10000
   --readings 10000
+----
+Food Prices::
+[source,bash]
+----
+docker run --rm ghcr.io/xtdb/xtdb-bench:nightly food-prices \
+  --size small
 ----
 Products::
 [source,bash]

--- a/modules/bench/mirrors/food-prices/README.md
+++ b/modules/bench/mirrors/food-prices/README.md
@@ -1,0 +1,55 @@
+# food-prices
+
+The dataset behind the `food-prices` benchmark: a monthly retail food-price series, fanned out over synthetic regions and baked to Arrow so the benchmark can hand batches straight to ADBC.
+
+## Where it comes from
+
+The source is the WFP Turkey retail food-price series as carried by [jr200-labs/polars-hist-db](https://github.com/jr200-labs/polars-hist-db), whose ingestion pipeline the benchmark ports.
+It is checked in there rather than fetched, so `mirror.py` reads it over raw.githubusercontent by default; pass `--source` to point at a local copy instead.
+
+Upstream is small — 4 places, 52 products, 9 units, 75 months from 2013-05 to 2019-12, 7,381 rows.
+That is the right *shape* for the workload and nowhere near the right *size*, so `--size` fans it out across synthetic regions:
+
+| Size | Places | Rows | On disk |
+| --- | --- | --- | --- |
+| `tiny` | 4 | 7,381 | 270 KB |
+| `small` | 100 | 260,149 | 8 MB |
+| `med` | 1,000 | ~2.6M | ~80 MB |
+| `big` | 5,000 | ~13M | ~400 MB |
+
+Regions 0-3 are the real places carrying their real prices, so `tiny` reproduces the upstream series exactly and is what the tests run against.
+The rest are deterministic perturbations of the national average — seeded off a hash rather than a PRNG, so a re-mirror is byte-identical and runs stay comparable across refreshes.
+
+Each synthetic region repeats the previous month's price a fraction of the time (`--repeat-rate`, default 0.3).
+That is load-bearing: the benchmark's whole first act is deciding which rows actually changed, and a series where everything moves every month would never exercise it.
+
+## Layout
+
+Per size, four Arrow IPC streams:
+
+`places.arrow`, `products.arrow`, `units.arrow`
+
+: The dimension tables — `id`, `name`. One record batch each.
+
+`prices.arrow`
+
+: The fact table — `place_id`, `product_id`, `um_id`, `month`, `price`, `price_usd`.
+  **One record batch per month**, in ascending order, which is what makes a batch a partition: the benchmark reads it with `ArrowStreamReader` and treats each `loadNextBatch` as one restatement to ingest.
+
+`price_usd` is converted with the same hard-coded yearly USD/TRY table the library's `try_to_usd` transform uses, so the numbers line up with theirs.
+
+## Running it
+
+Python is deliberate and one-directional here: it exists to bake the Arrow, and nothing downstream depends on it.
+It needs `pyarrow`, which the JVM side does not.
+
+```bash
+python -m venv .venv && .venv/bin/pip install pyarrow
+
+.venv/bin/python mirror.py out            # all four sizes
+.venv/bin/python mirror.py out --sizes tiny,small
+
+./upload.sh out                           # -> s3://xtdb-datasets/food-prices/
+```
+
+Consumers don't run either script: `xtdb.bench.food-prices` fetches what it needs from S3 on its `:download` stage, into `modules/bench/dataset-downloads/food-prices/<size>/`.

--- a/modules/bench/mirrors/food-prices/mirror.py
+++ b/modules/bench/mirrors/food-prices/mirror.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Produces the food-prices dataset for S3: the WFP Turkey retail food-price series
+(as carried by jr200-labs/polars-hist-db) fanned out across synthetic regions and
+written as Arrow IPC, one record batch per monthly partition.
+
+Run occasionally, when refreshing the dataset. `mirror.py` fetches the upstream CSV
+and writes `<size>/{places,products,units,prices}.arrow` into an out-dir; `upload.sh`
+then syncs that dir to s3://xtdb-datasets/food-prices/. The benchmark pulls it back
+down itself (see xtdb.bench.food-prices) — no CSV parsing, no price arithmetic and
+no currency conversion on the load path, just Arrow batches straight into ADBC.
+
+Python is deliberate and one-directional: it exists to bake the Arrow, and nothing
+downstream depends on it. It needs pyarrow, which the JVM side does not.
+
+The upstream series is small — 4 places, 52 products, 9 units, 75 months from 2013-05
+to 2019-12 — so `--size` fans it out over synthetic regions to reach benchmark scale.
+Region 0-3 carry the real prices verbatim; the rest are deterministic perturbations of
+the national average, and each repeats the previous month's price with probability
+`--repeat-rate` so that delta detection has genuine unchanged rows to discard.
+"""
+
+import argparse
+import csv
+import hashlib
+import io
+import urllib.request
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.ipc as ipc
+
+UPSTREAM_CSV = (
+    "https://raw.githubusercontent.com/jr200-labs/polars-hist-db/master/"
+    "tests/_testdata_dataset_data/turkey_food_prices.csv"
+)
+
+# yearly USD/TRY, as used by polars-hist-db's `try_to_usd` transform
+FX_USDTRY = {
+    2010: 1.507, 2011: 1.674, 2012: 1.802, 2013: 1.915, 2014: 2.188,
+    2015: 2.724, 2016: 3.020, 2017: 3.646, 2018: 4.830, 2019: 5.680,
+    2020: 7.004, 2021: 8.886, 2022: 16.566, 2023: 23.085,
+}
+
+SIZES = {"tiny": 4, "small": 100, "med": 1000, "big": 5000}
+
+PRICES_SCHEMA = pa.schema([
+    pa.field("place_id", pa.int32(), nullable=False),
+    pa.field("product_id", pa.int32(), nullable=False),
+    pa.field("um_id", pa.int32(), nullable=False),
+    pa.field("month", pa.date32(), nullable=False),
+    pa.field("price", pa.float64(), nullable=False),
+    pa.field("price_usd", pa.float64(), nullable=False),
+])
+
+
+def read_csv(source):
+    """Reads the upstream CSV into dict rows. Product names embed commas
+    (`"Bulgur (wheat, dry) - Retail"`), so the quoting is load-bearing."""
+    if source.startswith("http"):
+        with urllib.request.urlopen(source) as resp:
+            text = resp.read().decode("utf-8")
+    else:
+        text = Path(source).read_text(encoding="utf-8")
+
+    return list(csv.DictReader(io.StringIO(text)))
+
+
+def jitter(seed_parts):
+    """A stable multiplier in [0.75, 1.25) derived from the given parts.
+
+    Seeded off a hash rather than `random` so a re-mirror produces byte-identical
+    output, which is what makes benchmark runs comparable across refreshes."""
+    digest = hashlib.sha256("|".join(str(p) for p in seed_parts).encode()).digest()
+    return 0.75 + (int.from_bytes(digest[:8], "big") / 2**64) * 0.5
+
+
+def curate(rows):
+    """Splits the raw CSV rows into dimensions plus a month -> real-price series.
+
+    Returns (places, products, units, series), where `series` maps
+    (place_name, product_id, um_id, month) -> price."""
+    places, products, units = {}, {}, {}
+    series = {}
+
+    for row in rows:
+        product_id, um_id = int(row["ProductId"]), int(row["UmId"])
+        products[product_id] = row["ProductName"]
+        units[um_id] = row["UmName"]
+        places.setdefault(row["Place"], len(places))
+        month = date(int(row["Year"]), int(row["Month"]), 1)
+        series[(row["Place"], product_id, um_id, month)] = float(row["Price"])
+
+    return places, products, units, series
+
+
+def write_table(out_dir, name, table):
+    """Writes a dimension table as a one-batch IPC stream — same format as prices.arrow,
+    so the benchmark reads every file through one code path."""
+    path = out_dir / f"{name}.arrow"
+    with ipc.new_stream(path, table.schema) as writer:
+        writer.write_table(table)
+    return path
+
+
+def mirror(out_dir, size, rows, repeat_rate):
+    place_count = SIZES[size]
+    places, products, units, series = curate(rows)
+    real_places = list(places)
+    months = sorted({month for _, _, _, month in series})
+    pairs = sorted({(pid, uid) for _, pid, uid, _ in series})
+
+    out_dir = out_dir / size
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    place_names = [
+        real_places[i] if i < len(real_places) else f"Region {i - len(real_places) + 1}"
+        for i in range(place_count)
+    ]
+    write_table(out_dir, "places", pa.table(
+        {"id": pa.array(range(place_count), pa.int32()),
+         "name": pa.array(place_names, pa.string())},
+        schema=pa.schema([pa.field("id", pa.int32(), nullable=False),
+                          pa.field("name", pa.string(), nullable=False)])))
+
+    write_table(out_dir, "products", pa.table(
+        {"id": pa.array(sorted(products), pa.int32()),
+         "name": pa.array([products[k] for k in sorted(products)], pa.string())},
+        schema=pa.schema([pa.field("id", pa.int32(), nullable=False),
+                          pa.field("name", pa.string(), nullable=False)])))
+
+    write_table(out_dir, "units", pa.table(
+        {"id": pa.array(sorted(units), pa.int32()),
+         "name": pa.array([units[k] for k in sorted(units)], pa.string())},
+        schema=pa.schema([pa.field("id", pa.int32(), nullable=False),
+                          pa.field("name", pa.string(), nullable=False)])))
+
+    # last emitted price per (place, product, unit), so a "repeat" month can restate it
+    # verbatim and the benchmark's delta filter has something to discard
+    previous = {}
+    total = 0
+
+    with ipc.new_stream(out_dir / "prices.arrow", PRICES_SCHEMA) as writer:
+        for month in months:
+            place_ids, product_ids, um_ids, prices, usd_prices = [], [], [], [], []
+            fx = FX_USDTRY[month.year]
+
+            for place_id in range(place_count):
+                for product_id, um_id in pairs:
+                    key = (place_id, product_id, um_id)
+                    real = series.get((place_names[place_id], product_id, um_id, month))
+
+                    synthetic = place_id >= len(real_places)
+
+                    if synthetic:
+                        national = series.get(("National Average", product_id, um_id, month))
+                        price = national and national * jitter((place_id, product_id, um_id))
+                    else:
+                        price = real
+
+                    if price is None:
+                        continue
+
+                    # real places stay verbatim, so `tiny` reproduces the upstream series
+                    if synthetic and key in previous and jitter((key, month)) < 0.75 + repeat_rate * 0.5:
+                        price = previous[key]
+
+                    price = round(price, 4)
+                    previous[key] = price
+
+                    place_ids.append(place_id)
+                    product_ids.append(product_id)
+                    um_ids.append(um_id)
+                    prices.append(price)
+                    usd_prices.append(round(price / fx, 4))
+
+            batch = pa.record_batch(
+                [pa.array(place_ids, pa.int32()), pa.array(product_ids, pa.int32()),
+                 pa.array(um_ids, pa.int32()), pa.array([month] * len(prices), pa.date32()),
+                 pa.array(prices, pa.float64()), pa.array(usd_prices, pa.float64())],
+                schema=PRICES_SCHEMA)
+            writer.write_batch(batch)
+            total += batch.num_rows
+
+    print(f"{size}: {place_count} places x {len(pairs)} product/unit pairs "
+          f"x {len(months)} months -> {total} rows in {out_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("out_dir", type=Path)
+    parser.add_argument("--source", default=UPSTREAM_CSV,
+                        help="upstream CSV URL or local path")
+    parser.add_argument("--sizes", default=",".join(SIZES),
+                        help=f"comma-separated subset of {','.join(SIZES)}")
+    parser.add_argument("--repeat-rate", type=float, default=0.3,
+                        help="fraction of restatements that repeat the previous price")
+    args = parser.parse_args()
+
+    rows = read_csv(args.source)
+    print(f"read {len(rows)} rows from {args.source}")
+
+    for size in args.sizes.split(","):
+        mirror(args.out_dir, size.strip(), rows, args.repeat_rate)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/bench/mirrors/food-prices/upload.sh
+++ b/modules/bench/mirrors/food-prices/upload.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Syncs the mirrored food-prices Arrow (produced by mirror.py) up to
+# s3://xtdb-datasets/food-prices/. Run occasionally, when refreshing the dataset.
+# The benchmark pulls it back down itself — see xtdb.bench.delta-ingest/download-dataset.
+
+set -xe
+
+cd "$(dirname "$0")"
+
+SRC="${1:-out}"
+
+aws s3 sync "$SRC" s3://xtdb-datasets/food-prices/

--- a/modules/bench/src/main/clojure/xtdb/bench/food_prices.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/food_prices.clj
@@ -1,0 +1,393 @@
+(ns xtdb.bench.food-prices
+  "Bitemporal delta ingestion over ADBC, ported from jr200-labs/polars-hist-db.
+
+  The library ingests a time-partitioned price series one partition at a time, and each partition
+  asks XTDB two keyed questions before it writes anything: which of these rows have actually
+  changed, and which of their foreign keys does the dimension table not hold yet. Both are answered
+  by binding the key set as a list parameter and `UNNEST`ing it, so a partition is:
+
+  - bind the batch's ids, join `food_prices` against them `FOR VALID_TIME AS OF` the batch's basis,
+    and keep only the rows whose price actually moved;
+  - resolve the place / product / unit foreign keys the same way, inserting any the dimension
+    tables don't hold yet;
+  - write the survivors back as one `BEGIN READ WRITE WITH (SYSTEM_TIME = …)` transaction,
+    optionally closing out the rows the batch no longer mentions.
+
+  So what this measures is the keyed temporal join against a growing fact table, and the cost of a
+  write that only carries the delta. Rows arrive as Arrow, one record batch per month, and go back
+  through `bulkIngest` — the same ADBC surface the library reaches over FlightSQL.
+
+  The library itself does not do it this way: lacking `UNNEST` on MariaDB, it materialises each key
+  set as a real table, joins against that, and erases it — four durable, replicated, compacted
+  writes of throwaway data per partition. That is portability tax rather than anything XTDB
+  requires, so it isn't reproduced here. The dataset is mirrored to S3 by `mirrors/food-prices`."
+
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [xtdb.api :as xt]
+            [xtdb.bench :as b]
+            [xtdb.bench.util :as bu]
+            [xtdb.error :as err]
+            [xtdb.util :as util]
+            [xtdb.vector.writer :as vw])
+  (:import (clojure.lang IReduceInit)
+           (io.micrometer.core.instrument Timer)
+           (java.io File)
+           (java.time Duration Instant LocalDate ZoneOffset)
+           (java.util.concurrent Callable)
+           (org.apache.arrow.adbc.core BulkIngestMode)
+           (org.apache.arrow.memory BufferAllocator)
+           (org.apache.arrow.vector.ipc ArrowStreamReader)
+           (software.amazon.awssdk.services.s3 S3Client)
+           (software.amazon.awssdk.services.s3.model GetObjectRequest)
+           (xtdb.api Xtdb$Connection Xtdb$Statement)
+           (xtdb.api.query IKeyFn$KeyFn)
+           (xtdb.arrow Relation RelationReader)))
+
+(def ^:private prices-table "food_prices")
+
+(def ^:private price-columns ["place_id" "product_id" "um_id" "price" "price_usd"])
+
+(def dimensions
+  "The price batch's foreign keys, and the tables they point at."
+  [{:file "places.arrow", :table "place_info", :fk "place_id"}
+   {:file "products.arrow", :table "product_info", :fk "product_id"}
+   {:file "units.arrow", :table "unit_info", :fk "um_id"}])
+
+;; matches the library's `max_rows_per_insert`
+(def ^:private chunk-size 10000)
+
+;; -- dataset --
+
+(def ^:dynamic *data-dir*
+  "Where the mirrored dataset lands. Dynamic so a test can point at a fixture of its own."
+  (io/file "modules/bench/dataset-downloads/food-prices"))
+
+(defn dataset-file ^File [size fname]
+  (io/file *data-dir* (name size) fname))
+
+(defn download-dataset [size]
+  (doseq [fname (cons "prices.arrow" (map :file dimensions))
+          :let [file (dataset-file size fname)]
+          :when (not (.exists file))]
+    (log/info "downloading" (str file))
+    (io/make-parents file)
+    (.getObject ^S3Client @bu/!s3-client
+                (-> (GetObjectRequest/builder)
+                    (.bucket "xtdb-datasets")
+                    (.key (format "food-prices/%s/%s" (name size) fname))
+                    ^GetObjectRequest (.build))
+                (.toPath file))))
+
+(defn- arrow-partitions
+  "The Arrow IPC stream at `file` as a reducible of partitions — each record batch a vector of row
+  maps keyed by column name. Reducible rather than a lazy seq because a batch's `Relation` is only
+  valid inside the reduce, and at `big` the whole stream doesn't fit in memory."
+  ^IReduceInit [^BufferAllocator al ^File file]
+  (reify IReduceInit
+    (reduce [_ f init]
+      (with-open [in (io/input-stream file)
+                  rdr (ArrowStreamReader. in al)]
+        (let [root (.getVectorSchemaRoot rdr)]
+          (loop [acc init]
+            (if (and (not (reduced? acc)) (.loadNextBatch rdr))
+              (recur (f acc (with-open [rel (Relation/fromRoot al root)]
+                              (vec (.toMaps rel IKeyFn$KeyFn/SNAKE_CASE_STRING)))))
+              (unreduced acc))))))))
+
+(defn- read-table
+  "The whole of a single-batch file — the dimension tables."
+  [al file]
+  (into [] cat (arrow-partitions al file)))
+
+;; -- timers --
+
+(def ^:private op-names [:delta-query :dim-resolve :dim-insert :ingest :dropout])
+
+(defn- ->timers
+  "Micrometer timers for the per-partition operations, so the summary reports the read/write split
+  rather than one ingest number. Empty outside a benchmark run, where there's no registry."
+  []
+  (when-let [registry b/*registry*]
+    (->> op-names
+         (into {} (map (fn [k]
+                         [k (-> (Timer/builder (name k))
+                                (.publishPercentiles (double-array b/percentiles))
+                                (.maximumExpectedValue (Duration/ofHours 1))
+                                (.minimumExpectedValue (Duration/ofNanos 1))
+                                (.register registry))]))))))
+
+(defmacro ^:private timed [timers k & body]
+  `(if-let [^Timer timer# (get ~timers ~k)]
+     (.recordCallable timer# ^Callable (fn [] ~@body))
+     (do ~@body)))
+
+;; -- the ADBC operations --
+
+(defn- execute!
+  "Runs a statement, binding `args` as one positional row if given. DML reads its args straight off
+  the bound relation, so unlike a query this needs no `prepare`."
+  ([conn sql] (execute! conn sql nil))
+  ([^Xtdb$Connection conn ^String sql args]
+   (with-open [stmt (.createStatement conn sql)]
+     (when (seq args)
+       (with-open [rel (vw/open-args (.getAllocator conn) args)]
+         (.bind stmt ^RelationReader rel)))
+     (.executeUpdate stmt))))
+
+(defn- ts-literal ^String [^Instant instant]
+  (format "TIMESTAMP WITH TIME ZONE '%s'" instant))
+
+(defn- tick!
+  "The next system time to write at: the batch's own basis, or a microsecond past the last write if
+  we're already there. XTDB requires system times to ascend and these are historic, so every write
+  in the run — the dimension inserts and the DDL included — comes off this one clock rather than the
+  wall. The library reaches the same place from the other end, reading `xt.txs` for the last system
+  time and bumping past it."
+  ^Instant [!clock ^Instant basis]
+  (swap! !clock (fn [^Instant prev]
+                  (if (and prev (not (.isBefore prev basis)))
+                    (.plusNanos prev 1000)
+                    basis))))
+
+(defn- with-tx!
+  "Runs `f` as one write transaction at the next system time. Writes inside an open transaction
+  buffer until the commit, so an ingest and its DML land together.
+
+  Commits through `commitSync` rather than a SQL `COMMIT`: the statement path discards the
+  `ExecutedTx`, so an aborted transaction would leave the benchmark reporting timings for writes
+  that never landed."
+  [^Xtdb$Connection conn !clock basis f]
+  (execute! conn (format "BEGIN READ WRITE WITH (SYSTEM_TIME = %s)" (ts-literal (tick! !clock basis))))
+  (try
+    (let [res (f)
+          executed (.commitSync conn)]
+      (when (and executed (not (.getCommitted executed)))
+        (throw (or (.getError executed)
+                   (err/fault :xtdb.bench/tx-aborted "Transaction aborted"))))
+      res)
+    (catch Throwable t
+      (.rollbackTx conn)
+      (throw t))))
+
+(defn- create-tables!
+  "Declares the tables up front. XTDB infers schema from writes, so the first partition would
+  otherwise ask after a `food_prices` that doesn't exist yet and get a planning error — the same
+  hole the library plugs, from the other side, by registering its table configs before it ingests."
+  [conn]
+  (execute! conn (format "CREATE TABLE %s (%s)" prices-table (str/join ", " (cons "_id" price-columns))))
+  (doseq [{:keys [table]} dimensions]
+    (execute! conn (format "CREATE TABLE %s (_id, id, name)" table))))
+
+(defn- bulk-ingest!
+  "The library's `adbc_ingest` — Arrow straight into the table, chunked as it chunks."
+  [^Xtdb$Connection conn ^String table rows]
+  (doseq [chunk (partition-all chunk-size rows)]
+    (with-open [rel (Relation/openFromRows (.getAllocator conn) (vec chunk))
+                stmt (.bulkIngest conn table BulkIngestMode/CREATE_APPEND)]
+      (.bind ^Xtdb$Statement stmt ^RelationReader rel)
+      (.executeUpdate stmt))))
+
+(defn ->pk
+  "The library's `xtdb-pk-v1:` encoding for a composite primary key — a deterministic text id built
+  from the key columns, so a row keeps the same `_id` across restatements."
+  ^String [row]
+  (str "xtdb-pk-v1:[[\"place_id\"," (get row "place_id")
+       "],[\"product_id\"," (get row "product_id")
+       "],[\"um_id\"," (get row "um_id") "]]"))
+
+(defn- held-by-id
+  "The rows XTDB holds at `basis` for the given ids, keyed by id. Chunked, because a partition at
+  `big` carries 260k ids and the library chunks its own keyed reads the same way."
+  [conn ^String sql ids ^Instant basis]
+  (into {}
+        (comp (mapcat (fn [chunk]
+                        (xt/q conn (cond-> [sql] basis (conj basis basis) :always (conj (vec chunk)))
+                              {:key-fn :snake-case-string})))
+              (map (juxt #(get % "_id") identity)))
+        (partition-all chunk-size ids)))
+
+(defn- current-prices
+  "The rows the batch is about to restate, as XTDB holds them at `basis`."
+  [conn ids ^Instant basis]
+  (held-by-id conn
+              (format "SELECT t._id, t.price, t.price_usd
+                       FROM %s FOR VALID_TIME AS OF ? FOR SYSTEM_TIME AS OF ? AS t
+                       WHERE t._id IN (SELECT k.x FROM UNNEST(?) AS k(x))"
+                      prices-table)
+              ids basis))
+
+(defn- changed
+  "Drops the rows XTDB already holds unchanged — the library's `drop_unchanged_rows`, which is the
+  whole reason for the lookup above: without it every partition would rewrite every row."
+  [rows current]
+  (into [] (remove (fn [row]
+                     (when-let [held (get current (get row "_id"))]
+                       (and (= (get row "price") (get held "price"))
+                            (= (get row "price_usd") (get held "price_usd"))))))
+        rows))
+
+(defn- resolve-dimension!
+  "Inserts the dimension rows `batch` references that `table` doesn't hold yet, found the same way
+  as the price delta: bind the referenced keys, probe, take the complement.
+
+  Scoped to the keys the batch actually carries, as the library's foreign-key deduction is — the
+  dimension files hold every key in the dataset, and resolving all of them every partition would
+  bill the read against rows that partition never mentions."
+  [conn timers !clock basis {:keys [table fk rows]} batch]
+  (let [referenced (into #{} (map #(get % fk)) batch)
+        rows (filterv #(referenced (get % "id")) rows)]
+    (when (seq rows)
+      (let [held (timed timers :dim-resolve
+                        (held-by-id conn
+                                    (format "SELECT t._id FROM %s AS t
+                                             WHERE t._id IN (SELECT k.x FROM UNNEST(?) AS k(x))"
+                                            table)
+                                    (map #(get % "id") rows) nil))
+            missing (remove #(held (get % "id")) rows)]
+        (when (seq missing)
+          (timed timers :dim-insert
+                 (with-tx! conn !clock basis
+                   #(bulk-ingest! conn table (map (fn [row] (assoc row "_id" (get row "id"))) missing)))))))))
+
+(defn- close-out-missing!
+  "The library's `dropout` finality: rows the batch no longer mentions stop being true as of the
+  batch's basis. Off by default — the food-prices pipeline doesn't enable it."
+  [conn ids ^Instant basis]
+  ;; the id list can't be chunked here as it can for the reads — a NOT IN over one chunk would close
+  ;; out rows the next chunk mentions
+  (execute! conn
+            (format "DELETE FROM %s FOR PORTION OF VALID_TIME FROM ? TO NULL AS t
+                     WHERE t._id NOT IN (SELECT k.x FROM UNNEST(?) AS k(x))"
+                    prices-table)
+            [basis (vec ids)]))
+
+(defn- ->basis
+  "A batch is published a month after the period it describes, and that publication is both its
+  system time and — since nothing in the batch carries one — the valid-from of its rows."
+  ^Instant [rows]
+  (-> ^LocalDate (get (first rows) "month")
+      (.plusMonths 1)
+      (.atStartOfDay ZoneOffset/UTC)
+      .toInstant))
+
+(defn- ingest-partition!
+  "One month of restatements, end to end. Returns the number of rows actually written."
+  [conn timers !clock dims rows {:keys [dropout?]}]
+  (let [rows (mapv #(assoc % "_id" (->pk %)) rows)
+        ids (mapv #(get % "_id") rows)
+        basis (->basis rows)
+        current (timed timers :delta-query (current-prices conn ids basis))
+        writes (changed rows current)]
+
+    (doseq [dim dims]
+      (resolve-dimension! conn timers !clock basis dim rows))
+
+    (with-tx! conn !clock basis
+      (fn []
+        (when dropout?
+          (timed timers :dropout (close-out-missing! conn ids basis)))
+        (timed timers :ingest
+               (bulk-ingest! conn prices-table
+                             (map #(select-keys % (cons "_id" price-columns)) writes)))))
+
+    (count writes)))
+
+(defn ingest!
+  "Ingests `partitions` — a reducible of row-map batches in ascending month order — resolving the
+  foreign keys of each against `dims`. Returns `{:partitions n, :written m}`."
+  [conn dims opts partitions]
+  (let [timers (->timers)
+        !clock (atom nil)]
+    (reduce (fn [{:keys [partitions written]} rows]
+              (when (Thread/interrupted) (throw (InterruptedException.)))
+              (let [basis (->basis rows)]
+                ;; the DDL is the run's first write, so it comes off the clock too — an
+                ;; auto-committed CREATE TABLE would stamp wall-clock now and fence out the
+                ;; back-dated writes that follow it
+                (when (zero? partitions)
+                  (with-tx! conn !clock basis #(create-tables! conn)))
+
+                (let [written (+ written (ingest-partition! conn timers !clock dims rows opts))
+                      partitions (inc partitions)]
+                  (when (zero? (mod partitions 10))
+                    (log/debugf "partition %d, %d rows written" partitions written))
+                  {:partitions partitions, :written written})))
+            {:partitions 0, :written 0}
+            partitions)))
+
+(defn- ->ingest-stage [size opts]
+  {:t :call, :stage :ingest
+   :f (fn [{:keys [node]}]
+        (with-open [conn (xt/open-adbc-conn node)]
+          (let [al (.getAllocator ^Xtdb$Connection conn)
+                dims (mapv #(assoc % :rows (read-table al (dataset-file size (:file %)))) dimensions)]
+            (log/infof "ingesting %s: %s" (name size)
+                       (str/join ", " (map #(format "%d %s" (count (:rows %)) (:table %)) dims)))
+
+            (let [{:keys [partitions written]}
+                  (ingest! conn dims opts (arrow-partitions al (dataset-file size "prices.arrow")))]
+              (log/infof "ingested %d partitions, %d rows written" partitions written)))))})
+
+(defn- ->query-stage [interval]
+  {:t :call, :stage (keyword (str "query-" (name interval)))
+   :f (fn [{:keys [node]}]
+        (with-open [conn (xt/open-adbc-conn node)]
+          (case interval
+            ;; the latest price for every product in every region
+            :latest (xt/q conn (format "SELECT p.place_id, p.product_id, AVG(p.price) AS avg_price
+                                        FROM %s AS p GROUP BY p.place_id, p.product_id" prices-table))
+
+            ;; the same question a few years of valid time ago — the read the library's `asof` hint serves
+            :as-of (xt/q conn [(format "SELECT p.place_id, p.product_id, AVG(p.price) AS avg_price
+                                        FROM %s FOR VALID_TIME AS OF ? AS p
+                                        GROUP BY p.place_id, p.product_id" prices-table)
+                               (.toInstant (.atStartOfDay (LocalDate/parse "2017-01-01") ZoneOffset/UTC))])
+
+            ;; the whole restatement history, which is what the bitemporality is being paid for
+            :history (xt/q conn (format "SELECT p.product_id, COUNT(*) AS versions
+                                         FROM %s FOR ALL VALID_TIME AS p
+                                         GROUP BY p.product_id" prices-table)))))})
+
+(defmethod b/cli-flags :food-prices [_]
+  [[nil "--size SIZE" "dataset size"
+    :parse-fn keyword
+    :default :small
+    :validate [#{:tiny :small :med :big} "size must be one of tiny, small, med, big"]]
+
+   [nil "--dropout" "close out rows the incoming batch no longer mentions"
+    :id :dropout?]
+
+   ["-h" "--help"]])
+
+(defmethod b/->benchmark :food-prices [_ {:keys [size dropout? seed no-load?] :or {seed 0}}]
+  (log/info {:size size :dropout? dropout? :seed seed :no-load? no-load?})
+  {:title "Food Prices"
+   :benchmark-type :food-prices
+   :seed seed
+   :parameters {:size size :dropout? dropout? :seed seed :no-load? no-load?}
+   :tasks (concat (when-not no-load?
+                    [{:t :call, :stage :download, :setup? true
+                      :f (fn [_] (download-dataset size))}
+
+                     (->ingest-stage size {:dropout? dropout?})
+
+                     {:t :call, :stage :sync
+                      :f (fn [{:keys [node]}] (b/sync-node node (Duration/ofHours 5)))}
+
+                     {:t :call, :stage :finish-block
+                      :f (fn [{:keys [node]}] (b/flush-block! node))}
+
+                     {:t :call, :stage :compact
+                      :f (fn [{:keys [node]}] (b/compact! node))}])
+
+                  (map ->query-stage [:latest :as-of :history]))})
+
+(comment
+  ;; a REPL run against the tiny dataset. A `^:benchmark` deftest, as the other bench namespaces
+  ;; carry, would be discovered by the module's test task — this namespace has a companion test,
+  ;; so it gets loaded there — and would then fail the build reaching for S3.
+  (util/with-tmp-dirs #{node-tmp-dir}
+    (-> (b/->benchmark :food-prices {:size :tiny})
+        (b/run-benchmark {:node-dir node-tmp-dir}))))

--- a/modules/bench/src/test/clojure/xtdb/bench/food_prices_test.clj
+++ b/modules/bench/src/test/clojure/xtdb/bench/food_prices_test.clj
@@ -1,0 +1,80 @@
+(ns xtdb.bench.food-prices-test
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.bench.food-prices :as fp]
+            [xtdb.test-util :as tu :refer [*node*]])
+  (:import (java.time LocalDate ZoneOffset)))
+
+(t/use-fixtures :each tu/with-node)
+
+(defn- prices [month & specs]
+  (for [[place-id product-id price] specs]
+    {"place_id" place-id, "product_id" product-id, "um_id" 1
+     "month" (LocalDate/parse month)
+     ;; derived, so an unchanged price leaves both compared columns unchanged
+     "price" price, "price_usd" (/ price 2.0)}))
+
+(def ^:private dims
+  [{:table "place_info", :fk "place_id", :rows [{"id" 0, "name" "Ankara"} {"id" 1, "name" "Izmir"}]}
+   {:table "product_info", :fk "product_id", :rows [{"id" 1, "name" "Rice"} {"id" 2, "name" "Bulgur"}]}
+   {:table "unit_info", :fk "um_id", :rows [{"id" 1, "name" "KG"}]}])
+
+(def ^:private partitions
+  ;; three monthly restatements; (0,2) doesn't move in February and (0,1) doesn't in March
+  [(prices "2013-01-01" [0 1 10.0] [0 2 20.0] [1 1 30.0])
+   (prices "2013-02-01" [0 1 11.0] [0 2 20.0] [1 1 31.0])
+   (prices "2013-03-01" [0 1 11.0] [0 2 21.0] [1 1 32.0])])
+
+(defn- ->instant [date]
+  (.toInstant (.atStartOfDay (LocalDate/parse date) ZoneOffset/UTC)))
+
+(deftest only-restatements-that-move-the-price-are-written
+  (with-open [conn (xt/open-adbc-conn *node*)]
+    (t/is (= {:partitions 3, :written 7}
+             (fp/ingest! conn dims {} partitions))
+          "two of the nine incoming rows repeat a held price, so they're never written")
+
+    (t/is (= 7 (:versions (first (xt/q conn "SELECT COUNT(*) AS versions
+                                             FROM food_prices FOR ALL VALID_TIME"))))
+          "and leave no version behind either — one row-version per write, not per row seen")))
+
+(deftest each-partition-is-visible-at-its-own-valid-time
+  (with-open [conn (xt/open-adbc-conn *node*)]
+    (fp/ingest! conn dims {} partitions)
+
+    (t/is (= [{:place-id 0, :product-id 1, :price 11.0}
+              {:place-id 0, :product-id 2, :price 21.0}
+              {:place-id 1, :product-id 1, :price 32.0}]
+             (xt/q conn "SELECT p.place_id, p.product_id, p.price FROM food_prices AS p
+                         ORDER BY p.place_id, p.product_id"))
+          "the latest basis holds March's prices")
+
+    ;; each batch is published a month in arrears, so February's landed on 2013-03-01
+    (t/is (= [{:place-id 0, :product-id 1, :price 11.0}
+              {:place-id 0, :product-id 2, :price 20.0}
+              {:place-id 1, :product-id 1, :price 31.0}]
+             (xt/q conn ["SELECT p.place_id, p.product_id, p.price
+                          FROM food_prices FOR VALID_TIME AS OF ? AS p
+                          ORDER BY p.place_id, p.product_id"
+                         (->instant "2013-03-15")])
+             )
+          "mid-March still holds February's, including the price that never moved")))
+
+(deftest foreign-keys-are-resolved-once-and-reused
+  (with-open [conn (xt/open-adbc-conn *node*)]
+    (fp/ingest! conn dims {} partitions)
+
+    (t/is (= [{:versions 2} {:versions 2} {:versions 1}]
+             (for [table ["place_info" "product_info" "unit_info"]]
+               (first (xt/q conn (format "SELECT COUNT(*) AS versions
+                                          FROM %s FOR ALL VALID_TIME" table)))))
+          "every partition re-resolves the dimensions, but only the first inserts them")))
+
+(deftest composite-keys-round-trip-through-the-library-encoding
+  (with-open [conn (xt/open-adbc-conn *node*)]
+    (fp/ingest! conn dims {} partitions)
+
+    (t/is (= [{:xt/id (fp/->pk {"place_id" 0, "product_id" 1, "um_id" 1})}]
+             (xt/q conn "SELECT p._id FROM food_prices AS p
+                         WHERE p.place_id = 0 AND p.product_id = 1"))
+          "the row is addressed by the encoded composite key, not a surrogate")))


### PR DESCRIPTION
## tl;dr

Adds a `food-prices` benchmark porting the XTDB-facing half of [jr200-labs/polars-hist-db](https://github.com/jr200-labs/polars-hist-db)'s ingestion pipeline, driven from Clojure over in-process ADBC. Runnable on demand; **not** wired into the nightly suite.

- **It's the *workload* that's ported, not their benchmark** — theirs fakes the database out and measures Polars.
- **What it stresses is the keyed temporal join**: at `med`, 23.3s of a 35.5s ingest stage, against 2.4s of writes.
- **`F1`: the library's temp-table workaround is unnecessary on XTDB** — `UNNEST` of a bound list does the job, verified. Reported upstream as [jr200-labs/polars-hist-db#339](https://github.com/jr200-labs/polars-hist-db/issues/339).
- **The dataset is already live** at `s3://xtdb-datasets/food-prices/`, all four sizes, so it runs out of the box.
- **`D5`: no nightly slot** — what it uniquely watches is narrow, and it adds no data shape the suite lacks.
- **`O1`: one pre-existing bug found, deliberately not fixed here** — an `aws-sso` version pin that breaks SSO credentials for every S3-backed benchmark.

No tracking issue — this started from a user's repo, so this description stands in for one.

## Context

polars-hist-db builds bitemporal data pipelines on top of XTDB, and it's worth being precise about why this isn't a translation of the benchmark it ships.

- **`benchmarks/xtdb_delta.py` stubs the database out entirely.** `CurrentRows` and `ForeignKeyStaging` are in-process fakes intercepting `table_query`/`table_insert`.
- **Its own docs say so** — the case table lists "XTDB network and write latency" under *Excluded* for every row.
- **So the published numbers measure Polars**, and porting them would tell us nothing about XTDB.
- **What's ported instead is `polars_hist_db/backends/xtdb*.py`** — the statements the library actually issues.

## What it measures

The keyed temporal join, not the write. Each partition asks XTDB two questions before writing anything: which of these rows changed, and which foreign keys are missing.

- **So one partition is:**
  - bind the batch's ids, probe `food_prices` `FOR VALID_TIME AS OF` the batch's basis, keep only rows whose price moved;
  - resolve the place / product / unit foreign keys the same way, inserting any the dimension tables don't yet hold;
  - write the survivors back as one `BEGIN READ WRITE WITH (SYSTEM_TIME = …)` transaction, optionally closing out rows the batch no longer mentions (`--dropout`, off by default as the upstream pipeline has it).
- **The read dominates, which is the point.** At `med` — 75 partitions, 1.86M rows written:

  ```
  delta-query       75 txns  avg    311.0ms  max   1028.8ms  total     23.3s
  ingest            75 txns  avg     31.6ms  max     85.8ms  total      2.4s
  dim-resolve      225 txns  avg      2.8ms  max     23.9ms  total      0.6s
  dim-insert        10 txns  avg      7.2ms  max     33.0ms  total      0.1s
  ```

- **`UNNEST` amortises well as the key set grows** — cost per bound key falls 13x across the sizes, so it isn't degrading into a per-key scan:

  | | fact rows | keys bound / query | `delta-query` avg | µs per key |
  | --- | --- | --- | --- | --- |
  | `tiny` | 7k | 208 | 16.7ms | 80 |
  | `small` | 186k | 5,200 | 58.6ms | 11.3 |
  | `med` | 1.86M | 52,000 | 311ms | 6.0 |

  Table size and key count scale together here, so the two aren't separated — but both a per-key-lookup model and a full-scan model predict 10x from `small` to `med`, and the observed growth is 5.3x.
- **Around 29% of incoming rows are elided** by the delta filter at `small` and above, so it's doing real work rather than passing everything through.

## Decisions

- **`D1`: named for its dataset, as `products` and `ts-devices` are.** Several benchmarks here already exercise deltas, so delta detection isn't the distinguishing feature.
- **`D2`: the delta comparison stays client-side, in Clojure.** That's where the library does it. Pushing it into XTDB would be a more flattering benchmark and a less faithful one.
- **`D3`: bind-and-`UNNEST` rather than the library's temp key tables.** See `F1` — reproducing the workaround would have made this a table-catalog-churn benchmark instead.
- **`D4`: in-process ADBC over pgwire.** `Xtdb.Connection.bulkIngest` is the analogue of the `adbc_ingest` the library reaches over FlightSQL, so the statement mix matches theirs rather than being an artefact of whichever driver we picked.
- **`D5`: runnable, but not in the nightly suite.** Weighed after the `UNNEST` rewrite (`D3`), which is what changed the answer — removing the temp-table churn removed most of what made the workload distinctive.
  - **What it uniquely watches is three things**: the large bound-list `UNNEST` lookup, read-before-write delta elision, and `DELETE … FOR PORTION OF VALID_TIME`. Nothing else in the suite covers any of them — `fusion`'s updates are blind `UPDATE … WHERE _id = ?`, with no prior read.
  - **It adds no data shape the suite lacks.** Three dimensions and one fact table, low entropy, 75 versions deep; `readings` goes far deeper on version depth, and `tsbs`, `readings` and `fusion` all already write at an explicit `SYSTEM_TIME` and read under temporal filters.
  - **So a slot would buy one query shape's trend line** for the cost of a job and a 490MB dataset sync each night. If we later want this watched continuously, folding the delta loop into `fusion` as a stage is the more likely home — it already owns the production-usage remit and would gain the read-modify-write pathology it currently lacks.

## Implementation notes

### `F1`: the library's temp-table workaround isn't needed on XTDB

Reported upstream as [jr200-labs/polars-hist-db#339](https://github.com/jr200-labs/polars-hist-db/issues/339) — it's a real cost they're paying for nothing.

- **What they do**: with no temp tables and no way to bind a large `IN`-list, each keyed lookup materialises its key set as a *real* table, joins against it, then `ERASE`s it. Four per partition.
- **What that costs**: four durable, replicated, compacted writes of throwaway data per partition, each leaving an undroppable catalog entry, for data whose useful life is one query. Measured on the first cut of this benchmark: **600 of 686 write transactions and 60% of measured time**, of which three quarters was re-resolving near-static dimensions.
- **What works instead**: `UNNEST` of a bound list. Verified — text lists, int lists, `WITH ORDINALITY`, **and lists of structs** (so composite keys and per-key payloads are covered), in the exact `FOR VALID_TIME AS OF` shape, at 20k bound keys in ~113ms. It compiles to the `[:table …]` inline-relation operator the planner already has.
- **Why they don't**: they target MariaDB as well, where `UNNEST` of a bound array isn't available. It's a portability tax, not an XTDB gap — and it sits exactly on their existing `XtdbBackend` / `MariaDbBackend` boundary, so an XTDB-specific path would fit their architecture.
- **`O2`: there is no discoverability gap — I was wrong about that.** `= ANY(?)` **does** take a bound list, as does `<> ALL(?)`, so the Postgres reflex works and you don't have to know to reach for `UNNEST`.
  - **Checking it turned up something better**: `UNNEST` works in every join shape we'd want — all twelve uncorrelated `UNNEST(?)` shapes (`INNER`/`LEFT`/`RIGHT`/`FULL`/`CROSS`, left-operand position, `WITH ORDINALITY`, under temporal filters) and eight of thirteen correlated `UNNEST(t.col)` ones. That closed #2084, open since 2022, leaving one follow-up (#5872) for a `RIGHT`/`FULL JOIN` over a *correlated* `UNNEST` that leaks an internal symbol instead of rejecting cleanly.
  - **The benchmark keeps `IN (SELECT … FROM UNNEST(?))` rather than switching to `= ANY(?)`.** `UNNEST` compiles to the `[:table …]` inline relation the planner can hash-join; I haven't measured whether `= ANY` over a 52k-element array does the same or degrades to a scan per row. Simpler isn't obviously faster, and the point of this benchmark is to represent the path a user chasing performance would take.

### Driving it from Clojure

Three things weren't obvious — grouped by the mechanism that silently did the wrong thing rather than failing where the mistake was.

- **Every write comes off one monotonic clock.** XTDB requires system times to ascend and these are historic: a batch describing 2013-05 is published at 2013-06-01.
  - So the dimension inserts and the `CREATE TABLE` are stamped from the same clock as the price writes.
  - **One auto-committed write at wall-clock now fences out every back-dated write after it** — and surfaces much later as a table-not-found.
  - The library reaches the same place from the other end, reading `xt.txs` and bumping past the last system time.
- **Commit through `commitSync`, not a SQL `COMMIT`.** `Statement.executeUpdate` calls `commitSync()` and discards the `ExecutedTx`, so an aborted transaction raises nothing.
  - That is how the clock bug stayed invisible during development: the writes never landed and the benchmark carried on timing them.
  - **Worth knowing beyond this PR** — any in-process ADBC caller framing its own transactions in SQL has the same hole.
- **The tables are declared up front.** XTDB infers schema from writes, so the first partition would otherwise ask after a `food_prices` that doesn't exist yet and get a planning error.
  - `CREATE TABLE` is idempotent, and the library plugs the same hole from the other side by registering its table configs before it ingests.
- **`modules/bench` gains a test source set, which it didn't previously have.** Worth knowing before adding more tests there.
  - Its namespaces are now loaded by a test task, so a `^:benchmark` deftest in one becomes discoverable and runs.
  - The REPL runner in `food_prices.clj` is a `comment` block for that reason — as a `deftest` it failed `./gradlew test` reaching for S3.
  - The existing bench namespaces are unaffected, since nothing loads them.

## The dataset

A monthly retail food-price series, baked to Arrow at mirror time so the load path is just Arrow — the GLEIF/Edgar pattern.

- **Upstream is a 7,381-row CSV** committed to the library's own repo: the right shape, nowhere near the right size.
- **`mirrors/food-prices/mirror.py` fans it out** over synthetic regions to four sizes, one record batch per month.

  | Size | Places | Rows |
  | --- | --- | --- |
  | `tiny` | 4 | 7,381 |
  | `small` | 100 | 260,149 |
  | `med` | 1,000 | 2,629,849 |
  | `big` | 5,000 | 13,161,849 |

- **Regions 0-3 keep the real prices verbatim**, so `tiny` reproduces the upstream series exactly and is what the tests assert against.
- **Synthetic regions repeat the previous month's price about a third of the time.** Load-bearing: a series where everything moves every month would never exercise the filter the workload is mostly built around.
- **Python is one-directional** — it exists to produce the Arrow, and nothing downstream depends on it. It needs `pyarrow`; the JVM side doesn't.

## Usage

```bash
./gradlew food-prices -Psize=small        # -Pdropout=true for the dropout path
```

`small` (the default) finishes in about 7s; `med` is where the join dominates at 66% of the ingest stage, and is the size to reach for when the point is to measure something. The `xtdb-bench` image works too — `docker run --rm ghcr.io/xtdb/xtdb-bench:nightly food-prices --size small`.

- **Nothing needs doing first** — all four sizes are published under `s3://xtdb-datasets/food-prices/` and the `download` stage fetches what it needs.
- **To refresh or regenerate the dataset:**

  ```bash
  cd modules/bench/mirrors/food-prices
  python -m venv .venv && .venv/bin/pip install pyarrow
  .venv/bin/python mirror.py out && ./upload.sh out
  ```

- **`O1`: SSO credentials didn't work for any S3-backed benchmark locally — fixed separately, not in this PR.** `gradle/libs.versions.toml` pinned `aws-sso`/`aws-ssooidc` at 2.16.76 against an otherwise 2.42.30 SDK, and the mismatch threw `AbstractMethodError` in `SsoProfileCredentialsProviderFactory`; it hit `products`, `clickbench` and `ts-devices` identically, and CI never saw it because it injects static keys via `xtdb-aws-datasets-secret`.
  - Fixed on `main` by putting all five AWS artifacts on the shared `aws-sdk` ref and bumping it to 2.51.3 — a version-catalog change with no business being in a benchmark PR.

## Out of scope

- **The upstream benchmark's Polars-side cases** — selective delta, foreign-key staging, time partitioning, the Arrow override CRDT round-trip. They measure dataframe operations with the database faked out.
- **Reproducing the temp-table workaround**, even behind a flag (`F1`). It would have preserved the suite's only `ERASE`/DDL-churn coverage, but trending a pathology we know how to avoid isn't worth a nightly slot — if we want that coverage it should be its own benchmark.
- **A nightly slot (`D5`).** It ships runnable, not scheduled — see the decision below for why.
- **`O1` and `O2` are done rather than out of scope** — the AWS SDK fix landed on `main`; #2084 was closed as completed and #5872 raised.

## Test plan

- **4 unit tests** in `xtdb.bench.food-prices-test`, driving the ingest loop against an in-memory node with hand-built partitions — one per property the workload has to hold:
  - unchanged restatements are neither written nor left as a version;
  - each partition is visible at its own valid time, including a price that never moved;
  - foreign keys resolve without re-inserting;
  - composite keys round-trip through the library's `xtdb-pk-v1:` encoding.
- **End to end at three sizes** — `tiny` 75 partitions / 6,990 of 7,381 rows, `small` 185,585 of 260,149, `med` 1,859,077 of 2,629,849. The elided rows are genuine repeats in the series, which is also what proves the delta query is finding held rows rather than quietly returning empty.
- **`-Pdropout=true`** at `tiny`, confirming the `DELETE … FOR PORTION OF VALID_TIME` path runs (75 txns) and that closed-out rows are subsequently rewritten.
- **The `download` stage exercised for real against S3**, with the local copy deleted first.
- **`./gradlew test`** — 2,119 tests, 0 failures, with `modules:bench:test` executing fresh rather than cached.
- **`./gradlew food-prices --dry-run`** — confirms the task still resolves with no CI wiring behind it.
- **Not run:** the benchmark at `big`.
