### PR TITLE
fix(adbc): declare union typeIds on schemas bound for Arrow Java

### DIFF
--- a/api/src/main/kotlin/xtdb/arrow/ArrowTypes.kt
+++ b/api/src/main/kotlin/xtdb/arrow/ArrowTypes.kt
@@ -15,6 +15,7 @@ import org.apache.arrow.vector.types.Types.MinorType
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeVisitor
 import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
 import xtdb.arrow.extensions.IntervalMDMType
 import xtdb.arrow.extensions.KeywordType
 import xtdb.arrow.extensions.OidType
@@ -64,6 +65,34 @@ val STRUCT_TYPE: ArrowType = MinorType.STRUCT.type
 
 @JvmField
 val UNION_TYPE: ArrowType = MinorType.DENSEUNION.type
+
+/**
+ * This field, with `typeIds` declared explicitly on every union in its tree — `0 until childCount`.
+ *
+ * Only for schemas bound for an Arrow Java consumer. Absent `typeIds` already means positional, so the fields
+ * XTDB stores are correct without them, and declaring them there would grow every Arrow file we write —
+ * shifting log offsets, and tx-ids with them. Arrow Java can't read its own absent form back off the wire,
+ * though: its IPC reader rebuilds it as `int[0]`, which `DenseUnionVector.registerNewTypeId` then indexes
+ * (#5863, apache/arrow-java#414).
+ */
+fun Field.withUnionTypeIds(): Field {
+    val newChildren = children.map { it.withUnionTypeIds() }
+    val unionType = type as? ArrowType.Union
+
+    return when {
+        unionType != null -> Field(
+            name,
+            FieldType(
+                isNullable, ArrowType.Union(unionType.mode, IntArray(newChildren.size) { it }),
+                fieldType.dictionary, metadata
+            ),
+            newChildren
+        )
+
+        newChildren == children -> this
+        else -> Field(name, fieldType, newChildren)
+    }
+}
 
 @JvmField
 val IID_TYPE: ArrowType = ArrowType.FixedSizeBinary(16)

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -395,7 +395,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
                 override fun executeSchema(paramFields: List<Field>): Schema {
                     val pq = preparedQuery ?: throw Incorrect("call prepare() first", "xtdb.adbc/not-prepared")
-                    return Schema(pq.getColumnFields(paramFields))
+                    return Schema(pq.getColumnFields(paramFields).map { it.withUnionTypeIds() })
                 }
 
                 override fun bind(root: VectorSchemaRoot) {
@@ -1074,7 +1074,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         }
 
         private fun ResultCursor.toArrowReader(): ArrowReader {
-            val schema = Schema(resultTypes.map { (name, type) -> type.toField(name) })
+            val schema = Schema(resultTypes.map { (name, type) -> type.toField(name).withUnionTypeIds() })
 
             return object : ArrowReader(allocator) {
                 override fun readSchema() = schema
@@ -1187,7 +1187,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
 
         private fun getTableSchema(catalog: DatabaseName, table: TableRef): Schema {
             val types = dbCat.databaseOrNull(catalog)?.getColumnTypes(table) ?: return Schema(emptyList())
-            return Schema(types.entries.map { (name, type) -> type.toField(name) })
+            return Schema(types.entries.map { (name, type) -> type.toField(name).withUnionTypeIds() })
         }
 
         override fun getObjects(

--- a/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
+++ b/src/test/kotlin/xtdb/FlightSqlAdbcTest.kt
@@ -1115,6 +1115,16 @@ class FlightSqlAdbcTest {
     }
 
     @Test
+    fun `a polymorphic column round-trips over FlightSQL`() {
+        fsqlClient.executeUpdate("INSERT INTO docs RECORDS {_id: 1, v: 'str'}, {_id: 2, v: 42}", *emptyCallOpts)
+
+        assertEquals(
+            listOf(mapOf("_id" to 1L, "v" to "str"), mapOf("_id" to 2L, "v" to 42L)),
+            fsqlClient.execute("SELECT _id, v FROM docs ORDER BY _id", *emptyCallOpts).readRows()
+        )
+    }
+
+    @Test
     fun `test FlightSQL bulk ingest streams multiple batches`() {
         multiBatchIngest("users", listOf(
             listOf(1L to 10L, 2L to 20L),
@@ -1180,6 +1190,28 @@ class FlightSqlAdbcTest {
 
             val tableSchema = schemaBytes.deserialiseArrowSchema()
             assertEquals(setOf("_id", "name"), tableSchema.fields.map { it.name }.toSet())
+        }
+    }
+
+    @Test
+    fun `getTables includeSchema returns a polymorphic column a client can build a root from`() {
+        fsqlClient.executeUpdate("INSERT INTO docs RECORDS {_id: 1, v: 'str'}, {_id: 2, v: 42}", *emptyCallOpts)
+
+        val info = fsqlClient.getTables(null, null, "docs", null, true, *emptyCallOpts)
+        fsqlClient.getStream(info.endpoints.first().ticket, *emptyCallOpts).use { stream ->
+            assertTrue(stream.next())
+            val root = stream.root
+
+            val schemaVec = root.getVector("table_schema") as VarBinaryVector
+            val rowIdx = (0 until root.rowCount).first {
+                (root.getVector("table_name").getObject(it) as? Text)?.toString() == "docs"
+            }
+            val tableSchema = (schemaVec.getObject(rowIdx) ?: error("table_schema bytes were null"))
+                .deserialiseArrowSchema()
+
+            VectorSchemaRoot.create(tableSchema, al).use {
+                assertEquals(setOf("_id", "v"), it.schema.fields.map { f -> f.name }.toSet())
+            }
         }
     }
 


### PR DESCRIPTION
Part of #5863.

## tl;dr

- **Any Arrow Java client reading a polymorphic column over FlightSQL crashed before it saw a single row** — `ArrayIndexOutOfBoundsException` from `DenseUnionVector.registerNewTypeId`, while building its root from the schema message.
- **The fault is inside Arrow Java, not in what XTDB emits.** Arrow's format says an absent `typeIds` means "number the legs by child offset", which is exactly what XTDB writes — but Arrow Java's IPC reader rebuilds absent as `int[0]` and then indexes it.
- **Fixed at the boundary**: declare the ids only on the schemas XTDB hands to an Arrow Java consumer. What XTDB stores is untouched.
- **Declaring them at source was measured and rejected** — it grows every Arrow file by 24 bytes, which shifts tx-ids and trie filenames.
- **`note:`** the base carries an unrelated AWS SDK bump from `jarohen/main` that hasn't reached upstream yet; only the second commit is this change.

## Root cause

Four links, all verified against Arrow 19.0.0's own source:

- **`Types.java:698`** — `DENSEUNION(new Union(Dense, null))`. XTDB's `UNION_TYPE` is this constant, so its `typeIds` are `null`.
- **`DenseUnionVector.java:241-255`** — `null` is a *supported, meaningful* value in `registerNewTypeId`: it falls through to `typeId = nextTypeId`, i.e. positional. Only non-null takes `typeIds[nextTypeId]`.
- **`ArrowType.java:522-527`** — the write side is correct. `if (this.typeIds != null) addTypeIds(...)`, so null is omitted from the flatbuffer rather than written as an empty vector.
- **`ArrowType.java:1658`** — the read side destroys the distinction. `int[] typeIds = new int[unionType.typeIdsLength()]`, so an absent field comes back as **`int[0]`, never `null`** — and `typeIds[0]` on a zero-length array throws, on the first leg, deterministically.

So Arrow's pojo layer can express "positional", its IPC layer cannot, and its vector layer treats the two differently. Absent and empty are the same bytes on the wire, so nothing the sender does distinguishes them.

The observed trace, client-side:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at DenseUnionVector.registerNewTypeId(DenseUnionVector.java:250)
	at DenseUnionVector.initializeChildrenFromFields(DenseUnionVector.java:170)
	at Field.createVector(Field.java:107)
	at VectorSchemaRoot.create(VectorSchemaRoot.java:126)
	at FlightStream$Observer.onNext(FlightStream.java:464)
```

`FlightStream:464` handles the *schema* message, so this fires before any data arrives — it doesn't even need a row to actually contain a union value.

## Decision rationale

- **Declaring the ids is spec-equivalent, not a divergence.** Explicit `[0, 1, … n-1]` says precisely what omitting the field says, so a conformant reader is unaffected and XTDB's own vectors already number their legs that way (`DenseUnionVector.kt:271` gives each new leg `legVectors.size`).
- **`Field.withUnionTypeIds()` is applied at three sites**, all on the `AdbcConnection`/`AdbcStatement` surface — that surface *is* the Arrow-Java boundary, and every FlightSQL schema route resolves through one of them, so there is no path left sending the absent form.
- **`getTableSchema` was the easiest one to miss and the sharpest.** `getStreamTables` serialises it into the `table_schema` column, so `getTables(includeSchema = true)` against a table with a polymorphic column handed the client a schema it could not build a root from. Found by review, then red-greened.
- **Storage deliberately keeps the absent form.** It is the correct encoding, and XTDB's own reader takes a union's legs from its children rather than its ids (`Vector.kt:149`), so it never consults them.

## Alternatives considered

- **Vendor and patch `ArrowType.java`.** Rejected: it fixes the wrong side of the wire. The crash is in the *consumer's* process, so patching our copy fixes our own JVM's clients and does nothing for a user connecting with their own Arrow Java — green tests, equally broken product. It also means shadowing another artifact's class by classpath order, in a 1600-line file, re-broken on every Arrow bump.
- **Declare the ids at source**, on `VectorType.Poly.toField`, `asUnionFieldOf` and `DenseUnionVector.fieldType`. Built and measured rather than argued: **18 further test failures**. Every Arrow file grows 24 bytes; because a tx-id is a log offset, tx-ids shift (`4039` → `4071`); block boundaries move with them, so the compactor emits tries under different keys (`FileNotFoundException` for `l02-rc-p0-b11f.arrow.edn`); and Clojure `Field` equality against `#xt/field` literals breaks with unreadable `x != x` messages, since `serde/types.clj` cannot express typeIds. A high price for a bug on the consumer's side.
- **Wait for upstream.** [apache/arrow-java#414](https://github.com/apache/arrow/issues/414) — "Arrow Java can't read union vector from ArrowStreamReader written by its own bugs" — has been open since 2019 with zero comments, and `arrow-java` 19.0.0 is the current release. Not something to wait for. Worth filing our specific facet separately, since no upstream issue covers it.

## Out of scope

- **`xt.metrics_counters` over FlightSQL still fails**, on a distinct server-side fault: the declared result schema and the batch actually unloaded disagree, so `VectorLoader` reports nodes and buffers left unconsumed. Same issue, different bug — #5863 stays open for it, and its reproduction is not included here so that the suite stays green.

## Test plan

- **`a polymorphic column round-trips over FlightSQL`** — the regression test for the reported symptom. Fails on the parent commit with the trace above.
- **`getTables includeSchema returns a polymorphic column a client can build a root from`** — red-greened for the review finding: confirmed failing with `registerNewTypeId` / `VectorSchemaRoot.create` in the trace before the one-line `getTableSchema` fix, passing after.
- **Full `./gradlew test` — 1667/1667.**
- **`./gradlew property-test` — 27/27**, run against the wider at-source variant, of which this change is a strict subset in blast radius.
- **No reflection or boxed-math warnings.**
- **`feature-dev:code-reviewer` pass over the diff** — one finding, the `getTableSchema` boundary, fixed above.
