### PR TITLE
feat(healthz): read the bound healthz port back off the node

### DIFF
--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -11,12 +11,11 @@
             [xtdb.node :as xtn]
             [xtdb.util :as util])
   (:import (io.micrometer.prometheusmetrics PrometheusMeterRegistry)
-           [java.lang AutoCloseable]
            [java.net InetAddress]
-           org.eclipse.jetty.server.Server
+           (org.eclipse.jetty.server NetworkConnector Server)
            (xtdb.api Xtdb$Config)
            (xtdb.api.log SourceMessage$FlushBlock)
-           (xtdb.api.metrics HealthzConfig)
+           (xtdb.api.metrics Healthz HealthzConfig)
            xtdb.api.Xtdb$Config
            (xtdb.database Database Database$Catalog)
            xtdb.NodeBase
@@ -174,9 +173,9 @@
   "Starts the healthz server against `base`'s meter registry and the databases in `db-cat`.
 
   `extra-handler-opts` are merged into each request seen by the endpoint handlers."
-  (^AutoCloseable [base db-cat config] (open-server base db-cat config {}))
+  (^Healthz [base db-cat config] (open-server base db-cat config {}))
 
-  (^AutoCloseable [^NodeBase base ^Database$Catalog db-cat ^HealthzConfig config extra-handler-opts]
+  (^Healthz [^NodeBase base ^Database$Catalog db-cat ^HealthzConfig config extra-handler-opts]
    (let [^InetAddress host (.getHost config)
          initial-target-message-ids (into {}
                                           (for [^String db-name (.getDatabaseNames db-cat)
@@ -188,12 +187,20 @@
                                              :db-cat db-cat
                                              :initial-target-message-ids initial-target-message-ids}
                                             extra-handler-opts))
-                            (j/run-jetty {:host (some-> host (.getHostAddress)), :port (.getPort config), :async? true, :join? false}))]
+                            (j/run-jetty {:host (some-> host (.getHostAddress)), :port (.getPort config), :async? true, :join? false}))
 
-     (log/info "Healthz server started at" (str (.getURI server))
-               "- startup targets:" (pr-str initial-target-message-ids))
+         ;; `run-jetty` has bound by the time it returns, so the connector carries the resolved port.
+         ;; Captured here rather than read on demand, so it outlives `.stop`. `Server.getURI` is the
+         ;; obvious read but resolves the local hostname to fill in a wildcard-host connector, and
+         ;; returns nil if that lookup throws.
+         port (.getLocalPort ^NetworkConnector (first (.getConnectors server)))]
 
-     (reify AutoCloseable
+     (log/infof "Healthz server started at http://%s:%d - startup targets: %s"
+                (if host (.getHostAddress host) "*") port (pr-str initial-target-message-ids))
+
+     (reify Healthz
+       (getPort [_] port)
+
        (close [_]
          (.stop server)
          (log/info "Healthz server stopped."))))))

--- a/core/src/main/clojure/xtdb/node/impl.clj
+++ b/core/src/main/clojure/xtdb/node/impl.clj
@@ -20,7 +20,7 @@
            xtdb.NodeBase
            xtdb.XtdbInternal
            (xtdb.api DataSource Xtdb Xtdb$CompactorNode Xtdb$Config Xtdb$Connection)
-           (xtdb.api.metrics ConnectionMetrics)
+           (xtdb.api.metrics ConnectionMetrics Healthz)
            xtdb.api.module.XtdbModule$Factory
            (xtdb.database Database$Catalog)
            (xtdb.query IQuerySource SqlPlanner)
@@ -122,6 +122,11 @@
   (getFlightSqlPort [this]
     (if-let [fsql (util/component this :xtdb.flight-sql/server)]
       (.getPort ^xtdb.api.FlightSql fsql)
+      -1))
+
+  (getHealthzPort [this]
+    (if-let [healthz (util/component this :xtdb/healthz)]
+      (.getPort ^Healthz healthz)
       -1))
 
   (getDatabaseNames [_] (.getDatabaseNames db-cat))

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -13,7 +13,7 @@
            io.netty.util.internal.PlatformDependent
            (java.io File IOException Writer)
            java.lang.AutoCloseable
-           (java.net MalformedURLException ServerSocket URI URL)
+           (java.net MalformedURLException URI URL)
            java.nio.ByteBuffer
            (java.nio.channels ClosedByInterruptException ClosedByInterruptException FileChannel FileChannel$MapMode)
            (java.nio.file CopyOption FileVisitResult Files LinkOption OpenOption Path Paths SimpleFileVisitor StandardCopyOption StandardOpenOption)
@@ -482,17 +482,6 @@
          (with-tmp-dirs #{~@more-bindings}
            ~@body)))
     `(do ~@body)))
-
-(defn port-free? [^long port]
-  (try
-    (.close (ServerSocket. port))
-    true
-    (catch java.net.BindException _e
-      false)))
-
-(defn free-port ^long []
-  (with-open [s (ServerSocket. 0)]
-    (.getLocalPort s)))
 
 (defn seeded-gensym
   ([] (seeded-gensym "" 0))

--- a/core/src/main/kotlin/xtdb/api/IngestNode.kt
+++ b/core/src/main/kotlin/xtdb/api/IngestNode.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
+import xtdb.api.metrics.Healthz
 import xtdb.api.metrics.HealthzConfig
 import xtdb.cache.DiskCache
 import xtdb.cache.MemoryCache
@@ -38,9 +39,12 @@ class IngestNode internal constructor(
     private val base: NodeBase,
     private val databases: Map<DatabaseName, Database>,
     private val rootJob: Job,
-    private val healthzServer: AutoCloseable?,
+    private val healthzServer: Healthz?,
 ) : AutoCloseable {
     private val closing = AtomicBoolean(false)
+
+    /** The port the healthz server bound to, or -1 if healthz isn't configured on this node. */
+    val healthzPort: Int get() = healthzServer?.port ?: -1
 
     /**
      * The running [Database] for [name], if configured — lets an embedder reach the live database,
@@ -155,13 +159,13 @@ class IngestNode internal constructor(
                 val rootJob = SupervisorJob()
                 val rootScope = CoroutineScope(rootJob)
                 val openedDbs = LinkedHashMap<DatabaseName, Database>()
-                val healthzServer: AutoCloseable?
+                val healthzServer: Healthz?
                 try {
                     for ((dbName, dbConfig) in databases)
                         openedDbs[dbName] = Database.open(base, dbName, dbConfig, base.compactor, rootScope)
 
                     healthzServer = healthz?.let {
-                        openHealthzServer.invoke(base, FixedDbCatalog(openedDbs), it) as AutoCloseable
+                        openHealthzServer.invoke(base, FixedDbCatalog(openedDbs), it) as Healthz
                     }
                 } catch (t: Throwable) {
                     // Cancel the job tree (Phase 1) before freeing the already-opened databases

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -79,6 +79,9 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
     val serverReadOnlyPort: Int
     val flightSqlPort: Int
 
+    /** The port the healthz server bound to, or -1 if healthz isn't configured on this node. */
+    val healthzPort: Int
+
     /** The names of the databases this node currently serves. */
     val databaseNames: Collection<DatabaseName>
 

--- a/core/src/main/kotlin/xtdb/api/metrics/Healthz.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/Healthz.kt
@@ -1,0 +1,10 @@
+package xtdb.api.metrics
+
+/**
+ * A running healthz server. Opened by `xtdb.healthz/open-server`.
+ */
+interface Healthz : AutoCloseable {
+
+    /** The port the server actually bound to - resolved, so never 0 even when [HealthzConfig.port] is. */
+    val port: Int
+}

--- a/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
+++ b/core/src/main/kotlin/xtdb/api/metrics/HealthzConfig.kt
@@ -10,6 +10,14 @@ import java.net.InetAddress
 @Serializable
 data class HealthzConfig(
     var host: InetAddress? = InetAddress.getLoopbackAddress(),
+
+    /**
+     * Port to run the healthz server on.
+     *
+     * Default is 0, to have the server choose an available port - read it back with [xtdb.api.Xtdb.healthzPort].
+     * Deployments that need a well-known port (container health checks, Kubernetes probes, Prometheus scrape
+     * targets) MUST set it explicitly.
+     */
     var port: Int = 0
 ) {
     fun host(host: InetAddress?) = apply { this.host = host }

--- a/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
+++ b/core/src/test/kotlin/xtdb/api/IngestNodeTest.kt
@@ -13,7 +13,6 @@ import xtdb.api.tx.ExternalSource
 import xtdb.api.tx.ExternalSourceToken
 import xtdb.api.tx.TxIndexer
 import xtdb.api.tx.TxIndexer.TxResult
-import java.net.ServerSocket
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -105,19 +104,18 @@ class IngestNodeTest {
     fun `serves healthz endpoints when configured`() {
         val indexed = CountDownLatch(1)
         val source = CountingExternalSource.Factory(1, indexed, ConcurrentLinkedQueue())
-        val port = ServerSocket(0).use { it.localPort }
 
         IngestNode.Config()
             .database("orders", extDbConfig(source))
-            .healthz(HealthzConfig(port = port))
+            .healthz(HealthzConfig())
             .open()
-            .use {
+            .use { node ->
                 assertTrue(indexed.await(30, TimeUnit.SECONDS), "the source ran alongside healthz")
 
                 val client = HttpClient.newHttpClient()
                 fun get(path: String): HttpResponse<String> =
                     client.send(
-                        HttpRequest.newBuilder(URI("http://localhost:$port$path")).build(),
+                        HttpRequest.newBuilder(URI("http://localhost:${node.healthzPort}$path")).build(),
                         HttpResponse.BodyHandlers.ofString(),
                     )
 

--- a/docs/src/content/docs/ops/config/monitoring.md
+++ b/docs/src/content/docs/ops/config/monitoring.md
@@ -7,19 +7,20 @@ These include a **Healthz Server** for health checks, **Metrics** for performanc
 
 ## Healthz Server
 
-The Healthz Server is a lightweight HTTP server that runs by default on all XTDB nodes.
-It provides health indicators, making it useful for monitoring in containerized and orchestrated environments.
+The Healthz Server is a lightweight HTTP server that provides health indicators and metrics, making it useful for monitoring in containerized and orchestrated environments.
+It runs on a node that has a `healthz` block in its configuration.
 
 ### Configuration
-
-The Healthz Server can be configured to run on a custom port:
 
 ``` yaml
 healthz:
   # Port to run the Healthz Server on.
-  # Default: 8080 (can be set as an !Env value).
+  # Default: 0, i.e. an available port chosen at startup (can be set as an !Env value).
   port: 8080
 ```
+
+Anything that needs to reach the Healthz Server at a known address — a container health check, a Kubernetes probe, a Prometheus scrape target — needs the port set explicitly.
+The XTDB container images and Helm charts set it to 8080.
 
 ### Health Routes
 

--- a/src/test/clojure/xtdb/healthz_test.clj
+++ b/src/test/clojure/xtdb/healthz_test.clj
@@ -18,9 +18,8 @@
 
 (t/deftest test-healthz-endpoints
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [_node (tu/->local-node {:node-dir local-path
-                                          :healthz-port port})]
+    (with-open [node (tu/->local-node {:node-dir local-path})]
+      (let [port (.getHealthzPort node)]
         (t/testing "started endpoint"
           (let [resp (clj-http/get (->healthz-url port "started"))]
             (t/is (= 200 (:status resp)))
@@ -38,16 +37,15 @@
 
 (t/deftest test-started-catchup-4273
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [node (tu/->local-node {:node-dir local-path
-                                         :compactor-threads 0})]
-        (xt/execute-tx node [[:put-docs :docs {:xt/id 1, :foo 1}]]
-                       {:default-tz #xt/zone "Asia/Kolkata"})
-        (tu/flush-block! node))
+    (with-open [node (tu/->local-node {:node-dir local-path
+                                       :compactor-threads 0})]
+      (xt/execute-tx node [[:put-docs :docs {:xt/id 1, :foo 1}]]
+                     {:default-tz #xt/zone "Asia/Kolkata"})
+      (tu/flush-block! node))
 
-      (with-open [_node (tu/->local-node {:node-dir local-path
-                                          :healthz-port port
-                                          :compactor-threads 0})]
+    (with-open [node (tu/->local-node {:node-dir local-path
+                                       :compactor-threads 0})]
+      (let [port (.getHealthzPort node)]
         (t/testing "started endpoint"
           (let [timeout-at-ms (+ (System/currentTimeMillis) 1000)]
             (loop []
@@ -65,9 +63,8 @@
 
 (t/deftest test-indexer-error
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [_node (tu/->local-node {:node-dir local-path
-                                          :healthz-port port})]
+    (with-open [node (tu/->local-node {:node-dir local-path})]
+      (let [port (.getHealthzPort node)]
         (t/testing "alive endpoint - non errored indexer"
           (t/is (= 200 (:status (clj-http/get (->healthz-url port "alive"))))))
 
@@ -79,9 +76,8 @@
 
 (t/deftest test-error-response
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [_node (tu/->local-node {:node-dir local-path
-                                          :healthz-port port})]
+    (with-open [node (tu/->local-node {:node-dir local-path})]
+      (let [port (.getHealthzPort node)]
         (t/testing "server thrown error responds with reasonable message"
           (with-redefs [healthz/get-ingestion-error (fn [_] (throw (Exception. "Some server error.")))]
             (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
@@ -89,10 +85,10 @@
               (t/is (re-find #"Exception when calling endpoint - java.lang.Exception: Some server error." (:body resp))))))))))
 
 (t/deftest test-block-lag-healthy-4364
-  (let [port (tu/free-port)]
-    (with-open [_node (xtn/start-node {:log [:in-memory]
-                                       :storage [:in-memory]
-                                       :healthz {:port port}})]
+  (with-open [node (xtn/start-node {:log [:in-memory]
+                                    :storage [:in-memory]
+                                    :healthz {}})]
+    (let [port (.getHealthzPort node)]
       (t/testing "block lag health"
         (letfn [(alive-resp []
                   (let [{:keys [status headers]} (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
@@ -107,126 +103,122 @@
 
 (t/deftest test-block-lag-uses-list-after
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [node (tu/->local-node {:node-dir local-path
-                                         :healthz-port port
-                                         :compactor-threads 0})]
-        (let [db (db/primary-db node)
-              bp (.getBufferPool db)
-              block-cat (.getBlockCatalog db)]
+    (with-open [node (tu/->local-node {:node-dir local-path
+                                       :compactor-threads 0})]
+      (let [port (.getHealthzPort node)
+            db (db/primary-db node)
+            bp (.getBufferPool db)
+            block-cat (.getBlockCatalog db)]
 
-          (t/testing "no blocks yet"
-            (t/is (nil? (.getCurrentBlockIndex block-cat)))
-            (t/is (nil? (BufferPoolKt/latestAvailableBlockIndex bp nil)))
-            (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
-              (t/is (= 200 (:status resp)))))
+        (t/testing "no blocks yet"
+          (t/is (nil? (.getCurrentBlockIndex block-cat)))
+          (t/is (nil? (BufferPoolKt/latestAvailableBlockIndex bp nil)))
+          (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+            (t/is (= 200 (:status resp)))))
 
-          (xt/execute-tx node [[:put-docs :foo {:xt/id :foo}]])
-          (tu/flush-block! node)
+        (xt/execute-tx node [[:put-docs :foo {:xt/id :foo}]])
+        (tu/flush-block! node)
 
-          (t/testing "after first block, block-lag is zero"
-            (t/is (= 0 (.getCurrentBlockIndex block-cat)))
-            (t/is (= 0 (BufferPoolKt/latestAvailableBlockIndex bp 0)))
-            (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
-              (t/is (= 200 (:status resp)))))
+        (t/testing "after first block, block-lag is zero"
+          (t/is (= 0 (.getCurrentBlockIndex block-cat)))
+          (t/is (= 0 (BufferPoolKt/latestAvailableBlockIndex bp 0)))
+          (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+            (t/is (= 200 (:status resp)))))
 
-          (xt/execute-tx node [[:put-docs :foo {:xt/id :bar}]])
-          (tu/flush-block! node)
+        (xt/execute-tx node [[:put-docs :foo {:xt/id :bar}]])
+        (tu/flush-block! node)
 
-          (t/testing "after second block, listAfter from first finds it"
-            ;; invalidate cache to simulate TTL expiry — otherwise we'd get stale cached values
-            (BufferPoolKt/invalidateLatestAvailableBlockCache bp)
-            (t/is (= 1 (.getCurrentBlockIndex block-cat)))
-            (t/is (= 1 (BufferPoolKt/latestAvailableBlockIndex bp 0))
-                  "listing after block 0 finds block 1")
-            (t/is (= 1 (BufferPoolKt/latestAvailableBlockIndex bp 1))
-                  "listing after block 1 returns block 1 (no new blocks)")
-            (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
-              (t/is (= 200 (:status resp))))))))))
+        (t/testing "after second block, listAfter from first finds it"
+          ;; invalidate cache to simulate TTL expiry — otherwise we'd get stale cached values
+          (BufferPoolKt/invalidateLatestAvailableBlockCache bp)
+          (t/is (= 1 (.getCurrentBlockIndex block-cat)))
+          (t/is (= 1 (BufferPoolKt/latestAvailableBlockIndex bp 0))
+                "listing after block 0 finds block 1")
+          (t/is (= 1 (BufferPoolKt/latestAvailableBlockIndex bp 1))
+                "listing after block 1 returns block 1 (no new blocks)")
+          (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+            (t/is (= 200 (:status resp)))))))))
 
 (t/deftest test-finish-block-endpoint
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [node (tu/->local-node {:node-dir local-path
-                                         :healthz-port port})]
-        (let [block-cat (.getBlockCatalog (db/primary-db node))]
+    (with-open [node (tu/->local-node {:node-dir local-path})]
+      (let [port (.getHealthzPort node)
+            block-cat (.getBlockCatalog (db/primary-db node))]
 
-          (t/testing "no latest completed tx"
-            (clj-http/post (->system-url port "finish-block") {:throw-exceptions false}))
+        (t/testing "no latest completed tx"
+          (clj-http/post (->system-url port "finish-block") {:throw-exceptions false}))
+
+        (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]])
+
+        (t/is (= nil (:tx-id (.getLatestCompletedTx block-cat))))
+
+        (let [first-latest-tx-id (:tx-id (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]
+                                                              [:put-docs :bar {:xt/id "bar2"}]
+                                                              [:put-docs :bar {:xt/id "bar3"}]]))]
+
+          (t/testing "successful block flush"
+            (let [resp (clj-http/post (->system-url port "finish-block") {:throw-exceptions false})]
+              (t/is (= 200 (:status resp)))))
 
           (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]])
 
-          (t/is (= nil (:tx-id (.getLatestCompletedTx block-cat))))
+          (t/is (= first-latest-tx-id (:tx-id (.getLatestCompletedTx block-cat)))))
 
-          (let [first-latest-tx-id (:tx-id (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]
-                                                                [:put-docs :bar {:xt/id "bar2"}]
-                                                                [:put-docs :bar {:xt/id "bar3"}]]))]
+        (let [second-latest-tx-id (:tx-id (xt/execute-tx node [[:put-docs :bar {:xt/id "bar7"}]
+                                                               [:put-docs :bar {:xt/id "bar8"}]
+                                                               [:put-docs :bar {:xt/id "bar9"}]]))]
 
-            (t/testing "successful block flush"
-              (let [resp (clj-http/post (->system-url port "finish-block") {:throw-exceptions false})]
-                (t/is (= 200 (:status resp)))))
+          (t/testing "second successful block flush"
+            (let [resp (clj-http/post (->system-url port "finish-block") {:throw-exceptions false})]
+              (t/is (= 200 (:status resp)))))
 
-            (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]])
+          (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]])
 
-            (t/is (= first-latest-tx-id (:tx-id (.getLatestCompletedTx block-cat)))))
-
-          (let [second-latest-tx-id (:tx-id (xt/execute-tx node [[:put-docs :bar {:xt/id "bar7"}]
-                                                                 [:put-docs :bar {:xt/id "bar8"}]
-                                                                 [:put-docs :bar {:xt/id "bar9"}]]))]
-
-            (t/testing "second successful block flush"
-              (let [resp (clj-http/post (->system-url port "finish-block") {:throw-exceptions false})]
-                (t/is (= 200 (:status resp)))))
-
-            (xt/execute-tx node [[:put-docs :bar {:xt/id "bar1"}]])
-
-            (t/is (= second-latest-tx-id (:tx-id (.getLatestCompletedTx block-cat))))))))))
+          (t/is (= second-latest-tx-id (:tx-id (.getLatestCompletedTx block-cat)))))))))
 
 ;; --- multi-db tests ---
 
 (t/deftest test-alive-critical-secondary
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [node (tu/->local-node {:node-dir local-path
-                                         :healthz-port port})]
-        (let [^Database$Catalog db-cat (db/<-node node)]
-          (.attach db-cat "critical-db"
-                   (-> (Database$Config.)
-                       (.critical true)))
+    (with-open [node (tu/->local-node {:node-dir local-path})]
+      (let [port (.getHealthzPort node)
+            ^Database$Catalog db-cat (db/<-node node)]
+        (.attach db-cat "critical-db"
+                 (-> (Database$Config.)
+                     (.critical true)))
 
-          (.attach db-cat "non-critical-db"
-                   (Database$Config.))
+        (.attach db-cat "non-critical-db"
+                 (Database$Config.))
 
-          (t/testing "all healthy"
-            (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
-              (t/is (= 200 (:status resp)))
-              (t/is (= "3" (get-in resp [:headers "X-XTDB-Databases-Checked"])))))
+        (t/testing "all healthy"
+          (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+            (t/is (= 200 (:status resp)))
+            (t/is (= "3" (get-in resp [:headers "X-XTDB-Databases-Checked"])))))
 
-          (t/testing "non-critical secondary ingestion error does not affect liveness"
-            (let [orig-fn healthz/get-ingestion-error]
-              (with-redefs [healthz/get-ingestion-error (fn [^Database db]
-                                                          (if (= "non-critical-db" (.getName db))
-                                                            (Exception. "Non-critical error")
-                                                            (orig-fn db)))]
-                (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
-                  (t/is (= 200 (:status resp)))
-                  (t/is (= "1" (get-in resp [:headers "X-XTDB-Databases-Unhealthy"])))))))
+        (t/testing "non-critical secondary ingestion error does not affect liveness"
+          (let [orig-fn healthz/get-ingestion-error]
+            (with-redefs [healthz/get-ingestion-error (fn [^Database db]
+                                                        (if (= "non-critical-db" (.getName db))
+                                                          (Exception. "Non-critical error")
+                                                          (orig-fn db)))]
+              (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+                (t/is (= 200 (:status resp)))
+                (t/is (= "1" (get-in resp [:headers "X-XTDB-Databases-Unhealthy"])))))))
 
-          (t/testing "critical secondary ingestion error triggers 503"
-            (let [orig-fn healthz/get-ingestion-error]
-              (with-redefs [healthz/get-ingestion-error (fn [^Database db]
-                                                          (if (= "critical-db" (.getName db))
-                                                            (Exception. "Critical error")
-                                                            (orig-fn db)))]
-                (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
-                  (t/is (= 503 (:status resp)))
-                  (t/is (re-find #"critical-db" (:body resp))))))))))))
+        (t/testing "critical secondary ingestion error triggers 503"
+          (let [orig-fn healthz/get-ingestion-error]
+            (with-redefs [healthz/get-ingestion-error (fn [^Database db]
+                                                        (if (= "critical-db" (.getName db))
+                                                          (Exception. "Critical error")
+                                                          (orig-fn db)))]
+              (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]
+                (t/is (= 503 (:status resp)))
+                (t/is (re-find #"critical-db" (:body resp)))))))))))
 
 (t/deftest test-alive-primary-always-critical
   (util/with-tmp-dirs #{local-path}
-    (let [port (tu/free-port)]
-      (with-open [_node (tu/->local-node {:node-dir local-path
-                                          :healthz-port port})]
+    (with-open [node (tu/->local-node {:node-dir local-path})]
+      (let [port (.getHealthzPort node)]
         (t/testing "primary database ingestion error triggers 503"
           (with-redefs [healthz/get-ingestion-error (fn [_] (Exception. "Primary error"))]
             (let [resp (clj-http/get (->healthz-url port "alive") {:throw-exceptions false})]

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -303,12 +303,11 @@
                                            instant-source-for-non-tx-msgs? storage-epoch default-tz tracer
                                            skip-dbs]
                                     :or {buffers-dir "objects"
-                                         healthz-port 8080
+                                         healthz-port 0
                                          instant-source-for-non-tx-msgs? false
                                          storage-epoch 0
                                          default-tz (ZoneId/of "Europe/London")}}]
-  (let [instant-src (or instant-src (->mock-clock))
-        healthz-port (if (util/port-free? healthz-port) healthz-port (util/free-port))]
+  (let [instant-src (or instant-src (->mock-clock))]
     (xtn/start-node (cond-> {:healthz {:port healthz-port
                                        :host "*"}
                              :log [:local {:path (.resolve node-dir "log"), :instant-src instant-src


### PR DESCRIPTION
## Summary

`HealthzConfig.port` has defaulted to 0 since v2.1.0, so a node with a bare `healthz:` block lands on whatever port the OS hands it — but nothing could ask the node which port that was. This adds the read-back path, so the free-port default is actually usable, and drops the last place that hard-coded 8080.

## Context

The user-facing shape asked for here — random port by default, Dockerfiles pinning 8080 — already half-existed: the config default is 0, and every shipped deployment config (`docker/*/config.yaml`, the AWS/Azure/GCP helm charts, `.devcontainer/xtdb.yaml`) sets `port: 8080` explicitly. What was missing was the other half of the pgwire pattern: a way to read the resolved port back.

Without it, every consumer had to pick a port up front and hope:

- `tu/->local-node` defaulted to **8080** with a `util/port-free?` check and a `util/free-port` fallback. The check is a separate socket open-and-close from the bind that follows it, so two nodes starting concurrently — two Gradle workers, two worktrees, a dev node alongside a test run — can both see 8080 free and one then fails to bind. That's the reported symptom: healthz can't run twice on one machine.
- `xtdb.healthz-test` called `tu/free-port` nine times and formatted its URLs from the port it chose.
- `IngestNodeTest` took a port from a `ServerSocket(0)` it had already closed.

## Current state → future state

pgwire and Flight SQL both already close this loop, and `Xtdb` already exposes their ports:

- `xtdb.pgwire/serve` rebinds `port` from `(.getLocalPort accept-socket)` and stores it on the `Server` record; `Xtdb.serverPort` reads it back.
- `FlightSql.open` captures `server.port` into a `val` on the returned instance; `Xtdb.flightSqlPort` reads it back.

Healthz now matches: `xtdb.healthz/open-server` reifies a new `xtdb.api.metrics.Healthz` (`AutoCloseable` + `val port: Int`) in place of the bare `AutoCloseable` it returned before, surfaced as `Xtdb.healthzPort` and `IngestNode.healthzPort`, returning -1 when healthz isn't configured — the same convention as `flightSqlPort`.

`tu/->local-node` then defaults `healthz-port` to 0 and the `port-free?` dance goes away, so no two test nodes contend for a port.

## Implementation notes

**The port is captured at open, not read on demand.** `Server.getURI` is the obvious read, and the startup log line already used it — but it fills in a wildcard-host connector by resolving the local hostname, and returns nil outright if that lookup throws, which would make `getPort` NPE. `host: '*'` is the common case rather than an edge one: `tu/->local-node` sets it on every test node and every shipped deployment example configures healthz that way. Reading `NetworkConnector.getLocalPort()` once sidesteps hostname resolution altogether, and the captured int outlives `.stop`. The log line now formats host and port itself for the same reason — it reads `Healthz server started at http://127.0.0.1:41529` rather than going back through `getURI`.

**Dead code removed.** `xtdb.util/port-free?` and `xtdb.util/free-port` existed only to serve the fixture's 8080 dance and have no remaining callers. `tu/free-port` in the test fixtures is a separate fn and stays — `docker_test` still uses it to map a container's pgwire port.

**Docs correction.** `ops/config/monitoring.md` claimed healthz "runs by default on all XTDB nodes" and defaults to 8080. Neither has been true since v2.1.0, and `ops/config.md` already had the enablement right, so the two pages contradicted each other. No changelog entry: this is a stale fact rather than a transition, since there's no version at which a reader saw 8080 as the default.

## Out of scope

The deployment configs are left alone — `docker/*/config.yaml`, the three helm charts, `.devcontainer/xtdb.yaml`, `src/dev/clojure/dev.clj` (8081) and the `modules/datasets` compose stacks all pin an explicit port deliberately, because a container health check, a Kubernetes probe or a Prometheus scrape target needs a well-known address. That's exactly what the new `HealthzConfig.port` kdoc now says.

## Changes

1. `feat(healthz):` the `Healthz` interface and the `healthzPort` read-back on `Xtdb` / `IngestNode`.
2. `test:` fixture defaults to a free port, tests read it back, dead `xtdb.util` helpers removed.
3. `docs:` the monitoring-page correction.

## Test plan

- `./gradlew test` — green, 1669 tests.
- `./gradlew :test --tests 'xtdb.healthz_test*'` and `:xtdb-core:test --tests '*IngestNodeTest*'` — green, and the startup log confirms a real bound port rather than 0.
- One full-suite run failed `xtdb.indexer-test/can-ingest-ts-devices-mini-with-stop-start-and-reach-same-state` (10 blocks vs 11). That assertion counts object-store files 250ms after `await-node` returns, against a block flush the test itself notes it has no hook for. It passed 3/3 in isolation and on two subsequent full-suite runs; filed as #5876 rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
