### PR TITLE
fix(flight-sql): BEGIN and the SET surface over ADBC executeUpdate

### DIFF
--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -27,7 +27,7 @@
            (xtdb.tx TxOp$PatchDocs TxOp$PutDocs)
            (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
            (xtdb.arrow RelationReader VectorReader)
-           xtdb.query.SqlPlanner
+           (xtdb.query ParsedStatement$Dml SqlParser SqlPlanner)
            xtdb.api.TableRef
            xtdb.util.StringUtil))
 
@@ -3576,8 +3576,6 @@
   (visitEraseStatement [_ _])
 
   (visitAssertStatement [_ _])
-  (visitQueryExpr [_ _])
-  (visitShowVariableStatement [_ _])
 
   ;; not statically expandable — fall through to the raw Sql op, which the indexer interprets
   (visitGrantRoleStatement [_ _])
@@ -3588,20 +3586,26 @@
   ([sql args-rel] (sql->static-ops sql args-rel {}))
 
   ([sql ^RelationReader args-rel {:keys [scope] :as opts}]
-   ;; parsed outside the catch below: a syntax error is the caller's, so it propagates to whoever is
+   ;; classified outside the catch below: a syntax error is the caller's, so it propagates to whoever is
    ;; expanding (which surfaces and counts it) rather than being swallowed into an op that reaches the
    ;; log and only fails in the indexer.
-   (let [ast (antlr/parse-statement sql)]
-     (try
-       (let [arg-rows (some-> args-rel (.toTuples #xt/key-fn :snake-case-string))
-             arg-fields (mapv VectorReader/.getField (or args-rel []))
+   ;;
+   ;; Only DML reduces to static ops, so the visitor's obligation is the DML alternatives rather than
+   ;; every `directlyExecutableStatement` in the grammar. Without the gate an unimplemented alternative
+   ;; is an AbstractMethodError — an Error, so it escapes the catch below rather than falling back to a
+   ;; raw Sql op (#5856).
+   (let [parsed (SqlParser/parseStatement sql)]
+     (when (instance? ParsedStatement$Dml parsed)
+       (try
+         (let [arg-rows (some-> args-rel (.toTuples #xt/key-fn :snake-case-string))
+               arg-fields (mapv VectorReader/.getField (or args-rel []))
 
-             {:keys [!errors !warnings] :as env} (-> (->env opts)
-                                                     (assoc :arg-fields arg-fields))
-             tx-ops (.accept ast (->SqlToStaticOpsVisitor env scope arg-rows))]
-         (when (and (empty? @!errors) (empty? @!warnings))
-           tx-ops))
+               {:keys [!errors !warnings] :as env} (-> (->env opts)
+                                                       (assoc :arg-fields arg-fields))
+               tx-ops (.accept (.getAst parsed) (->SqlToStaticOpsVisitor env scope arg-rows))]
+           (when (and (empty? @!errors) (empty? @!warnings))
+             tx-ops))
 
-       ;; a statement this visitor can't reduce to static ops is indexed as SQL instead
-       (catch IllegalArgumentException _)
-       (catch RuntimeException _)))))
+         ;; DML this visitor can't reduce to static ops is indexed as SQL instead
+         (catch IllegalArgumentException _)
+         (catch RuntimeException _))))))

--- a/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
+++ b/core/src/main/kotlin/xtdb/flight_sql/XtdbProducer.kt
@@ -1,7 +1,7 @@
 package xtdb.flight_sql
 
+import xtdb.InternalApi
 import xtdb.query.ParsedStatement
-import xtdb.query.parseStatement
 import com.google.protobuf.Any as ProtoAny
 import com.google.protobuf.ByteString
 import com.google.protobuf.Message
@@ -34,7 +34,6 @@ import xtdb.api.error.*
 import xtdb.api.error.Anomaly.Companion.toAnomaly
 import xtdb.arrow.Relation
 import xtdb.asBytes
-import xtdb.tx.TxOp
 import xtdb.util.closeAll
 import xtdb.util.closeOnCatch
 import xtdb.util.logger
@@ -72,7 +71,14 @@ private fun StreamListener<PutResult>.sendDoPutUpdateRes(allocator: BufferAlloca
     onCompleted()
 }
 
-private fun isDml(sql: String): Boolean = parseStatement(sql) is ParsedStatement.Dml
+/**
+ * Whether this statement is DML, as the connection classified it when the SQL was set.
+ *
+ * Asked of the statement rather than re-parsed here, so the producer's routing decisions and the
+ * connection's dispatch can't disagree about what a statement is.
+ */
+@OptIn(InternalApi::class)
+private val Xtdb.Statement.isDml get() = parsedStatement is ParsedStatement.Dml
 
 /**
  * Translate a throwable into a [FlightRuntimeException] carrying the XTDB anomaly's
@@ -250,8 +256,16 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         allocator.close()
     }
 
-    private fun execDml(op: TxOp, ctx: CallContext?, txHandle: TxHandle?) {
-        txOrSessionConnection(ctx, txHandle).executeTxOp(op)
+    /**
+     * Run a non-query statement on the connection's own statement, so it is classified and dispatched
+     * there (DML, transaction control, the session `SET` surface) rather than submitted as a raw SQL
+     * op — which only DML is.
+     */
+    private fun execUpdate(sql: String, ctx: CallContext?, txHandle: TxHandle?) {
+        txOrSessionConnection(ctx, txHandle).createStatement().use { stmt ->
+            stmt.setSqlQuery(sql)
+            stmt.executeUpdate()
+        }
     }
 
     override fun acceptPutStatement(
@@ -261,8 +275,8 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         ackStream: StreamListener<PutResult>
     ): Runnable = Runnable {
         ackStream.reportingErrors {
-            execDml(
-                TxOp.Sql(cmd.query),
+            execUpdate(
+                cmd.query,
                 ctx,
                 if (cmd.hasTransactionId()) cmd.transactionId else null
             )
@@ -362,15 +376,15 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
         val sql = cmd.queryBytes.toStringUtf8()
         val dbName = resolveDb(ctx)
 
-        // see #5082 — Python ADBC's cursor.execute() routes DML through the query path
-        if (isDml(sql)) {
-            throw CallStatus.INVALID_ARGUMENT
-                .withDescription("DML statements should be submitted via executeUpdate, not executeQuery (in Python ADBC, use cursor.executescript())")
-                .toRuntimeException()
-        }
         val ticketHandle = newHandle()
         val reader = connectionFor(ctx, dbName).createStatement().use { stmt ->
             stmt.setSqlQuery(sql)
+
+            // see #5082 — Python ADBC's cursor.execute() routes DML through the query path
+            if (stmt.isDml) throw CallStatus.INVALID_ARGUMENT
+                .withDescription("DML statements should be submitted via executeUpdate, not executeQuery (in Python ADBC, use cursor.executescript())")
+                .toRuntimeException()
+
             stmt.executeQuery().reader
         }
         reader.closeOnCatch { rdr ->
@@ -450,7 +464,7 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
                     ByteString.copyFrom(xtdbStmt.parameterSchema.serializeAsMessageInterruptibly())
                 )
 
-            if (!isDml(sql)) {
+            if (!xtdbStmt.isDml) {
                 resultBuilder.setDatasetSchema(
                     ByteString.copyFrom(xtdbStmt.executeSchema().serializeAsMessageInterruptibly())
                 )
@@ -474,13 +488,13 @@ class XtdbProducer(private val node: Xtdb) : NoOpFlightSqlProducer(), AutoClosea
     ): SchemaResult = flightCall {
         val sql = cmd.query
         val dbName = resolveDb(ctx)
-        if (isDml(sql)) {
-            throw CallStatus.INVALID_ARGUMENT
-                .withDescription("executeSchema only supports queries (DML returns a row count, not a schema)")
-                .toRuntimeException()
-        }
         connectionFor(ctx, dbName).createStatement().use { stmt ->
             stmt.setSqlQuery(sql)
+
+            if (stmt.isDml) throw CallStatus.INVALID_ARGUMENT
+                .withDescription("executeSchema only supports queries (DML returns a row count, not a schema)")
+                .toRuntimeException()
+
             stmt.prepare()
             SchemaResult(stmt.executeSchema())
         }

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2383,6 +2383,24 @@ SELECT PERIOD(DATE '2022-12-31', TIMESTAMP '2023-01-02') CONTAINS (DATE '2023-01
                                                  [{"_id" 1, "value" "mundo"}])]
                (sql/sql->static-ops "INSERT INTO bar RECORDS $1" args))))))
 
+(t/deftest test-sql->static-ops-non-dml-5856
+  (t/are [sql] (nil? (sql/sql->static-ops sql vw/empty-args))
+    "BEGIN READ WRITE WITH (SYSTEM_TIME TIMESTAMP '2021-08-03T00:00:00Z')"
+    "BEGIN"
+    "COMMIT"
+    "ROLLBACK"
+    "SET TIME ZONE 'America/New_York'"
+    "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY"
+    "SET ROLE xtdb"
+    "SHOW TIME ZONE"
+    "SHOW AWAIT_TOKEN"
+    "SELECT 1"
+    "PREPARE foo AS SELECT 1"
+    "EXECUTE foo"
+    "ATTACH DATABASE other_db"
+    "DETACH DATABASE other_db"
+    "COPY foo FROM STDIN WITH (FORMAT 'transit-json')"))
+
 (t/deftest test-sql->static-ops-decimals-4483
   (t/is (= [{:op :put-docs, :table-name 'public/foo,
              :docs [{"_id" 1, "dec" 1.01M} {"_id" 2, "dec" 1.012M}],

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -11,6 +11,7 @@ import org.apache.arrow.flight.FlightClient
 import org.apache.arrow.flight.FlightDescriptor
 import org.apache.arrow.flight.FlightInfo
 import org.apache.arrow.flight.FlightRuntimeException
+import org.apache.arrow.flight.FlightStatusCode
 import org.apache.arrow.flight.CallHeaders
 import org.apache.arrow.flight.CallInfo
 import org.apache.arrow.flight.CallStatus
@@ -768,6 +769,81 @@ class FlightSqlAdbcTest {
             runCatching { fsqlClient.rollback(tx2, *emptyCallOpts) }
             throw t
         }
+    }
+
+    // -- SQL transaction & session control --
+    //
+    // Driven through a session-bound client: BEGIN/SET are connection state, and only a session cookie
+    // ties a client to its own connection (a cookieless caller shares one per database).
+
+    private fun sessionClient(): FlightSqlClient =
+        cookieAwareClient().also { it.setSessionOptions(catalogOpt("xtdb"), *emptyCallOpts) }
+
+    @Test
+    fun `SQL BEGIN with SYSTEM_TIME backfills at the requested system-time`() {
+        sessionClient().use { client ->
+            client.executeUpdate("BEGIN READ WRITE WITH (SYSTEM_TIME TIMESTAMP '2021-08-03T00:00:00Z')", *emptyCallOpts)
+            client.executeUpdate("INSERT INTO docs RECORDS {_id: 1, v: 'backfill'}", *emptyCallOpts)
+            client.executeUpdate("COMMIT", *emptyCallOpts)
+        }
+
+        assertEquals(
+            listOf(
+                mapOf(
+                    "_id" to 1L, "v" to "backfill",
+                    "_system_from" to ZonedDateTime.parse("2021-08-03T00:00Z[UTC]")
+                )
+            ),
+            fsqlClient.execute("SELECT _id, v, _system_from FROM docs", *emptyCallOpts).readRows()
+        )
+    }
+
+    @Test
+    fun `SQL ROLLBACK discards the transaction's writes`() {
+        fsqlClient.executeUpdate("INSERT INTO docs RECORDS {_id: 1}", *emptyCallOpts)
+
+        sessionClient().use { client ->
+            client.executeUpdate("BEGIN READ WRITE", *emptyCallOpts)
+            client.executeUpdate("INSERT INTO docs RECORDS {_id: 2}", *emptyCallOpts)
+            client.executeUpdate("ROLLBACK", *emptyCallOpts)
+        }
+
+        assertEquals(
+            listOf(mapOf("_id" to 1L)),
+            fsqlClient.execute("SELECT _id FROM docs ORDER BY _id", *emptyCallOpts).readRows()
+        )
+    }
+
+    @Test
+    fun `SET TIME ZONE is reflected by SHOW timezone on the same session`() {
+        sessionClient().use { client ->
+            client.executeUpdate("SET TIME ZONE 'America/New_York'", *emptyCallOpts)
+
+            assertEquals(
+                listOf(mapOf("timezone" to "America/New_York")),
+                client.execute("SHOW timezone", *emptyCallOpts).readRows(client)
+            )
+        }
+
+        assertEquals(
+            listOf(mapOf("timezone" to "Z")),
+            fsqlClient.execute("SHOW timezone", *emptyCallOpts).readRows(),
+            "the session's zone doesn't leak to another connection"
+        )
+    }
+
+    // Transaction control has no result set, so the ExecuteQuery route can't carry it — but it must say
+    // so as INVALID_ARGUMENT rather than failing inside the planner. See #5856.
+    @Test
+    fun `SQL BEGIN through the query path is rejected as an argument error`() {
+        val ex = assertThrows(FlightRuntimeException::class.java) {
+            fsqlClient.execute("BEGIN READ WRITE", *emptyCallOpts)
+        }
+        assertEquals(FlightStatusCode.INVALID_ARGUMENT, ex.status().code())
+        assertTrue(
+            ex.message?.contains("not a preparable query") == true,
+            "expected message containing 'not a preparable query', got: ${ex.message}"
+        )
     }
 
     // -- executeSchema --


### PR DESCRIPTION
Resolves #5856.

## tl;dr

- **Two bugs, one per layer** — a statement reached a layer it had no business reaching, and that layer answered "can this be reduced to static ops?" with a crash instead of a `nil`.
- **Never BEGIN-specific** — `SET TIME ZONE` failed identically. Every non-DML statement over ADBC's `execute_update` did.
- **`D1`: the gate goes before the visitor**, not into more visit methods — classifying up front shrinks the visitor's obligation to a set that can be checked against the grammar.
- **`con:` one hazard arrives with this fix** — a cookieless client's SQL `BEGIN` opens on the shared connection (#5862). The one thing here worth a second opinion.

## Root cause

One node per layer; either alone is a bug.

- **`acceptPutStatement` never classified the statement.** It built a `TxOp.Sql` from the client's SQL and handed it to `Connection.executeTxOp` — the **raw-DML path**. So anything that wasn't DML went hunting a static-ops expansion it could never have.
- **`sql->static-ops` crashed rather than declining.** It walked the tree with `SqlToStaticOpsVisitor`, a `defrecord` over the ANTLR-generated `SqlVisitor` interface that defines the DML alternatives and nothing else.
  - **`AbstractMethodError` is an `Error`**, so it sailed past the `catch RuntimeException` fallback that exists precisely to answer "can't reduce this, index it as SQL instead".

## Changes (reading order)

- **`fix(sql)` — classify before visiting.** `sql->static-ops` runs `SqlParser/parseStatement` first, and only walks the tree for a `ParsedStatement.Dml`. Verified green standalone (453/453), so it's cherry-pickable on its own.
- **`fix(flight-sql)` — route the ad-hoc DoPut through the connection**, and stop the producer re-classifying statements itself. `createStatement` / `setSqlQuery` / `executeUpdate`; see Delegation below.

## Decision rationale

- **`D1`: the gate belongs before the visitor, not in more visit methods.**
  - **More visit methods fix the symptom and keep the shape** — a visitor obliged to cover every `directlyExecutableStatement` in the grammar, with nothing enforcing it.
  - **The gate closes that obligation to nine `Dml` alternatives**, plus the `insertColumnsAndSource` and `patchSource` sub-rules — small enough to check by hand, and a grammar addition can't silently extend it.
  - `visitQueryExpr` and `visitShowVariableStatement` go with it, unreachable behind the gate.
- **`D2`: the Flight producer was the only frontend not routed through the connection.**
  - `Xtdb.Statement.executeUpdate` already switches on `ParsedStatement`, handling Begin / Commit / Rollback / Dml / the session `SET` surface — the surface #5750 built out for ADBC and FlightSQL clients.
  - The prepared-statement DoPut (`acceptPutPreparedStatementUpdate`) always went through it; the ad-hoc route never did.
  - **DML behaviour is unchanged** — an unbound statement submits the same `TxOp.Sql` with null args.

## Delegation

The routing change came with the producer still classifying statements on its own, in three places — duplication removed in the same commit.

- **Each query-path handler called a free `isDml(sql)`** — a second `parseStatement` of SQL the statement it then opened would parse again. Two independent derivations of the same fact, free to drift.
- **`Xtdb.Statement.parsedStatement` already holds the classification**, so the producer now asks the statement. The free function goes; `isDml` becomes an extension on the statement, behind `@OptIn(InternalApi::class)`.
- **Behaviour-preserving.** The guards move inside the statement block, and `setSqlQuery` raises the same parse error `isDml`'s own parse raised, ahead of the same check.
- **Route policy deliberately stays in the producer.** Rejecting DML on the ExecuteQuery route (#5082) and omitting `datasetSchema` for DML are Flight SQL protocol decisions, and the "use `cursor.executescript()`" hint is Python-ADBC-specific — none of it belongs on the connection.
- **`idea:` what's still duplicated is the question, not the answer.** pgwire, this producer and `Statement.doPrepare` each ask "what kind of statement is this?" in their own vocabulary, when a frontend actually wants "does it have a result set?". That wants a first-class property on `Xtdb.Statement` — designed once alongside the result-less statement mode #5861 needs, rather than half-added here.

## Invariants preserved

- **A syntax error still propagates.** Classification sits outside the `try`, so an unparseable statement surfaces to whoever is expanding rather than being swallowed into an op that reaches the log and only fails in the indexer.

## Usage

Historical backfill over ADBC / FlightSQL — what #5856 was reaching for:

```python
import adbc_driver_flightsql.dbapi

conn = adbc_driver_flightsql.dbapi.connect("grpc://localhost:9832")
cur = conn.cursor()
cur.executescript("BEGIN READ WRITE WITH (SYSTEM_TIME TIMESTAMP '2021-08-03T00:00:00Z')")
cur.executescript("INSERT INTO docs RECORDS {_id: 1, v: 'backfill'}")
cur.executescript("COMMIT")
```

- **The whole classified statement surface now works over `execute_update`** — `BEGIN` with access mode and commit options, `COMMIT` / `ROLLBACK`, the session `SET` operators.
- **`executescript`, not `execute`** — see Out of scope.
- **No migration, config or flag** — the fix is behavioural.

## Out of scope

- **`#5861`: transaction control over the ExecuteQuery route.**
  - **Python's DB-API prepares every statement**, so `cursor.execute` and `cursor.executemany` land on `Statement.prepare()`, which rejects a `BEGIN` as unpreparable.
  - **Now a clean `INVALID_ARGUMENT`** rather than an `INTERNAL` `AbstractMethodError`, and a test pins that — but still a rejection.
  - **Closing it needs a fourth statement mode** — "executes, but has no result set" — answering `prepare` / `parameterSchema` / `executeSchema` / `executeQuery` coherently, plus an empty-stream ticket in the producer.
  - **Deferred because `Xtdb.Statement` is the surface pgwire is due to be routed through.** That mode wants adding once, deliberately, with pgwire's Parse/Describe behaviour for `BEGIN` in view — not inside a bugfix.

## Reviewer's attention

- **`con:` a cookieless client's SQL `BEGIN` opens on the shared connection (#5862).**
  - `connectionFor` falls back to `defaultConns[dbName]` when there's no session cookie, and **an open transaction is connection state** — so it would capture another cookieless client's autocommit write, silently.
  - **That is what `beginTransaction`'s dedicated per-handle connection prevents**, and there's already a test for it (`test FlightSQL transaction does not capture another cookieless clients autocommit write`). SQL `BEGIN` has no handle to key one on.
  - **The sharing predates this PR; reaching it doesn't** — it was unreachable while `BEGIN` crashed.
  - **The new tests drive session-bound clients**, so they document the correct usage rather than enshrining the shared-connection behaviour.

## Test plan

- **`FlightSqlAdbcTest`** — three reproductions (`BEGIN … WITH (SYSTEM_TIME …)` backfilling at the requested system-time, `ROLLBACK` discarding its writes, `SET TIME ZONE` reflected by `SHOW timezone` and not leaking to another connection), plus one pinning the ExecuteQuery route as `INVALID_ARGUMENT`.
- **`sql_test/test-sql->static-ops-non-dml-5856`** — every non-DML statement kind returns `nil` rather than throwing, at the layer the crash actually lived in.
- **`./gradlew test` — 1668/1669**, and a 545/545 no-regression sweep across `FlightSqlAdbcTest`, `InProcessAdbcTest`, `sql_test`, `sql.patch_test`, `api_adbc_test`, `flight_sql_test`, `pgwire_test`, the `pgwire.*` suites and `api_test`. The single failure was `xtdb.expression.temporal-test/test-cast-to-time`, the known flake #2241 (DST spring-forward, `2035-03-11T02:00` in `America/Boise`).
- **`check:` those runs predate the rebase onto `8d9d9850c`.** The four changed files are byte-identical to the verified tree — confirmed by diffing against the pre-rebase tip — but the base advanced, so CI is the authority on the current head.
- **First commit verified standalone** — 453/453 across the sql, pgwire and ADBC/FlightSQL suites at `fix(sql)` alone, which is what justifies keeping it separate.
- **No reflection, boxed-math or opt-in warnings.** `feature-dev:code-reviewer` pass over the diff: no findings above threshold.
