### PR TITLE
fix: reject a transaction log at an earlier epoch than storage

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -59,7 +59,10 @@ class InMemoryLog<M> @JvmOverloads constructor(
             ReadOnlyLog(openReplicaLog(remotes, partitions))
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
-            dbConfig.inMemoryLog = inMemoryLog { }
+            dbConfig.inMemoryLog = inMemoryLog {
+                this.epoch = this@Factory.epoch
+                this.termEpoch = this@Factory.termEpoch
+            }
         }
     }
 

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -390,6 +390,8 @@ class LocalLog<M> @JvmOverloads constructor(
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.localLog = localLog {
                 this.path = this@Factory.path.toString()
+                this.epoch = this@Factory.epoch
+                this.termEpoch = this@Factory.termEpoch
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -57,8 +57,14 @@ interface Log<M> : AutoCloseable {
 
             internal fun fromProto(config: DatabaseConfig): Factory =
                 when (config.logCase) {
-                    IN_MEMORY_LOG -> inMemoryLog
-                    LOCAL_LOG -> localLog(config.localLog.path.asPath)
+                    IN_MEMORY_LOG -> config.inMemoryLog.let {
+                        inMemoryLog.epoch(it.epoch).termEpoch(it.termEpoch)
+                    }
+
+                    LOCAL_LOG -> config.localLog.let {
+                        localLog(it.path.asPath).epoch(it.epoch).termEpoch(it.termEpoch)
+                    }
+
                     OTHER_LOG -> config.otherLog.let {
                         (otherLogs[it.typeUrl] ?: error("unknown log")).fromProto(it)
                     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -197,10 +197,11 @@ class Database(
     }
 
     companion object {
-        private fun logNewEpoch() {
+        private fun logNewEpoch(logEpoch: Int, processedEpoch: Int) {
             LOG.info(
-                "Starting node with a log that has a different epoch than the latest processed message " +
-                        "(this is expected if you are starting a new epoch) " +
+                "Starting node with a log at a later epoch than the latest processed message " +
+                        "(log epoch=$logEpoch, latest processed message epoch=$processedEpoch) " +
+                        "- this is expected if you are starting a new epoch " +
                         "- skipping offset validation."
             )
         }
@@ -233,10 +234,18 @@ class Database(
             val logEpoch = log.epoch
             val latestSubmittedOffset = log.latestSubmittedOffset()
 
+            // Epochs are monotonic (see /ops/config/log#epochs), and the direction matters.
+            // Skipping offset validation is only safe on a later epoch, where the log is
+            // genuinely new and there's nothing to validate against.
+            //
+            // A log at an earlier epoch is the opposite case. Msg-ids pack the epoch above the
+            // offset, so every id on it sorts below the storage watermark: replay would discard
+            // the whole log, and transactions submitted afterwards would be acked and then
+            // dropped as stale - never committing, never aborting.
             when {
-                processedEpoch != logEpoch -> logNewEpoch()
+                logEpoch > processedEpoch -> logNewEpoch(logEpoch, processedEpoch)
 
-                latestSubmittedOffset < processedOffset ->
+                logEpoch < processedEpoch || latestSubmittedOffset < processedOffset ->
                     throwIllegalLogState(dbName, latestSubmittedOffset, logEpoch, processedEpoch, processedOffset)
             }
         }

--- a/core/src/main/proto/xtdb/database/proto/db.proto
+++ b/core/src/main/proto/xtdb/database/proto/db.proto
@@ -14,10 +14,20 @@ enum DatabaseMode {
 }
 
 message InMemoryLog {
+    int32 epoch = 1 [default = 0];
+
+    // declares that the leader-election counter behind this log has been reset, so terms from
+    // before the reset order below terms from after it. See #5817.
+    int32 term_epoch = 2 [default = 0];
 }
 
 message LocalLog {
     string path = 1;
+    int32 epoch = 2 [default = 0];
+
+    // declares that the leader-election counter behind this log has been reset, so terms from
+    // before the reset order below terms from after it. See #5817.
+    int32 term_epoch = 3 [default = 0];
 }
 
 message InMemoryStorage {

--- a/core/src/test/kotlin/xtdb/api/log/LogFactoryTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LogFactoryTest.kt
@@ -1,0 +1,50 @@
+package xtdb.api.log
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import xtdb.api.storage.Storage
+import xtdb.database.Database
+import xtdb.util.asPath
+
+class LogFactoryTest {
+
+    private fun roundTrip(factory: Log.Factory): Log.Factory {
+        val dbConfig = Database.Config(factory, Storage.local("storage".asPath))
+        return Database.Config.fromProto(dbConfig.serializedConfig).log
+    }
+
+    @Test
+    fun `round-trips in-memory defaults`() {
+        val restored = roundTrip(InMemoryLog.Factory()) as InMemoryLog.Factory
+
+        assertEquals(0, restored.epoch)
+        assertEquals(0, restored.termEpoch)
+    }
+
+    @Test
+    fun `round-trips in-memory epoch and termEpoch`() {
+        val restored = roundTrip(InMemoryLog.Factory().epoch(42).termEpoch(3)) as InMemoryLog.Factory
+
+        assertEquals(42, restored.epoch)
+        assertEquals(3, restored.termEpoch)
+    }
+
+    @Test
+    fun `round-trips local defaults`() {
+        val restored = roundTrip(LocalLog.Factory("log".asPath)) as LocalLog.Factory
+
+        assertEquals("log".asPath, restored.path)
+        assertEquals(0, restored.epoch)
+        assertEquals(0, restored.termEpoch)
+    }
+
+    @Test
+    fun `round-trips local epoch and termEpoch`() {
+        val original = LocalLog.Factory("log".asPath).epoch(42).termEpoch(3)
+        val restored = roundTrip(original) as LocalLog.Factory
+
+        assertEquals("log".asPath, restored.path)
+        assertEquals(42, restored.epoch)
+        assertEquals(3, restored.termEpoch)
+    }
+}

--- a/docs/src/content/docs/ops/backup-and-restore/out-of-sync-log.md
+++ b/docs/src/content/docs/ops/backup-and-restore/out-of-sync-log.md
@@ -53,4 +53,6 @@ For full details about epochs, see [Epochs](/ops/config/log#epochs).
 - Always take a backup of storage before making epoch changes.
 - The new epoch marks a clean slate for the log but does **not** delete any existing storage files.
 - All nodes must use the same epoch value.
-  Mismatched epochs will cause startup failures.
+- Epochs only move forwards.
+  A node whose log is at an earlier epoch than its indexed storage will fail to start with the error above, naming both epochs.
+  Choosing an epoch *lower* than the current one is not a way to undo a bump: restore the storage backup that matches the log instead.

--- a/docs/src/content/docs/ops/config/log.md
+++ b/docs/src/content/docs/ops/config/log.md
@@ -5,6 +5,17 @@ title: Log
 <details>
 <summary>Changelog (last updated v2.2)</summary>
 
+v2.2: earlier epochs rejected at startup
+
+: A node whose log is at an *earlier* epoch than its indexed storage now refuses to start, pointing at [Out of Sync Log & Intact Storage](/ops/backup-and-restore/out-of-sync-log).
+  See [Epochs](#epochs).
+
+  Previously any epoch difference — in either direction — was treated as the start of a new epoch, logged at INFO, and offset validation was skipped.
+  That is only safe going forwards.
+  Because a message id packs the epoch above the offset, every id on an earlier-epoch log sorts below the storage watermark, so the log replayed as entirely stale and transactions submitted afterwards were acknowledged and then discarded without ever committing or aborting.
+
+  To upgrade: nothing to do, unless a node is already running against an earlier epoch than its storage — in which case it will now fail to start, and the recovery is to restore the storage backup that matches the log, or to move forwards to a higher epoch.
+
 v2.2: source/replica log split
 
 : Each database now uses two logs under the hood — a source log (client writes) and a replica log (the indexing leader's output) — to support [single-writer indexing](/about/dbs-in-xtdb#database-architecture).
@@ -90,6 +101,9 @@ Where:
 - `<new-epoch>` is a positive integer greater than the previous epoch.
 
 All nodes within the same cluster **must** use an identical epoch value at startup.
+
+Epochs only move forwards.
+A node started with an epoch *below* the one its storage has already indexed refuses to start, and points at [Out of Sync Log & Intact Storage](/ops/backup-and-restore/out-of-sync-log) — there is no way to reconcile the two, because everything on the earlier log ranks below what storage has already processed.
 
 #### Bumping an Epoch
 

--- a/src/test/clojure/xtdb/log_test.clj
+++ b/src/test/clojure/xtdb/log_test.clj
@@ -246,6 +246,27 @@
       (t/testing "can finish another block"
         (t/is (nil? (tu/flush-block! node)))))))
 
+(t/deftest test-local-log-rejects-an-earlier-epoch-than-storage
+  (util/with-tmp-dirs #{node-dir}
+    (let [storage [:local {:path (.resolve node-dir "objects")}]
+          old-log [:local {:path (.resolve node-dir "log")}]
+          new-log [:local {:path (.resolve node-dir "new-log") :epoch 1}]]
+
+      (with-open [node (xtn/start-node {:log old-log, :storage storage})]
+        (xt/execute-tx node [[:put-docs :docs {:xt/id :foo}]])
+        (t/is (nil? (tu/flush-block! node))))
+
+      (with-open [node (xtn/start-node {:log new-log, :storage storage})]
+        (xt/execute-tx node [[:put-docs :docs {:xt/id :bar}]])
+        (t/is (nil? (tu/flush-block! node))))
+
+      (t/is
+        (thrown-with-msg?
+          IllegalStateException
+          #"Database 'xtdb' failed to start due to an invalid transaction log state \(epoch=0, offset=\d+\) that does not correspond with the latest processed message \(epoch=1 and offset=\d+\)"
+          (xtn/start-node {:log old-log, :storage storage}))
+        "a log left behind at the previous epoch is rejected, not mistaken for a new one"))))
+
 (t/deftest test-local-log-starts-at-correct-point-after-block-cut
   (util/with-tmp-dirs #{node-dir}
     (t/testing "Start a node, write a number of transactions to the log - ensure block is cut"

--- a/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
+++ b/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
@@ -1,5 +1,5 @@
 {:block-idx 0,
- :latest-processed-msg-id 120,
+ :latest-processed-msg-id 124,
  :table-names #{"xt/txs" "xt/role_membership"},
  :secondary-dbs
  {"new_db"


### PR DESCRIPTION
Resolves #5865

## Summary

`Database.validateOffsets` compared the log's epoch with storage's using `!=`, so a log at an *earlier* epoch than the indexed storage took the same branch as a fresh later one — an INFO line, and offset validation skipped. The check exists to catch exactly this class of divergence, and declined to fire in the one direction where reading further cannot recover it.

Sizing the fix surfaced a prerequisite: the log epoch was never persisted for `!Local` and `!InMemory` databases, so an attached secondary was already landing in this bug on every restart. That goes in first, as its own commit, because the direction check turns the same state into a startup failure.

## Changes

1. **`fix(log): persist epoch and termEpoch for local and in-memory logs`** — `DatabaseConfig` had no epoch field for either core log type, so `writeTo` had nothing to write and `fromProto` rebuilt the factory at the default. Kafka has persisted both since #5817, with round-trip coverage; this brings the core logs in line and adds the equivalent test.
2. **`fix(database): reject a log at an earlier epoch than storage`** — the direction check itself, its regression test, and the docs correction.

## Why the comparison is by direction, not equality

Epochs are documented as monotonic — `/ops/config/log#epochs` defines one as "a manually assigned, monotonically increasing integer", and the recovery steps say to pick "an integer greater than the previous epoch". So this enforces a stated contract rather than introducing one.

The message-id encoding makes it structural rather than merely conventional. `offsetToMsgId` packs the epoch above the offset, giving a total order across epochs — and that order only means anything while the epoch never goes down.

That is also why the existing skip was sound in one direction only. Skipping offset validation on a later epoch is fine because the log is genuinely new and there is nothing to compare against. On an earlier epoch there *is* something to compare against, and it is behind. Same branch, opposite justification.

## Decision rationale — no escape hatch

The issue's Direction section asked for an explicit way to abandon a higher epoch deliberately. Dropped, and worth recording why.

The legitimate "I bumped by mistake" case never reaches this check. Until storage has processed a message at the new epoch, the two epochs still agree and we fall through to the offset branch. The error only fires once storage has genuinely indexed at the higher epoch — at which point running below it *is* the broken state the check exists to catch, so a flag would open only onto the failure mode.

The real recoveries are to restore the storage backup that matches the log, or to move forwards to another epoch. Neither wants a flag. `termEpoch` carries an identical never-lower-it rule with no override, and its fence simply refuses; the two existing hatches, `XTDB_SKIP_TXS` and `XTDB_SKIP_DBS`, each skip something nameable the operator can account for, and here there would be nothing to name.

If it is ever wanted, the house shape is settled: an `Xtdb.Config` property, an `XTDB_SKIP_*` env var, a `:skip-*` EDN key, and a one-shot log line when it fires, per `skipTxs`.

## Rollout / compatibility

The proto change is additive. Configs persisted by earlier versions decode the absent fields as 0, which is what they resolved to before, so existing records read unchanged.

It stops further loss rather than recovering it. A secondary whose epoch was bumped before this lands still comes back at 0 once, and now gets a startup failure rather than silent divergence — which is the correct diagnosis, but worth knowing before it is met in the field. Re-attaching with the right epoch is the fix for that database.

The `attach-db` block fixture moves by four bytes because `LocalLog` offsets are byte positions within the log file, so two extra fields on the serialized `ATTACH DATABASE` record shift every subsequent offset. The arrow-edn fixtures do pin tx-ids (which are those same offsets), but only a log containing an `ATTACH DATABASE` record is affected, so none of them moved — confirmed by re-running every fixture-bearing namespace with `--rerun-tasks`.

## Out of scope

`MsgIdUtil.offsetToMsgId` guards `epoch < 65536`, but an epoch from 32768 up sets the Long's sign bit and `msgIdToEpoch`'s arithmetic `shr` sign-extends it back as negative. `LeaderTerm` already accounts for this by deliberately using 15 bits; `MsgIdUtil` does not. Pre-existing, not reachable through any realistic epoch value, and left for a separate card.

`dev/doc/db.allium` models the log epoch inside `MessageId` but has no startup-validation rule at all, so there was nothing to bring into line. Adding one is a larger piece of spec work than this fix warrants.

The wider questions the issue set aside — where the epoch should live, and whether it can be derived rather than declared — stay out.

## Test plan

`test-local-log-rejects-an-earlier-epoch-than-storage` in `xtdb.log-test` indexes and flushes at epoch 0 against one log directory, does the same at epoch 1 against another, then restarts pointed back at the first — the "restored an older log backup" scenario from the issue. Nothing previously covered `processedEpoch > logEpoch`; it was the branch that quietly did nothing.

Red-greened: with the check reverted, that test alone fails with `actual: nil` (the node starts cleanly), and the other 11 tests in the namespace still pass. Restored, all 12 pass.

`LogFactoryTest` covers the proto round-trip for both core log types, mirroring `KafkaLogFactoryTest`.

Full suite green in the final state: `./gradlew test` 1665/1665, `./gradlew property-test` 27 test functions, and the fixture-bearing namespaces re-run with `--rerun-tasks`.

Not tested: the inferred downstream symptom, where a transaction is acknowledged and then dropped as stale without ever committing or aborting. The fix makes that unreachable from startup, so a test would pin a path this change closes.
