### PR TITLE
feat(flight-sql): drive xtdb.api over a FlightSQL connection

### DIFF
--- a/core/src/main/clojure/xtdb/adbc.clj
+++ b/core/src/main/clojure/xtdb/adbc.clj
@@ -63,7 +63,7 @@
         (when pinned?
           (.rollbackTx conn))))))
 
-(defn- reduce-page
+(defn reduce-page
   "Reduces `f`/`acc` over one page's rows, preserving a `reduced` short-circuit so the cursor loop
   stops (`transduce` can't — it unwraps `reduced` per page, so early termination wouldn't cross a
   page boundary). `->clj` turns the decode's java.util list/struct/set collections into Clojure

--- a/core/src/main/clojure/xtdb/flight_sql.clj
+++ b/core/src/main/clojure/xtdb/flight_sql.clj
@@ -1,9 +1,32 @@
 (ns xtdb.flight-sql
-  "FlightSQL server integrant component."
-  (:require [integrant.core :as ig]
+  "FlightSQL server integrant component, and the Clojure client that lets `xtdb.api` drive a node over
+  the FlightSQL wire.
+
+  The client is a `xtdb.protocols/Connectable`, so `xt/q`, `xt/submit-tx`, `xt/execute-tx` and
+  `xt/status` work against it exactly as they do against a node, a JDBC connection or an in-process
+  `Xtdb.Connection`. Every operation is expressed as SQL and parameter binding — the only two things
+  FlightSQL carries — mirroring the statement sequence the pgwire path sends."
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [integrant.core :as ig]
+            [xtdb.adbc :as adbc]
+            [xtdb.error :as err]
             [xtdb.node :as xtn]
-            [xtdb.util :as util])
-  (:import [xtdb.api FlightSql FlightSqlConfig Xtdb$Config]))
+            [xtdb.protocols :as xtp]
+            [xtdb.serde :as serde]
+            [xtdb.time :as time]
+            [xtdb.util :as util]
+            [xtdb.vector.writer :as vw])
+  (:import (clojure.lang IReduceInit)
+           (java.io Closeable)
+           (java.util.concurrent ExecutionException)
+           (org.apache.arrow.flight CallOption FlightClient FlightEndpoint FlightInfo FlightRuntimeException FlightStatusCode Location SetSessionOptionsRequest SessionOptionValueFactory)
+           (org.apache.arrow.flight.client ClientCookieMiddleware$Factory)
+           (org.apache.arrow.flight.sql FlightSqlClient)
+           (org.apache.arrow.memory BufferAllocator RootAllocator)
+           (org.apache.arrow.vector VectorSchemaRoot)
+           (xtdb.api FlightSql FlightSqlConfig Xtdb$Config)
+           (xtdb.arrow Relation)))
 
 (defmethod xtn/apply-config! :flight-sql [^Xtdb$Config config _ {:keys [host port]}]
   (cond-> (.getFlightSql config)
@@ -19,3 +42,278 @@
 
 (defmethod ig/halt-key! ::server [_ server]
   (util/try-close server))
+
+;; -- client --
+
+(def ^:private ^"[Lorg.apache.arrow.flight.CallOption;" no-call-opts
+  (make-array CallOption 0))
+
+(defn- unwrap-flight-ex ^FlightRuntimeException [^FlightRuntimeException ex]
+  ;; `FlightSqlClient`'s doPut helpers rewrap whatever the server sent as a description-less CANCELLED
+  ;; carrying the real error as its cause, so the status and message we want are one or two links down.
+  (if (= FlightStatusCode/CANCELLED (.code (.status ex)))
+    (let [cause (.getCause ex)
+          cause (if (instance? ExecutionException cause) (.getCause ^ExecutionException cause) cause)]
+      (if (instance? FlightRuntimeException cause)
+        (recur cause)
+        ex))
+    ex))
+
+;; the server maps an anomaly's category to a Flight status and its message to the description; this
+;; is the inverse, so a wire error surfaces as the same category of `xtdb.error` anomaly the other
+;; connectables throw. The error code doesn't cross the wire, so it comes back nil.
+(extend-protocol err/ToAnomaly
+  FlightRuntimeException
+  (->anomaly [ex data]
+    (let [ex (unwrap-flight-ex ex)
+          msg (.getMessage ex)
+          data (into {::err/cause ex} data)]
+      (condp = (.code (.status ex))
+        FlightStatusCode/INVALID_ARGUMENT (err/incorrect nil msg data)
+        FlightStatusCode/UNIMPLEMENTED (err/unsupported nil msg data)
+        FlightStatusCode/NOT_FOUND (err/not-found nil msg data)
+        FlightStatusCode/UNAUTHENTICATED (err/forbidden nil msg data)
+        FlightStatusCode/UNAUTHORIZED (err/forbidden nil msg data)
+        FlightStatusCode/CANCELLED (err/interrupted nil msg data)
+        FlightStatusCode/RESOURCE_EXHAUSTED (err/busy nil msg data)
+        FlightStatusCode/UNAVAILABLE (err/unavailable nil msg data)
+        (err/fault nil msg data)))))
+
+;; -- SQL literals --
+;;
+;; BEGIN and SET aren't preparable statements, so their options can't be bound as parameters the way
+;; the pgwire path binds them — they're rendered into the statement text instead.
+
+(defn- str-literal [s]
+  (str \' (str/replace (str s) "'" "''") \'))
+
+(defn- ts-literal [t default-tz]
+  (format "TIMESTAMP %s" (str-literal (str (time/->instant t {:default-tz default-tz})))))
+
+(defn- begin-ro-sql [{:keys [default-tz await-token snapshot-token snapshot-time current-time]}]
+  (let [opts (cond-> []
+               default-tz (conj (str "TIMEZONE = " (str-literal default-tz)))
+               snapshot-token (conj (str "SNAPSHOT_TOKEN = " (str-literal snapshot-token)))
+               snapshot-time (conj (str "SNAPSHOT_TIME = " (ts-literal snapshot-time default-tz)))
+               current-time (conj (str "CLOCK_TIME = " (ts-literal current-time default-tz)))
+               await-token (conj (str "AWAIT_TOKEN = " (str-literal await-token))))]
+    ;; without overrides we don't open a tx at all: the query then reads at the connection's own
+    ;; basis, which already awaits this connection's writes.
+    (when (seq opts)
+      (format "BEGIN READ ONLY WITH (%s)" (str/join ", " opts)))))
+
+(defn- begin-rw-sql [{:keys [system-time default-tz metadata async?]}]
+  (when metadata
+    (throw (err/unsupported :xtdb.flight-sql/metadata-unsupported
+                            "`:metadata` is not supported over FlightSQL: BEGIN can't be parameterised, and a metadata map has no faithful SQL-literal rendering"
+                            {:metadata metadata})))
+
+  (format "BEGIN READ WRITE WITH (%s)"
+          (str/join ", " (cond-> [(str "ASYNC = " (boolean async?))]
+                           default-tz (conj (str "TIMEZONE = " (str-literal default-tz)))
+                           system-time (conj (str "SYSTEM_TIME = " (ts-literal system-time default-tz)))))))
+
+;; -- tx ops --
+
+(defn- table-sql [table-name]
+  (format "\"%s\".\"%s\"" (namespace table-name) (name table-name)))
+
+(defn- for-valid-time-sql [valid-from valid-to]
+  (if (or valid-from valid-to)
+    "FOR VALID_TIME FROM ? TO ?"
+    ""))
+
+(defn- records-stmts
+  "Renders a doc op as `RECORDS {\"col\": ?, …}` statements — one per run of consecutive docs sharing a
+  column set, so a homogeneous batch stays a single statement while document order is preserved.
+
+  The columns go in the statement text rather than in a `RECORDS ?` struct param, because the latter
+  can only be planned once the arg struct is known: FlightSQL plans a statement at `prepare`, before the
+  args arrive (the pgwire path sidesteps this by not preparing its DML at all)."
+  [verb table-name for-vt vt-args docs]
+  (for [run (partition-by keys (map (fn [doc]
+                                      (into (sorted-map)
+                                            (map (juxt (comp util/->normal-form-str key) val))
+                                            doc))
+                                    docs))]
+    {:sql (format "%s %s %s RECORDS {%s}" verb (table-sql table-name) for-vt
+                  (str/join ", " (map #(format "\"%s\": ?" (str/replace % "\"" "\"\""))
+                                      (keys (first run)))))
+     :arg-rows (mapv #(into (vec vt-args) (vals %)) run)}))
+
+(defn- op->stmts
+  "Renders one parsed tx-op as a seq of `{:sql .., :arg-rows ..}`.
+
+  `:arg-rows` nil sends the statement unparameterised; otherwise the rows are bound as one batch, which
+  the server accumulates into a single multi-row tx op.
+
+  put-docs has no `FOR VALID_TIME` form on INSERT, so its valid-time bounds ride in the record itself,
+  as they do on the pgwire path's COPY."
+  [{:keys [op table-name docs doc-ids valid-from valid-to sql arg-rows]}]
+  (let [for-vt (for-valid-time-sql valid-from valid-to)
+        vt-args (when (seq for-vt) [valid-from valid-to])]
+    (case op
+      :put-docs (records-stmts "INSERT INTO" table-name "" nil
+                               (cond->> docs
+                                 (or valid-from valid-to)
+                                 (map (partial into (->> {:xt/valid-from valid-from, :xt/valid-to valid-to}
+                                                         (into {} (remove (comp nil? val))))))))
+
+      :patch-docs (records-stmts "PATCH INTO" table-name for-vt vt-args docs)
+
+      :delete-docs (when (seq doc-ids)
+                     [{:sql (format "DELETE FROM %s %s WHERE _id = ?" (table-sql table-name) for-vt)
+                       :arg-rows (mapv (fn [doc-id] (conj (vec vt-args) doc-id)) doc-ids)}])
+
+      :erase-docs (when (seq doc-ids)
+                    [{:sql (format "ERASE FROM %s WHERE _id = ?" (table-sql table-name))
+                      :arg-rows (mapv vector doc-ids)}])
+
+      :sql [{:sql sql, :arg-rows arg-rows}])))
+
+;; -- statement execution --
+
+(defn- ->param-root ^VectorSchemaRoot [^BufferAllocator allocator arg-rows]
+  (util/with-open [^Relation rel (apply vw/open-args allocator arg-rows)]
+    (.openAsRoot rel allocator)))
+
+(defn- exec-update!
+  "Runs a statement that returns no rows. The prepared statement takes ownership of the parameter root."
+  [^BufferAllocator allocator ^FlightSqlClient client ^String sql arg-rows]
+  (if (nil? arg-rows)
+    (.executeUpdate client sql no-call-opts)
+
+    (when (seq arg-rows)
+      (with-open [ps (.prepare client sql no-call-opts)]
+        (.setParameters ps (->param-root allocator arg-rows))
+        (.executeUpdate ps no-call-opts)))))
+
+(defn- reduce-stream [^BufferAllocator allocator ^FlightSqlClient client ^FlightInfo flight-info key-fn f start]
+  (let [ticket (.getTicket ^FlightEndpoint (first (.getEndpoints flight-info)))]
+    (with-open [stream (.getStream client ticket no-call-opts)]
+      (let [root (.getRoot stream)]
+        (with-open [rel (Relation/fromRoot allocator root)]
+          (loop [acc start]
+            (if (or (reduced? acc) (not (.next stream)))
+              (unreduced acc)
+              (do
+                (.loadFromArrow rel root)
+                (recur (adbc/reduce-page f acc rel key-fn))))))))))
+
+(defn- exec-query! [^BufferAllocator allocator ^FlightSqlClient client ^String sql args key-fn f start]
+  (if (seq args)
+    ;; a query binds one row of positional params, so it needs the prepared path
+    (with-open [ps (.prepare client sql no-call-opts)]
+      (.setParameters ps (->param-root allocator [(vec args)]))
+      (reduce-stream allocator client (.execute ps no-call-opts) key-fn f start))
+
+    (reduce-stream allocator client (.execute client sql no-call-opts) key-fn f start)))
+
+(defn- rollback!
+  "Best-effort: a rollback that fails mustn't mask the failure that provoked it."
+  [allocator client]
+  (try
+    (exec-update! allocator client "ROLLBACK" nil)
+    (catch Throwable t
+      (log/warn t "couldn't roll back the FlightSQL transaction"))))
+
+(defn- plan-q ^clojure.lang.IReduceInit [^BufferAllocator allocator ^FlightSqlClient client sql args {:keys [key-fn] :as opts}]
+  (let [key-fn (serde/read-key-fn (or key-fn :kebab-case-keyword))]
+    (reify IReduceInit
+      (reduce [_ f start]
+        (err/wrap-anomaly {:sql sql}
+          (let [begin-sql (begin-ro-sql opts)]
+            (when begin-sql
+              (exec-update! allocator client begin-sql nil))
+            (try
+              (exec-query! allocator client sql args key-fn f start)
+              (finally
+                (when begin-sql
+                  (rollback! allocator client))))))))))
+
+(defn- submit-tx*
+  "Runs the ops between BEGIN and COMMIT on the session's connection, then reads the tx back off it —
+  the same statement sequence the pgwire path sends, and the only way to learn the tx key: a FlightSQL
+  transaction runs on a connection the server discards at commit."
+  [^BufferAllocator allocator ^FlightSqlClient client tx-ops tx-opts]
+  (err/wrap-anomaly {}
+    (exec-update! allocator client (begin-rw-sql tx-opts) nil)
+    (try
+      (doseq [tx-op tx-ops
+              {:keys [sql arg-rows]} (op->stmts tx-op)]
+        (err/wrap-anomaly {:sql sql}
+          (exec-update! allocator client sql arg-rows)))
+
+      (exec-update! allocator client "COMMIT" nil)
+
+      (catch Throwable t
+        (rollback! allocator client)
+        (throw t))))
+
+  (first (into [] (plan-q allocator client "SHOW LATEST_SUBMITTED_TX" nil {}))))
+
+(deftype FlightSqlConn [^BufferAllocator allocator, ^FlightSqlClient client]
+  xtp/Connectable
+  ;; already bound to its database (chosen at open), so it rejects `:database` as the other
+  ;; connection-level impls do.
+  (-plan-q [this sql args opts]
+    (xtp/check-no-database this opts)
+    (plan-q allocator client sql args opts))
+
+  (-submit-tx [this tx-ops opts]
+    (xtp/check-no-database this opts)
+    {:tx-id (:tx-id (submit-tx* allocator client tx-ops (assoc opts :async? true)))})
+
+  (-execute-tx [this tx-ops opts]
+    (xtp/check-no-database this opts)
+    (let [{:keys [tx-id system-time error]} (submit-tx* allocator client tx-ops (assoc opts :async? false))]
+      ;; a SQL COMMIT doesn't raise an aborted tx's error (pgwire reads it off the result itself), so
+      ;; we surface it from the tx we've just read back.
+      (when error
+        (throw (if (instance? Throwable error)
+                 error
+                 (err/fault :xtdb/tx-aborted "Transaction aborted" {:error error}))))
+
+      (serde/->TxKey tx-id (time/->instant system-time))))
+
+  (-status [this] (xtp/build-status this))
+
+  Closeable
+  (close [_]
+    (util/close [client allocator])))
+
+(defn open-conn
+  "Opens a FlightSQL connection to an XTDB node, for use with `xtdb.api`'s `q`/`submit-tx`/`execute-tx`/
+  `status`. The caller closes it.
+
+    * `:host`: the host the FlightSQL server is on (default `127.0.0.1`)
+    * `:port`: the FlightSQL port — see `Xtdb.getFlightSqlPort`
+    * `:dbname`: the database to connect to (default `xtdb`)
+
+  The connection carries a FlightSQL session cookie, so it gets a server-side connection of its own —
+  reads see its own writes, and its transactions aren't shared with other clients."
+  ^java.io.Closeable [{:keys [^String host ^long port dbname]
+                       :or {host "127.0.0.1", dbname "xtdb"}}]
+  (let [allocator (RootAllocator.)]
+    (try
+      (let [client (FlightSqlClient. (-> (FlightClient/builder allocator (Location/forGrpcInsecure host port))
+                                         (.intercept (ClientCookieMiddleware$Factory.))
+                                         (.build)))]
+        (try
+          ;; mints the session (and hence the server-side connection), as well as selecting the database
+          (let [res (.setSessionOptions client
+                                        (SetSessionOptionsRequest.
+                                         {"catalog" (SessionOptionValueFactory/makeSessionOptionValue ^String dbname)})
+                                        no-call-opts)]
+            (when (.hasErrors res)
+              (throw (err/incorrect :xtdb/unknown-db (str "Unknown database: " dbname) {:db-name dbname}))))
+
+          (->FlightSqlConn allocator client)
+
+          (catch Throwable t
+            (util/try-close client)
+            (throw t))))
+
+      (catch Throwable t
+        (util/try-close allocator)
+        (throw t)))))

--- a/src/test/clojure/xtdb/api_flight_sql_test.clj
+++ b/src/test/clojure/xtdb/api_flight_sql_test.clj
@@ -1,0 +1,181 @@
+(ns xtdb.api-flight-sql-test
+  "Exercises `xtdb.api` over a FlightSQL connection — the same cases as `xtdb.api-adbc-test`, but
+  driven over the wire."
+  (:require [clojure.test :as t :refer [deftest]]
+            [xtdb.api :as xt]
+            [xtdb.flight-sql :as fsql]
+            [xtdb.serde :as serde]
+            [xtdb.test-util :as tu :refer [*node*]]
+            [xtdb.time :as time])
+  (:import (java.time ZoneId)
+           (xtdb.api Xtdb)))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-node)
+
+(defn- open-conn ^java.io.Closeable []
+  (fsql/open-conn {:port (.getFlightSqlPort ^Xtdb *node*)}))
+
+(deftest execute-tx-and-query
+  (with-open [conn (open-conn)]
+    (t/is (= (serde/->TxKey 0 (time/->instant #inst "2020-01-01"))
+             (xt/execute-tx conn [[:put-docs :docs {:xt/id :foo, :n 1}]]))
+          "execute-tx over a FlightSQL connection returns the tx-key")
+
+    (t/is (= [{:xt/id :foo, :n 1}]
+             (xt/q conn "SELECT _id, n FROM docs"))
+          "the connection reads its own write (read-your-writes)")
+
+    (t/is (= {:tx-id 1} (xt/submit-tx conn [[:put-docs :docs {:xt/id :bar, :n 2}]]))
+          "submit-tx returns the tx-id")
+
+    (t/is (= #{{:xt/id :foo, :n 1} {:xt/id :bar, :n 2}}
+             (set (xt/q conn "SELECT _id, n FROM docs"))))))
+
+(deftest client-op-conversions
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:put-docs :docs {:xt/id "a", :n 1}]
+                         [:put-docs :docs {:xt/id "b", :n 2}]
+                         [:put-docs :docs {:xt/id "c", :n 3}]])
+
+    (xt/execute-tx conn [[:patch-docs :docs {:xt/id "a", :n 10}]
+                         [:delete-docs :docs "b"]
+                         [:sql "INSERT INTO docs (_id, n) VALUES ('d', ?)" [4]]])
+
+    (t/is (= #{{:xt/id "a", :n 10} {:xt/id "c", :n 3} {:xt/id "d", :n 4}}
+             (set (xt/q conn "SELECT _id, n FROM docs")))
+          "patch updated a, delete removed b, raw sql inserted d")
+
+    (xt/execute-tx conn [[:erase-docs :docs "a"]])
+    (t/is (= #{{:xt/id "c", :n 3} {:xt/id "d", :n 4}}
+             (set (xt/q conn "SELECT _id, n FROM docs")))
+          "erase removed a")))
+
+(deftest multi-op-tx-is-atomic
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:put-docs :docs {:xt/id :seed, :n 0}]])
+
+    (t/is (anomalous? [:conflict nil #"Assert failed"]
+                      (xt/execute-tx conn [[:put-docs :docs {:xt/id :a, :n 1}]
+                                           [:sql "ASSERT (SELECT COUNT(*) FROM docs) = 0"]]))
+          "the failed assert surfaces from execute-tx")
+
+    (t/is (= [{:xt/id :seed}] (xt/q conn "SELECT _id FROM docs"))
+          "and the put in the same tx didn't land - the ops are one transaction")))
+
+(deftest multi-row-batches
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:sql "INSERT INTO docs (_id, n) VALUES (?, ?)" [1 10] [2 20] [3 30]]])
+    (t/is (= #{{:xt/id 1, :n 10} {:xt/id 2, :n 20} {:xt/id 3, :n 30}}
+             (set (xt/q conn "SELECT _id, n FROM docs")))
+          "a batched :sql insert applies every arg-row")
+
+    (xt/execute-tx conn [[:delete-docs :docs 1 2]])
+    (t/is (= #{{:xt/id 3, :n 30}}
+             (set (xt/q conn "SELECT _id, n FROM docs")))
+          "delete-docs with several ids removes them all")))
+
+(deftest put-docs-valid-time
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:put-docs {:into :docs, :valid-from #inst "2018-01-01", :valid-to #inst "2019-01-01"}
+                          {:xt/id :foo, :n 1}]])
+
+    (t/is (= [] (xt/q conn "SELECT _id FROM docs"))
+          "the doc's valid-time window has closed by the current time")
+
+    (t/is (= [{:xt/id :foo, :n 1}]
+             (xt/q conn "SELECT _id, n FROM docs FOR VALID_TIME AS OF DATE '2018-06-01'"))
+          "and it's there when we look inside the window")))
+
+(deftest query-args-and-plan-q
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:put-docs :docs {:xt/id :foo, :n 1}]
+                         [:put-docs :docs {:xt/id :bar, :n 2}]])
+
+    (t/is (= [{:xt/id :foo, :n 1}]
+             (xt/q conn ["SELECT _id, n FROM docs WHERE _id = ?" :foo]))
+          "positional args bind over the wire")
+
+    (t/is (= [1 2]
+             (sort (into [] (map :n) (xt/plan-q conn "SELECT n FROM docs"))))
+          "plan-q streams rows over the wire")
+
+    (t/is (= [{"_id" :foo, "n" 1}]
+             (xt/q conn ["SELECT _id, n FROM docs WHERE _id = ?" :foo] {:key-fn :snake-case-string}))
+          ":key-fn is honoured")))
+
+(deftest query-basis-opts
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:put-docs :docs {:xt/id :foo, :n 1}]])
+    (let [snapshot-token (:tok (first (xt/q conn "SELECT SNAPSHOT_TOKEN tok")))]
+      (xt/execute-tx conn [[:put-docs :docs {:xt/id :bar, :n 2}]])
+
+      (t/is (= [{:xt/id :foo, :n 1}]
+               (xt/q conn "SELECT _id, n FROM docs" {:snapshot-token snapshot-token}))
+            "a snapshot-token pins the read basis to before the second tx"))
+
+    (t/is (= [{:ts (.atZone (time/->instant #inst "2023-06-01") (ZoneId/of "Europe/London"))}]
+             (xt/q conn "SELECT CURRENT_TIMESTAMP AS ts"
+                   {:current-time #inst "2023-06-01", :default-tz (ZoneId/of "Europe/London")}))
+          ":current-time and :default-tz both reach the query")))
+
+(deftest tx-opts
+  (with-open [conn (open-conn)]
+    (t/is (= (serde/->TxKey 0 (time/->instant #inst "2021-06-01"))
+             (xt/execute-tx conn [[:put-docs :docs {:xt/id :foo}]] {:system-time #inst "2021-06-01"}))
+          ":system-time is honoured")
+
+    (t/is (anomalous? [:unsupported :xtdb.flight-sql/metadata-unsupported]
+                      (xt/execute-tx conn [[:put-docs :docs {:xt/id :bar}]] {:metadata {:foo "bar"}}))
+          ":metadata has no FlightSQL rendering, so it's rejected rather than dropped")))
+
+(deftest submit-tx-then-query-sees-write
+  (with-open [conn (open-conn)]
+    (xt/submit-tx conn [[:put-docs :docs {:xt/id :foo, :n 1}]])
+    (t/is (= [{:xt/id :foo, :n 1}]
+             (xt/q conn "SELECT _id, n FROM docs"))
+          "an async submit-tx is awaited by a subsequent read on the same connection")))
+
+(deftest connection-rejects-database-opt
+  (with-open [conn (open-conn)]
+    (t/is (anomalous? [:incorrect :cannot-set-db]
+                      (xt/execute-tx conn [[:put-docs :docs {:xt/id 1}]] {:database :some-db})))
+
+    (t/is (anomalous? [:incorrect :cannot-set-db]
+                      (xt/submit-tx conn [[:put-docs :docs {:xt/id 1}]] {:database :some-db})))
+
+    (t/is (anomalous? [:incorrect :cannot-set-db]
+                      (into [] (xt/plan-q conn "SELECT 1" {:database :some-db}))))))
+
+(deftest unknown-db-is-rejected-at-open
+  (t/is (anomalous? [:incorrect :xtdb/unknown-db]
+                    (fsql/open-conn {:port (.getFlightSqlPort ^Xtdb *node*), :dbname "no-such-db"}))))
+
+(deftest sql-anomaly-propagates
+  (with-open [conn (open-conn)]
+    (t/is (anomalous? [:incorrect nil "Cannot parse date"]
+                      (xt/q conn "SELECT DATE 'not-a-date'"))
+          "a server-side anomaly comes back as the same category of anomaly")))
+
+(deftest a-committed-write-is-visible-to-another-connection
+  (with-open [conn1 (open-conn)
+              conn2 (open-conn)]
+    (xt/execute-tx conn1 [[:put-docs :docs {:xt/id :foo}]])
+
+    (t/is (= [{:xt/id :foo}] (xt/q conn2 "SELECT _id FROM docs")))
+    (t/is (= [{:xt/id :foo}] (xt/q conn1 "SELECT _id FROM docs")))))
+
+(deftest status-over-flight-sql
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:put-docs :docs {:xt/id :foo}]])
+
+    (let [status (xt/status conn)]
+      (t/is (map? status))
+      (t/is (contains? status :latest-completed-txs)))))
+
+(deftest mixed-type-column-round-trips
+  (with-open [conn (open-conn)]
+    (xt/execute-tx conn [[:put-docs :docs {:xt/id 1, :v "str"}]
+                         [:put-docs :docs {:xt/id 2, :v 42}]])
+
+    (t/is (= [{:xt/id 1, :v "str"} {:xt/id 2, :v 42}]
+             (xt/q conn "SELECT _id, v FROM docs ORDER BY _id")))))


### PR DESCRIPTION
## tl;dr

`xtdb.flight-sql/open-conn` returns a connection the `xtdb.api` fns drive, so exercising the FlightSQL frontend is now ordinary Clojure rather than hand-rolled Arrow.

- **`xt/q`, `xt/submit-tx`, `xt/execute-tx` and `xt/status` all work over the FlightSQL wire** — the connection satisfies `xtdb.protocols/Connectable`, as a node, a JDBC connection and an in-process `Xtdb.Connection` already do.
- **Purely additive** — no config, no flag, no migration. All you need is a node with `flightSql` enabled, and its port.
- **Writes go as a SQL `BEGIN` / ops / `COMMIT` sequence**, not Flight's transaction Actions, because the Actions can carry neither a tx key nor begin-time options (`D4`).
- **One gap: `:metadata` on a transaction throws `err/unsupported`.** Everything else `xt/execute-tx` accepts is honoured.

## Motivation

A FlightSQL test used to be an Arrow test, which is why so little of the frontend had Clojure-level coverage.

- **Reaching the frontend meant building `VectorSchemaRoot`s, packing tickets and draining streams by hand**, so what coverage existed tested Arrow mechanics as much as it tested XTDB.
- **The `Connectable` protocol already abstracts exactly this** — a node, a JDBC connection and an in-process `Xtdb.Connection` are all driven through it, and FlightSQL was the one frontend with no impl.

## Usage

Open a connection against a node's FlightSQL port and use the ordinary `xt` fns.

```clojure
(require '[xtdb.api :as xt] '[xtdb.flight-sql :as fsql])

(with-open [conn (fsql/open-conn {:port (.getFlightSqlPort node)})]
  (xt/execute-tx conn [[:put-docs :docs {:xt/id 1, :n 10}]])
  (xt/q conn "SELECT _id, n FROM docs"))
```

- **`:port` is required**; `:host` defaults to `127.0.0.1` and `:dbname` to `xtdb`.
- **The connection carries a FlightSQL session cookie**, so it gets a server-side connection of its own — it reads its own writes, and its transactions aren't shared with other clients.
- **Nothing to adopt** — no migration, env var, flag or deploy-order constraint. The one prerequisite is that the node runs a `flightSql` server.

## Decision rationale

Four choices shaped the impl; `D4` is the load-bearing one.

- **`D1`: it lives in `core`, not `xtdb.api`.** The `xtdb-api` artifact has no Arrow Flight dependency, and Flight belongs to `core` — the same reason `xtdb.node/start-node` isn't in `xtdb.api`.
- **`D2`: a distinct `deftype FlightSqlConn`, not an extension onto the `AdbcConnection` interface.**
  - **`Xtdb.Connection` is itself an `AdbcConnection`**, so extending the interface would put the in-process impl's protocol dispatch precedence in question for no gain.
  - **A separate type settles that structurally**, and it owns its allocator and client — which a borrowed `AdbcConnection` couldn't.
- **`D3`: `FlightSqlClient`, not the ADBC FlightSQL driver.** `FlightSqlConnection` (adbc-driver-flight-sql 0.23.0) throws `notImplemented` from `setAutoCommit`, `commit` and `rollback`, so only the Action-based client surface works.
- **`D4`: writes go as the pgwire path's own SQL sequence** — `BEGIN`, the ops, `COMMIT`, then `SHOW LATEST_SUBMITTED_TX` for the key. See `A1` for what this rules out and why.
- **`D5`: doc ops render their columns into the statement text.** `INSERT INTO t RECORDS {"_id": ?, "n": ?}`, one statement per run of consecutive docs sharing a column set — so a homogeneous batch stays one statement and document order survives.

## Alternatives considered

Two, one per layer the write path could have used — Flight's own transaction API, and parameterised DML.

- **`A1`: Flight's transaction Actions (`beginTransaction` / `endTransaction`).** The obvious route, and it doesn't fit.
  - **The server gives a Flight transaction its own connection and closes it at `endTransaction`**, so there's nothing left to read the tx key back off.
  - **`beginTransaction` carries no begin-time options.**
  - **Net: it buys atomicity and forfeits** `:system-time`, `:default-tz`, async/sync commit and the tx key — all of which `xt/execute-tx` is expected to return or honour.
- **`A2`: `RECORDS ?` with a struct param for doc ops.** Tidier, and it fails at `prepare` with "RECORDS ? not supported outside of DML".
  - **FlightSQL plans a statement before its arguments arrive**; pgwire escapes that by not preparing its DML at all, which isn't an option here.

## Coverage

Everything `xtdb.api-adbc-test` covers for the in-process connection, plus the wire-specific cases.

- **All five tx-op forms**, multi-op atomicity, the returned tx key, `:system-time`, `:default-tz`, and async and sync commit.
- **Reads**: query args, `:key-fn`, and the `:snapshot-token` / `:snapshot-time` / `:current-time` / `:default-tz` / `:await-token` basis.
- **Errors**: an anomaly propagates with its category preserved, and `:database` is rejected — a connection is already bound to its database, as the other connection-level impls are.
- **`:metadata` throws `err/unsupported`** — `BEGIN` isn't preparable, so its options must be SQL literals, and a metadata map has no faithful literal rendering.

## Implementation notes

Three sub-concerns, each with something non-obvious in it.

- **Error mapping inverts the server's own anomaly-to-Flight-status mapping**, so a wire error surfaces as the same anomaly category the other connectables throw.
  - **The error code doesn't cross the wire**, so it comes back nil.
  - **`FlightSqlClient`'s doPut helpers rewrap the server's error** as a description-less `CANCELLED` carrying the real one as its cause, hence the unwrapping step.
- **A caller-supplied basis pins a read-only tx** via `BEGIN READ ONLY WITH (…)`, rolled back afterwards, mirroring `xtdb.adbc/with-cursor` in-process.
  - **Without overrides no tx is opened at all** — the query reads at the connection's own basis, which already awaits its writes.
- **`xtdb.adbc/reduce-page` goes public** (its own commit) so both paths shape rows identically: `util/->clj` per page, with the `reduced` short-circuit `transduce` can't preserve across a page boundary.
  - **A second copy would drift**, and results from the two paths would stop comparing `=`.

## Depends on

Two server-side bugs this branch surfaced, both fixed on their own terms in `main` rather than worked around here.

- **#5877 — a dense union's `typeIds` don't survive Arrow IPC.** Any mixed-type column killed an Arrow Java client as it rebuilt its root.
- **#5881 — info-schema structs declared without their keys.** `xt/status` reads `xt.metrics_*`, whose `tags` was a childless `:struct` while the data carried a key per meter tag.

## Changes (reading order)

- **`tidy(adbc): expose reduce-page`** — equivalence change, `defn-` → `defn`, so the FlightSQL path can share the row shaping rather than copy it. No behaviour change.
- **`feat(flight-sql): drive xtdb.api over a FlightSQL connection`** — `open-conn`, `FlightSqlConn`, the anomaly mapping and the test namespace.

## Test plan

Green on `fa517d353`, with one known flake.

- **New `xtdb.api-flight-sql-test` — 15 tests**, mirroring `xtdb.api-adbc-test` where the cases apply and adding the wire-specific ones, including `status-over-flight-sql` and `mixed-type-column-round-trips`.
- **Full `./gradlew test` — 1688/1689.** The single failure is `xtdb.indexer-test/can-ingest-ts-devices-mini-with-stop-start-and-reach-same-state`, seeing 10 of 11 blocks — the flake tracked as **#5876**, and unreachable from this diff, which touches nothing in indexing.
- **No reflection or boxed-math warnings.**
- **`feature-dev:code-reviewer` pass over the diff** — no findings.
