### PR TITLE
feat(postgres-source)!: always create failover slots, requiring PG17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     command: start-dev
 
   postgres:
-    image: postgres:16
+    image: postgres:17
     ports:
       - "5433:5432"
     environment:

--- a/docs/src/content/docs/ops/external-sources/postgres/reference.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/reference.md
@@ -4,6 +4,8 @@ title: Postgres External Source
 
 ## Prerequisites
 
+PostgreSQL 17 or later.
+
 A [role](https://www.postgresql.org/docs/current/user-manag.html) with the following attributes and privileges:
 - The [`LOGIN`](https://www.postgresql.org/docs/current/role-attributes.html) attribute. Allows opening a session in Postgres.
 - The [`REPLICATION`](https://www.postgresql.org/docs/current/role-attributes.html) attribute. Allows opening a replication-mode connection to Postgres.
@@ -23,6 +25,7 @@ Doing so will leave the table in an inconsistent state in XTDB.
 This feature is tracked [here](https://github.com/xtdb/xtdb/issues/5497)
 :::
 
+If the upstream is an HA pair, see [surviving a Postgres failover](#surviving-a-postgres-failover) for what it needs configured in order for the replication slot to survive a promotion.
 
 ## Configuration
 
@@ -91,6 +94,19 @@ The system time of rows depends on the phase of the Postgres External Source.
 | --- | --- |
 | Snapshot | XTDB's internal system time (i.e. it is unrelated to the upstream Postgres' system clock) |
 | Streaming | The timestamp of the Postgres transaction (the timestamp on the `commit` message) |
+
+
+## Surviving a Postgres failover
+
+XTDB relies on PostgreSQL 17's [slot synchronisation](https://www.postgresql.org/docs/17/logical-replication-failover.html) to keep its replication slot across a failover of the upstream.
+It sets `failover` on the slot it creates, which makes that slot eligible to be copied to a standby.
+
+This requires XTDB to be pointed at the primary, and the following configuration options on Postgres:
+- On the standby
+  - `sync_replication_slots = on`  - run the worker that copies eligible slots
+  - `hot_standby_feedback = on` - the primary retains what the copy still needs
+- On the primary
+  - `synchronized_standby_slots = '<standby's physical slot>'` - to hold decoding back until it confirms receipt
 
 
 ## Indexers

--- a/docs/src/content/docs/ops/external-sources/postgres/setup.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/setup.md
@@ -22,7 +22,12 @@ As with other [external sources](/ops/external-sources/overview) you will need:
 Ensure that you have a transaction log and object store that do not conflict with other databases.
 :::
 
-Additionally you will need to ensure that Postgres is configured with [`wal_level=logical`](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-WAL-LEVEL).
+Additionally you will need:
+
+- PostgreSQL 17 or later.
+- Postgres configured with [`wal_level=logical`](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-WAL-LEVEL).
+
+If the upstream is an HA pair, see [surviving a Postgres failover](/ops/external-sources/postgres/reference#surviving-a-postgres-failover) for what it needs configured in order for the replication slot to survive a promotion.
 
 ## Create the Postgres role
 

--- a/docs/src/content/docs/ops/external-sources/postgres/troubleshooting.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/troubleshooting.md
@@ -4,6 +4,34 @@ title: Troubleshooting a Postgres external source
 
 If a source's ingestion has stopped, you can make the database dormant — see [Skipping Databases](/ops/troubleshooting#skipping-databases-v22) in the general troubleshooting guide.
 
+## Ingestion won't start on PostgreSQL 16 or earlier
+
+**Symptom:**
+Ingestion never starts, and the database reports an error containing `unrecognized option: failover`.
+
+**Cause:**
+XTDB creates its replication slot with the `failover` option, which was introduced in PostgreSQL 17.
+Earlier versions reject the whole command, so no slot is created and nothing is left behind on the upstream.
+
+**Resolution:**
+Upgrade the upstream to PostgreSQL 17 or later.
+There is no configuration that makes an earlier version work — see [prerequisites](/ops/external-sources/postgres/reference#prerequisites).
+
+If you need to run against an earlier version, please [raise an issue](https://github.com/xtdb/xtdb/issues/new) — supporting one is something we would consider.
+
+## Ingestion won't start against a standby
+
+**Symptom:**
+Ingestion never starts, and the database reports an error containing `cannot enable failover for a replication slot created on the standby`.
+
+**Cause:**
+The source is pointed at a standby rather than a primary.
+Postgres allows logical decoding from a standby, but rejects the `failover` option on a slot created there, and XTDB always sets it.
+
+**Resolution:**
+Point the source at the primary.
+If you were reading from a standby to keep decoding load off the primary, note that this is not currently supported.
+
 ## Recovering from a failed initial snapshot
 
 **Symptom:**

--- a/modules/datasets/edgar/docker-compose.yml
+++ b/modules/datasets/edgar/docker-compose.yml
@@ -55,7 +55,7 @@ services:
   # source can consume CDC; the EDGAR tables + publication are created by init/ on
   # first boot (the loader UPSERTs into them from the REPL).
   postgres:
-    image: postgres:16
+    image: postgres:17
     ports:
       - '127.0.0.1:5432:5432'
     environment:

--- a/modules/datasets/gleif/docker-compose.yml
+++ b/modules/datasets/gleif/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   # Postgres source can consume CDC; the GLEIF tables + publication are created
   # by init/ on first boot (the loader UPSERTs into them from the REPL).
   postgres:
-    image: postgres:16
+    image: postgres:17
     ports:
       - '127.0.0.1:5432:5432'
     environment:

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -10,6 +10,7 @@ import org.postgresql.PGProperty
 import org.postgresql.replication.LogSequenceNumber
 import org.postgresql.replication.PGReplicationStream
 import org.postgresql.util.PSQLException
+import xtdb.api.error.Conflict
 import xtdb.api.error.Fault
 import xtdb.api.error.Incorrect
 import xtdb.pgwire.PgType
@@ -46,11 +47,31 @@ private val IDLE_POLL_PAUSE = 50.milliseconds
 private fun coerceText(text: String, typeOid: Int): Any? =
     PgType.fromOid(typeOid)?.readText(text.toByteArray()) ?: text
 
+private const val SQLSTATE_DUPLICATE_OBJECT = "42710"
+
 private data class CreatedSlot(val consistentPoint: Long, val snapshotName: String)
 
 private fun Connection.createLogicalSlot(slotName: String): CreatedSlot =
     createStatement().use { stmt ->
-        stmt.executeQuery("CREATE_REPLICATION_SLOT $slotName LOGICAL pgoutput (SNAPSHOT 'export')").use { rs ->
+        val created =
+            try {
+                stmt.executeQuery("CREATE_REPLICATION_SLOT $slotName LOGICAL pgoutput (SNAPSHOT 'export')")
+            } catch (e: PSQLException) {
+                val data = mapOf("slot-name" to slotName)
+
+                throw if (e.sqlState == SQLSTATE_DUPLICATE_OBJECT)
+                    Conflict(
+                        "Replication slot '$slotName' already exists: ${e.message}",
+                        "xtdb.postgres/slot-exists", data, e,
+                    )
+                else
+                    Incorrect(
+                        "Failed to create replication slot '$slotName': ${e.message}",
+                        "xtdb.postgres/slot-creation-failed", data, e,
+                    )
+            }
+
+        created.use { rs ->
             if (!rs.next())
                 throw Fault(
                     "CREATE_REPLICATION_SLOT returned no row for slot '$slotName'",

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -55,9 +55,9 @@ private fun Connection.createLogicalSlot(slotName: String): CreatedSlot =
     createStatement().use { stmt ->
         val created =
             try {
-                stmt.executeQuery("CREATE_REPLICATION_SLOT $slotName LOGICAL pgoutput (SNAPSHOT 'export')")
+                stmt.executeQuery("CREATE_REPLICATION_SLOT $slotName LOGICAL pgoutput (SNAPSHOT 'export', FAILOVER)")
             } catch (e: PSQLException) {
-                val data = mapOf("slot-name" to slotName)
+                val data = mapOf("slot-name" to slotName, "psql/state" to e.sqlState)
 
                 throw if (e.sqlState == SQLSTATE_DUPLICATE_OBJECT)
                     Conflict(
@@ -66,7 +66,8 @@ private fun Connection.createLogicalSlot(slotName: String): CreatedSlot =
                     )
                 else
                     Incorrect(
-                        "Failed to create replication slot '$slotName': ${e.message}",
+                        "Failed to create replication slot '$slotName' with failover enabled" +
+                                " — postgres-source needs PostgreSQL 17 or later, connected to a primary: ${e.message}",
                         "xtdb.postgres/slot-creation-failed", data, e,
                     )
             }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -10,6 +10,7 @@ import org.postgresql.PGProperty
 import org.postgresql.replication.LogSequenceNumber
 import org.postgresql.replication.PGReplicationStream
 import org.postgresql.util.PSQLException
+import xtdb.api.error.Fault
 import xtdb.api.error.Incorrect
 import xtdb.pgwire.PgType
 import xtdb.util.debug
@@ -44,6 +45,25 @@ private val IDLE_POLL_PAUSE = 50.milliseconds
  */
 private fun coerceText(text: String, typeOid: Int): Any? =
     PgType.fromOid(typeOid)?.readText(text.toByteArray()) ?: text
+
+private data class CreatedSlot(val consistentPoint: Long, val snapshotName: String)
+
+private fun Connection.createLogicalSlot(slotName: String): CreatedSlot =
+    createStatement().use { stmt ->
+        stmt.executeQuery("CREATE_REPLICATION_SLOT $slotName LOGICAL pgoutput (SNAPSHOT 'export')").use { rs ->
+            if (!rs.next())
+                throw Fault(
+                    "CREATE_REPLICATION_SLOT returned no row for slot '$slotName'",
+                    errorCode = "xtdb.postgres/slot-creation-no-result",
+                    data = mapOf("slot-name" to slotName),
+                )
+
+            CreatedSlot(
+                consistentPoint = LogSequenceNumber.valueOf(rs.getString("consistent_point")).asLong(),
+                snapshotName = rs.getString("snapshot_name"),
+            )
+        }
+    }
 
 /** @suppress */
 class PgWireDriver(
@@ -85,23 +105,13 @@ class PgWireDriver(
 
         val replConn = openReplicationConnection()
         try {
-            val pgReplConn = replConn.unwrap(PGConnection::class.java)
-
             LOG.debug { "[$dbName] Creating replication slot '$slotName' with pgoutput" }
 
-            val slotInfo = pgReplConn.replicationAPI
-                .createReplicationSlot()
-                .logical()
-                .withSlotName(slotName)
-                .withOutputPlugin("pgoutput")
-                .make()
+            val slot = replConn.createLogicalSlot(slotName)
 
-            val snapshotName = slotInfo.snapshotName!!
-            val slotLsn = slotInfo.consistentPoint.asLong()
+            LOG.info("[$dbName] Created slot '$slotName' at LSN ${LogSequenceNumber.valueOf(slot.consistentPoint)}, snapshot=${slot.snapshotName}")
 
-            LOG.info("[$dbName] Created slot '$slotName' at LSN ${LogSequenceNumber.valueOf(slotLsn)}, snapshot=$snapshotName")
-
-            return PgWireSnapshotReader(replConn, snapshotName, slotLsn)
+            return PgWireSnapshotReader(replConn, slot.snapshotName, slot.consistentPoint)
         } catch (e: Throwable) {
             replConn.close()
             throw e

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFailoverTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFailoverTest.kt
@@ -11,7 +11,6 @@ import org.testcontainers.images.builder.ImageFromDockerfile
 import org.testcontainers.lifecycle.Startables
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
-import org.postgresql.PGProperty
 import xtdb.XtdbInternal
 import xtdb.api.Xtdb
 import xtdb.postgres.proto.PostgresSourceToken
@@ -19,7 +18,6 @@ import java.nio.file.Files
 import java.sql.Connection
 import java.sql.DriverManager
 import java.time.Duration
-import java.util.Properties
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -139,23 +137,6 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
     private fun pgExec(host: String, port: Int, sql: String) =
         conn(host, port).use { c -> c.createStatement().use { it.execute(sql) } }
 
-    /** `ALTER_REPLICATION_SLOT` isn't SQL — it's only accepted on a connection started with
-     * `replication=database`. Simple query mode goes with it: such connections reject the extended
-     * query protocol pgjdbc otherwise defaults to. */
-    private fun replicationCommand(host: String, port: Int, command: String) {
-        val props = Properties().apply {
-            PGProperty.USER.set(this, "testuser")
-            PGProperty.PASSWORD.set(this, "testpass")
-            PGProperty.REPLICATION.set(this, "database")
-            PGProperty.ASSUME_MIN_SERVER_VERSION.set(this, "9.4")
-            PGProperty.PREFER_QUERY_MODE.set(this, "simple")
-        }
-
-        DriverManager.getConnection("jdbc:postgresql://$host:$port/testdb", props).use { c ->
-            c.createStatement().use { it.execute(command) }
-        }
-    }
-
     private fun latestToken(node: Xtdb): PostgresSourceToken? =
         (node as XtdbInternal).dbCatalog["cdc"]?.watchers?.externalSourceToken
             ?.let { PostgresSourceToken.parseFrom(it) }
@@ -274,7 +255,7 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
     }
 
     @Test
-    fun `an operator-enabled failover slot survives promotion`() = runTest(timeout = 600.seconds) {
+    fun `a failover slot survives promotion`() = runTest(timeout = 600.seconds) {
         val slot = unique("xtdb_slot")
         val pub = unique("xtdb_pub")
         val logDir = Files.createTempDirectory("sync-log")
@@ -306,37 +287,17 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
                 awaitStreaming(node)
 
                 assertEquals(
-                    listOf("f"),
+                    listOf("t"),
                     pgColumn(ha.primaryHost, ha.primaryPort, "SELECT failover FROM pg_replication_slots WHERE slot_name = '$slot'"),
-                    "test precondition: XTDB creates its slot without failover",
+                    "test precondition: the source creates a failover slot",
                 )
-            }
 
-            // ALTER_REPLICATION_SLOT blocks on an active slot rather than erroring, so the source
-            // has to be stopped first — an unclean disconnect can hold it until wal_sender_timeout
-            eventually(90.seconds) {
-                assertEquals(
-                    listOf("f"),
-                    pgColumn(ha.primaryHost, ha.primaryPort, "SELECT active FROM pg_replication_slots WHERE slot_name = '$slot'"),
-                    "slot released once the node closed",
-                )
-            }
-
-            replicationCommand(ha.primaryHost, ha.primaryPort, "ALTER_REPLICATION_SLOT $slot (FAILOVER true)")
-
-            assertEquals(
-                listOf("t"),
-                pgColumn(ha.primaryHost, ha.primaryPort, "SELECT failover FROM pg_replication_slots WHERE slot_name = '$slot'"),
-                "the operator's ALTER took effect",
-            )
-
-            openNode(logDir, storageDir, ha.primaryHost, ha.primaryPort).use { node ->
                 // consuming keeps restart_lsn moving with the standby; a frozen slot can't be copied
-                pgExecute(ha.primary, "INSERT INTO widgets (_id, name) VALUES (2, 'after-alter')")
+                pgExecute(ha.primary, "INSERT INTO widgets (_id, name) VALUES (2, 'streamed-row')")
                 eventually(30.seconds) {
                     assertTrue(
                         xtQuery(node, "cdc", "SELECT _id FROM public.widgets WHERE _id = 2").isNotEmpty(),
-                        "source resumed against the upgraded slot",
+                        "streamed row mirrored",
                     )
                 }
 
@@ -352,7 +313,7 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
                 listOf("t", "t"),
                 pgColumn(ha.standbyHost, ha.standbyPort, "SELECT failover FROM pg_replication_slots WHERE slot_name = '$slot'") +
                     pgColumn(ha.standbyHost, ha.standbyPort, "SELECT synced FROM pg_replication_slots WHERE slot_name = '$slot'"),
-                "the slot survived promotion, unlike the unflagged one",
+                "the slot survived promotion, unlike a slot without the flag",
             )
 
             openNode(logDir, storageDir, ha.standbyHost, ha.standbyPort).use { node ->

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFailoverTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFailoverTest.kt
@@ -159,18 +159,13 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
     fun `resuming against a promoted standby surfaces an ingestion error`() = runTest(timeout = 600.seconds) {
         val slot = unique("xtdb_slot")
         val pub = unique("xtdb_pub")
-        val logDir = Files.createTempDirectory("failover-log")
-        val storageDir = Files.createTempDirectory("failover-storage")
-        val cdcLog = Files.createTempDirectory("failover-cdc-log")
-        val cdcStorage = Files.createTempDirectory("failover-cdc-storage")
+        val logDir = Files.createTempDirectory("ha-log")
+        val storageDir = Files.createTempDirectory("ha-storage")
+        val cdcLog = Files.createTempDirectory("ha-cdc-log")
+        val cdcStorage = Files.createTempDirectory("ha-cdc-storage")
 
         HaPair(haImage).use { ha ->
             ha.start()
-
-            val primaryHost = ha.primary.host
-            val primaryPort = ha.primary.firstMappedPort
-            val standbyHost = ha.standby.host
-            val standbyPort = ha.standby.getMappedPort(5432)
 
             pgExecute(
                 ha.primary,
@@ -181,12 +176,12 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
 
             eventually(60.seconds) {
                 assertEquals(
-                    listOf("t"), pgColumn(standbyHost, standbyPort, "SELECT pg_is_in_recovery()"),
+                    listOf("t"), pgColumn(ha.standbyHost, ha.standbyPort, "SELECT pg_is_in_recovery()"),
                     "standby is up and in recovery",
                 )
             }
 
-            openNode(logDir, storageDir, primaryHost, primaryPort).use { node ->
+            openNode(logDir, storageDir, ha.primaryHost, ha.primaryPort).use { node ->
                 attachCdc(node, "cdc", cdcLog, cdcStorage, slot, pub)
                 awaitStreaming(node)
 
@@ -200,38 +195,39 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
                     )
                 }
 
-                assertTrue(latestToken(node)?.snapshotCompleted == true, "test precondition: resume path")
                 assertEquals(
-                    listOf(slot),
-                    pgColumn(primaryHost, primaryPort, "SELECT slot_name FROM pg_replication_slots WHERE slot_type = 'logical'"),
-                    "test precondition: our slot exists before the failover",
+                    listOf("t"),
+                    pgColumn(ha.primaryHost, ha.primaryPort, "SELECT failover FROM pg_replication_slots WHERE slot_name = '$slot'"),
+                    "test precondition: the source creates a failover slot",
                 )
+                assertTrue(latestToken(node)?.snapshotCompleted == true, "test precondition: resume path")
 
-                // the lagging-standby case is a different failure, blocked on #5828
+                // the one difference from `a failover slot survives promotion`: the slot is never
+                // synced, so the standby holds no copy of it
                 ha.promote()
                 ha.primary.stop()
             }
 
             // asserted so the test can't pass off the back of a different failure — a missing
             // publication throws `Incorrect` from another path and would look the same outside
-            assertEquals(listOf("f"), pgColumn(standbyHost, standbyPort, "SELECT pg_is_in_recovery()"))
+            assertEquals(listOf("f"), pgColumn(ha.standbyHost, ha.standbyPort, "SELECT pg_is_in_recovery()"))
             assertEquals(
                 listOf("1", "2"),
-                pgColumn(standbyHost, standbyPort, "SELECT _id FROM widgets ORDER BY _id"),
+                pgColumn(ha.standbyHost, ha.standbyPort, "SELECT _id FROM widgets ORDER BY _id"),
                 "rows survive the failover — Postgres loses no committed data",
             )
             assertEquals(
                 listOf("1"),
-                pgColumn(standbyHost, standbyPort, "SELECT count(*) FROM pg_publication WHERE pubname = '$pub'"),
+                pgColumn(ha.standbyHost, ha.standbyPort, "SELECT count(*) FROM pg_publication WHERE pubname = '$pub'"),
                 "the publication survives — ordinary catalog, physically replicated",
             )
             assertEquals(
                 emptyList<String?>(),
-                pgColumn(standbyHost, standbyPort, "SELECT slot_name FROM pg_replication_slots"),
+                pgColumn(ha.standbyHost, ha.standbyPort, "SELECT slot_name FROM pg_replication_slots"),
                 "but no slot does — pg_replslot is neither WAL-logged nor base-backed-up",
             )
 
-            openNode(logDir, storageDir, standbyHost, standbyPort).use { node ->
+            openNode(logDir, storageDir, ha.standbyHost, ha.standbyPort).use { node ->
                 val dbs = (node as XtdbInternal).dbCatalog
 
                 // the disabled `slot recreation silently drops changes` in
@@ -258,10 +254,10 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
     fun `a failover slot survives promotion`() = runTest(timeout = 600.seconds) {
         val slot = unique("xtdb_slot")
         val pub = unique("xtdb_pub")
-        val logDir = Files.createTempDirectory("sync-log")
-        val storageDir = Files.createTempDirectory("sync-storage")
-        val cdcLog = Files.createTempDirectory("sync-cdc-log")
-        val cdcStorage = Files.createTempDirectory("sync-cdc-storage")
+        val logDir = Files.createTempDirectory("ha-log")
+        val storageDir = Files.createTempDirectory("ha-storage")
+        val cdcLog = Files.createTempDirectory("ha-cdc-log")
+        val cdcStorage = Files.createTempDirectory("ha-cdc-storage")
 
         HaPair(haImage).use { ha ->
             ha.start()
@@ -286,13 +282,8 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
                 attachCdc(node, "cdc", cdcLog, cdcStorage, slot, pub)
                 awaitStreaming(node)
 
-                assertEquals(
-                    listOf("t"),
-                    pgColumn(ha.primaryHost, ha.primaryPort, "SELECT failover FROM pg_replication_slots WHERE slot_name = '$slot'"),
-                    "test precondition: the source creates a failover slot",
-                )
-
-                // consuming keeps restart_lsn moving with the standby; a frozen slot can't be copied
+                // advances the token past the snapshot's consistent point, so the reopen below
+                // takes the resume path rather than re-snapshotting
                 pgExecute(ha.primary, "INSERT INTO widgets (_id, name) VALUES (2, 'streamed-row')")
                 eventually(30.seconds) {
                     assertTrue(
@@ -301,6 +292,14 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
                     )
                 }
 
+                assertEquals(
+                    listOf("t"),
+                    pgColumn(ha.primaryHost, ha.primaryPort, "SELECT failover FROM pg_replication_slots WHERE slot_name = '$slot'"),
+                    "test precondition: the source creates a failover slot",
+                )
+                assertTrue(latestToken(node)?.snapshotCompleted == true, "test precondition: resume path")
+
+                // consuming above kept restart_lsn moving with the standby; a frozen slot can't be copied
                 eventually(60.seconds) {
                     assertEquals(listOf(slot), ha.syncSlots(), "slot copied to the standby")
                 }

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFailoverTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFailoverTest.kt
@@ -334,4 +334,60 @@ class PostgresSourceFailoverTest : PostgresSourceTestBase() {
             }
         }
     }
+
+    /** Logical decoding from a standby has worked since PG16 and a plain slot creates there fine —
+     * this is a limitation of always creating failover slots, not of standbys. */
+    @Test
+    fun `a source cannot read from a standby`() = runTest(timeout = 600.seconds) {
+        val slot = unique("xtdb_slot")
+        val pub = unique("xtdb_pub")
+        val logDir = Files.createTempDirectory("ha-log")
+        val storageDir = Files.createTempDirectory("ha-storage")
+        val cdcLog = Files.createTempDirectory("ha-cdc-log")
+        val cdcStorage = Files.createTempDirectory("ha-cdc-storage")
+
+        HaPair(haImage).use { ha ->
+            ha.start()
+
+            pgExecute(
+                ha.primary,
+                "CREATE TABLE widgets (_id INT PRIMARY KEY, name TEXT)",
+                "INSERT INTO widgets (_id, name) VALUES (1, 'snapshot-row')",
+                "CREATE PUBLICATION $pub FOR TABLE widgets",
+            )
+
+            // waited for, or the source fails its publication check first and this passes off the
+            // back of the wrong error
+            eventually(60.seconds) {
+                assertEquals(
+                    listOf("1"),
+                    pgColumn(ha.standbyHost, ha.standbyPort, "SELECT count(*) FROM pg_publication WHERE pubname = '$pub'"),
+                    "publication replicated to the standby",
+                )
+            }
+
+            openNode(logDir, storageDir, ha.standbyHost, ha.standbyPort).use { node ->
+                attachCdc(node, "cdc", cdcLog, cdcStorage, slot, pub)
+
+                val cdc = (node as XtdbInternal).dbCatalog
+                val error = eventually(30.seconds) {
+                    assertNotNull(cdc["cdc"]?.ingestionError, "a source pointed at a standby must fail, not stream")
+                }
+
+                val rendered = error.stackTraceToString()
+                assertTrue(
+                    rendered.contains("cannot enable failover for a replication slot created on the standby"),
+                    "expected Postgres' standby refusal, got: $rendered",
+                )
+
+                assertEquals(
+                    emptyList<String?>(),
+                    pgColumn(ha.standbyHost, ha.standbyPort, "SELECT slot_name FROM pg_replication_slots"),
+                    "and the refused create leaves no slot behind",
+                )
+
+                assertPrimaryDbHealthy(node)
+            }
+        }
+    }
 }

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -80,8 +80,8 @@ class PostgresSourceIntegrationTest {
 
     private fun pgExecute(vararg statements: String) = postgres.executeSql(*statements)
 
-    private fun newDedicatedPostgres(): PostgreSQLContainer =
-        PostgreSQLContainer("postgres:17-alpine")
+    private fun newDedicatedPostgres(image: String = "postgres:17-alpine"): PostgreSQLContainer =
+        PostgreSQLContainer(image)
             .withNetwork(network)
             .withDatabaseName("testdb")
             .withUsername("testuser")
@@ -583,6 +583,71 @@ class PostgresSourceIntegrationTest {
             }
         } finally {
             runCatching { dedicatedPg.stop() }
+        }
+    }
+
+    @Test
+    fun `slots are created with failover enabled`() = runTest(timeout = 60.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_failover (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_failover (_id, name) VALUES (1, 'Alice')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_failover",
+        )
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresSource(node, slotName = slotName, publicationName = pubName)
+
+            awaitTxs(node, 2, db = "cdc")
+
+            assertEquals(true, pgSlotFailover(slotName), "slot created with failover enabled")
+            assertEquals(setOf("Alice"),
+                xtQueryDb(node, "cdc", "SELECT name FROM public.pg_failover").map { it["name"] }.toSet(),
+                "a failover slot snapshots and streams like any other")
+        }
+    }
+
+    @Test
+    fun `postgres before 17 is unsupported, and says so`() = runTest(timeout = 180.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+        val pg16 = newDedicatedPostgres("postgres:16-alpine")
+        Startables.deepStart(pg16).join()
+
+        try {
+            pg16.executeSql(
+                "CREATE TABLE pg_old (_id INT PRIMARY KEY, name TEXT)",
+                "CREATE PUBLICATION $pubName FOR TABLE pg_old",
+            )
+
+            openNode(sourceTopic, pgContainer = pg16).use { node ->
+                attachPostgresSource(node, slotName = slotName, publicationName = pubName)
+
+                val cdc = (node as XtdbInternal).dbCatalog
+                eventually(30.seconds) {
+                    assertTrue(cdc["cdc"]?.ingestionError != null, "cdc surfaces ingestionError on a pre-17 server")
+                }
+
+                val chain = generateSequence(cdc["cdc"]?.ingestionError as Throwable?) { it.cause }.toList()
+                assertTrue(
+                    chain.any { it.message?.contains("needs PostgreSQL 17 or later") == true },
+                    "we name the requirement, since Postgres doesn't: " +
+                            chain.joinToString { "${it::class.simpleName}: ${it.message}" },
+                )
+                assertTrue(
+                    chain.any { it.message?.contains("unrecognized option: failover") == true },
+                    "and Postgres' own message survives: " +
+                            chain.joinToString { "${it::class.simpleName}: ${it.message}" },
+                )
+
+                assertPrimaryDbHealthy(node)
+            }
+        } finally {
+            runCatching { pg16.stop() }
         }
     }
 
@@ -1213,6 +1278,15 @@ class PostgresSourceIntegrationTest {
             }
         }
     }
+
+    private fun pgSlotFailover(slotName: String): Boolean? =
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery("SELECT failover FROM pg_replication_slots WHERE slot_name = '$slotName'").use { rs ->
+                    if (rs.next()) rs.getBoolean("failover") else null
+                }
+            }
+        }
 
     private fun pgSlotConfirmedFlushLsn(slotName: String): Long =
         DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -18,6 +18,7 @@ import org.testcontainers.lifecycle.Startables
 import org.testcontainers.postgresql.PostgreSQLContainer
 import xtdb.XtdbInternal
 import xtdb.api.Xtdb
+import xtdb.api.error.Conflict
 import xtdb.api.log.KafkaCluster
 import xtdb.time.Interval
 import java.math.BigDecimal
@@ -608,6 +609,46 @@ class PostgresSourceIntegrationTest {
             }
             assertNotNull(cdc["cdc"]?.ingestionError,
                 "missing publication must surface IngestionStoppedException, not silently stall")
+
+            assertPrimaryDbHealthy(node)
+        }
+    }
+
+    @Test
+    fun `source fails when the replication slot already exists`() = runTest(timeout = 60.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_dup_slot (_id INT PRIMARY KEY, name TEXT)",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_dup_slot",
+            "SELECT pg_create_logical_replication_slot('$slotName', 'pgoutput')",
+        )
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresSource(node, slotName = slotName, publicationName = pubName)
+
+            val cdc = (node as XtdbInternal).dbCatalog
+            eventually(30.seconds) {
+                assertTrue(cdc["cdc"]?.ingestionError != null, "cdc surfaces ingestionError for a pre-existing slot")
+            }
+
+            val chain = generateSequence(cdc["cdc"]?.ingestionError as Throwable?) { it.cause }.toList()
+            val conflict = chain.filterIsInstance<Conflict>().firstOrNull()
+                ?: throw AssertionError(
+                    "a pre-existing slot must surface as Conflict, got: " +
+                            chain.joinToString { "${it::class.simpleName}: ${it.message}" }
+                )
+
+            assertEquals(
+                Keyword.intern("xtdb.postgres", "slot-exists"),
+                conflict.data.valAt(Keyword.intern("xtdb.error", "code")),
+            )
+            assertTrue(
+                conflict.message?.contains("already exists") == true,
+                "Postgres' own message survives the wrap, got: ${conflict.message}",
+            )
 
             assertPrimaryDbHealthy(node)
         }


### PR DESCRIPTION
Resolves #5828

## Summary

Postgres external sources now create their replication slot with PostgreSQL 17's `failover` option set, so that an HA promotion no longer takes the slot with it. The cost is that postgres-source requires PostgreSQL 17, connected to a primary.

Before this, every slot XTDB created had `failover = false`. Slot synchronisation therefore never copied it to a standby, a promotion left nothing to resume from, and the only recovery was a fresh snapshot into a new database — losing every change between the last `confirmed_flush_lsn` and the promotion.

## The decision

There is no `failover` setting. Two reasons, pulling the same way.

**To reduce support requests.** With failover always on, a database whose upstream has HA configured doesn't lose data at a promotion — rather than losing it and telling us afterwards.

**To reduce complexity.** We'd rather decide the behaviour than offer flexibility that doesn't buy anyone much. On a standalone primary a failover slot is indistinguishable from a plain one so the option would mostly have been a way to be accidentally unprotected.

## Consequences

**PostgreSQL 17 is now the floor** for postgres-source, up from 15. Accepted deliberately rather than overlooked; if someone needs an earlier version we'd like to hear about it, and the docs say so. The failure is immediate and leaves nothing behind — `unrecognized option: failover`, no slot created.

**A source can no longer read from a standby.** PG17 refuses `FAILOVER` on a slot created in recovery, while a plain logical slot creates there fine. Anyone decoding off a read replica to spare their primary loses that.

**Slots created before this keep whatever they were created with.** The flag is only ever set at creation and nothing re-reads it, so an existing slot is unaffected and re-attaching won't change it. The appendix below is the upgrade path.

## Implementation notes

**The flag can only be set at creation.** Not because `ALTER_REPLICATION_SLOT` doesn't exist — it does, and altering on a second replication connection works in 12ms with the snapshot connection still held open. It's that create-then-alter makes "slot exists, `failover = false`" a state the system can reach and then sit in, which is exactly the state this issue is about removing. A crash or a dropped connection between the two commands is enough.

**pgjdbc can't do it**, so slot creation moves off its fluent `createReplicationSlot()` builder — whose only option is the output plugin — onto a raw `CREATE_REPLICATION_SLOT … (SNAPSHOT 'export', FAILOVER)` on the replication connection, reading the same four columns off the `ResultSet`. Debezium reached the same place for the same reason.

**Slot-creation failures are now XTDB anomalies** rather than a bare `PSQLException`, which `pgwire.clj` couldn't classify since it dispatches on anomaly category and error code. SQLSTATE `42710` becomes a `Conflict` — a slot that already exists is a name collision, not bad configuration. Everything else is an `Incorrect` carrying Postgres' own message and the raw SQLSTATE.

One thing worth flagging for review: that `Incorrect` names the PG17 requirement, but `unrecognized option: failover` turns out to carry SQLSTATE `XX000` — `internal_error`, a catch-all — so unlike `42710` it can't be discriminated on. A `max_replication_slots` exhaustion on a perfectly modern PG17 primary will therefore also mention PostgreSQL 17. Postgres' own message rides along, so the reader isn't stranded, but it isn't ideal.

## Changes

1. `tidy` — slot creation moves to the raw protocol command. Equivalence change.
2. `fix` — slot-creation failures become XTDB anomalies, with `42710` as a `Conflict`.
3. `feat!` — `FAILOVER` set unconditionally; PG17 floor.
4. `tidy` — the two HA failover tests aligned so their single difference is visible.
5. `build` — the three dev Postgres compose stacks moved to 17.
6. `test` — pins that a source can't read from a standby.
7. `docs` — the PG17 prerequisite, the failover section, two troubleshooting entries.

## Rollout

`docker-compose.yml` and the gleif and edgar demo stacks all ran `postgres:16` with `wal_level=logical` — they exist to be local CDC sources, so they'd have broken. They're bumped to 17. Each has a named volume, and Postgres won't start against a data directory from a different major, so drop it: `docker volume rm xtdb2_postgres-data`, or the demo equivalent. Dev-only data.

## Test plan

`./gradlew :modules:xtdb-postgres-source:test :property-test :integration-test` — 6 / 6 / 37 with 1 skipped, 0 failures.

New coverage: the slot is created with `failover = t` and still snapshots and streams; a PG16 upstream fails with both Postgres' message and ours; a source pointed at a standby fails with Postgres' standby refusal and leaves no slot behind. `a failover slot survives promotion` (reframed from `an operator-enabled failover slot survives promotion`, whose precondition — that XTDB creates slots *without* failover — this change makes false) drives a real primary/standby promotion and asserts a row written on the promoted primary reaches XT.

One intermittency seen during this work, unrelated to the change and not reproduced since: eight tests failed together at `assertPrimaryDbHealthy`, which writes to the node's Kafka-backed primary database, then passed on an immediate re-run of identical source. Suspected container-load pressure — this branch adds a third HA pair and a dedicated PG16 container to that suite.

## Not in this change

Whether XTDB should detect that a promoted standby's slot sits behind our resume token. The synced copy's position is maintained independently of the token we persist, so a standby promoted while lagging leaves XT holding rows the new primary never received — divergence with no error raised. Reproducible, but what it would assert is a gap rather than a guarantee, so it wants its own issue.

---

# Appendix: enabling `failover` on an existing slot

For slots created before this change. Not needed for anything attached afterwards.

There are two ways to do it, and they differ only at step 4 — either run the `pg-enable-slot-failover` tool, or issue the `ALTER_REPLICATION_SLOT` yourself. Every other step is the same. The tool is the safer of the two: see [Without the tool](#without-the-tool) for what it checks that you'd be doing by eye otherwise.

**The command is not on `main`.** `pg-enable-slot-failover` lives on the `pg-source-failover-tool` branch and hasn't been merged, so it isn't in a released build. It is in the image `ghcr.io/xtdb/xtdb-azure:g5fb9cb7`, built from that branch.

## Prerequisites

Access:

- A Postgres role with the `REPLICATION` attribute, and somewhere to run a JVM with the node config and network access to Postgres.
- The `ATTACH DATABASE` statement originally used, since you'll re-run it verbatim.

Postgres:

- Version 17 or later, `wal_level = logical`.
- On the standby, `sync_replication_slots = on` and `hot_standby_feedback = on`.
- On the primary, `synchronized_standby_slots` naming the standby's physical slot, which stops the copy falling far enough behind to be discarded at promotion. Read-only on Azure Database for PostgreSQL, so the copy is best-effort there.

The source must have finished snapshotting and be streaming.

## Method

**1. Check the slot's current state.**

```sql
SELECT slot_name, slot_type, database, active, failover
FROM pg_replication_slots WHERE slot_type = 'logical';
```

`failover` should read `f`, and `database` should match the remote's database — `ALTER_REPLICATION_SLOT` is not scoped by database, so a name that collides with another database's slot would otherwise be altered instead.

**2. Detach the database in XTDB.** The slot must be idle: `ALTER_REPLICATION_SLOT` doesn't error on an active slot, it parks with no output and then applies whenever the consumer eventually goes away.

```sql
DETACH DATABASE <database>;
```

Nothing is lost. Detaching leaves the log and storage alone, so re-attaching resumes from the recorded position rather than re-snapshotting.

**3. Confirm the slot went idle.**

```sql
SELECT slot_name, active, active_pid FROM pg_replication_slots WHERE slot_name = '<slot>';
```

Wait for `active = f`. An unclean disconnect can hold it until `wal_sender_timeout`.

**4. Enable failover.** Or do it by hand — see [Without the tool](#without-the-tool), which replaces this step and this step only.

```
pg-enable-slot-failover -f <node-config.yaml> <remote-alias> <slot-name>
```

From the image, on a network that can reach Postgres:

```
docker run --rm --network <network> -v <node-config.yaml>:/config.yaml:ro \
  ghcr.io/xtdb/xtdb-azure:g5fb9cb7 pg-enable-slot-failover -f /config.yaml <remote-alias> <slot-name>
```

It resolves the alias against the `remotes:` block of your node config, so `!Env` credentials keep working. Expected output:

```
Enabled failover on replication slot '<slot>'.
  <host>:<port>/<db>  failover=true  active=false
```

If it reports `already had failover enabled — nothing altered`, the slot was upgraded previously; carry on at step 5. Any other failure names what went wrong; either fix it, or skip to step 6 and resolve separately — nothing has been altered at that point.

**5. Verify.**

```sql
SELECT slot_name, failover FROM pg_replication_slots WHERE slot_name = '<slot>';
```

**6. Re-attach**, with the original `ATTACH DATABASE` statement unchanged.

**7. Confirm the copy reached the standby.** Query the standby directly:

```sql
SELECT slot_name, failover, synced, wal_status FROM pg_replication_slots;
```

`synced = t` is the confirmation. Where you can't reach the standby — Azure Flexible Server, for instance — the `logical_replication_slot_sync_status` metric is the equivalent signal, exposed by `metrics.collector_database_activity = on`, reading `1` when synchronised and `0` when not.

Worth knowing either way: `pg_replication_slots` **on the primary** reports whether a slot is *eligible* for copying and never whether it has been copied, so a working deployment and one whose standby has never synced look identical from there.

## Without the tool

This replaces step 4. Everything before and after it is unchanged — you still detach, wait for the slot to go idle, verify, re-attach and confirm the copy.

`ALTER_REPLICATION_SLOT` is not SQL — there is no function for it, and it is only accepted on a connection opened with `replication=database`, which most GUI clients can't do. From `psql`, with the slot idle:

```
psql "host=<host> dbname=<db> user=<user> replication=database" \
  -c "ALTER_REPLICATION_SLOT <slot> (FAILOVER true)"
```

The tool exists because doing this by hand has two sharp edges it checks for: the command parks silently on an active slot rather than erroring, and it is scoped by neither database nor server version, so a mistyped slot name can quietly alter another database's slot and a pre-17 server answers with a bare `syntax error` that reads like a client bug.
