### PR TITLE
fix(kafka): tick the block-flush timeout on idle polls

### DIFF
--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -401,15 +401,15 @@ class KafkaCluster(
                         if (subscriptions.isNotEmpty()) {
                             @OptIn(ExperimentalCoroutinesApi::class)
                             onTimeout(0.milliseconds) {
-                                consumer.pollRecords()?.let { consumerRecords ->
-                                    for ((topic, recs) in consumerRecords.groupBy { it.topic() }) {
-                                        val sub = checkNotNull(subscriptions[topic]) {
-                                            "Received records for unsubscribed topic $topic"
-                                        }
+                                val recsByTopic = consumer.pollRecords().groupBy { it.topic() }
 
-                                        sub.processRecords(recs)
-                                    }
+                                check(subscriptions.keys.containsAll(recsByTopic.keys)) {
+                                    "Received records for unsubscribed topics: ${recsByTopic.keys - subscriptions.keys}"
                                 }
+
+                                // the empty batch matters: it's what ticks the leader's block-flush timeout
+                                for ((topic, sub) in subscriptions.toList())
+                                    sub.processRecords(recsByTopic[topic].orEmpty())
                             }
                         }
                     }

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -653,6 +653,32 @@ class KafkaClusterTest {
     }
 
     @Test
+    fun `a database with a quiet source log still cuts a block on the flush timeout`() = runBlocking {
+        val topicName = "test-quiet-flush-${UUID.randomUUID()}"
+
+        Xtdb.openNode {
+            server { port = 0 }; flightSql = null
+            logCluster("kafka", KafkaCluster.ClusterFactory(container.bootstrapServers))
+            log(KafkaCluster.LogFactory("kafka", topicName))
+            indexer { flushDuration = Duration.ofSeconds(1) }
+        }.use { node ->
+            node.connection.use { conn ->
+                conn.createStatement().use { stmt -> stmt.execute("INSERT INTO foo (_id) VALUES ('a')") }
+            }
+
+            // one row is far short of rowsPerBlock, so the row-count path can't cut this block
+            val blockCatalog = (node as XtdbInternal).dbCatalog.primary.blockCatalog
+
+            assertNotNull(
+                withTimeoutOrNull(30.seconds) {
+                    while (blockCatalog.currentBlockIndex == null) delay(100.milliseconds)
+                },
+                "flush timeout cuts a block",
+            )
+        }
+    }
+
+    @Test
     fun `shared consumer survives all databases unsubscribing then new one subscribing`() =
         runTest(timeout = 60.seconds) {
             val topic1 = "test-shared-drain-${UUID.randomUUID()}"


### PR DESCRIPTION
## tl;dr

- A **quiet source log** never ticks the block-flush timeout, so the open block waits for `rowsPerBlock` instead.
- The exposure is small in bytes but **unbounded in time**, which is the part worth fixing.
- **Kafka-only** — `InMemoryLog` already ticks on an empty batch, and the simulation tests run in-memory.
- The fix **services every subscription on every poll**, empty or not, leaving the flush check on the poll thread.
- **#5867 is blocked on it**: it gates an external source's resume-token confirmation on block durability.

## Summary

- The block-flush timeout **only fires while a database's source log is busy**.
- A database whose source log goes quiet **stops checking it**, so its open block is never cut on time — it waits for `rowsPerBlock`, however long that takes.

## Context

- The leader checks its flush timeout **once per `processRecords` batch** — `LeaderLogProcessor.processRecords` → `maybeFlushBlock`.
- **An empty poll reached no subscription at all.** The shared group consumer grouped each poll's records by topic and serviced only the topics that appeared.
- The gap is **Kafka-only**, and untested.
  - `InMemoryLog` has always ticked with an empty batch on a one-minute timeout, for exactly this reason.
  - The simulation tests run in-memory, so nothing caught it.
- The timeout **bounds the recovery window**: everything since the last block lives only in the log and the leader's live index.
- It also bounds **cold-start and catch-up time**, and **freshness for block-based readers** pointed at another deployment's storage.
- A quiet partition holds **less data** than a busy one, so the exposure is small — but it is unbounded in time.

## Where it costs most

- An **external-source database's source log is quiet by design**.
  - Its transactions arrive through the `TxIndexer`, leaving the log to carry only flush, tries and block coordination.
  - Blocks cut on `rowsPerBlock`, and nothing else ticks.
- That becomes a **durability question under #5867**, which gates an external source's upstream resume-token confirmation on block durability.
  - A Postgres replication slot would pin WAL for as long as the block stayed open.
  - #5867 is not sound until this lands.

## Decision rationale

- **Service every subscription per poll**, rather than moving the flush check onto the leader's persister coroutine.
  - `requestFlushBlock` appends to the source log. Appending from the persister while the poll thread waits on it risks the self-deadlock `BlockUploader` documents — the source log's sole consumer waiting on room that only it can make.
  - Keeping the check on the poll thread **preserves today's hazard profile exactly**.
- The extra calls are **cheap on both paths**.
  - `TopicSubscription.processRecords` returns early unless the partition is leader-committed, so followers and transitioning partitions are untouched.
  - `BlockFlusher.checkBlockTimeout` short-circuits until the timeout has elapsed, so the higher call rate cannot produce more than one flush request per timeout.

## Out of scope

- The four-hour default `flushDuration` — that is **#5866's subject**. This makes the timeout fire when it is supposed to; it does not change what it is set to.

## Test plan

- `a database with a quiet source log still cuts a block on the flush timeout` in `KafkaClusterTest`: a node on Kafka with a one-second `flushDuration`, one row written (far short of `rowsPerBlock`), then silence; asserts a block appears.
- **Red-green**: with the fix reverted, that test is the only failure in the class — it times out at 30s waiting for a block, and all 23 neighbours still pass.
- Green on the final state: `:modules:xtdb-kafka:integration-test` 24/24 and `:modules:xtdb-kafka:test` 47/47.
