### PR TITLE
Stop a stalled object store taking the node down with it

### DIFF
--- a/core/src/main/clojure/xtdb/compactor/reset.clj
+++ b/core/src/main/clojure/xtdb/compactor/reset.clj
@@ -137,7 +137,7 @@
 
               (doseq [file-key compacted-file-keys]
                 (log/debugf "Deleting file: %s" file-key)
-                (.deleteIfExists bp file-key)
+                (.deleteIfExistsSync bp file-key)
                 (log/debugf "Deleted file: %s" file-key))
 
               (log/info "Compacted files deleted - you can now upgrade the nodes."))))))))

--- a/core/src/main/clojure/xtdb/export.clj
+++ b/core/src/main/clojure/xtdb/export.clj
@@ -99,7 +99,7 @@
                      (try
                        (let [dest-path (.resolve export-root path)]
                          (log/debugf "Copying %s -> %s" path dest-path)
-                         (.copyObject buffer-pool path dest-path))
+                         (.copyObjectSync buffer-pool path dest-path))
                        (catch Exception e
                          (log/errorf e "Failed to copy %s" path)
                          (throw e))))

--- a/core/src/main/kotlin/xtdb/ArrowWriter.kt
+++ b/core/src/main/kotlin/xtdb/ArrowWriter.kt
@@ -1,8 +1,19 @@
 package xtdb
 
+import kotlinx.coroutines.runBlocking
 import xtdb.trie.FileSize
 
 interface ArrowWriter : AutoCloseable {
     fun writePage()
-    fun end(): FileSize
+
+    /**
+     * Writes out the file, returning its size.
+     *
+     * Suspends: for a remote buffer pool this is a network upload, and holding a dispatcher thread
+     * for its duration is what turned one stalled S3 request into a node-wide stall (#5850).
+     */
+    suspend fun end(): FileSize
+
+    /** For callers that aren't coroutine-native — see [end]. */
+    fun endSync(): FileSize = runBlocking { end() }
 }

--- a/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
+++ b/core/src/main/kotlin/xtdb/api/storage/ObjectStore.kt
@@ -49,21 +49,21 @@ interface ObjectStore : AutoCloseable {
     data class StoredObject(val key: Path, val size: Long)
 
     /**
-     * Asynchronously returns the given object in a ByteBuffer.
+     * Returns the given object in a ByteBuffer.
      *
-     * If the object doesn't exist, the CompletableFuture completes with an IllegalStateException.
+     * If the object doesn't exist, throws an IllegalStateException.
      */
-    fun getObject(k: Path): CompletableFuture<ByteBuffer>
+    suspend fun getObject(k: Path): ByteBuffer
 
     /**
-     * Asynchronously writes the object to the given path.
+     * Writes the object to the given path.
      *
      * Replaces any existing file at the given path.
      *
-     * If the object doesn't exist, the CompletableFuture completes with an IllegalStateException.
+     * If the object doesn't exist, throws an IllegalStateException.
      */
-    fun getObject(k: Path, outPath: Path): CompletableFuture<Path> =
-        getObject(k).thenApply { buf ->
+    suspend fun getObject(k: Path, outPath: Path): Path =
+        getObject(k).let { buf ->
             FileChannel.open(outPath, CREATE, WRITE, TRUNCATE_EXISTING).use { it.write(buf) }
             outPath
         }
@@ -73,7 +73,7 @@ interface ObjectStore : AutoCloseable {
      *
      * The provided ByteBuffer must not be modified during the execution of this method.
      */
-    fun putObject(k: Path, buf: ByteBuffer): CompletableFuture<Unit>
+    suspend fun putObject(k: Path, buf: ByteBuffer)
 
     /**
      * Recursively lists all objects in the object store.
@@ -97,12 +97,12 @@ interface ObjectStore : AutoCloseable {
     fun listAfter(dir: Path, afterKey: Path): Iterable<StoredObject> =
         listAllObjects(dir).filter { it.key > afterKey }
 
-    fun copyObject(src: Path, dest: Path): CompletableFuture<Unit>
+    suspend fun copyObject(src: Path, dest: Path)
 
     /**
      * Deletes the object with the given path from the object store.
      */
-    fun deleteIfExists(k: Path): CompletableFuture<Unit>
+    suspend fun deleteIfExists(k: Path)
 
     override fun close() {
     }

--- a/core/src/main/kotlin/xtdb/arrow/Relation.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Relation.kt
@@ -15,7 +15,6 @@ import org.apache.arrow.vector.ipc.message.MessageSerializer
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.pojo.Field
 import org.apache.arrow.vector.types.pojo.Schema
-import xtdb.ArrowWriter
 import xtdb.api.ICursor
 import xtdb.arrow.ArrowUnloader.Mode
 import xtdb.arrow.ArrowUnloader.Mode.FILE
@@ -86,9 +85,16 @@ class Relation(
                 }
             }
 
-    inner class RelationUnloader(private val arrowUnloader: ArrowUnloader) : ArrowWriter {
+    /**
+     * Writes Arrow pages to a local channel.
+     *
+     * Deliberately not an [xtdb.ArrowWriter] — that's a handle on an object in a [xtdb.storage.BufferPool],
+     * whose backing store may be remote and whose `end` therefore suspends. This one only ever touches a
+     * local channel, and its callers (query spill, shuffle, compaction output) are not coroutine-native.
+     */
+    inner class RelationUnloader(private val arrowUnloader: ArrowUnloader) : AutoCloseable {
 
-        override fun writePage() {
+        fun writePage() {
             try {
                 openArrowRecordBatch().use { arrowUnloader.writeBatch(it) }
             } catch (_: ClosedByInterruptException) {
@@ -96,7 +102,7 @@ class Relation(
             }
         }
 
-        override fun end() = arrowUnloader.end()
+        fun end() = arrowUnloader.end()
 
         override fun close() = arrowUnloader.close()
     }

--- a/core/src/main/kotlin/xtdb/indexer/CrashLogger.kt
+++ b/core/src/main/kotlin/xtdb/indexer/CrashLogger.kt
@@ -67,11 +67,11 @@ class CrashLogger @JvmOverloads constructor(
 
         LOG.warn("writing crash log: $crashDir")
 
-        bufferPool.putObject(crashDir.resolve("crash.edn"), ByteBuffer.wrap(crashEdn.toByteArray()))
+        bufferPool.putObjectSync(crashDir.resolve("crash.edn"), ByteBuffer.wrap(crashEdn.toByteArray()))
 
         val liveTable = liveIndex.table(table) ?: return
 
-        bufferPool.putObject(
+        bufferPool.putObjectSync(
             crashDir.resolve("live-trie.binpb"),
             ByteBuffer.wrap(liveTable.liveTrie.asProto)
         )
@@ -82,7 +82,7 @@ class CrashLogger @JvmOverloads constructor(
 
         writeArrow(crashDir.resolve("open-tx-table.arrow"), openTxTable.txRelation)
 
-        bufferPool.putObject(crashDir.resolve("open-tx-trie.binpb"), ByteBuffer.wrap(openTxTable.trie.asProto))
+        bufferPool.putObjectSync(crashDir.resolve("open-tx-trie.binpb"), ByteBuffer.wrap(openTxTable.trie.asProto))
 
         queryRel?.let { writeArrow(crashDir.resolve("query-rel.arrow"), it) }
         txOpsRdr?.let { writeTxOpsToArrow(crashDir.resolve("tx-ops.arrow"), it) }

--- a/core/src/main/kotlin/xtdb/indexer/CrashLogger.kt
+++ b/core/src/main/kotlin/xtdb/indexer/CrashLogger.kt
@@ -38,7 +38,7 @@ class CrashLogger @JvmOverloads constructor(
         rel.openDirectSlice(allocator).use { slicedRel ->
             bufferPool.openArrowWriter(path, slicedRel).use { writer ->
                 writer.writePage()
-                writer.end()
+                writer.endSync()
             }
         }
     }
@@ -48,7 +48,7 @@ class CrashLogger @JvmOverloads constructor(
             Relation(allocator, listOf(slicedVec), txOpsRdr.valueCount).use { txOpsRel ->
                 bufferPool.openArrowWriter(path, txOpsRel).use { writer ->
                     writer.writePage()
-                    writer.end()
+                    writer.endSync()
                 }
             }
         }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -532,6 +532,7 @@ internal class LeaderLogProcessor(
                 } catch (t: Throwable) {
                     // A genuine term fault (e.g. an append-pump commit fault) surfaces to queries as a
                     // failed term. Idempotent — the apply arm may already have notified for its own faults.
+                    LOG.error(t) { "[$dbName] leader term failed" }
                     cause = t
                     watchers.notifyError(t)
                 } finally {

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -1,5 +1,7 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.IndexerConfig
 import xtdb.api.TransactionKey
@@ -57,6 +59,7 @@ class LiveIndex private constructor(
     @Volatile var latestCompletedTx: TransactionKey?,
     initialBlockIdx: Long,
     indexerConfig: IndexerConfig,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : Snapshot.Source, AutoCloseable {
 
     private val tables = HashMap<TableRef, LiveTable>()
@@ -186,7 +189,8 @@ class LiveIndex private constructor(
     fun blockMetadata(): Map<TableRef, LiveTable.BlockMetadata> =
         this@LiveIndex.tables.mapValues { (_, lt) -> lt.blockMetadata() }
 
-    fun finishBlock(bp: BufferPool, blockIdx: BlockIndex) = this@LiveIndex.tables.finishBlock(bp, blockIdx)
+    suspend fun finishBlock(bp: BufferPool, blockIdx: BlockIndex) =
+        this@LiveIndex.tables.finishBlock(bp, blockIdx, ioDispatcher)
 
     private val skipTxsLogged = AtomicBoolean(false)
 
@@ -227,6 +231,11 @@ class LiveIndex private constructor(
         fun open(
             allocator: BufferAllocator, blockCatalog: BlockCatalog, tableCatalog: TableCatalog,
             trieCatalog: TrieCatalog, indexerConfig: IndexerConfig = IndexerConfig(),
+            /**
+             * Dispatcher for the per-table block-write fan-out. Sims inject the seeded dispatcher so the
+             * fan-out stays on the simulation's thread, and hence within its quiescence fixed point.
+             */
+            ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
         ) = safelyOpening {
             LiveIndex(
                 open { allocator.newChildAllocator("live-index", 0, Long.MAX_VALUE) },
@@ -234,6 +243,7 @@ class LiveIndex private constructor(
                 blockCatalog.latestCompletedTx,
                 (blockCatalog.currentBlockIndex ?: -1L) + 1L,
                 indexerConfig,
+                ioDispatcher,
             ).also { it.refreshSnap() }
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
@@ -1,8 +1,10 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.arrow.*
@@ -75,7 +77,11 @@ class LiveTable @JvmOverloads constructor(
         val hllDeltas: Map<FieldName, HLL>
     )
 
-    fun finishBlock(bp: BufferPool, blockIdx: BlockIndex): FinishedBlock {
+    /** For callers that aren't coroutine-native — see [finishBlock]. */
+    fun finishBlockSync(bp: BufferPool, blockIdx: BlockIndex): FinishedBlock =
+        runBlocking { finishBlock(bp, blockIdx) }
+
+    suspend fun finishBlock(bp: BufferPool, blockIdx: BlockIndex): FinishedBlock {
         val rowCount = liveRelation.rowCount
         val trieKey = Trie.l0Key(blockIdx).toString()
 
@@ -104,13 +110,20 @@ class LiveTable @JvmOverloads constructor(
                 return type.children
             }
 
-        @JvmStatic
-        fun Map<TableRef, LiveTable>.finishBlock(bp: BufferPool, blockIdx: BlockIndex): Map<TableRef, FinishedBlock> =
-            // migrated here because of #5107 - may migrate the rest later.
-            runBlocking {
+        /**
+         * Writes every table's block in parallel on [ioDispatcher].
+         *
+         * The dispatcher is a parameter rather than [Dispatchers.IO] because hardcoding it would put this
+         * fan-out outside whatever dispatcher the caller runs on — which, under a deterministic simulation,
+         * means outside the scheduler whose quiescence the simulation treats as its fixed point.
+         */
+        suspend fun Map<TableRef, LiveTable>.finishBlock(
+            bp: BufferPool, blockIdx: BlockIndex, ioDispatcher: CoroutineDispatcher
+        ): Map<TableRef, FinishedBlock> =
+            coroutineScope {
                 this@finishBlock
                     .map { (tableName, liveTable) ->
-                        async(Dispatchers.IO) {
+                        async(ioDispatcher) {
                             tableName to liveTable.finishBlock(bp, blockIdx)
                         }
                     }

--- a/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
@@ -229,7 +229,7 @@ internal class TxResolver(
     private fun indexSkippedTx(msgId: MessageId, msgTimestamp: Instant, payload: ByteArray): ResolvedTx {
         LOG.warn("[$dbName] Skipping transaction id $msgId - within XTDB_SKIP_TXS")
 
-        bufferPool.putObject("skipped-txs/${msgId.asLexDec}".asPath, ByteBuffer.wrap(payload))
+        bufferPool.putObjectSync("skipped-txs/${msgId.asLexDec}".asPath, ByteBuffer.wrap(payload))
 
         return indexSourceLogTx(msgId, msgTimestamp, null, null, null, null, null)
     }

--- a/core/src/main/kotlin/xtdb/multipart/IMultipartUpload.kt
+++ b/core/src/main/kotlin/xtdb/multipart/IMultipartUpload.kt
@@ -1,22 +1,21 @@
 package xtdb.multipart
 
 import java.nio.ByteBuffer
-import java.util.concurrent.CompletableFuture
 
 interface IMultipartUpload<Part> {
 
     /**
-     * Asynchronously uploads a part to the multipart request and adds it to the internal list of completed parts.
+     * Uploads a part to the multipart request and adds it to the internal list of completed parts.
      */
-    fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<Part>
+    suspend fun uploadPart(idx: Int, buf: ByteBuffer): Part
 
     /**
-     * Asynchronously completes the multipart request.
+     * Completes the multipart request.
      */
-    fun complete(parts: List<Part>): CompletableFuture<Unit>
+    suspend fun complete(parts: List<Part>)
 
     /**
-     * Asynchronously cancels the multipart request, useful for cleaning up any parts of the multipart upload in case of an error.
+     * Cancels the multipart request, useful for cleaning up any parts of the multipart upload in case of an error.
      */
-    fun abort(): CompletableFuture<Unit>
+    suspend fun abort()
 }

--- a/core/src/main/kotlin/xtdb/multipart/SupportsMultipart.kt
+++ b/core/src/main/kotlin/xtdb/multipart/SupportsMultipart.kt
@@ -1,20 +1,20 @@
 package xtdb.multipart
 
 import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import xtdb.api.storage.ObjectStore
 import xtdb.storage.RemoteBufferPool
 import xtdb.util.logger
 import xtdb.util.warn
 import java.nio.ByteBuffer
 import java.nio.file.Path
-import java.util.concurrent.CompletableFuture
 
 interface SupportsMultipart<Part> : ObjectStore {
-    fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<Part>>
+    suspend fun startMultipart(k: Path): IMultipartUpload<Part>
 
     companion object {
 
@@ -22,31 +22,37 @@ interface SupportsMultipart<Part> : ObjectStore {
 
         private val LOGGER = RemoteBufferPool::class.logger
 
+        // bounds the number of parts in flight, and hence the buffers pinned for them. Note that a
+        // `limitedParallelism` view of `Dispatchers.IO` is *elastic* — it draws on an unbounded pool
+        // rather than IO's own permits — so this caps concurrency, not thread supply.
         private val multipartUploadDispatcher =
             IO.limitedParallelism(MAX_CONCURRENT_PART_UPLOADS, "upload-multipart")
 
-        @JvmStatic
-        fun <P> SupportsMultipart<P>.uploadMultipartBuffers(key: Path, nioBuffers: List<ByteBuffer>): Unit = runBlocking {
-            val upload = startMultipart(key).await()
+        suspend fun <P> SupportsMultipart<P>.uploadMultipartBuffers(key: Path, nioBuffers: List<ByteBuffer>): Unit =
+            coroutineScope {
+                val upload = startMultipart(key)
 
-            try {
-                val waitingParts = nioBuffers.mapIndexed { idx, it ->
-                    async(multipartUploadDispatcher) {
-                        upload.uploadPart(idx, it).await()
-                    }
-                }
-
-                upload.complete(waitingParts.awaitAll()).await()
-            } catch (e: Throwable) {
                 try {
-                    LOGGER.warn("Error caught in uploadMultipartBuffers - aborting multipart upload of $key")
-                    upload.abort().get()
-                } catch (abortError: Throwable) {
-                    LOGGER.warn(abortError, "Throwable caught when aborting uploadMultipartBuffers")
-                    e.addSuppressed(abortError)
+                    val waitingParts = nioBuffers.mapIndexed { idx, it ->
+                        async(multipartUploadDispatcher) { upload.uploadPart(idx, it) }
+                    }
+
+                    upload.complete(waitingParts.awaitAll())
+                } catch (e: Throwable) {
+                    // NonCancellable because the common reason for getting here is that our scope was
+                    // cancelled — a request timeout, say. Aborting is itself a suspending call to the
+                    // store, so without this it would fail immediately and leave the parts orphaned.
+                    withContext(NonCancellable) {
+                        try {
+                            LOGGER.warn("Error caught in uploadMultipartBuffers - aborting multipart upload of $key")
+                            upload.abort()
+                        } catch (abortError: Throwable) {
+                            LOGGER.warn(abortError, "Throwable caught when aborting uploadMultipartBuffers")
+                            e.addSuppressed(abortError)
+                        }
+                    }
+                    throw e
                 }
-                throw e
             }
-        }
     }
 }

--- a/core/src/main/kotlin/xtdb/multipart/SupportsMultipart.kt
+++ b/core/src/main/kotlin/xtdb/multipart/SupportsMultipart.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import xtdb.api.storage.ObjectStore
 import xtdb.storage.RemoteBufferPool
+import xtdb.storage.withRequestTimeout
 import xtdb.util.logger
 import xtdb.util.warn
 import java.nio.ByteBuffer
@@ -28,24 +29,35 @@ interface SupportsMultipart<Part> : ObjectStore {
         private val multipartUploadDispatcher =
             IO.limitedParallelism(MAX_CONCURRENT_PART_UPLOADS, "upload-multipart")
 
+        // each round-trip to the store is bounded in its own right rather than the upload as a whole:
+        // a large file over a slow link can legitimately take a long time in aggregate, but no single
+        // part can, so a per-request bound can be generous enough to need no tuning.
         suspend fun <P> SupportsMultipart<P>.uploadMultipartBuffers(key: Path, nioBuffers: List<ByteBuffer>): Unit =
             coroutineScope {
-                val upload = startMultipart(key)
+                val upload = withRequestTimeout("startMultipart $key") { startMultipart(key) }
 
                 try {
                     val waitingParts = nioBuffers.mapIndexed { idx, it ->
-                        async(multipartUploadDispatcher) { upload.uploadPart(idx, it) }
+                        async(multipartUploadDispatcher) {
+                            withRequestTimeout("uploadPart $idx of $key") { upload.uploadPart(idx, it) }
+                        }
                     }
 
-                    upload.complete(waitingParts.awaitAll())
+                    // awaited outside the bound: parts run at most MAX_CONCURRENT_PART_UPLOADS at a
+                    // time, so waiting on all of them is an aggregate, and only `complete` is a request.
+                    val parts = waitingParts.awaitAll()
+
+                    withRequestTimeout("completeMultipart $key") { upload.complete(parts) }
                 } catch (e: Throwable) {
                     // NonCancellable because the common reason for getting here is that our scope was
                     // cancelled — a request timeout, say. Aborting is itself a suspending call to the
                     // store, so without this it would fail immediately and leave the parts orphaned.
+                    // It gets its own bound for the same reason: a store that hung the upload can hang
+                    // the abort, and NonCancellable means nothing else would ever unstick it.
                     withContext(NonCancellable) {
                         try {
                             LOGGER.warn("Error caught in uploadMultipartBuffers - aborting multipart upload of $key")
-                            upload.abort()
+                            withRequestTimeout("abortMultipart $key") { upload.abort() }
                         } catch (abortError: Throwable) {
                             LOGGER.warn(abortError, "Throwable caught when aborting uploadMultipartBuffers")
                             e.addSuppressed(abortError)

--- a/core/src/main/kotlin/xtdb/storage/BufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/BufferPool.kt
@@ -47,7 +47,16 @@ interface BufferPool : AutoCloseable {
 
     suspend fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch
 
-    fun putObject(key: Path, buffer: ByteBuffer)
+    /**
+     * Stores an object in the buffer pool.
+     *
+     * Suspends: for a remote pool this is a network write, and holding a dispatcher thread across it
+     * is what let one stalled upload take a node down (#5857). [putObjectSync] is the blocking bridge.
+     */
+    suspend fun putObject(key: Path, buffer: ByteBuffer)
+
+    /** For callers that aren't coroutine-native — see [putObject]. */
+    fun putObjectSync(key: Path, buffer: ByteBuffer) = runBlocking { putObject(key, buffer) }
 
     /**
      * Recursively lists all objects in the buffer pool
@@ -66,9 +75,15 @@ interface BufferPool : AutoCloseable {
     fun listAfter(dir: Path, afterKey: Path): Iterable<StoredObject> =
         listAllObjects(dir).filter { it.key > afterKey }
 
-    fun copyObject(src: Path, dest: Path)
+    suspend fun copyObject(src: Path, dest: Path)
 
-    fun deleteIfExists(key: Path)
+    /** For callers that aren't coroutine-native — see [copyObject]. */
+    fun copyObjectSync(src: Path, dest: Path) = runBlocking { copyObject(src, dest) }
+
+    suspend fun deleteIfExists(key: Path)
+
+    /** For callers that aren't coroutine-native — see [deleteIfExists]. */
+    fun deleteIfExistsSync(key: Path) = runBlocking { deleteIfExists(key) }
 
     fun openArrowWriter(key: Path, rel: Relation): ArrowWriter
 
@@ -81,11 +96,11 @@ interface BufferPool : AutoCloseable {
             override fun getByteArray(key: Path) = unsupported("getByteArray")
             override fun getFooter(key: Path) = unsupported("getFooter")
             override suspend fun getRecordBatch(key: Path, idx: Int) = unsupported("getRecordBatch")
-            override fun putObject(key: Path, buffer: ByteBuffer) = unsupported("putObject")
+            override suspend fun putObject(key: Path, buffer: ByteBuffer) = unsupported("putObject")
             override fun listAllObjects() = unsupported("listAllObjects")
             override fun listAllObjects(dir: Path) = unsupported("listAllObjects")
-            override fun copyObject(src: Path, dest: Path) = unsupported("copyObject")
-            override fun deleteIfExists(key: Path) = unsupported("deleteIfExists")
+            override suspend fun copyObject(src: Path, dest: Path) = unsupported("copyObject")
+            override suspend fun deleteIfExists(key: Path) = unsupported("deleteIfExists")
             override fun openArrowWriter(key: Path, rel: Relation) = unsupported("openArrowWriter")
 
             override fun close() = Unit
@@ -138,7 +153,7 @@ class ReadOnlyBufferPool(private val delegate: BufferPool) : BufferPool {
 
     override suspend fun getRecordBatch(key: Path, idx: Int): ArrowRecordBatch = delegate.getRecordBatch(key, idx)
 
-    override fun putObject(key: Path, buffer: ByteBuffer) {
+    override suspend fun putObject(key: Path, buffer: ByteBuffer) {
         throw Fault("Attempted write to read-only storage: $key")
     }
 
@@ -148,11 +163,11 @@ class ReadOnlyBufferPool(private val delegate: BufferPool) : BufferPool {
 
     override fun listAfter(dir: Path, afterKey: Path): Iterable<StoredObject> = delegate.listAfter(dir, afterKey)
 
-    override fun copyObject(src: Path, dest: Path) {
+    override suspend fun copyObject(src: Path, dest: Path) {
         throw Fault("Attempted copy in read-only storage: $src -> $dest")
     }
 
-    override fun deleteIfExists(key: Path) {
+    override suspend fun deleteIfExists(key: Path) {
         throw Fault("Attempted delete from read-only storage: $key")
     }
 

--- a/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
@@ -115,7 +115,7 @@ internal class LocalStorage(
         }
     }
 
-    override fun putObject(key: Path, buffer: ByteBuffer) {
+    override suspend fun putObject(key: Path, buffer: ByteBuffer) {
         try {
             val tmpPath = rootPath.createTempUploadFile()
             buffer.writeToPath(tmpPath)
@@ -136,14 +136,14 @@ internal class LocalStorage(
     override fun listAllObjects(): Iterable<StoredObject> = rootPath.listAll()
     override fun listAllObjects(dir: Path) = rootPath.resolve(dir).listAll()
 
-    override fun copyObject(src: Path, dest: Path) {
+    override suspend fun copyObject(src: Path, dest: Path) {
         Files.copy(
             rootPath.resolve(src).normalize(),
             rootPath.resolve(dest).normalize().also { it.createParentDirectories() }
         )
     }
 
-    override fun deleteIfExists(key: Path) {
+    override suspend fun deleteIfExists(key: Path) {
         rootPath.resolve(key).deleteIfExists()
     }
 

--- a/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/LocalStorage.kt
@@ -160,7 +160,7 @@ internal class LocalStorage(
                         }
                     }
 
-                    override fun end(): FileSize {
+                    override suspend fun end(): FileSize {
                         unloader.end()
                         fileChannel.close()
 

--- a/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
@@ -98,7 +98,7 @@ internal class MemoryStorage(
                         unloader.writePage()
                     }
 
-                    override fun end(): FileSize {
+                    override suspend fun end(): FileSize {
                         unloader.end()
                         writeChannel.close()
                         val bytes = baos.toByteArray()

--- a/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
+++ b/core/src/main/kotlin/xtdb/storage/MemoryStorage.kt
@@ -56,7 +56,7 @@ internal class MemoryStorage(
         }
     }
 
-    override fun putObject(key: Path, buffer: ByteBuffer) {
+    override suspend fun putObject(key: Path, buffer: ByteBuffer) {
         synchronized(memoryStore) {
             memoryStore.put(key, buffer.openArrowBufView(allocator))?.close()
         }
@@ -74,7 +74,7 @@ internal class MemoryStorage(
                 .map { StoredObject(it.key, it.value.capacity()) }
         }
 
-    override fun copyObject(src: Path, dest: Path) =
+    override suspend fun copyObject(src: Path, dest: Path) =
         throw Unsupported("copyObject unsupported on MemoryStorage")
 
     private fun deleteAllObjects() {
@@ -84,7 +84,7 @@ internal class MemoryStorage(
         }
     }
 
-    override fun deleteIfExists(key: Path): Unit =
+    override suspend fun deleteIfExists(key: Path): Unit =
         synchronized(memoryStore) {
             memoryStore.remove(key)?.also { it.close() }
         }

--- a/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
@@ -171,7 +171,7 @@ internal class RemoteBufferPool(
                     object : ArrowWriter {
                         override fun writePage() = unloader.writePage()
 
-                        override fun end(): FileSize {
+                        override suspend fun end(): FileSize {
                             unloader.end()
                             fileChannel.close()
 

--- a/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
@@ -2,8 +2,16 @@ package xtdb.storage
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
 import org.apache.arrow.memory.ArrowBuf
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.ipc.message.ArrowFooter
@@ -45,6 +53,8 @@ internal class RemoteBufferPool(
 ) : BufferPool, IEvictBufferTest, Closeable {
 
     private val allocator = allocator.openChildAllocator("buffer-pool")
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val arrowFooterCache = arrowFooterCache()
 
@@ -96,20 +106,25 @@ internal class RemoteBufferPool(
         }
     }
 
-    private fun ObjectStore.uploadArrowFile(key: Path, tmpPath: Path) {
+    private suspend fun ObjectStore.uploadArrowFile(key: Path, tmpPath: Path) {
         val mmapBuffer = toMmapPath(tmpPath)
 
         if (this !is SupportsMultipart<*> || mmapBuffer.remaining() <= minMultipartPartSize) {
-            putObject(key, mmapBuffer).get()
+            putObject(key, mmapBuffer)
         } else {
             mmapBuffer.openArrowBufView(allocator).use { uploadMultipartBuffers(key, it.toParts()) }
         }
     }
 
+    // The one place object-store I/O crosses back out of coroutines. `DiskCache.Fetch` is a
+    // future-returning functional interface, so a suspending read has to be bridged for it; every other
+    // path through here stays suspending end-to-end. Cancellation does not cross this boundary — a read
+    // abandoned here leaves its request running, unlike a write.
     private fun getObject(key: Path, tmpFile: Path) =
-        objectStore.getObject(key, tmpFile).thenApply { path ->
-            networkRead?.increment(path.fileSize().toDouble())
-            path
+        scope.future {
+            objectStore.getObject(key, tmpFile).also { path ->
+                networkRead?.increment(path.fileSize().toDouble())
+            }
         }
 
     override fun getByteArray(key: Path): ByteArray = runBlocking {
@@ -158,9 +173,9 @@ internal class RemoteBufferPool(
     override fun listAllObjects() = objectStore.listAllObjects()
     override fun listAllObjects(dir: Path) = objectStore.listAllObjects(dir)
     override fun listAfter(dir: Path, afterKey: Path) = objectStore.listAfter(dir, afterKey)
-    override fun copyObject(src: Path, dest: Path): Unit = objectStore.copyObject(src, dest).get()
+    override suspend fun copyObject(src: Path, dest: Path) = objectStore.copyObject(src, dest)
 
-    override fun deleteIfExists(key: Path): Unit = runBlocking { objectStore.deleteIfExists(key).await() }
+    override suspend fun deleteIfExists(key: Path) = objectStore.deleteIfExists(key)
 
     override fun openArrowWriter(key: Path, rel: Relation): ArrowWriter {
         val tmpPath = diskCache.createTempPath()
@@ -193,12 +208,13 @@ internal class RemoteBufferPool(
             }
     }
 
-    override fun putObject(key: Path, buffer: ByteBuffer) {
+    override suspend fun putObject(key: Path, buffer: ByteBuffer) {
         networkWrite?.increment(buffer.capacity().toDouble())
-        objectStore.putObject(key, buffer).get()
+        objectStore.putObject(key, buffer)
     }
 
     override fun close() {
+        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
         objectStore.close()
         allocator.close()
     }

--- a/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
+++ b/core/src/main/kotlin/xtdb/storage/RemoteBufferPool.kt
@@ -110,21 +110,22 @@ internal class RemoteBufferPool(
         val mmapBuffer = toMmapPath(tmpPath)
 
         if (this !is SupportsMultipart<*> || mmapBuffer.remaining() <= minMultipartPartSize) {
-            putObject(key, mmapBuffer)
+            withRequestTimeout("putObject $key") { putObject(key, mmapBuffer) }
         } else {
             mmapBuffer.openArrowBufView(allocator).use { uploadMultipartBuffers(key, it.toParts()) }
         }
     }
 
-    // The one place object-store I/O crosses back out of coroutines. `DiskCache.Fetch` is a
-    // future-returning functional interface, so a suspending read has to be bridged for it; every other
-    // path through here stays suspending end-to-end. Cancellation does not cross this boundary — a read
-    // abandoned here leaves its request running, unlike a write.
+    // The one place object-store I/O crosses back out of coroutines: `DiskCache.Fetch` is a
+    // future-returning functional interface, because the disk cache is a Caffeine `AsyncCache`.
+    //
+    // The timeout therefore has to go on the inside of the bridge. That's also the only correct place
+    // for it: the future is shared between every concurrent reader of the key, so a bound owned by one
+    // awaiter would tear down a fetch the others are still waiting on.
     private fun getObject(key: Path, tmpFile: Path) =
         scope.future {
-            objectStore.getObject(key, tmpFile).also { path ->
-                networkRead?.increment(path.fileSize().toDouble())
-            }
+            withRequestTimeout("getObject $key") { objectStore.getObject(key, tmpFile) }
+                .also { path -> networkRead?.increment(path.fileSize().toDouble()) }
         }
 
     override fun getByteArray(key: Path): ByteArray = runBlocking {
@@ -173,9 +174,11 @@ internal class RemoteBufferPool(
     override fun listAllObjects() = objectStore.listAllObjects()
     override fun listAllObjects(dir: Path) = objectStore.listAllObjects(dir)
     override fun listAfter(dir: Path, afterKey: Path) = objectStore.listAfter(dir, afterKey)
-    override suspend fun copyObject(src: Path, dest: Path) = objectStore.copyObject(src, dest)
+    override suspend fun copyObject(src: Path, dest: Path) =
+        withRequestTimeout("copyObject $src -> $dest") { objectStore.copyObject(src, dest) }
 
-    override suspend fun deleteIfExists(key: Path) = objectStore.deleteIfExists(key)
+    override suspend fun deleteIfExists(key: Path) =
+        withRequestTimeout("deleteIfExists $key") { objectStore.deleteIfExists(key) }
 
     override fun openArrowWriter(key: Path, rel: Relation): ArrowWriter {
         val tmpPath = diskCache.createTempPath()
@@ -210,7 +213,7 @@ internal class RemoteBufferPool(
 
     override suspend fun putObject(key: Path, buffer: ByteBuffer) {
         networkWrite?.increment(buffer.capacity().toDouble())
-        objectStore.putObject(key, buffer)
+        withRequestTimeout("putObject $key") { objectStore.putObject(key, buffer) }
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/storage/RequestTimeout.kt
+++ b/core/src/main/kotlin/xtdb/storage/RequestTimeout.kt
@@ -1,0 +1,39 @@
+package xtdb.storage
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import xtdb.api.error.Unavailable
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * The bound on a single object-store request.
+ *
+ * Generous by design, and deliberately not configurable: this is a watchdog on a client that has
+ * accepted a request it will never answer (#5850, #5218), not a latency budget. No healthy single
+ * request comes near it, and a value low enough to be worth tuning would start failing healthy
+ * flushes. `var` only so tests can shorten it.
+ */
+internal var requestTimeout: Duration = 10.minutes
+
+/**
+ * Runs [body] under [requestTimeout], reporting a breach as [Unavailable].
+ *
+ * The bound has to sit *inside* the coroutine that issues the request, so that a breach cancels the
+ * call and the client tears the request down. A bound applied from outside — `orTimeout` on a future,
+ * a timeout held by whoever is awaiting the result — only stops us waiting, and leaves the request
+ * running with nothing left to complete it.
+ *
+ * Rethrown as an ordinary exception because [TimeoutCancellationException] is a `CancellationException`,
+ * which the block-write path above here reads as "we're shutting down" and discards — the same silence
+ * this exists to break.
+ */
+internal suspend fun <T> withRequestTimeout(desc: String, body: suspend () -> T): T =
+    try {
+        withTimeout(requestTimeout) { body() }
+    } catch (e: TimeoutCancellationException) {
+        throw Unavailable(
+            "object store did not respond within $requestTimeout: $desc",
+            "xtdb/object-store-timeout", cause = e
+        )
+    }

--- a/core/src/main/kotlin/xtdb/trie/DataFileWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/DataFileWriter.kt
@@ -24,7 +24,7 @@ class DataFileWriter(
         dataRel.clear()
     }
 
-    fun end(): FileSize = dataFileWriter.end()
+    suspend fun end(): FileSize = dataFileWriter.end()
 
     override fun close() {
         dataFileWriter.close()

--- a/core/src/main/kotlin/xtdb/trie/LiveTrieWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/LiveTrieWriter.kt
@@ -9,7 +9,7 @@ class LiveTrieWriter(
     private val al: BufferAllocator, private val bp: BufferPool,
     private val calculateBlooms: Boolean
 ) {
-    fun writeLiveTrie(table: TableRef, trieKey: TrieKey, trie: MemoryHashTrie, dataRel: RelationReader): FileSize =
+    suspend fun writeLiveTrie(table: TableRef, trieKey: TrieKey, trie: MemoryHashTrie, dataRel: RelationReader): FileSize =
         DataFileWriter(al, bp, table, trieKey, dataRel.schema).use { dataFileWriter ->
             MetadataFileWriter(al, bp, table, trieKey, dataFileWriter.dataRel, calculateBlooms, false)
                 .use { metaFileWriter ->

--- a/core/src/main/kotlin/xtdb/trie/MetadataFileWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/MetadataFileWriter.kt
@@ -113,7 +113,7 @@ class MetadataFileWriter(
         return metaPos
     }
 
-    fun end(): TrieMetadata {
+    suspend fun end(): TrieMetadata {
         bp.openArrowWriter(table.metaFilePath(trieKey), metaRel)
             .use { metaFileWriter ->
                 metaFileWriter.writePage()

--- a/core/src/main/kotlin/xtdb/trie/PageTrieWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/PageTrieWriter.kt
@@ -49,7 +49,7 @@ class PageTrieWriter(
         }
     }
 
-    fun writePageTree(
+    suspend fun writePageTree(
         table: TableRef, trieKey: TrieKey,
         loader: Relation.Loader, pageTree: PageTree?,
         pageSize: Int

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -184,7 +184,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 tables = listOf(table),
                 secondaryDatabases = null
             )
-            sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+            sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             blockCatalog.refresh(block)
         }
 
@@ -242,7 +242,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 tables = listOf(table),
                 secondaryDatabases = null
             )
-            sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+            sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             blockCatalog.refresh(block)
         }
 
@@ -319,7 +319,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 tables = listOf(table),
                 secondaryDatabases = null
             )
-            sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+            sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             blockCatalog.refresh(block)
         }
 
@@ -390,7 +390,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     tables = listOf(table),
                     secondaryDatabases = null
                 )
-                sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+                sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.blockCatalog.refresh(block)
             }
         }
@@ -462,7 +462,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     tables = listOf(table),
                     secondaryDatabases = null
                 )
-                sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+                sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.blockCatalog.refresh(block)
             }
         }
@@ -557,7 +557,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 tables = listOf(table),
                 secondaryDatabases = null
             )
-            sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+            sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             blockCatalog.refresh(block)
         }
 
@@ -608,7 +608,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     tables = listOf(table),
                     secondaryDatabases = null
                 )
-                sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+                sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.blockCatalog.refresh(block)
             }
         }
@@ -698,7 +698,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     tables = listOf(table),
                     secondaryDatabases = null
                 )
-                sharedBufferPool.putObject(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
+                sharedBufferPool.putObjectSync(BlockCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.blockCatalog.refresh(block)
             }
         }

--- a/core/src/test/kotlin/xtdb/SimulationTestUtils.kt
+++ b/core/src/test/kotlin/xtdb/SimulationTestUtils.kt
@@ -25,8 +25,8 @@ class SimulationTestUtils {
         fun addTriesToBufferPool(bufferPool: BufferPool, tableRef: TableRef, tries: List<TrieDetails>) {
             tries.forEach { trie ->
                 val trieKey = trie.trieKey
-                bufferPool.putObject(tableRef.dataFilePath(trieKey), ByteBuffer.allocate(1))
-                bufferPool.putObject(tableRef.metaFilePath(trieKey), ByteBuffer.allocate(1))
+                bufferPool.putObjectSync(tableRef.dataFilePath(trieKey), ByteBuffer.allocate(1))
+                bufferPool.putObjectSync(tableRef.metaFilePath(trieKey), ByteBuffer.allocate(1))
             }
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -100,7 +100,10 @@ class LeaderDriverSimTest : SimulationTestBase() {
         val tableCatalog = TableCatalog(bufferPool)
         val trieCatalog = createTrieCatalog()
         val liveIndex =
-            LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, IndexerConfig(rowsPerBlock = rowsPerBlock))
+            LiveIndex.open(
+                allocator, blockCatalog, tableCatalog, trieCatalog,
+                IndexerConfig(rowsPerBlock = rowsPerBlock), ioDispatcher = dispatcher
+            )
 
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -1,5 +1,7 @@
 package xtdb.indexer
 
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -158,7 +160,7 @@ class LeaderLogProcessorTest {
     fun `FlushBlock triggers block finish when CAS matches`() = runTest(timeout = 5.seconds) {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val liveIndex = liveIndexMock {
-            every { finishBlock(any(), any()) } returns emptyMap()
+            coEvery { finishBlock(any(), any()) } returns emptyMap()
             every { latestCompletedTx } returns null
         }
         val trieCatalog = mockk<TrieCatalog>(relaxed = true) {
@@ -194,7 +196,7 @@ class LeaderLogProcessorTest {
         ))
         watchers.awaitSource(0)
 
-        verify { liveIndex.finishBlock(any(), eq(0)) }
+        coVerify { liveIndex.finishBlock(any(), eq(0)) }
         verify { liveIndex.nextBlock() }
         verify { compactor.signalBlock() }
         assertTrue(replicaLog.latestSubmittedOffset() >= 0, "replica log should have block messages")
@@ -212,7 +214,7 @@ class LeaderLogProcessorTest {
         ))
         watchers.awaitSource(0)
 
-        verify(exactly = 0) { liveIndex.finishBlock(any(), any()) }
+        coVerify(exactly = 0) { liveIndex.finishBlock(any(), any()) }
     }
 
     @Test
@@ -229,7 +231,7 @@ class LeaderLogProcessorTest {
         val tableRef = fromSchemaAndTable("public/foo")
 
         val liveIndex = liveIndexMock {
-            every { finishBlock(any(), any()) } returns mapOf(tableRef to finishedBlock)
+            coEvery { finishBlock(any(), any()) } returns mapOf(tableRef to finishedBlock)
             every { latestCompletedTx } returns null
         }
         val trieCatalog = mockk<TrieCatalog>(relaxed = true) {
@@ -602,7 +604,7 @@ class LeaderLogProcessorTest {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
 
         val liveIndex = liveIndexMock {
-            every { finishBlock(any(), any()) } returns emptyMap()
+            coEvery { finishBlock(any(), any()) } returns emptyMap()
             every { latestCompletedTx } returns null
         }
         val trieCatalog = mockk<TrieCatalog>(relaxed = true) {

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -3,6 +3,7 @@
 package xtdb.indexer
 
 import clojure.lang.Keyword
+import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -277,7 +278,7 @@ class LiveIndexTest {
 
             assertNotNull(db.liveIndex.table(table))
 
-            db.liveIndex.finishBlock(db.bp, 0L)
+            runBlocking { db.liveIndex.finishBlock(db.bp, 0L) }
             db.liveIndex.nextBlock()
 
             assertNull(db.liveIndex.table(table))
@@ -299,7 +300,7 @@ class LiveIndexTest {
 
             db.liveIndex.openSnapshot(Instant.parse("2000-01-01T00:00:00Z")).use { snap ->
                 val before = snap.table(table).single().relation.rowCount
-                db.liveIndex.finishBlock(db.bp, 0L)
+                runBlocking { db.liveIndex.finishBlock(db.bp, 0L) }
                 assertEquals(before, snap.table(table).single().relation.rowCount)
                 assertEquals(1, before)
             }
@@ -328,7 +329,7 @@ class LiveIndexTest {
                 }
 
                 // drive the BlockUploader flow up to (but not including) nextBlock
-                for ((t, fb) in db.liveIndex.finishBlock(db.bp, 0L)) {
+                for ((t, fb) in runBlocking { db.liveIndex.finishBlock(db.bp, 0L) }) {
                     val trieDetails = TrieDetails.newBuilder()
                         .setTableName(t.schemaAndTable)
                         .setTrieKey(fb.trieKey)

--- a/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -175,7 +176,7 @@ class LiveTableTest {
                     TableSnapshot.open(allocator, liveTable).use { snap ->
                         val before = snap.snapData()
 
-                        liveTable.finishBlock(bp, 0L)
+                        runBlocking { liveTable.finishBlock(bp, 0L) }
 
                         val after = snap.snapData()
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -162,7 +162,8 @@ class LogProcessorSimTest : SimulationTestBase() {
         val blockCatalog = BlockCatalog(null)
         val tableCatalog = TableCatalog(bp)
         val trieCatalog = createTrieCatalog()
-        val liveIndex = LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, indexerConfig)
+        val liveIndex =
+            LiveIndex.open(allocator, blockCatalog, tableCatalog, trieCatalog, indexerConfig, ioDispatcher = dispatcher)
 
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
 

--- a/core/src/test/kotlin/xtdb/storage/LocalStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/LocalStorageTest.kt
@@ -54,8 +54,8 @@ class LocalStorageTest : PartitionedStorageTest() {
     fun `partitioned pools nest under a parts-N marker on disk`() {
         openPartitionedStorage(0, 2).use { p0 ->
             openPartitionedStorage(1, 2).use { p1 ->
-                p0.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(3)))
-                p1.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(7)))
+                p0.putObjectSync("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(3)))
+                p1.putObjectSync("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(7)))
             }
         }
 
@@ -67,7 +67,7 @@ class LocalStorageTest : PartitionedStorageTest() {
     @Test
     fun `single-partition pool keeps the unmarked on-disk layout`() {
         openPartitionedStorage(0, 1).use { bp ->
-            bp.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
+            bp.putObjectSync("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
         }
 
         assertTrue(
@@ -85,10 +85,10 @@ class LocalStorageTest : PartitionedStorageTest() {
         val outsidePath = "../outside/external-copy.txt".asPath
         
         // Put original object
-        localStorage.putObject(srcPath, ByteBuffer.wrap(testData))
+        localStorage.putObjectSync(srcPath, ByteBuffer.wrap(testData))
         
         // Test copying within root directory
-        localStorage.copyObject(srcPath, destPath)
+        localStorage.copyObjectSync(srcPath, destPath)
         
         // Verify both files exist on disk
         val rootPath = localStorage.rootPath
@@ -105,7 +105,7 @@ class LocalStorageTest : PartitionedStorageTest() {
         assertEquals(testData.contentToString(), destContent.contentToString())
         
         // Test copying outside root directory (using .. to go up)
-        localStorage.copyObject(srcPath, outsidePath)
+        localStorage.copyObjectSync(srcPath, outsidePath)
         
         // Verify the file exists outside root
         val outsideFile = rootPath.resolve(outsidePath).normalize()

--- a/core/src/test/kotlin/xtdb/storage/PartitionedStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/PartitionedStorageTest.kt
@@ -41,7 +41,7 @@ abstract class PartitionedStorageTest : StorageTest() {
                 assertEquals(1L, p1.latestAvailableBlockIndex(), "block discovery is per-partition")
 
                 // delete is GC's primitive — a partition's GC must never touch a sibling's files
-                p0.deleteIfExists("blocks/b${0L.asLexHex}.binpb".asPath)
+                p0.deleteIfExistsSync("blocks/b${0L.asLexHex}.binpb".asPath)
 
                 assertEquals(emptyList<StoredObject>(), p0.listAllObjects().toList())
                 assertEquals(2, p1.listAllObjects().count(), "partition 1 unaffected by partition 0's delete")

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -85,8 +85,8 @@ class RemoteStorageTest : PartitionedStorageTest() {
     fun `partitioned pools scope object keys under parts-N`() {
         openPartitionedStorage(0, 2).use { p0 ->
             openPartitionedStorage(1, 2).use { p1 ->
-                p0.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(3)))
-                p1.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(7)))
+                p0.putObjectSync("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(3)))
+                p1.putObjectSync("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(7)))
             }
         }
 
@@ -104,7 +104,7 @@ class RemoteStorageTest : PartitionedStorageTest() {
     @Test
     fun `single-partition pool keeps the unmarked key-space`() {
         openPartitionedStorage(0, 1).use { bp ->
-            bp.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
+            bp.putObjectSync("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
         }
 
         assertEquals(
@@ -126,8 +126,8 @@ class RemoteStorageTest : PartitionedStorageTest() {
         openPartitionedStorage(0, 2).use { p0 ->
             openPartitionedStorage(1, 2).use { p1 ->
                 val key = "blocks/b00.binpb".asPath
-                p0.putObject(key, ByteBuffer.wrap(ByteArray(3)))
-                p1.putObject(key, ByteBuffer.wrap(ByteArray(7)))
+                p0.putObjectSync(key, ByteBuffer.wrap(ByteArray(3)))
+                p1.putObjectSync(key, ByteBuffer.wrap(ByteArray(7)))
 
                 // p0 reads first, seeding the shared cache under this key
                 assertEquals(3, p0.getByteArray(key).size, "partition 0 reads its own bytes")

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -144,7 +144,7 @@ class RemoteStorageTest : PartitionedStorageTest() {
                 val v = relation["a"]
                 for (i in 0 until 10) v.writeInt(i)
                 writer.writePage()
-                writer.end()
+                writer.endSync()
             }
         }
 
@@ -184,7 +184,7 @@ class RemoteStorageTest : PartitionedStorageTest() {
                 val v = relation["a"]
                 for (i in 0 until 10) v.writeInt(i)
                 writer.writePage()
-                writer.end()
+                writer.endSync()
             }
         }
 
@@ -199,7 +199,7 @@ class RemoteStorageTest : PartitionedStorageTest() {
                     val v = relation["a"]
                     for (i in 0 until 10) v.writeInt(i)
                     writer.writePage()
-                    writer.end()
+                    writer.endSync()
                     throw Exception("Test exception")
                 }
             }

--- a/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/RemoteStorageTest.kt
@@ -4,19 +4,26 @@ import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
+import java.util.concurrent.TimeUnit.SECONDS
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
+import xtdb.api.error.Unavailable
 import xtdb.api.storage.InMemoryBucket
 import xtdb.api.storage.ObjectStore
 import xtdb.api.storage.PrefixedObjectStore
 import xtdb.api.storage.Storage
 import xtdb.api.storage.Storage.remote
+import xtdb.api.storage.StoreOperation.ABORT
 import xtdb.api.storage.StoreOperation.COMPLETE
 import xtdb.api.storage.StoreOperation.UPLOAD
 import xtdb.arrow.Relation
@@ -30,6 +37,7 @@ import xtdb.util.asPath
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import kotlin.io.path.listDirectoryEntries
+import kotlin.time.Duration.Companion.milliseconds
 import com.google.protobuf.Any as ProtoAny
 
 @ExtendWith(AllocatorResolver::class)
@@ -171,6 +179,56 @@ class RemoteStorageTest : PartitionedStorageTest() {
             val rel = Relation.fromRecordBatch(al, footer.schema, rb)
             rel.close()
         }
+    }
+
+    /**
+     * The bound asserted here is the production [requestTimeout]: everything stays on the test
+     * dispatcher, so runTest's virtual clock skips it for free and there's nothing to rig. That also
+     * makes runTest's own timeout the hang-protection — a regression cancels cleanly and fails the test.
+     */
+    @Test
+    fun `a write to a store that never answers fails rather than hanging`() = runTest {
+        val stall = InMemoryBucket.Stall().also { xtdbBucket.stall = it }
+
+        assertInstanceOf(
+            Unavailable::class.java,
+            runCatching {
+                remoteBufferPool.putObject("blocks/b00.binpb".asPath, ByteBuffer.wrap(ByteArray(10)))
+            }.exceptionOrNull(),
+            "the write failed rather than hanging"
+        )
+
+        assertTrue(stall.cancelled.isCompleted, "the stalled request was cancelled, not merely abandoned")
+    }
+
+    /**
+     * No runTest here: parts upload on a real dispatcher, outside the test scheduler, so the bound is
+     * real-clock and has to be shortened by hand. SEPARATE_THREAD because a regression would then wedge
+     * the run rather than fail it, and the default thread mode only checks the clock after the fact.
+     */
+    @Test
+    @Timeout(value = 30, unit = SECONDS, threadMode = SEPARATE_THREAD)
+    fun `a stalled part upload aborts the multipart upload`(al: BufferAllocator) {
+        val stall = InMemoryBucket.Stall().also { xtdbBucket.stall = it }
+
+        val prevTimeout = requestTimeout
+        requestTimeout = 100.milliseconds
+
+        try {
+            Relation(al, "a" ofType I32).use { relation ->
+                remoteBufferPool.openArrowWriter(Path.of("aw"), relation).use { writer ->
+                    val v = relation["a"]
+                    for (i in 0 until 10) v.writeInt(i)
+                    writer.writePage()
+                    assertThrows(Unavailable::class.java) { writer.endSync() }
+                }
+            }
+        } finally {
+            requestTimeout = prevTimeout
+        }
+
+        assertTrue(stall.cancelled.isCompleted, "the stalled part upload was cancelled")
+        assertEquals(listOf(ABORT), xtdbBucket.calls, "the parts were aborted rather than left orphaned")
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/storage/StorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/StorageTest.kt
@@ -29,9 +29,9 @@ abstract class StorageTest {
     @Test
     fun listObjectTests_3545() {
         val storage = storage().apply {
-            putObject("a/b/c".asPath, ByteBuffer.wrap(ByteArray(10)))
-            putObject("a/b/d".asPath, ByteBuffer.wrap(ByteArray(10)))
-            putObject("a/e".asPath, ByteBuffer.wrap(ByteArray(10)))
+            putObjectSync("a/b/c".asPath, ByteBuffer.wrap(ByteArray(10)))
+            putObjectSync("a/b/d".asPath, ByteBuffer.wrap(ByteArray(10)))
+            putObjectSync("a/e".asPath, ByteBuffer.wrap(ByteArray(10)))
         }
 
         Thread.sleep(100)
@@ -49,7 +49,7 @@ abstract class StorageTest {
     }
 
     protected fun BufferPool.writeBlock(blockIndex: Long, size: Int = 10) {
-        putObject("blocks/b${blockIndex.asLexHex}.binpb".asPath, ByteBuffer.wrap(ByteArray(size)))
+        putObjectSync("blocks/b${blockIndex.asLexHex}.binpb".asPath, ByteBuffer.wrap(ByteArray(size)))
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/storage/StorageTest.kt
+++ b/core/src/test/kotlin/xtdb/storage/StorageTest.kt
@@ -99,7 +99,7 @@ abstract class StorageTest {
                 val relation = Relation(al, listOf(fooVec), fooVec.valueCount)
                 bp.openArrowWriter("foo".asPath, relation).use { writer ->
                     writer.writePage()
-                    assertEquals(526, writer.end())
+                    assertEquals(526, writer.endSync())
                 }
             }
         }

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -5,7 +5,6 @@ package xtdb.aws
 import com.google.protobuf.Any as ProtoAny
 import kotlinx.coroutines.*
 import kotlinx.coroutines.future.await
-import kotlinx.coroutines.future.future
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -38,10 +37,8 @@ import xtdb.util.asPath
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file.Path
-import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Used to set configuration options for an S3 Object Store, which can be used as implementation of objectStore within a [xtdb.api.storage.Storage.RemoteStorageFactory].
@@ -73,10 +70,7 @@ class S3(
     coroutineContext: CoroutineContext = Dispatchers.IO
 ) : ObjectStore, SupportsMultipart<CompletedPart> {
 
-    private val scope = CoroutineScope(SupervisorJob() + coroutineContext)
-
     override fun close() {
-        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
         client.close()
     }
 
@@ -88,7 +82,7 @@ class S3(
             // (couldn't achive this effect by S3 client configuration)
             .let(AsyncRequestBody::fromPublisher)
 
-    override fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<CompletedPart>> = scope.future {
+    override suspend fun startMultipart(k: Path): IMultipartUpload<CompletedPart> {
         val s3Key = prefix.resolve(k).toString()
         val initResp = client.createMultipartUpload {
             it.bucket(bucket)
@@ -97,7 +91,7 @@ class S3(
 
         val uploadId = initResp.uploadId()
 
-        object : IMultipartUpload<CompletedPart> {
+        return object : IMultipartUpload<CompletedPart> {
             fun S3AsyncClient.uploadPart(body: AsyncRequestBody, configure: Consumer<UploadPartRequest.Builder>) =
                 uploadPart(configure, body)
 
@@ -105,26 +99,25 @@ class S3(
              * part-numbers have to be in ascending order, so we increment the counter synchronously.
              * caller therefore needs to call this method in order.
              */
-            override fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<CompletedPart> =
-                scope.future {
-                    val contentLength = buf.remaining().toLong()
-                    val partNum = idx + 1
+            override suspend fun uploadPart(idx: Int, buf: ByteBuffer): CompletedPart {
+                val contentLength = buf.remaining().toLong()
+                val partNum = idx + 1
 
-                    val partResp = client.uploadPart(efficientAsyncRequestBody(buf)) {
-                        it.bucket(bucket)
-                        it.key(s3Key)
-                        it.uploadId(uploadId)
-                        it.partNumber(partNum)
-                        it.contentLength(contentLength)
-                    }.await()
+                val partResp = client.uploadPart(efficientAsyncRequestBody(buf)) {
+                    it.bucket(bucket)
+                    it.key(s3Key)
+                    it.uploadId(uploadId)
+                    it.partNumber(partNum)
+                    it.contentLength(contentLength)
+                }.await()
 
-                    CompletedPart.builder().apply {
-                        partNumber(partNum)
-                        eTag(partResp.eTag())
-                    }.build()
-                }
+                return CompletedPart.builder().apply {
+                    partNumber(partNum)
+                    eTag(partResp.eTag())
+                }.build()
+            }
 
-            override fun complete(parts: List<CompletedPart>) = scope.future {
+            override suspend fun complete(parts: List<CompletedPart>) {
                 client.completeMultipartUpload { req ->
                     req.bucket(bucket)
                     req.key(s3Key)
@@ -135,7 +128,7 @@ class S3(
                 Unit
             }
 
-            override fun abort() = scope.future {
+            override suspend fun abort() {
                 client.abortMultipartUpload {
                     it.bucket(bucket)
                     it.key(s3Key)
@@ -161,41 +154,39 @@ class S3(
                 if (it is NoSuchKeyException || it.cause is NoSuchKeyException) throwMissingKey(k) else throw it
             }
 
-    override fun getObject(k: Path) = scope.future {
+    override suspend fun getObject(k: Path): ByteBuffer =
         getObject(k, AsyncResponseTransformer.toBytes()).await().asByteBuffer()
-    }
 
-    override fun getObject(k: Path, outPath: Path) = scope.future {
+    override suspend fun getObject(k: Path, outPath: Path): Path {
         getObject(k, AsyncResponseTransformer.toFile(outPath, FileTransformerConfiguration.defaultCreateOrReplaceExisting())).await()
-        outPath
+        return outPath
     }
 
     private fun S3AsyncClient.putObject(body: AsyncRequestBody, configure: Consumer<PutObjectRequest.Builder>) =
         putObject(configure, body)
 
-    override fun putObject(k: Path, buf: ByteBuffer) =
-        scope.future {
-            val s3Key = prefix.resolve(k).toString()
-            val headResp = runCatching {
-                client.headObject {
-                    it.bucket(bucket)
-                    it.key(s3Key)
-                    configurator.configureHead(it)
-                }.await()
-            }.exceptionOrNull()
-
-            if (headResp == null) return@future
-            if (headResp !is NoSuchKeyException && headResp.cause !is NoSuchKeyException) throw headResp
-
-            val contentLength = buf.remaining().toLong()
-
-            client.putObject(efficientAsyncRequestBody(buf)) {
+    override suspend fun putObject(k: Path, buf: ByteBuffer) {
+        val s3Key = prefix.resolve(k).toString()
+        val headResp = runCatching {
+            client.headObject {
                 it.bucket(bucket)
                 it.key(s3Key)
-                it.contentLength(contentLength)
-                configurator.configurePut(it)
+                configurator.configureHead(it)
             }.await()
-        }
+        }.exceptionOrNull()
+
+        if (headResp == null) return
+        if (headResp !is NoSuchKeyException && headResp.cause !is NoSuchKeyException) throw headResp
+
+        val contentLength = buf.remaining().toLong()
+
+        client.putObject(efficientAsyncRequestBody(buf)) {
+            it.bucket(bucket)
+            it.key(s3Key)
+            it.contentLength(contentLength)
+            configurator.configurePut(it)
+        }.await()
+    }
 
     private fun listAllObjects0(listPrefix: Path) =
         sequence {
@@ -244,7 +235,7 @@ class S3(
     override fun listAfter(dir: Path, afterKey: Path) =
         listAfter0(prefix.resolve(dir).normalize(), afterKey)
 
-    override fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> = scope.future {
+    override suspend fun copyObject(src: Path, dest: Path) {
         client.copyObject {
             it.sourceBucket(bucket)
             it.sourceKey(prefix.resolve(src).normalize().toString())
@@ -264,7 +255,7 @@ class S3(
             .toSet()
     }
 
-    override fun deleteIfExists(k: Path) = scope.future<Unit> {
+    override suspend fun deleteIfExists(k: Path) {
         client.deleteObject {
             it.bucket(bucket)
             it.key(prefix.resolve(k).toString())

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -11,7 +11,6 @@ import com.azure.storage.blob.models.BlobStorageException
 import com.azure.storage.blob.models.ListBlobsOptions
 import com.azure.storage.common.StorageSharedKeyCredential
 import kotlinx.coroutines.*
-import kotlinx.coroutines.future.future
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -41,11 +40,8 @@ import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Path
 import java.util.*
 import java.util.UUID.randomUUID
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletableFuture.completedFuture
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.path.deleteIfExists
-import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
 /**
@@ -78,7 +74,9 @@ class BlobStorage(
     private val prefix: Path,
     private val connectionString: String?,
     private val storageAccountKey: String?,
-    coroutineContext: CoroutineContext = Dispatchers.IO
+    // these SDK calls are synchronous, so each operation holds a thread for its duration -
+    // this is the dispatcher that thread comes from.
+    private val ioContext: CoroutineContext = Dispatchers.IO
 ) : ObjectStore, SupportsMultipart<String> {
 
     private val client =
@@ -104,12 +102,10 @@ class BlobStorage(
             buildClient()
         }.getBlobContainerClient(factory.container).also { it.createIfNotExists() }
 
-    private val scope = CoroutineScope(SupervisorJob() + coroutineContext)
-
-    override fun getObject(k: Path) = scope.future {
+    override suspend fun getObject(k: Path): ByteBuffer =
         try {
             unwrappingReactorException {
-                runInterruptible {
+                runInterruptible(ioContext) {
                     client.getBlobClient(prefix.resolve(k).toString())
                         .downloadContent()
                         .toByteBuffer()
@@ -126,26 +122,25 @@ class BlobStorage(
             LOGGER.log(WARNING, "Exception thrown when getting object $k", e)
             throw e
         }
-    }
 
-    override fun getObject(k: Path, outPath: Path) = scope.future {
+    override suspend fun getObject(k: Path, outPath: Path): Path {
         try {
             outPath.deleteIfExists()
             unwrappingReactorException {
-                runInterruptible {
+                runInterruptible(ioContext) {
                     client.getBlobClient(prefix.resolve(k).toString())
                         .downloadToFile(outPath.toString())
                 }
             }
 
-            outPath
+            return outPath
         } catch (e: UncheckedIOException) {
             if (e.cause !is FileAlreadyExistsException) {
                 LOGGER.log(WARNING, "Exception thrown when getting object $k", e)
                 throw e
             }
 
-            return@future outPath
+            return outPath
         } catch (e: BlobStorageException) {
             if (e.statusCode == 404) throwMissingKey(k)
 
@@ -159,20 +154,20 @@ class BlobStorage(
         }
     }
 
-    override fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<String>> = scope.future {
+    override suspend fun startMultipart(k: Path): IMultipartUpload<String> {
         val prefixedKey = prefix.resolve(k).toString()
         val blockBlobClient = client.getBlobClient(prefixedKey).blockBlobClient
 
-        object : IMultipartUpload<String> {
+        return object : IMultipartUpload<String> {
 
             private val b64 = Base64.getEncoder()
             private val newBlockId get() = randomUUID().asBytes.let { b64.encodeToString(it) }
 
-            override fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<String> = scope.future {
-                try {
+            override suspend fun uploadPart(idx: Int, buf: ByteBuffer): String {
+                return try {
                     unwrappingReactorException {
                         val blockId = newBlockId
-                        runInterruptible { blockBlobClient.stageBlock(blockId, BinaryData.fromByteBuffer(buf)) }
+                        runInterruptible(ioContext) { blockBlobClient.stageBlock(blockId, BinaryData.fromByteBuffer(buf)) }
                         blockId
                     }
                 } catch (e: InterruptedException) {
@@ -183,10 +178,10 @@ class BlobStorage(
                 }
             }
 
-            override fun complete(parts: List<String>) = scope.future<Unit> {
+            override suspend fun complete(parts: List<String>) {
                 try {
                     unwrappingReactorException {
-                        runInterruptible { blockBlobClient.commitBlockList(parts) }
+                        runInterruptible(ioContext) { blockBlobClient.commitBlockList(parts) }
                     }
                 } catch (e: BlobStorageException) {
                     if (e.statusCode == 409)
@@ -203,12 +198,12 @@ class BlobStorage(
                 }
             }
 
-            override fun abort() = completedFuture(Unit)
+            override suspend fun abort() {}
         }
     }
 
-    override fun putObject(k: Path, buf: ByteBuffer) = scope.future {
-        runInterruptible {
+    override suspend fun putObject(k: Path, buf: ByteBuffer) {
+        runInterruptible(ioContext) {
             val prefixedKey = prefix.resolve(k).toString()
             try {
                 unwrappingReactorException {
@@ -269,10 +264,10 @@ class BlobStorage(
             .asIterable()
     }
 
-    override fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> = scope.future {
+    override suspend fun copyObject(src: Path, dest: Path) {
         try {
             unwrappingReactorException {
-                runInterruptible {
+                runInterruptible(ioContext) {
                     val srcBlobClient = client.getBlobClient(prefix.resolve(src).normalize().toString())
                     val destBlobClient = client.getBlobClient(prefix.resolve(dest).normalize().toString())
                     destBlobClient.copyFromUrl(srcBlobClient.blobUrl)
@@ -286,10 +281,10 @@ class BlobStorage(
         }
     }
 
-    override fun deleteIfExists(k: Path): CompletableFuture<Unit> = scope.future<Unit> {
+    override suspend fun deleteIfExists(k: Path) {
         val prefixedKey = prefix.resolve(k).toString()
 
-        runInterruptible {
+        runInterruptible(ioContext) {
             try {
                 unwrappingReactorException {
                     client.getBlobClient(prefixedKey).deleteIfExists()
@@ -301,10 +296,6 @@ class BlobStorage(
                 throw e
             }
         }
-    }
-
-    override fun close() {
-        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
     }
 
     companion object {

--- a/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
+++ b/modules/azure/src/main/kotlin/xtdb/azure/BlobStorage.kt
@@ -44,6 +44,10 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.io.path.deleteIfExists
 import com.google.protobuf.Any as ProtoAny
 
+// elastic, unlike a `Dispatchers.Default` view: it draws on an unbounded pool rather than IO's own
+// permits, so a stalled store can't starve them. 64 matches IO's default width.
+private val defaultIoDispatcher = Dispatchers.IO.limitedParallelism(64, "azure-blob")
+
 /**
  * Used to set configuration options for Azure Blob Storage, which can be used as implementation of an [object store][xtdb.api.storage.Storage.RemoteStorageFactory.objectStore].
  *
@@ -74,9 +78,8 @@ class BlobStorage(
     private val prefix: Path,
     private val connectionString: String?,
     private val storageAccountKey: String?,
-    // these SDK calls are synchronous, so each operation holds a thread for its duration -
-    // this is the dispatcher that thread comes from.
-    private val ioContext: CoroutineContext = Dispatchers.IO
+    // the SDK is synchronous - each operation holds a thread from here for its duration.
+    private val ioContext: CoroutineContext = defaultIoDispatcher
 ) : ObjectStore, SupportsMultipart<String> {
 
     private val client =
@@ -334,7 +337,7 @@ class BlobStorage(
         var userManagedIdentityClientId: String? = null,
         var storageAccountEndpoint: String? = null,
         var remote: RemoteAlias? = null,
-        @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.IO
+        @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = defaultIoDispatcher
     ) : ObjectStore.Factory {
 
         fun prefix(prefix: Path) = apply { this.prefix = prefix }

--- a/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
+++ b/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
@@ -9,7 +9,6 @@ import com.google.cloud.storage.Storage.BlobListOption
 import com.google.cloud.storage.StorageException
 import com.google.cloud.storage.StorageOptions
 import kotlinx.coroutines.*
-import kotlinx.coroutines.future.future
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -26,9 +25,7 @@ import xtdb.gcp.proto.gcsObjectStoreConfig
 import xtdb.util.asPath
 import java.nio.ByteBuffer
 import java.nio.file.Path
-import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
 /**
@@ -58,15 +55,15 @@ class CloudStorage(
     private val projectId: String,
     private val bucket: String,
     private val prefix: Path,
-    coroutineContext: CoroutineContext = Dispatchers.IO
+    // these SDK calls are synchronous, so each operation holds a thread for its duration -
+    // this is the dispatcher that thread comes from.
+    private val ioContext: CoroutineContext = Dispatchers.IO
 ) : ObjectStore {
 
     private val client = StorageOptions.newBuilder().run { setProjectId(projectId); build() }.service
 
-    private val scope = CoroutineScope(SupervisorJob() + coroutineContext)
-
-    override fun getObject(k: Path) = scope.future {
-        runInterruptible {
+    override suspend fun getObject(k: Path): ByteBuffer =
+        runInterruptible(ioContext) {
             val prefixedKey = prefix.resolve(k).toString()
 
             try {
@@ -82,10 +79,9 @@ class CloudStorage(
                 )
             }
         }
-    }
 
-    override fun putObject(k: Path, buf: ByteBuffer) = scope.future {
-        runInterruptible {
+    override suspend fun putObject(k: Path, buf: ByteBuffer) {
+        runInterruptible(ioContext) {
             val resolvedPath = prefix.resolve(k).toString()
             try {
                 client.writer(BlobInfo.newBuilder(bucket, resolvedPath).build(), Storage.BlobWriteOption.doesNotExist())
@@ -104,8 +100,8 @@ class CloudStorage(
         }
     }
 
-    override fun deleteIfExists(k: Path) = scope.future<Unit> {
-        runInterruptible {
+    override suspend fun deleteIfExists(k: Path) {
+        runInterruptible(ioContext) {
             client.delete(bucket, prefix.resolve(k).toString())
         }
     }
@@ -127,8 +123,8 @@ class CloudStorage(
             .filter { it.key > afterKey }
     }
 
-    override fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> = scope.future {
-        runInterruptible {
+    override suspend fun copyObject(src: Path, dest: Path) {
+        runInterruptible(ioContext) {
             val srcKey = prefix.resolve(src).normalize().toString()
             val destKey = prefix.resolve(dest).normalize().toString()
             
@@ -151,7 +147,6 @@ class CloudStorage(
     }
 
     override fun close() {
-        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
         client.close()
     }
 

--- a/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
+++ b/modules/google-cloud/src/main/kotlin/xtdb/gcp/CloudStorage.kt
@@ -28,6 +28,10 @@ import java.nio.file.Path
 import kotlin.coroutines.CoroutineContext
 import com.google.protobuf.Any as ProtoAny
 
+// elastic, unlike a `Dispatchers.Default` view: it draws on an unbounded pool rather than IO's own
+// permits, so a stalled bucket can't starve them. 64 matches IO's default width.
+private val defaultIoDispatcher = Dispatchers.IO.limitedParallelism(64, "gcs")
+
 /**
  * Used to set configuration options for a Google Cloud Storage Object Store, which can be used as implementation of an [object store][xtdb.api.storage.Storage.RemoteStorageFactory.objectStore].
  *
@@ -55,9 +59,8 @@ class CloudStorage(
     private val projectId: String,
     private val bucket: String,
     private val prefix: Path,
-    // these SDK calls are synchronous, so each operation holds a thread for its duration -
-    // this is the dispatcher that thread comes from.
-    private val ioContext: CoroutineContext = Dispatchers.IO
+    // the SDK is synchronous - each operation holds a thread from here for its duration.
+    private val ioContext: CoroutineContext = defaultIoDispatcher
 ) : ObjectStore {
 
     private val client = StorageOptions.newBuilder().run { setProjectId(projectId); build() }.service
@@ -172,7 +175,7 @@ class CloudStorage(
         val projectId: String,
         val bucket: String,
         var prefix: Path? = null,
-        @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.IO
+        @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = defaultIoDispatcher
     ) : ObjectStore.Factory {
 
         fun prefix(prefix: Path) = apply { this.prefix = prefix }

--- a/src/test/clojure/xtdb/aws/minio_test.clj
+++ b/src/test/clojure/xtdb/aws/minio_test.clj
@@ -13,7 +13,7 @@
            [java.nio.file Path]
            [software.amazon.awssdk.services.s3 S3AsyncClient]
            [software.amazon.awssdk.services.s3.model ListMultipartUploadsRequest ListMultipartUploadsResponse]
-           [xtdb.api.storage ObjectStore Storage]
+           [xtdb.api.storage ObjectStore ObjectStoreSync Storage]
            [xtdb.aws S3]
            [xtdb.multipart IMultipartUpload SupportsMultipart]
            [xtdb.storage RemoteBufferPool]))
@@ -100,27 +100,27 @@
 (t/deftest ^:minio multipart-start-and-cancel
   (with-open [os (object-store (random-uuid))]
     (let [multipart-key (util/->path "test-multi-created")
-          multipart-upload ^IMultipartUpload  @(.startMultipart ^SupportsMultipart os multipart-key)]
+          multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os multipart-key)]
 
       ;; MinIO doesn't seem to support listing incomplete uploads
 
       (t/testing "Call to abort a multipart upload should work"
-        (t/is @(.abort multipart-upload))))))
+        (t/is (ObjectStoreSync/abort multipart-upload))))))
 
 (t/deftest ^:minio multipart-put-test
   (with-open [os (object-store (random-uuid))]
     (let [prefix (:prefix os)
-          ^IMultipartUpload multipart-upload @(.startMultipart ^SupportsMultipart os (util/->path "test-multi-put"))
+          ^IMultipartUpload multipart-upload (ObjectStoreSync/startMultipart os (util/->path "test-multi-put"))
           part-size (* 5 1024 1024)
           file-part-1 (os-test/generate-random-byte-buffer part-size)
           file-part-2 (os-test/generate-random-byte-buffer part-size)
 
           parts [;; Uploading parts to multipart upload
-                 (.uploadPart multipart-upload 0 file-part-1)
-                 (.uploadPart multipart-upload 1 file-part-2)]]
+                 (ObjectStoreSync/uploadPart multipart-upload 0 file-part-1)
+                 (ObjectStoreSync/uploadPart multipart-upload 1 file-part-2)]]
 
       (t/testing "Call to complete a multipart upload should work - should be removed from the upload list"
-        @(.complete multipart-upload (mapv deref parts))
+        (ObjectStoreSync/complete multipart-upload parts)
         (let [list-multipart-uploads-response @(.listMultipartUploads ^S3AsyncClient (:client os)
                                                                       (-> (ListMultipartUploadsRequest/builder)
                                                                           (.bucket bucket)
@@ -134,7 +134,7 @@
                                      (* 2 part-size))]
                  (.listAllObjects ^ObjectStore os)))
 
-        (let [^ByteBuffer uploaded-buffer @(.getObject ^ObjectStore os (util/->path "test-multi-put"))]
+        (let [^ByteBuffer uploaded-buffer (ObjectStoreSync/getObject ^ObjectStore os (util/->path "test-multi-put"))]
           (t/testing "capacity should be equal to total of 2 parts"
             (t/is (= (* 2 part-size) (.capacity uploaded-buffer)))))))))
 

--- a/src/test/clojure/xtdb/aws/s3_test.clj
+++ b/src/test/clojure/xtdb/aws/s3_test.clj
@@ -11,7 +11,7 @@
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
   (:import [java.nio ByteBuffer]
-           [xtdb.api.storage ObjectStore Storage]
+           [xtdb.api.storage ObjectStore ObjectStoreSync Storage]
            [xtdb.aws S3]
            [xtdb.multipart IMultipartUpload SupportsMultipart]
            [xtdb.storage RemoteBufferPool]))
@@ -99,33 +99,33 @@
 (t/deftest ^:s3 multipart-start-and-cancel
   (with-open [os (object-store (random-uuid))]
     (let [multipart-key (util/->path "test-multi-created")
-          multipart-upload ^IMultipartUpload  @(.startMultipart ^SupportsMultipart os multipart-key)]
+          multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os multipart-key)]
 
       (t/is (= #{multipart-key} (set (.listUploads os))) "multipart upload should be present in the list")
 
       (t/testing "Call to abort a multipart upload should work - should be removed from the upload list"
-        @(.abort multipart-upload)
+        (ObjectStoreSync/abort multipart-upload)
         (t/is (empty? (.listUploads os)))))))
 
 (t/deftest ^:s3 multipart-put-test
   (with-open [os (object-store (random-uuid))]
-    (let [multipart-upload ^IMultipartUpload @(.startMultipart ^SupportsMultipart os (util/->path "test-multi-put"))
+    (let [multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os (util/->path "test-multi-put"))
           part-size (* 5 1024 1024)
           file-part-1 (os-test/generate-random-byte-buffer part-size)
           file-part-2 (os-test/generate-random-byte-buffer part-size)
           parts [;; Uploading parts to multipart upload
-                 (.uploadPart multipart-upload 0 file-part-1)
-                 (.uploadPart multipart-upload 1 file-part-2)]]
+                 (ObjectStoreSync/uploadPart multipart-upload 0 file-part-1)
+                 (ObjectStoreSync/uploadPart multipart-upload 1 file-part-2)]]
 
       (t/testing "Call to complete a multipart upload should work - should be removed from the upload list"
-        @(.complete multipart-upload (mapv deref parts))
+        (ObjectStoreSync/complete multipart-upload parts)
         (t/is (empty? (.listUploads os))))
 
       (t/testing "Multipart upload works correctly - file present and contents correct"
         (t/is (= [(os/->StoredObject (util/->path "test-multi-put") (* 2 part-size))]
                  (vec (.listAllObjects ^ObjectStore os))))
 
-        (let [^ByteBuffer uploaded-buffer @(.getObject ^ObjectStore os (util/->path "test-multi-put"))]
+        (let [^ByteBuffer uploaded-buffer (ObjectStoreSync/getObject ^ObjectStore os (util/->path "test-multi-put"))]
           (t/testing "capacity should be equal to total of 2 parts"
             (t/is (= (* 2 part-size) (.capacity uploaded-buffer)))))))))
 

--- a/src/test/clojure/xtdb/azure_test.clj
+++ b/src/test/clojure/xtdb/azure_test.clj
@@ -14,7 +14,7 @@
             [xtdb.util :as util])
   (:import (java.nio ByteBuffer)
            (java.nio.file Files)
-           (xtdb.api.storage ObjectStore Storage)
+           (xtdb.api.storage ObjectStore ObjectStoreSync Storage)
            (xtdb.azure BlobStorage)
            (xtdb.multipart IMultipartUpload SupportsMultipart)
            (xtdb.storage RemoteBufferPool)))
@@ -65,11 +65,11 @@
 
         (let [out-path (.resolve local-disk-cache "alice.edn")]
           (t/testing "first get successful"
-            (t/is (= out-path @(.getObject os alice-key out-path)))
+            (t/is (= out-path (ObjectStoreSync/getObject os alice-key out-path)))
             (t/is (= alice (read-string (Files/readString out-path)))))
 
           (t/testing "second get successful & doesn't throw"
-            (t/is (= out-path @(.getObject os alice-key out-path)))
+            (t/is (= out-path (ObjectStoreSync/getObject os alice-key out-path)))
             (t/is (= alice (read-string (Files/readString out-path))))))))))
 
 (defn start-kafka-node [local-disk-cache prefix]
@@ -149,36 +149,36 @@
 (t/deftest ^:azure multipart-start-and-cancel
   (with-open [os (object-store (random-uuid))]
     (t/testing "Call to start multipart should work/return an object"
-      (let [multipart-upload ^IMultipartUpload @(.startMultipart ^SupportsMultipart os (util/->path "test-multi-created"))]
+      (let [multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os (util/->path "test-multi-created"))]
         (t/is multipart-upload)
 
         (t/testing "Uploading a part should create an uncomitted blob"
           (= #{"test-multi-created"} (set (.listUncommittedBlobs os))))
 
         (t/testing "Call to abort a multipart upload should work - no file comitted"
-          @(.abort multipart-upload)
+          (ObjectStoreSync/abort multipart-upload)
           (t/is (= #{} (set (.listAllObjects os)))))))))
 
 (t/deftest ^:azure multipart-put-test
   (with-open [os (object-store (random-uuid))]
-    (let [multipart-upload ^IMultipartUpload @(.startMultipart ^SupportsMultipart os (util/->path "test-multi-put"))
+    (let [multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os (util/->path "test-multi-put"))
           part-size 500
           file-part-1 ^ByteBuffer (os-test/generate-random-byte-buffer part-size)
           file-part-2 ^ByteBuffer (os-test/generate-random-byte-buffer part-size)
 
           parts [;; Uploading parts to multipart upload
-                 @(.uploadPart multipart-upload 0 file-part-1)
-                 @(.uploadPart multipart-upload 1 file-part-2)]]
+                 (ObjectStoreSync/uploadPart multipart-upload 0 file-part-1)
+                 (ObjectStoreSync/uploadPart multipart-upload 1 file-part-2)]]
 
       (t/testing "Call to complete a multipart upload should work - should be removed from the uncomitted list"
-        @(.complete multipart-upload parts)
+        (ObjectStoreSync/complete multipart-upload parts)
         (t/is (empty? (.listUncommittedBlobs os))))
 
       (t/testing "Multipart upload works correctly - file present and contents correct"
         (t/is (= [(os/->StoredObject (util/->path "test-multi-put") (* 2 part-size))]
                  (vec (.listAllObjects ^ObjectStore os))))
 
-        (let [^ByteBuffer uploaded-buffer @(.getObject ^ObjectStore os (util/->path "test-multi-put"))]
+        (let [^ByteBuffer uploaded-buffer (ObjectStoreSync/getObject ^ObjectStore os (util/->path "test-multi-put"))]
           (t/testing "capacity should be equal to total of 2 parts"
             (t/is (= (* 2 part-size) (.capacity uploaded-buffer)))))))))
 
@@ -212,23 +212,23 @@
 
 (t/deftest ^:azure multipart-uploads-with-more-parts-work-correctly
   (with-open [os (object-store (random-uuid))]
-    (let [multipart-upload ^IMultipartUpload @(.startMultipart ^SupportsMultipart os (util/->path "test-larger-multi-put"))
+    (let [multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os (util/->path "test-larger-multi-put"))
           part-size 500
           parts (doall
                  (for [i (range 20)]
                    (let [buf ^ByteBuffer (os-test/generate-random-byte-buffer part-size)]
                      {:buf buf
-                      :!part (.uploadPart multipart-upload i buf)})))]
+                      :!part (ObjectStoreSync/uploadPart multipart-upload i buf)})))]
 
       (t/testing "Call to complete a multipart upload should work - should be removed from the uncomitted list"
-        @(.complete multipart-upload (mapv (comp deref :!part) parts))
+        (ObjectStoreSync/complete multipart-upload (mapv :!part parts))
         (t/is (empty? (.listUncommittedBlobs os))))
 
       (t/testing "Multipart upload works correctly - file present and contents correct"
         (t/is (= [(os/->StoredObject (util/->path "test-larger-multi-put") (* 20 part-size))]
                  (vec (.listAllObjects ^ObjectStore os))))
 
-        (let [^ByteBuffer uploaded-buffer @(.getObject ^ObjectStore os (util/->path "test-larger-multi-put"))]
+        (let [^ByteBuffer uploaded-buffer (ObjectStoreSync/getObject ^ObjectStore os (util/->path "test-larger-multi-put"))]
           (t/testing "capacity should be equal to total of 20 parts"
             (t/is (= (* 20 part-size) (.capacity uploaded-buffer)))))))))
 
@@ -237,13 +237,13 @@
     (let [part-size 500]
 
       (t/testing "Initial multipart works correctly"
-        (let [initial-multipart-upload ^IMultipartUpload @(.startMultipart os (util/->path "test-multipart"))
+        (let [initial-multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os (util/->path "test-multipart"))
               parts (doall
                      (for [_ (range 2)]
                        (let [file-part ^ByteBuffer (os-test/generate-random-byte-buffer part-size)]
-                         (.uploadPart initial-multipart-upload 0 file-part))))]
+                         (ObjectStoreSync/uploadPart initial-multipart-upload 0 file-part))))]
 
-          @(.complete initial-multipart-upload (mapv deref parts))
+          (ObjectStoreSync/complete initial-multipart-upload parts)
 
           (t/is (= [(os/->StoredObject (util/->path "test-multipart") (* 2 part-size))]
                    (vec (.listAllObjects ^ObjectStore os))))
@@ -251,13 +251,13 @@
           (t/is (empty? (.listUncommittedBlobs os)))))
 
       (t/testing "Attempt to multipart upload to an existing object shouldn't throw, should abort and remove uncomitted blobs"
-        (let [second-multipart-upload ^IMultipartUpload @(.startMultipart os (util/->path "test-multipart"))
+        (let [second-multipart-upload ^IMultipartUpload (ObjectStoreSync/startMultipart os (util/->path "test-multipart"))
               parts (doall
                      (for [i (range 3)]
                        (let [file-part ^ByteBuffer (os-test/generate-random-byte-buffer part-size)]
-                         (.uploadPart second-multipart-upload i file-part))))]
+                         (ObjectStoreSync/uploadPart second-multipart-upload i file-part))))]
 
-          @(.complete second-multipart-upload (mapv deref parts))
+          (ObjectStoreSync/complete second-multipart-upload parts)
 
           (t/is (empty? (.listUncommittedBlobs os)))))
 
@@ -265,7 +265,7 @@
         (t/is (= [(os/->StoredObject (util/->path "test-multipart") (* 2 part-size))]
                  (vec (.listAllObjects ^ObjectStore os))))
 
-        (let [^ByteBuffer uploaded-buffer @(.getObject ^ObjectStore os (util/->path "test-multipart"))]
+        (let [^ByteBuffer uploaded-buffer (ObjectStoreSync/getObject ^ObjectStore os (util/->path "test-multipart"))]
           (t/testing "capacity should be equal to total of 2 parts (ie, initial upload)"
             (t/is (= (* 2 part-size) (.capacity uploaded-buffer)))))))))
 
@@ -276,7 +276,7 @@
                          (fn []
                            (try
                              ;; Start the multipart upload
-                             (SupportsMultipart/uploadMultipartBuffers os (util/->path "multipart-interrupted") parts)
+                             (ObjectStoreSync/uploadMultipartBuffers os (util/->path "multipart-interrupted") parts)
                              (catch InterruptedException _
                                (log/warn "Upload was interrupted")))))]
       ;; Start the upload thread

--- a/src/test/clojure/xtdb/buffer_pool_test.clj
+++ b/src/test/clojure/xtdb/buffer_pool_test.clj
@@ -16,7 +16,7 @@
            (java.nio.file Path)
            (org.apache.arrow.vector.types.pojo Schema)
            (xtdb.api.storage ObjectStore ObjectStore$Factory Storage Storage$Factory)
-           (xtdb.api.storage PrefixedObjectStore InMemoryBucket StoreOperation)
+           (xtdb.api.storage PrefixedObjectStore InMemoryBucket StoreOperation UnusedObjectStore$Factory)
            xtdb.arrow.Relation
            (xtdb.cache DiskCache MemoryCache)
            (xtdb.storage BufferPool BufferPoolKt RemoteBufferPool)))
@@ -97,13 +97,13 @@
       (with-open [bp (-> (Storage/remote (prefixing-obj-store-factory bucket))
                          (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 nil Storage/VERSION {}))]
         (t/testing "if <= min part size, putObject is used"
-          (.putObject bp (util/->path "min-part-put") (utf8-buf "12"))
+          (.putObjectSync bp (util/->path "min-part-put") (utf8-buf "12"))
           (t/is (= [StoreOperation/PUT] (.getCalls bucket)))
           (test-get-object bp (util/->path "min-part-put") (utf8-buf "12")))))))
 
 (defn open-mem-cache-entry [^BufferPool bp k len]
   (let [^ByteBuffer buf (utf8-buf (apply str (repeat len "a")))]
-    (.putObject bp k buf)
+    (.putObjectSync bp k buf)
     (.getPinnedObject bp k)))
 
 (defn file-info [^Path dir]
@@ -111,7 +111,7 @@
     {:file-count (count files) :file-names (set (map #(.getName ^File %) files))}))
 
 (defn insert-utf8-to-local-cache [^BufferPool bp k len]
-  (.putObject bp k (utf8-buf (apply str (repeat len "a"))))
+  (.putObjectSync bp k (utf8-buf (apply str (repeat len "a"))))
   ;; Add to local disk cache
   (.getByteArray bp k))
 
@@ -137,17 +137,6 @@
         (Thread/sleep 100)
         (t/is (= 2 (:file-count (file-info *disk-cache-dir*))))))))
 
-(defn no-op-object-store-factory []
-  (reify ObjectStore$Factory
-    (openObjectStore [_ _storage-root _remotes]
-      (reify ObjectStore
-        (getObject [_ _k] (throw (UnsupportedOperationException. "foo")))
-        (getObject [_ _ _k] (throw (UnsupportedOperationException. "foo")))
-        (putObject [_ _k _v] (throw (UnsupportedOperationException. "foo")))
-        (listAllObjects [_] (throw (UnsupportedOperationException. "foo")))
-        (listAllObjects [_ _] (throw (UnsupportedOperationException. "foo")))
-        (deleteIfExists [_ _k] (throw (UnsupportedOperationException. "foo")))))))
-
 (t/deftest local-disk-cache-with-previous-values
   (let [obj-store-factory (prefixing-obj-store-factory (InMemoryBucket.))
         path-a (util/->path "a")
@@ -162,7 +151,7 @@
 
       ;; Starting a new buffer pool - should load buffers correctly from disk (can be sure its grabbed from disk since using a memory cache and memory object store)
       ;; passing a no-op object store to ensure objects are not loaded from object store and instead only the cache is under test.
-      (with-open [bp (-> (Storage/remote (no-op-object-store-factory))
+      (with-open [bp (-> (Storage/remote UnusedObjectStore$Factory/INSTANCE)
                          (.open tu/*allocator* *mem-cache* *disk-cache* "xtdb" 0 1 nil Storage/VERSION {}))]
         (t/is (= 0 (util/compare-nio-buffers-unsigned (utf8-buf "aaaa") (ByteBuffer/wrap (.getByteArray bp path-a)))))
         (t/is (= 0 (util/compare-nio-buffers-unsigned (utf8-buf "aaaa") (ByteBuffer/wrap (.getByteArray bp path-b)))))))))
@@ -186,7 +175,7 @@
 
 (defn put-edn [^BufferPool buffer-pool ^Path k obj]
   (let [^ByteBuffer buf (.encode StandardCharsets/UTF_8 (pr-str obj))]
-    (.putObject buffer-pool k buf)))
+    (.putObjectSync buffer-pool k buf)))
 
 (defn test-list-objects [^BufferPool buffer-pool]
   (put-edn buffer-pool (util/->path "bar/alice") :alice)
@@ -223,10 +212,10 @@
 
 (defn test-latest-available-block [^BufferPool buffer-pool]
   ;; block keys: b00.binpb = block 0, b01.binpb = block 1, etc.
-  (.putObject buffer-pool (util/->path "blocks/b00.binpb") (ByteBuffer/wrap (byte-array 10)))
-  (.putObject buffer-pool (util/->path "blocks/b01.binpb") (ByteBuffer/wrap (byte-array 10)))
-  (.putObject buffer-pool (util/->path "blocks/b02.binpb") (ByteBuffer/wrap (byte-array 10)))
-  (.putObject buffer-pool (util/->path "blocks/b03.binpb") (ByteBuffer/wrap (byte-array 10)))
+  (.putObjectSync buffer-pool (util/->path "blocks/b00.binpb") (ByteBuffer/wrap (byte-array 10)))
+  (.putObjectSync buffer-pool (util/->path "blocks/b01.binpb") (ByteBuffer/wrap (byte-array 10)))
+  (.putObjectSync buffer-pool (util/->path "blocks/b02.binpb") (ByteBuffer/wrap (byte-array 10)))
+  (.putObjectSync buffer-pool (util/->path "blocks/b03.binpb") (ByteBuffer/wrap (byte-array 10)))
   (Thread/sleep 1000)
 
   (t/testing "full listing finds latest block"
@@ -304,7 +293,7 @@
               ^ByteBuffer v1 (utf8-buf "aaa")
               ^ByteBuffer v2 (utf8-buf "bbb")]
           (t/testing "read side"
-            (.putObject bp k1 v1)
+            (.putObjectSync bp k1 v1)
 
             (t/is (= 0.0 (.count ^Counter (.counter (.find registry "buffer-pool.network.read")))))
 
@@ -320,6 +309,6 @@
 
             (t/is (= 3.0 (.count ^Counter (.counter (.find registry "buffer-pool.network.write")))))
 
-            (.putObject bp k2 v2)
+            (.putObjectSync bp k2 v2)
 
             (t/is (= 6.0 (.count ^Counter (.counter (.find registry "buffer-pool.network.write")))))))))))

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -35,7 +35,7 @@
           (util/with-open [rel (tu/open-put-log-rel allocator 0 (->max-depth-puts uuid n))]
             (.importData live-table rel))
 
-          (.finishBlock live-table bp 0)
+          (.finishBlockSync live-table bp 0)
 
           (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/live-table-test/max-depth-trie")))
                                    (.resolve path "objects")))))))

--- a/src/test/clojure/xtdb/object_store_test.clj
+++ b/src/test/clojure/xtdb/object_store_test.clj
@@ -4,23 +4,20 @@
             [xtdb.buffer-pool :as bp]
             [xtdb.object-store :as os]
             [xtdb.util :as util])
-  (:import [java.lang AutoCloseable]
-           [java.nio ByteBuffer]
+  (:import [java.nio ByteBuffer]
            [java.nio.charset StandardCharsets]
            [java.nio.file Files Path]
            [java.nio.file.attribute FileAttribute]
-           [java.util NavigableMap]
-           [java.util.concurrent CompletableFuture ConcurrentSkipListMap]
-           [xtdb.api.storage ObjectStore ObjectStore$Factory ObjectStore$StoredObject]))
+           [xtdb.api.storage InMemoryObjectStore ObjectStore ObjectStore$Factory ObjectStoreSync]))
 
 (defn- get-edn [^ObjectStore obj-store, ^Path k]
-  (-> (let [^ByteBuffer buf @(.getObject obj-store k)]
+  (-> (let [^ByteBuffer buf (ObjectStoreSync/getObject obj-store k)]
         (edn/read-string (str (.decode StandardCharsets/UTF_8 buf))))
       (util/rethrowing-cause)))
 
 (defn put-edn [^ObjectStore obj-store ^Path k obj]
   (let [^ByteBuffer buf (.encode StandardCharsets/UTF_8 (pr-str obj))]
-    @(.putObject obj-store k buf)))
+    (ObjectStoreSync/putObject obj-store k buf)))
 
 (defn generate-random-byte-buffer ^ByteBuffer [buffer-size]
   (let [random (java.util.Random.)
@@ -32,47 +29,10 @@
           (recur (inc i)))
         (.flip byte-buffer)))))
 
-(deftype InMemoryObjectStore [^NavigableMap os]
-  ObjectStore
-  (getObject [_this k]
-    (CompletableFuture/completedFuture
-     (let [^ByteBuffer buf (or (.get os k)
-                                (throw (os/obj-missing-exception k)))]
-       (.slice buf))))
-
-  (getObject [_this k out-path]
-    (CompletableFuture/supplyAsync
-     (fn []
-       (let [^ByteBuffer buf (or (.get os k)
-                                  (throw (os/obj-missing-exception k)))]
-         (with-open [ch (util/->file-channel out-path util/write-truncate-open-opts)]
-           (.write ch buf)
-           out-path)))))
-
-  (putObject [_this k buf]
-    (.putIfAbsent os k (.slice buf))
-    (CompletableFuture/completedFuture nil))
-
-  (listAllObjects [_this]
-    (->> os (map (fn [e] (ObjectStore$StoredObject. (key e) (.capacity ^ByteBuffer (val e)))))))
-
-  (listAllObjects [_ prefix]
-    (->> (.tailMap os prefix)
-         (take-while #(-> ^Path (key %) (.startsWith prefix)))
-         (map (fn [e] (ObjectStore$StoredObject. (key e) (.capacity ^ByteBuffer (val e)))))))
-  
-  (deleteIfExists [_this k]
-    (.remove os k)
-    (CompletableFuture/completedFuture nil))
-
-  AutoCloseable
-  (close [_]
-    (.clear os)))
-
 (defmethod bp/->object-store-factory ::memory-object-store [_ _]
   (reify ObjectStore$Factory
     (openObjectStore [_ _storage-root _remotes]
-      (->InMemoryObjectStore (ConcurrentSkipListMap.)))))
+      (InMemoryObjectStore.))))
 
 (defn test-put-delete [^ObjectStore obj-store]
   (let [alice {:xt/id :alice, :name "Alice"}
@@ -87,13 +47,13 @@
       (put-edn obj-store alice-key {:xt/id :alice, :name "Alice", :version 2})
       (t/is (= alice (get-edn obj-store alice-key))))
 
-    (let [temp-path @(.getObject obj-store alice-key
+    (let [temp-path (ObjectStoreSync/getObject obj-store alice-key
                                  (doto (Files/createTempFile "alice" ".edn"
                                                              (make-array FileAttribute 0))
                                    Files/delete))]
       (t/is (= alice (read-string (Files/readString temp-path)))))
 
-    @(.deleteIfExists obj-store alice-key)
+    (ObjectStoreSync/deleteIfExists obj-store alice-key)
 
     (t/is (thrown? IllegalStateException (get-edn obj-store alice-key)))))
 

--- a/src/test/kotlin/xtdb/api/storage/ObjectStoreTest.kt
+++ b/src/test/kotlin/xtdb/api/storage/ObjectStoreTest.kt
@@ -1,6 +1,5 @@
 package xtdb.api.storage
 
-import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
 import xtdb.util.asPath
 import java.nio.ByteBuffer
@@ -33,11 +32,11 @@ abstract class ObjectStoreTest {
     }
 
     private suspend fun ObjectStore.putString(k: String, v: String) {
-        putObject(k.asPath, ByteBuffer.wrap(v.encodeToByteArray())).await()
+        putObject(k.asPath, ByteBuffer.wrap(v.encodeToByteArray()))
     }
 
     private suspend fun ObjectStore.getString(k: String): String =
-        getObject(k.asPath).await()
+        getObject(k.asPath)
             .let { buffer ->
                 val bytes = ByteArray(buffer.remaining())
                 buffer.get(bytes)
@@ -58,15 +57,15 @@ abstract class ObjectStoreTest {
 
         val tempDir = createTempDirectory()
         try {
-            val outPath = objectStore.getObject("alice".asPath, tempDir.resolve("alice.edn")).await()
+            val outPath = objectStore.getObject("alice".asPath, tempDir.resolve("alice.edn"))
             outPath.readText().also { assertEquals(aliceData, it) }
         } finally {
             tempDir.deleteRecursively()
         }
 
-        objectStore.deleteIfExists("alice".asPath).await()
-        objectStore.deleteIfExists("alice".asPath).await()
-        objectStore.deleteIfExists("missing".asPath).await()
+        objectStore.deleteIfExists("alice".asPath)
+        objectStore.deleteIfExists("alice".asPath)
+        objectStore.deleteIfExists("missing".asPath)
 
         assertFailsWith(IllegalStateException::class) { objectStore.getString("alice") }
     }
@@ -165,15 +164,15 @@ abstract class ObjectStoreTest {
         objectStore.putString("original", originalData)
         
         // Test copying within root directory
-        objectStore.copyObject("original".asPath, "copy1".asPath).await()
+        objectStore.copyObject("original".asPath, "copy1".asPath)
         assertEquals(originalData, objectStore.getString("copy1"))
-        
+
         // Test copying to subdirectory
-        objectStore.copyObject("original".asPath, "subdir/copy2".asPath).await()
+        objectStore.copyObject("original".asPath, "subdir/copy2".asPath)
         assertEquals(originalData, objectStore.getString("subdir/copy2"))
-        
+
         // Test copying to path outside of root directory using relative path
-        objectStore.copyObject("original".asPath, "../other-dir/copy3".asPath).await()
+        objectStore.copyObject("original".asPath, "../other-dir/copy3".asPath)
 
         // Verify objects within root show up in allObjects
         val allObjects = objectStore.allObjects()

--- a/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
+++ b/src/test/kotlin/xtdb/azure/BlobStorageTest.kt
@@ -3,7 +3,6 @@ package xtdb.azure
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -69,16 +68,16 @@ class BlobStorageTest : ObjectStoreTest() {
     fun `multipart put test`() = runTest(timeout = 10.seconds) {
         val objectStore = this@BlobStorageTest.objectStore as BlobStorage
 
-        val multipart = objectStore.startMultipart("test-multipart".asPath).await()
+        val multipart = objectStore.startMultipart("test-multipart".asPath)
         val part1 = randomByteBuffer(500)
         val part2 = randomByteBuffer(500)
 
         val parts = awaitAll(
-            async { multipart.uploadPart(0, part1).await() },
-            async { multipart.uploadPart(1, part2).await() }
+            async { multipart.uploadPart(0, part1) },
+            async { multipart.uploadPart(1, part2) }
         )
 
-        multipart.complete(parts).await()
+        multipart.complete(parts)
         assertTrue { objectStore.listUncommittedBlobs().toList().isEmpty() }
 
         assertEquals(
@@ -86,7 +85,7 @@ class BlobStorageTest : ObjectStoreTest() {
             objectStore.listAllObjects().map { it.key.toString() }.toSet()
         )
 
-        val downloaded = objectStore.getObject("test-multipart".asPath).await()
+        val downloaded = objectStore.getObject("test-multipart".asPath)
         assertEquals(part1.capacity() + part2.capacity(), downloaded.capacity())
     }
 
@@ -96,7 +95,7 @@ class BlobStorageTest : ObjectStoreTest() {
     fun `test 20 parts`() = runTest(timeout = 10.seconds) {
         val objectStore = this@BlobStorageTest.objectStore as BlobStorage
 
-        val upload = objectStore.startMultipart("test-20-parts".asPath).await()
+        val upload = objectStore.startMultipart("test-20-parts".asPath)
 
         val parts = (0 until 20).map { randomByteBuffer(1024) }
         val totalSize = parts.sumOf { it.capacity().toLong() }
@@ -109,11 +108,11 @@ class BlobStorageTest : ObjectStoreTest() {
         val uploadedParts = parts.mapIndexed { idx, it ->
             async(dispatcher) {
                 Thread.sleep(Random.nextLong(100L..200L))
-                upload.uploadPart(idx, it).await()
+                upload.uploadPart(idx, it)
             }
         }
 
-        upload.complete(uploadedParts.awaitAll()).await()
+        upload.complete(uploadedParts.awaitAll())
 
         assertTrue(objectStore.listUncommittedBlobs().toList().isEmpty(), "no uncommitted blobs")
 
@@ -122,14 +121,14 @@ class BlobStorageTest : ObjectStoreTest() {
             objectStore.listAllObjects().toList()
         )
 
-        val downloaded = objectStore.getObject("test-20-parts".asPath).await()
+        val downloaded = objectStore.getObject("test-20-parts".asPath)
         assertEquals(totalSize, downloaded.capacity().toLong())
         assertEquals(allParts, downloaded)
     }
 
-    private fun roundTrip(objectStore: BlobStorage, key: String, payload: ByteBuffer) {
-        objectStore.putObject(key.asPath, payload.duplicate()).get()
-        val downloaded = objectStore.getObject(key.asPath).get()
+    private suspend fun roundTrip(objectStore: BlobStorage, key: String, payload: ByteBuffer) {
+        objectStore.putObject(key.asPath, payload.duplicate())
+        val downloaded = objectStore.getObject(key.asPath)
         assertEquals(payload, downloaded)
         assertTrue(
             objectStore.listAllObjects().map { it.key.toString() }.toSet().contains(key),
@@ -138,7 +137,7 @@ class BlobStorageTest : ObjectStoreTest() {
     }
 
     @Test
-    fun `remote alias — connectionString`() {
+    fun `remote alias — connectionString`() = runTest {
         val remotes = mapOf<RemoteAlias, Remote>(
             "az" to AzureRemote(connectionString = azuriteConnectionString(), storageAccountKey = null),
         )
@@ -154,7 +153,7 @@ class BlobStorageTest : ObjectStoreTest() {
     }
 
     @Test
-    fun `remote alias — storageAccountKey`() {
+    fun `remote alias — storageAccountKey`() = runTest {
         val remotes = mapOf<RemoteAlias, Remote>(
             "az" to AzureRemote(connectionString = null, storageAccountKey = AZURITE_KEY),
         )

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -35,7 +35,7 @@ class BlockGarbageCollectorTest {
             this.tableNames.addAll(tableNames)
         }
         val bytes = ByteBuffer.wrap(block.toByteArray())
-        basePaths.forEach { bufferPool.putObject(it.resolve("b${index.asLexHex}.binpb"), bytes.duplicate()) }
+        basePaths.forEach { bufferPool.putObjectSync(it.resolve("b${index.asLexHex}.binpb"), bytes.duplicate()) }
     }
 
     private fun assertBlockCount(bufferPool: BufferPool, path: Path, expected: Int) {

--- a/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
@@ -1,5 +1,7 @@
 package xtdb.api.storage
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
 import xtdb.api.storage.ObjectStore.StoredObject
 import xtdb.multipart.IMultipartUpload
 import java.nio.ByteBuffer
@@ -29,6 +31,26 @@ class InMemoryBucket(
     val buffers: NavigableMap<Path, ByteBuffer> = ConcurrentSkipListMap()
 ) {
 
+    /**
+     * A store that has accepted a write it will never answer (#5850).
+     *
+     * [cancelled] completes when the stalled call is cancelled, which is what distinguishes a bound
+     * that tore the request down from one that merely stopped waiting on it.
+     */
+    class Stall {
+        val cancelled = CompletableDeferred<Unit>()
+
+        suspend fun hang(): Nothing =
+            try {
+                awaitCancellation()
+            } finally {
+                cancelled.complete(Unit)
+            }
+    }
+
+    @Volatile
+    var stall: Stall? = null
+
     private fun copyByteBuffer(buffer: ByteBuffer) =
         ByteBuffer.allocate(buffer.remaining()).put(buffer.duplicate()).flip()
 
@@ -51,6 +73,7 @@ class InMemoryBucket(
     }
 
     suspend fun putObject(k: Path, buf: ByteBuffer) {
+        stall?.hang()
         buffers[k] = buf
         calls.add(StoreOperation.PUT)
     }
@@ -79,6 +102,7 @@ class InMemoryBucket(
     suspend fun startMultipart(k: Path): IMultipartUpload<ByteBuffer> =
         object : IMultipartUpload<ByteBuffer> {
             override suspend fun uploadPart(idx: Int, buf: ByteBuffer): ByteBuffer {
+                stall?.hang()
                 calls.add(StoreOperation.UPLOAD)
                 return copyByteBuffer(buf)
             }

--- a/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/InMemoryBucket.kt
@@ -39,21 +39,20 @@ class InMemoryBucket(
         return buffer.flip()
     }
 
-    fun getObject(k: Path): CompletableFuture<ByteBuffer> =
-        completedFuture(buffers[k])
+    suspend fun getObject(k: Path): ByteBuffer =
+        buffers[k] ?: throw IllegalStateException("Object $k doesn't exist")
 
-    fun getObject(k: Path, outPath: Path): CompletableFuture<Path> =
-        buffers[k]?.let { buffer ->
-            val bytes = ByteArray(buffer.remaining())
-            buffer.duplicate().get(bytes)
-            outPath.toFile().writeBytes(bytes)
-            completedFuture(outPath)
-        } ?: failedFuture(IllegalStateException("Object $k doesn't exist"))
+    suspend fun getObject(k: Path, outPath: Path): Path {
+        val buffer = buffers[k] ?: throw IllegalStateException("Object $k doesn't exist")
+        val bytes = ByteArray(buffer.remaining())
+        buffer.duplicate().get(bytes)
+        outPath.toFile().writeBytes(bytes)
+        return outPath
+    }
 
-    fun putObject(k: Path, buf: ByteBuffer): CompletableFuture<Unit> {
+    suspend fun putObject(k: Path, buf: ByteBuffer) {
         buffers[k] = buf
         calls.add(StoreOperation.PUT)
-        return completedFuture(Unit)
     }
 
     fun listAllObjects() = buffers.map { (key, buffer) -> StoredObject(key, buffer.capacity().toLong()) }
@@ -68,36 +67,29 @@ class InMemoryBucket(
             .takeWhile { it.key.startsWith(dir) }
             .map { (key, buffer) -> StoredObject(key, buffer.capacity().toLong()) }
 
-    fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> {
-        val srcBuffer = buffers[src] ?: return failedFuture(IllegalStateException("Object $src doesn't exist"))
+    suspend fun copyObject(src: Path, dest: Path) {
+        val srcBuffer = buffers[src] ?: throw IllegalStateException("Object $src doesn't exist")
         buffers[dest] = copyByteBuffer(srcBuffer)
-        return completedFuture(Unit)
     }
 
-    fun deleteIfExists(k: Path): CompletableFuture<Unit> {
+    suspend fun deleteIfExists(k: Path) {
         buffers.remove(k)
-        return completedFuture(Unit)
     }
 
-    fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<ByteBuffer>> {
-        val upload = object : IMultipartUpload<ByteBuffer> {
-            override fun uploadPart(idx: Int, buf: ByteBuffer): CompletableFuture<ByteBuffer> {
+    suspend fun startMultipart(k: Path): IMultipartUpload<ByteBuffer> =
+        object : IMultipartUpload<ByteBuffer> {
+            override suspend fun uploadPart(idx: Int, buf: ByteBuffer): ByteBuffer {
                 calls.add(StoreOperation.UPLOAD)
-                return completedFuture(copyByteBuffer(buf))
+                return copyByteBuffer(buf)
             }
 
-            override fun complete(parts: List<ByteBuffer>): CompletableFuture<Unit> {
+            override suspend fun complete(parts: List<ByteBuffer>) {
                 calls.add(StoreOperation.COMPLETE)
                 buffers[k] = concatByteBuffers(parts)
-                return completedFuture(Unit)
             }
 
-            override fun abort(): CompletableFuture<Unit> {
+            override suspend fun abort() {
                 calls.add(StoreOperation.ABORT)
-                return completedFuture(Unit)
             }
         }
-
-        return completedFuture(upload)
-    }
 }

--- a/src/testFixtures/kotlin/xtdb/api/storage/InMemoryObjectStore.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/InMemoryObjectStore.kt
@@ -1,0 +1,56 @@
+package xtdb.api.storage
+
+import xtdb.api.storage.ObjectStore.Companion.throwMissingKey
+import xtdb.api.storage.ObjectStore.StoredObject
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
+import java.nio.file.StandardOpenOption.WRITE
+import java.util.NavigableMap
+import java.util.concurrent.ConcurrentSkipListMap
+
+/**
+ * A whole [ObjectStore] backed by a map, for exercising the object-store contract without a cloud account.
+ *
+ * Writes are put-if-absent, so a test that re-puts a key asserts the *first* value survives. That is the
+ * one behaviour separating this from [InMemoryBucket], whose writes overwrite.
+ *
+ * Kotlin rather than a Clojure `deftype` because the write methods suspend, and Clojure interop cannot
+ * implement a suspend method — its JVM signature carries a hidden `Continuation` parameter.
+ */
+class InMemoryObjectStore(
+    private val objects: NavigableMap<Path, ByteBuffer> = ConcurrentSkipListMap()
+) : ObjectStore {
+
+    override suspend fun getObject(k: Path): ByteBuffer = (objects[k] ?: throwMissingKey(k)).slice()
+
+    override suspend fun getObject(k: Path, outPath: Path): Path {
+        val buf = objects[k] ?: throwMissingKey(k)
+        FileChannel.open(outPath, WRITE, TRUNCATE_EXISTING, CREATE).use { it.write(buf.slice()) }
+        return outPath
+    }
+
+    override suspend fun putObject(k: Path, buf: ByteBuffer) {
+        objects.putIfAbsent(k, buf.slice())
+    }
+
+    override fun listAllObjects(): Iterable<StoredObject> =
+        objects.map { (k, buf) -> StoredObject(k, buf.capacity().toLong()) }
+
+    override fun listAllObjects(dir: Path): Iterable<StoredObject> =
+        objects.tailMap(dir).entries
+            .takeWhile { it.key.startsWith(dir) }
+            .map { (k, buf) -> StoredObject(k, buf.capacity().toLong()) }
+
+    override suspend fun copyObject(src: Path, dest: Path) {
+        objects.putIfAbsent(dest, (objects[src] ?: throwMissingKey(src)).slice())
+    }
+
+    override suspend fun deleteIfExists(k: Path) {
+        objects.remove(k)
+    }
+
+    override fun close() = objects.clear()
+}

--- a/src/testFixtures/kotlin/xtdb/api/storage/ObjectStoreSync.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/ObjectStoreSync.kt
@@ -1,0 +1,54 @@
+package xtdb.api.storage
+
+import kotlinx.coroutines.runBlocking
+import xtdb.multipart.IMultipartUpload
+import xtdb.multipart.SupportsMultipart
+import xtdb.multipart.SupportsMultipart.Companion.uploadMultipartBuffers
+import java.nio.ByteBuffer
+import java.nio.file.Path
+
+/**
+ * Blocking bridges onto the suspending halves of [ObjectStore] and [SupportsMultipart], for Clojure tests.
+ *
+ * Clojure interop cannot call a suspend function — its JVM signature carries a hidden `Continuation`
+ * parameter that `.method` interop has no way to supply. These live in test fixtures rather than on the
+ * interfaces themselves so that production code has no blocking entry point into object-store I/O; that
+ * is the whole point of #5857, and a bridge on the interface would be an open invitation to undo it.
+ *
+ * Kotlin callers must not use these — suspend directly instead.
+ */
+object ObjectStoreSync {
+
+    @JvmStatic
+    fun getObject(os: ObjectStore, k: Path): ByteBuffer = runBlocking { os.getObject(k) }
+
+    @JvmStatic
+    fun getObject(os: ObjectStore, k: Path, outPath: Path): Path = runBlocking { os.getObject(k, outPath) }
+
+    @JvmStatic
+    fun putObject(os: ObjectStore, k: Path, buf: ByteBuffer) = runBlocking { os.putObject(k, buf) }
+
+    @JvmStatic
+    fun copyObject(os: ObjectStore, src: Path, dest: Path) = runBlocking { os.copyObject(src, dest) }
+
+    @JvmStatic
+    fun deleteIfExists(os: ObjectStore, k: Path) = runBlocking { os.deleteIfExists(k) }
+
+    @JvmStatic
+    fun <P> startMultipart(os: SupportsMultipart<P>, k: Path): IMultipartUpload<P> =
+        runBlocking { os.startMultipart(k) }
+
+    @JvmStatic
+    fun <P> uploadPart(upload: IMultipartUpload<P>, idx: Int, buf: ByteBuffer): P =
+        runBlocking { upload.uploadPart(idx, buf) }
+
+    @JvmStatic
+    fun <P> complete(upload: IMultipartUpload<P>, parts: List<P>) = runBlocking { upload.complete(parts) }
+
+    @JvmStatic
+    fun <P> abort(upload: IMultipartUpload<P>) = runBlocking { upload.abort() }
+
+    @JvmStatic
+    fun <P> uploadMultipartBuffers(os: SupportsMultipart<P>, k: Path, buffers: List<ByteBuffer>) =
+        runBlocking { os.uploadMultipartBuffers(k, buffers) }
+}

--- a/src/testFixtures/kotlin/xtdb/api/storage/PrefixedObjectStore.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/PrefixedObjectStore.kt
@@ -26,15 +26,15 @@ class PrefixedObjectStore(
 
     private fun StoredObject.relativized() = StoredObject(prefix.relativize(key), size)
 
-    override fun getObject(k: Path): CompletableFuture<ByteBuffer> = delegate.getObject(prefix.resolve(k))
+    override suspend fun getObject(k: Path): ByteBuffer = delegate.getObject(prefix.resolve(k))
 
-    override fun getObject(k: Path, outPath: Path): CompletableFuture<Path> =
+    override suspend fun getObject(k: Path, outPath: Path): Path =
         delegate.getObject(prefix.resolve(k), outPath)
 
-    override fun putObject(k: Path, buf: ByteBuffer): CompletableFuture<Unit> =
+    override suspend fun putObject(k: Path, buf: ByteBuffer) =
         delegate.putObject(prefix.resolve(k), buf)
 
-    override fun startMultipart(k: Path): CompletableFuture<IMultipartUpload<ByteBuffer>> =
+    override suspend fun startMultipart(k: Path): IMultipartUpload<ByteBuffer> =
         delegate.startMultipart(prefix.resolve(k))
 
     override fun listAllObjects(): Iterable<StoredObject> =
@@ -46,10 +46,10 @@ class PrefixedObjectStore(
     override fun listAfter(dir: Path, afterKey: Path): Iterable<StoredObject> =
         delegate.listAfter(prefix.resolve(dir), prefix.resolve(afterKey)).map { it.relativized() }
 
-    override fun copyObject(src: Path, dest: Path): CompletableFuture<Unit> =
+    override suspend fun copyObject(src: Path, dest: Path) =
         delegate.copyObject(prefix.resolve(src), prefix.resolve(dest))
 
-    override fun deleteIfExists(k: Path): CompletableFuture<Unit> = delegate.deleteIfExists(prefix.resolve(k))
+    override suspend fun deleteIfExists(k: Path) = delegate.deleteIfExists(prefix.resolve(k))
 
     override fun close() {}
 }

--- a/src/testFixtures/kotlin/xtdb/api/storage/UnusedObjectStore.kt
+++ b/src/testFixtures/kotlin/xtdb/api/storage/UnusedObjectStore.kt
@@ -1,0 +1,35 @@
+package xtdb.api.storage
+
+import xtdb.api.Remote
+import xtdb.api.RemoteAlias
+import xtdb.api.storage.ObjectStore.StoredObject
+import java.nio.ByteBuffer
+import java.nio.file.Path
+import com.google.protobuf.Any as ProtoAny
+
+/**
+ * An [ObjectStore] that throws on every operation, for tests asserting the cache layers serve a read
+ * without reaching the store at all — the throw is the assertion.
+ *
+ * Kotlin rather than a Clojure `reify` because the write methods suspend, and Clojure interop cannot
+ * implement a suspend method — its JVM signature carries a hidden `Continuation` parameter.
+ */
+object UnusedObjectStore : ObjectStore {
+
+    private fun unused(op: String): Nothing = throw UnsupportedOperationException(op)
+
+    override suspend fun getObject(k: Path): ByteBuffer = unused("getObject")
+    override suspend fun getObject(k: Path, outPath: Path): Path = unused("getObject")
+    override suspend fun putObject(k: Path, buf: ByteBuffer) = unused("putObject")
+    override fun listAllObjects(): Iterable<StoredObject> = unused("listAllObjects")
+    override fun listAllObjects(dir: Path): Iterable<StoredObject> = unused("listAllObjects")
+    override suspend fun copyObject(src: Path, dest: Path) = unused("copyObject")
+    override suspend fun deleteIfExists(k: Path) = unused("deleteIfExists")
+
+    object Factory : ObjectStore.Factory {
+        override fun openObjectStore(storageRoot: Path, remotes: Map<RemoteAlias, Remote>): ObjectStore =
+            UnusedObjectStore
+
+        override val configProto: ProtoAny get() = ProtoAny.newBuilder().build()
+    }
+}


### PR DESCRIPTION
Resolves #5857.

## tl;dr

- **A stalled object store can no longer take a node down with it.** Every object-store request is now bounded and genuinely cancellable, the block-write path holds no thread while one is in flight, and a store that stops answering surfaces as a log line, a 503 on `/healthz/alive` and failed transactions — where before it was silence.
- **Nothing user-facing changes.** No new config key, no API change, no migration. The ten-minute request bound is a constant, deliberately not a knob.
- **If you implement `ObjectStore`, it is now a `suspend` interface.** `listAllObjects`/`listAfter` are unchanged and still return `Iterable`.
- **Azure and GCP I/O moved off the shared `Dispatchers.IO`** onto their own named views, so a stalled bucket can no longer starve the memory cache, the garbage collectors or the database catalog's closer.

## Summary

The failure this fixes is a node that stops indexing and says nothing about it.

In #5850 the AWS SDK accepted requests it never answered. ~65 threads sat blocked in untimed `CompletableFuture.get` beneath `RemoteBufferPool.uploadArrowFile` while Netty's event loops idled with no open connections. Because those threads came from pools shared with the rest of the node, one stalled upload became hours of silence — no exception, no log line, no failing health check.

- **Holding a thread was the amplifier.** A request in flight now costs a continuation, so one hung store degrades its own subsystem rather than the node.
- **Being unbounded was the trigger.** Nothing capped those waits, so "slow" and "never" were indistinguishable.
- **Silence was what made it an outage rather than an incident.** The failure existed for hours with nothing to alert on.

## Changes

Five commits, best read in order. The first two are behaviour-preserving; the rest change behaviour.

1. `73509312b` **refactor(storage): suspend the block-write path** — `ArrowWriter.end()` is the hinge, propagating through `DataFileWriter`, `MetadataFileWriter`, `LiveTrieWriter`, `PageTrieWriter` and `LiveTable`/`LiveIndex.finishBlock` to meet `BlockUploader.uploadBlock`, which was already suspend. `writePage()` stays non-suspend — it only touches a local `FileChannel`.
2. `f15e21f7a` **refactor(storage): suspend the ObjectStore interface** — a net deletion: S3, Azure and GCP each kept a `CoroutineScope(SupervisorJob() + …)` purely to run `scope.future { }`, plus a five-second `cancelAndJoin` in `close()`.
3. `506511550` **fix(storage): bound object-store requests** — ten minutes per request, a breach surfacing as `Unavailable`.
4. `98ca6a64c` **fix(storage): isolate Azure and GCP I/O from the shared pool** — those two wrap synchronous SDKs and hold a thread per operation whatever the interface looks like.
5. `8eb607fe2` **fix(indexer): log a failed leader term** — one line, and the last of the three complaints.

## Implementation notes

Four things a reviewer would otherwise have to reconstruct from the diff.

- **Suspending had to come before bounding.** `CompletableFuture.orTimeout` completes *our* future and leaves the request running; `withTimeout` around a suspend call propagates cancellation into the SDK. Bounding a future-returning interface would have abandoned hung requests rather than tearing them down — a worse failure than the one being fixed.
- **The bound is per request, never around an aggregate.** In a multipart upload, `startMultipart`, each part, `complete` and `abort` are bounded individually, while `awaitAll` over the parts sits deliberately outside any bound — four parts run at once, so waiting on all of them is an aggregate a large file can legitimately spend a long time in. That's what lets the bound be generous enough to need no tuning, and hence be a constant rather than a config key.
- **A breach surfaces as `Unavailable`, not as the cancellation it starts life as.** `TimeoutCancellationException` is a `CancellationException`, which the block-write path above reads as "we're shutting down" and discards — the same silence this exists to break. Only that exception is converted, so a genuine shutdown cancel still propagates as cancellation.
- **The read bound sits inside the `DiskCache.Fetch` bridge.** The disk cache is a Caffeine `AsyncCache`, so its future is shared between every concurrent reader of a key; a bound owned by one awaiter would tear down a fetch the others are still waiting on.

## Alternatives considered

One per decision a reviewer is most likely to want to reopen.

- **A1 — bound the existing `CompletableFuture` with `orTimeout`, leaving the interface alone.** Rejected: it stops us waiting without cancelling, so a hung request keeps its connection and its buffers. This is why the two refactors precede the fix rather than being tidy-ups alongside it.
- **A2 — a semaphore around Azure/GCP requests instead of a dedicated dispatcher.** Rejected: it bounds without isolating. Capping in-flight requests while still running them on `Dispatchers.IO` limits how much of the shared budget a store takes but not *that* it takes from it, and at any cap at or above the permit count it is no protection at all. A dispatcher bounds thread supply; a semaphore bounds a resource that in-flight work pins, and here the scarce thing is threads.
- **A3 — expose the request bound as a config key.** Rejected: it is a watchdog on a client that has stopped answering, not a latency budget. There is no tuning case, and a value low enough to be worth setting would start failing healthy flushes.
- **A4 — put the blocking `*Sync` bridges on `ObjectStore` itself** rather than in test fixtures. Rejected despite being less code: a blocking entry point into object-store I/O on the production interface is an open invitation to undo the thing this PR is about. `BufferPool` is the exception and does carry them, because there the blocking callers are real rather than test scaffolding.

## Dead ends

Three beliefs that didn't survive, recorded so nobody re-derives them.

- **A dispatcher-starvation deadlock.** #5857 originally claimed `finishBlock` deadlocked against `IO.limitedParallelism(4)` in `uploadMultipartBuffers`. `Dispatchers.IO` views are *elastic* — `DefaultIoScheduler.limitedParallelism` delegates to `UnlimitedIoScheduler` — so no circular wait can exist. The tell was asking why Azure users had never hit it, given Azure implements `SupportsMultipart` too. Withdrawing it reversed the fix advice: with no deadlock, a timeout is straightforwardly correct rather than actively harmful.
- **That swapping `runBlocking` for `coroutineScope` in `LiveTable.finishBlock` was inert.** The per-table fan-out was pinned to `async(Dispatchers.IO)` — which predates this branch — and `runBlocking` had been blocking until it finished, so the escape from the caller's dispatcher was never *observable*. Making it observable broke the deterministic simulations, which treat quiescence of their own seeded dispatcher as the point at which a cascading effect has settled: `awaitIdle` returned with the flush still in flight, and a cancelled flush could wedge in `Cancelling` waiting to resume on a dispatcher no longer being drained. Nine assertions and a hang, none of it visible to `./gradlew test`, which excludes `@Tag("property")`. Fixed by injecting an `ioDispatcher` into `LiveIndex`, as `TrieGarbageCollector` and `BlockGarbageCollector` already do.
- **That deleting the per-store scopes was a clean removal.** It also removed the only reader of Azure's and GCP's `coroutineContext` config, leaving an unused constructor parameter — a warning rather than an error, so the build stayed green and no test noticed a published knob had stopped working. It is now a `private val ioContext` passed to all 11 `runInterruptible` sites, which also means the bound reaches the blocking call as a thread interrupt.

## Out of scope

One per thing a reader might reasonably expect to find here and won't.

- **Listing.** `listAllObjects`/`listAfter` stay non-suspend and unbounded. The incident never ran through listing, and converting it drags in both garbage collectors and `compactor/reset.clj`. It is the one concrete unbounded path left.
- **A liveness watchdog for a node that has stopped advancing.** Everything that *throws* is now loud, and block lag doesn't cover the remaining case — `latestAvailableBlockIndex - currentBlockIndex` stalls on both sides when the leader is the wedged one, so it detects follower lag rather than liveness. Left as an open question on #5857 rather than built speculatively.
- **Two write sites that remain bounded but thread-parking.** `TxResolver.indexSkippedTx` (the `XTDB_SKIP_TXS` path) and `CrashLogger` reach the store through `putObjectSync`/`endSync()` from a suspend caller whose scope carries no dispatcher element. Both route through `RemoteBufferPool`, so the bound applies and the exposure is a `Dispatchers.Default` thread held for up to the timeout rather than indefinitely. Closing it means suspending `TxResolver.indexTx` and `SourceLogTxIndexer` — the single-writer resolve path `live-index.allium` specifies as serial.
- **Accepted: a hung store still stalls indexing.** The next block cannot be written until this one is. The goal is a stall that says so, not continued progress, which would need a different write path entirely.

## Test plan

Green at `98ca6a64c` across all three task groups, with counts read out of the JUnit XML rather than off a summary; `8eb607fe2` on top is a single log line.

- **`./gradlew test`** — 1669, 0 failures.
- **`./gradlew property-test`** — 2714 simulation tests across five classes plus the root module's, 0 failures. This is the one that matters here: `./gradlew test` excludes `@Tag("property")` and so cannot see the simulations at all.
- **`./gradlew integration-test`** — clean. No Arrow leaks, no reflection or boxed-math warnings.
- **Two new tests in `RemoteStorageTest`, both red-greened** by removing the bound and watching them fail — a stalled write fails rather than hanging, asserting against the shipped ten-minute bound because `runTest`'s virtual clock skips it in 4ms; and a stalled part upload aborts the multipart upload, proving the bound tears the request down rather than abandoning it.
- **`check:` the Azure and GCP credentialed paths are `nightly-test` tags**, so commit 4 has had compilation and `integration-test` locally but nightly CI is its first real exercise.
- **Two flakes met along the way were tracked rather than absorbed** — #5851 (`dropSlot` teardown race) and #5880 (the property-test generator emitting the Postgres system column names `cmin`/`cmax`/`ctid`), the latter filed from this branch.
