### PR TITLE
fix(postgres-source): confirm the slot only as far as the last durable block

### DIFF
--- a/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
@@ -1,0 +1,27 @@
+package xtdb.api.tx
+
+import xtdb.api.TableRef
+import xtdb.api.TransactionKey
+import xtdb.database.proto.DatabaseConfig
+import xtdb.trie.BlockIndex
+import xtdb.types.MessageId
+
+/**
+ * What a block persisted to object storage carries.
+ *
+ * Deliberately knows nothing about the wire format: the block protobuf is the storage format, and the
+ * mapping from it lives with the catalog that reads it. Here a field a block may not carry is ordinary
+ * nullability, rather than a presence check at each read.
+ */
+data class BlockDetails(
+    val blockIndex: BlockIndex,
+    val latestCompletedTx: TransactionKey?,
+    val latestProcessedMsgId: MessageId?,
+    val boundaryReplicaMsgId: MessageId?,
+    // the leader term that produced this block's boundary; NONE for blocks written before
+    // term-fencing (see #5817)
+    val termId: Long,
+    val externalSourceToken: ExternalSourceToken?,
+    val tableNames: List<TableRef>,
+    val secondaryDatabases: Map<String, DatabaseConfig>,
+)

--- a/core/src/main/kotlin/xtdb/api/tx/ExternalSource.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/ExternalSource.kt
@@ -22,6 +22,13 @@ typealias ExternalSourceToken = ByteArray
  *
  * XTDB drives the source via [onPartitionAssigned] and persists the per-tx [ExternalSourceToken]
  * so the source can resume after the last indexed event.
+ *
+ * A source that also *confirms* progress upstream — advancing a Postgres replication slot, committing a
+ * consumer-group offset — must gate that on [TxIndexer.latestBlock] rather than on a transaction's own
+ * durability handle. Confirmation tells the upstream it may discard everything behind the confirmed
+ * position, so confirming a transaction that is only on the replica log leaves XTDB the sole holder of
+ * data nobody can re-send. Resuming is different: resume from the furthest position indexed, which may
+ * legitimately be ahead of the last block.
  */
 interface ExternalSource : AutoCloseable {
 

--- a/core/src/main/kotlin/xtdb/api/tx/TxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/TxIndexer.kt
@@ -1,6 +1,7 @@
 package xtdb.api.tx
 
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.StateFlow
 import xtdb.api.TransactionResult
 import java.time.Instant
 
@@ -15,6 +16,20 @@ import java.time.Instant
  * whether the caller waits for the result.
  */
 interface TxIndexer {
+
+    /**
+     * The latest block this database has durable in object storage, or null before its first block.
+     *
+     * This advances only once the block's file has landed in storage, so a source may treat the emitted
+     * [BlockDetails.externalSourceToken] as the furthest position it is safe to confirm upstream.
+     * Confirming past it tells the upstream to discard data that exists only in the replica log and the
+     * leader's live index — which the upstream cannot then re-send.
+     *
+     * Note this necessarily lags [submitTx]'s durability handle, which completes once the transaction is
+     * replicated and applied. A source that acknowledges per-transaction is therefore acknowledging a
+     * position storage does not yet hold.
+     */
+    val latestBlock: StateFlow<BlockDetails?>
 
     /** The outcome a [writer] returns: commit or abort, plus optional `userMetadata` recorded on the `xt/txs` table. */
     sealed interface TxResult {

--- a/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
@@ -1,6 +1,9 @@
 package xtdb.catalog
 
 import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import xtdb.api.log.LeaderTerm
 import xtdb.api.tx.ExternalSourceToken
 import xtdb.api.TransactionKey
@@ -22,9 +25,51 @@ import xtdb.util.asPath
 import java.nio.file.Path
 import kotlin.io.path.extension
 
-class BlockCatalog(
-    @field:Volatile private var latestBlock: Block?
+/**
+ * What a persisted block carries, as a Kotlin value.
+ *
+ * The proto remains the storage format; this is the in-memory truth, so a field that a block may
+ * not carry is ordinary nullability rather than a `hasX()` call at each read.
+ */
+data class BlockDetails(
+    val blockIndex: BlockIndex,
+    val latestCompletedTx: TransactionKey?,
+    val latestProcessedMsgId: MessageId?,
+    val boundaryReplicaMsgId: MessageId?,
+    // Default NONE for blocks written before term-fencing. See #5817.
+    val termId: Long,
+    val externalSourceToken: ExternalSourceToken?,
+    val tableNames: List<TableRef>,
+    val secondaryDatabases: Map<String, DatabaseConfig>,
 ) {
+    companion object {
+        fun fromProto(block: Block) = BlockDetails(
+            blockIndex = block.blockIndex,
+            latestCompletedTx = block.takeIf { it.hasLatestCompletedTx() }?.latestCompletedTx
+                ?.let { TransactionKey(it.txId, it.systemTime.microsAsInstant) },
+            latestProcessedMsgId = block.latestProcessedMsgId.takeIf { block.hasLatestProcessedMsgId() },
+            boundaryReplicaMsgId = block.boundaryReplicaMsgId.takeIf { block.hasBoundaryReplicaMsgId() },
+            termId = block.termId,
+            externalSourceToken = block.takeIf { it.hasExternalSourceToken() }?.externalSourceToken?.toByteArray(),
+            tableNames = block.tableNamesList.map { fromSchemaAndTable(it) },
+            secondaryDatabases = block.secondaryDatabasesMap,
+        )
+    }
+}
+
+class BlockCatalog(initialBlock: Block?) {
+
+    private val _latestBlock = MutableStateFlow(initialBlock?.let(BlockDetails::fromProto))
+
+    /**
+     * The latest block this catalog knows to be in object storage, advancing on [refresh] — which the
+     * leader calls once the block file has landed, and a follower once it has read the block back.
+     *
+     * A collector is therefore observing durability, not resolution: anything this emits is recoverable
+     * from storage alone. That is what lets an external source use the emitted `externalSourceToken` as
+     * the furthest position it may confirm upstream.
+     */
+    val latestBlock: StateFlow<BlockDetails?> = _latestBlock.asStateFlow()
 
     companion object {
         private val blocksPath = "blocks".asPath
@@ -55,7 +100,7 @@ class BlockCatalog(
 
     fun refresh(block: Block?) {
         if (block != null && block.blockIndex == currentBlockIndex) return
-        latestBlock = block
+        _latestBlock.value = block?.let(BlockDetails::fromProto)
     }
 
     fun buildBlock(
@@ -90,30 +135,22 @@ class BlockCatalog(
         }
     }
 
-    val currentBlockIndex get() = latestBlock?.blockIndex
+    val currentBlockIndex: BlockIndex? get() = _latestBlock.value?.blockIndex
 
-    val latestCompletedTx: TransactionKey?
-        get() = latestBlock
-            ?.takeIf { it.hasLatestCompletedTx() }
-            ?.latestCompletedTx
-            ?.let { TransactionKey(it.txId, it.systemTime.microsAsInstant) }
+    val latestCompletedTx: TransactionKey? get() = _latestBlock.value?.latestCompletedTx
 
     val latestProcessedMsgId: MessageId?
-        get() = latestBlock?.let { block -> block.latestProcessedMsgId.takeIf { block.hasLatestProcessedMsgId() } }
-            ?: latestCompletedTx?.txId
+        get() = _latestBlock.value?.latestProcessedMsgId ?: latestCompletedTx?.txId
 
-    val boundaryReplicaMsgId: MessageId?
-        get() = latestBlock?.let { block -> block.boundaryReplicaMsgId.takeIf { block.hasBoundaryReplicaMsgId() } }
+    val boundaryReplicaMsgId: MessageId? get() = _latestBlock.value?.boundaryReplicaMsgId
 
     // the leader term that produced the latest block's boundary; a follower seeds its read-side term
     // fence from here. Default 0 (plain scalar) for blocks written before term-fencing. See #5817.
-    val boundaryTermId: Long
-        get() = latestBlock?.termId ?: LeaderTerm.NONE
+    val boundaryTermId: Long get() = _latestBlock.value?.termId ?: LeaderTerm.NONE
 
-    val externalSourceToken: ExternalSourceToken?
-        get() = latestBlock?.takeIf { it.hasExternalSourceToken() }?.externalSourceToken?.toByteArray()
+    val externalSourceToken: ExternalSourceToken? get() = _latestBlock.value?.externalSourceToken
 
-    val allTables: List<TableRef> get() = latestBlock?.tableNamesList.orEmpty().map { fromSchemaAndTable(it) }
+    val allTables: List<TableRef> get() = _latestBlock.value?.tableNames.orEmpty()
 
-    val secondaryDatabases: Map<String, DatabaseConfig> get() = latestBlock?.secondaryDatabasesMap.orEmpty()
+    val secondaryDatabases: Map<String, DatabaseConfig> get() = _latestBlock.value?.secondaryDatabases.orEmpty()
 }

--- a/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/BlockCatalog.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import xtdb.api.log.LeaderTerm
+import xtdb.api.tx.BlockDetails
 import xtdb.api.tx.ExternalSourceToken
 import xtdb.api.TransactionKey
 import xtdb.types.MessageId
@@ -25,41 +26,23 @@ import xtdb.util.asPath
 import java.nio.file.Path
 import kotlin.io.path.extension
 
-/**
- * What a persisted block carries, as a Kotlin value.
- *
- * The proto remains the storage format; this is the in-memory truth, so a field that a block may
- * not carry is ordinary nullability rather than a `hasX()` call at each read.
- */
-data class BlockDetails(
-    val blockIndex: BlockIndex,
-    val latestCompletedTx: TransactionKey?,
-    val latestProcessedMsgId: MessageId?,
-    val boundaryReplicaMsgId: MessageId?,
-    // Default NONE for blocks written before term-fencing. See #5817.
-    val termId: Long,
-    val externalSourceToken: ExternalSourceToken?,
-    val tableNames: List<TableRef>,
-    val secondaryDatabases: Map<String, DatabaseConfig>,
-) {
-    companion object {
-        fun fromProto(block: Block) = BlockDetails(
-            blockIndex = block.blockIndex,
-            latestCompletedTx = block.takeIf { it.hasLatestCompletedTx() }?.latestCompletedTx
-                ?.let { TransactionKey(it.txId, it.systemTime.microsAsInstant) },
-            latestProcessedMsgId = block.latestProcessedMsgId.takeIf { block.hasLatestProcessedMsgId() },
-            boundaryReplicaMsgId = block.boundaryReplicaMsgId.takeIf { block.hasBoundaryReplicaMsgId() },
-            termId = block.termId,
-            externalSourceToken = block.takeIf { it.hasExternalSourceToken() }?.externalSourceToken?.toByteArray(),
-            tableNames = block.tableNamesList.map { fromSchemaAndTable(it) },
-            secondaryDatabases = block.secondaryDatabasesMap,
-        )
-    }
-}
+// The proto is the storage format, so this is the only place that reads its presence flags: everything
+// downstream sees ordinary Kotlin nullability.
+private fun Block.asBlockDetails() = BlockDetails(
+    blockIndex = blockIndex,
+    latestCompletedTx = takeIf { it.hasLatestCompletedTx() }?.latestCompletedTx
+        ?.let { TransactionKey(it.txId, it.systemTime.microsAsInstant) },
+    latestProcessedMsgId = latestProcessedMsgId.takeIf { hasLatestProcessedMsgId() },
+    boundaryReplicaMsgId = boundaryReplicaMsgId.takeIf { hasBoundaryReplicaMsgId() },
+    termId = termId,
+    externalSourceToken = takeIf { it.hasExternalSourceToken() }?.externalSourceToken?.toByteArray(),
+    tableNames = tableNamesList.map { fromSchemaAndTable(it) },
+    secondaryDatabases = secondaryDatabasesMap,
+)
 
 class BlockCatalog(initialBlock: Block?) {
 
-    private val _latestBlock = MutableStateFlow(initialBlock?.let(BlockDetails::fromProto))
+    private val _latestBlock = MutableStateFlow(initialBlock?.asBlockDetails())
 
     /**
      * The latest block this catalog knows to be in object storage, advancing on [refresh] — which the
@@ -100,7 +83,7 @@ class BlockCatalog(initialBlock: Block?) {
 
     fun refresh(block: Block?) {
         if (block != null && block.blockIndex == currentBlockIndex) return
-        _latestBlock.value = block?.let(BlockDetails::fromProto)
+        _latestBlock.value = block?.asBlockDetails()
     }
 
     fun buildBlock(

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -349,7 +349,7 @@ class Database(
             })
 
             val logProcessor = if (indexerConfig.enabled) {
-                val blockUploader = BlockUploader(storage, state, compactorForDb, dbCatalog, base.meterRegistry, scope)
+                val blockUploader = BlockUploader(storage, state, dbName, compactorForDb, dbCatalog, base.meterRegistry, scope)
 
                 LogProcessor(
                     allocator, base, crashLogger,

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -1,9 +1,11 @@
 package xtdb.indexer
 
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import java.nio.ByteBuffer
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
@@ -36,6 +38,7 @@ private val defaultBlockUploadDispatcher = IO.limitedParallelism(MAX_CONCURRENT_
 class BlockUploader(
     partitionStorage: PartitionStorage,
     partitionState: PartitionState,
+    dbName: String,
     private val compactor: Compactor.ForDatabase,
     private val dbCatalog: Database.Catalog?,
     private val meterRegistry: MeterRegistry?,
@@ -53,6 +56,22 @@ class BlockUploader(
         Timer.builder("block.upload.timer")
             .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
             .register(it)
+    }
+
+    // A timer records uploads that happened; this records the absence of one. An external source
+    // confirms its upstream position only as far as the last durable block, so a database whose blocks
+    // have quietly stopped landing pins the upstream's log while ingestion, queries and healthz all stay
+    // green — time-since-last-block is what makes that visible (#5867).
+    private val lastUploadEpochSeconds = AtomicLong(0)
+
+    init {
+        meterRegistry?.let { reg ->
+            Gauge.builder("xtdb.block.last_upload_time", lastUploadEpochSeconds) { it.get().toDouble() }
+                .description("epoch seconds at which this database's most recent block landed in object storage")
+                .baseUnit("seconds")
+                .tag("db", dbName)
+                .register(reg)
+        }
     }
 
     suspend fun uploadBlock(
@@ -107,6 +126,7 @@ class BlockUploader(
 
         bufferPool.putObject(BlockCatalog.blockFilePath(blockIdx), ByteBuffer.wrap(block.toByteArray()))
         blockCatalog.refresh(block)
+        lastUploadEpochSeconds.set(Instant.now().epochSecond)
 
         // Now signal followers that the block is available.
         val uploadedMsgId = replicaLog.appendMessage(

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -73,6 +73,8 @@ internal class LeaderLogProcessor(
     private val blockCatalog = partitionState.blockCatalog
     private val trieCatalog = partitionState.trieCatalog
 
+    override val latestBlock get() = blockCatalog.latestBlock
+
     // Resolves each source-log / attach-detach / ext-source tx and holds it — with every other
     // resolved-but-not-yet-applied tx — until we've read it back off our own replica log and committed it
     // into the live index. Driven only from the persister coroutine, and freed in close() once that job is

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -117,7 +117,7 @@ class ExternalSourceTest {
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", compactor, null, null, backgroundScope)
         val driver = wrapDriver(
             RealLeaderDriver(
                 partitionStorage, partitionState, blockUploader

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -117,7 +117,7 @@ class LeaderDriverSimTest : SimulationTestBase() {
                     RealLeaderDriver(
                         partitionStorage, partitionState,
                         BlockUploader(
-                            partitionStorage, partitionState, mockk<Compactor.ForDatabase>(relaxed = true),
+                            partitionStorage, partitionState, "xtdb", mockk<Compactor.ForDatabase>(relaxed = true),
                             null, null, scope, uploadDispatcher = dispatcher
                         )
                     )

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -98,7 +98,7 @@ class LeaderLogProcessorTest {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, uploadDispatcher)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", compactor, null, null, backgroundScope, uploadDispatcher)
         val driver = wrapDriver(
             RealLeaderDriver(
                 partitionStorage, partitionState, blockUploader
@@ -175,7 +175,7 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val driver = RealLeaderDriver(
             partitionStorage, partitionState, blockUploader
         )
@@ -248,7 +248,7 @@ class LeaderLogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val driver = RealLeaderDriver(
             partitionStorage, partitionState, blockUploader
         )
@@ -621,7 +621,7 @@ class LeaderLogProcessorTest {
 
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", compactor, null, null, backgroundScope, StandardTestDispatcher(testScheduler))
         val driver = RealLeaderDriver(
             partitionStorage, partitionState, blockUploader
         )

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -178,7 +178,7 @@ class LogProcessorSimTest : SimulationTestBase() {
             LogProcessor(
                 allocator, nodeBase, crashLogger,
                 partitionStorage, partitionState, dbName, watchers,
-                BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, scope, uploadDispatcher = dispatcher),
+                BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, scope, uploadDispatcher = dispatcher),
                 mockk<Compactor.ForDatabase>(relaxed = true), dbCatalog = null,
                 externalSourceFactory = object : ExternalSource.Factory {
                     override fun open(

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -77,7 +77,7 @@ class LogProcessorTest {
         val bufferPool = mockBufferPool()
         val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val scope = CoroutineScope(SupervisorJob())
@@ -99,7 +99,7 @@ class LogProcessorTest {
         val bufferPool = mockBufferPool(epoch = 1)
         val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         val scope = CoroutineScope(SupervisorJob())
@@ -126,7 +126,7 @@ class LogProcessorTest {
         val bufferPool = mockBufferPool()
         val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // a previous incarnation of the counter reached 9
@@ -157,7 +157,7 @@ class LogProcessorTest {
         val liveIndex = mockk<LiveIndex>(relaxed = true) { every { latestCompletedTx } returns null }
         val partitionState = newPartitionState(liveIndex = liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         replicaLog.appendMessage(ReplicaMessage.NoOp(termId = LeaderTerm.of(0, 9)))
@@ -188,7 +188,7 @@ class LogProcessorTest {
         }
         val partitionState = newPartitionState(liveIndex = liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log with a transaction
@@ -221,7 +221,7 @@ class LogProcessorTest {
         }
         val partitionState = newPartitionState(liveIndex = liveIndex)
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(partitionStorage, partitionState, mockk(relaxed = true), null, null, backgroundScope)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -641,7 +641,11 @@ variant NoOpMessage : ReplicaMessage {
 ---- Config
 
 config {
-    flush_timeout: Duration = 5.minutes
+    -- 4h, not the 5 minutes on LogProcessor's own constructor parameter: Database always
+    -- passes IndexerConfig.flushDuration, so that parameter default is unreachable outside
+    -- tests. It matters which one is written here, because this is the worst-case interval
+    -- over which an external source's upstream must retain its log.
+    flush_timeout: Duration = 4.hours
     rows_per_block: Integer = 102400
 }
 
@@ -1188,6 +1192,11 @@ rule LeaderUploadsBlockOnBoundary {
         block_uploader.uploadBlock(record.msg_id, log_processor.leader_term, record)
         log_processor.pending_block = null
 
+        -- uploadBlock has returned, so this block's files are in object storage. Announcing
+        -- that as its own event is what lets an external source confirm its upstream
+        -- position without reaching into the uploader.
+        BlockBecameDurable(database, record.external_source_token)
+
         watchers.notifyMsg(record.latest_processed_msg_id)
 
         BlockGcSignalled()
@@ -1508,6 +1517,32 @@ rule ClientOpensSnapshot {
         )
 }
 
+rule ExternalSourceLearnsDurableExtent {
+    -- Confirming a resume token tells the upstream it may discard everything behind it, so a
+    -- confirmed position is a claim that we can recover without it. Only a durable block
+    -- backs that claim: between apply and the next block the sole copies are the replica log
+    -- and the leader's live index, and the upstream cannot re-send what we told it to drop.
+    --
+    -- So this token, and not the applied position, is the source's licence to confirm. It is
+    -- also not watchers.external_source_token, which is the one that may run ahead —
+    -- replica-log replay advances it past block boundaries — which is why
+    -- ExternalSourceAssigned's after_token is not a position we are entitled to confirm.
+    --
+    -- What a source does with the licence is its own rule: it may confirm further where the
+    -- log above the extent demonstrably holds nothing we would need. See pgsrc.allium.
+    --
+    -- The gap this opens is the block cadence: a database whose blocks stop landing pins the
+    -- upstream's log while ingestion and queries stay healthy. That is a monitoring
+    -- obligation, not a correctness one (#5867).
+    when: BlockBecameDurable(database, external_source_token)
+    requires: log_processor.mode = Leader
+    requires: database.external_source != null
+    requires: external_source_token != null
+
+    ensures:
+        log_processor.external_source.durableExtentAdvanced(external_source_token)
+}
+
 ---- Rules: Error Handling
 
 rule ProcessingErrorHaltsNode {
@@ -1522,6 +1557,37 @@ rule ProcessingErrorHaltsNode {
     ensures:
         watchers.notifyError(error)
         NodeMarkedUnhealthy()
+}
+
+---- Contracts
+
+contract ExternalSourceConfirmation {
+    -- Obligations on an ExternalSource that confirms progress upstream. These are about the
+    -- ordering of confirmations against block durability over time, so they cannot be
+    -- expressed as single-snapshot invariants over entity state.
+
+    @invariant ConfirmedPositionIsRecoverable
+        -- Everything the upstream has been told it may discard is recoverable without it, so
+        -- recovery is the last block plus the upstream resumed from the token that block
+        -- carries — one artefact, not two.
+        -- - Ordinarily this bounds the confirmed position by the last durable block's token.
+        --   A source MAY confirm beyond it over a range that holds nothing of ours; that is
+        --   the source's rule to state and to justify, per pgsrc.allium.
+
+    @invariant ConfirmationNeverNamesAnUnappliedTransaction
+        -- No confirmed position covers a transaction that has not been applied.
+        -- - Below the durable extent this holds by construction rather than by a check: a
+        --   BlockBoundary is appended after the transactions it covers, so by the time a
+        --   block is durable every transaction its token names has already been applied.
+        --   The gate can therefore only hold confirmation back, never push it past apply.
+        -- - Above the extent it holds because the only positions a source may confirm there
+        --   are ones it has established name no transaction at all.
+
+    @invariant ConfirmationIsLeaderOnly
+        -- Only the leader for a database holds its ExternalSource, so only the leader
+        -- confirms. A follower has no upstream connection and no position of its own — it
+        -- reads watchers.latest_source_msg_id — so a leadership handover cannot produce two
+        -- nodes confirming different positions to the same upstream.
 }
 
 ---- Actor Declarations

--- a/dev/doc/pgsrc.allium
+++ b/dev/doc/pgsrc.allium
@@ -1,0 +1,315 @@
+-- allium: 3
+-- pgsrc.allium
+--
+-- Scope: what the Postgres external source may confirm to its upstream.
+--   Confirming is an instruction to discard, not a progress report, so the only
+--   question is which positions are safe to give.
+-- Includes: the positions tracked and their ordering; the confirmation rule;
+--   the re-delivery skip; the effect of a failed import.
+-- Excludes: XTDB's processing model (see db.allium); row and type mapping;
+--   TOAST and replica-identity constraints; slot and publication creation.
+--
+-- Split with db.allium:
+--   db.allium owns the property in XTDB's vocabulary — an external source
+--   confirms only as far as the last durable block. This spec owns the
+--   mechanism in the upstream's vocabulary, and carries the exception:
+--   confirmation may exceed the durable position over WAL holding nothing of
+--   ours.
+
+---- Given
+
+given {
+    source: PgSource
+    xtdb: XtdbTarget
+}
+
+---- External Entities
+
+external entity XtdbTarget {
+    -- Null until the target first flushes — a cadence, not a startup step.
+    durable_lsn: Integer?
+}
+
+external entity PgSlot {
+    confirmed_lsn: Integer
+}
+
+---- Contracts
+
+contract UpstreamWalSemantics {
+    -- What Postgres owes us.
+
+    deliver: (lsn: Integer) -> Boolean
+    keepalive: () -> Integer
+
+    @invariant RetainsEverythingAboveConfirmed
+        -- WAL above confirmed_lsn remains readable, and WAL below it may be
+        -- discarded at any moment.
+        -- - Retention is per-server, not per-publication: our slot holds every
+        --   database's WAL above our confirmed position.
+
+    @invariant ResendsFromConfirmed
+        -- On reconnection, delivery resumes from confirmed_lsn.
+        -- - So a torn-down stream costs a re-read, never a gap.
+        -- - And confirmed_lsn can lag a position we already imported, which is
+        --   what the re-delivery skip exists for.
+
+    @invariant IgnoresRetrogradeConfirmations
+        -- A confirmation below confirmed_lsn has no effect.
+        -- - So the confirmed position is monotonic whether or not we track it.
+
+    @invariant ReceivedTrailsUndeliveredCommits
+        -- The received position never reaches the commit LSN of a transaction whose
+        -- commit the upstream has not delivered.
+        -- - So nothing at or below it awaits delivery, whether it last advanced on
+        --   a keepalive or part-way through a transaction still in flight.
+        -- - The received branch of confirmable_lsn rests on this and on nothing
+        --   else about the upstream's position.
+        -- - Postgres additionally pins restart_lsn at the start of an in-progress
+        --   transaction, so one is always re-sent in full.
+
+    @invariant CopiesOnlyAdvancingSlots
+        -- A slot is copied to a standby only while its position advances.
+        -- - So upstream failover depends on our flush cadence.
+}
+
+contract TargetDurability {
+    -- What the target owes us: the meaning of durable_lsn.
+
+    submit: (lsn: Integer) -> Boolean
+    durable_position: () -> Integer
+
+    @invariant DurableIsRecoverableUnaided
+        -- Everything at or below durable_lsn is recoverable from the target's
+        -- storage alone, without the upstream.
+
+    @invariant DurableCoversOnlySubmitted
+        -- durable_lsn never names a position we did not submit.
+        -- - Violation means the two describe different slots, or a token
+        --   survived a re-snapshot it should not have.
+
+    @invariant DurableIsMonotonic
+        -- durable_lsn never retreats.
+        -- - A retreat would make an already-confirmed position unrecoverable.
+
+    @invariant NoDurableExtentMeansResnapshot
+        -- With no durable extent, recovery is a re-snapshot of the upstream's
+        -- current tables, and reads no WAL.
+        -- - no_incremental_recovery confirms over WAL on the strength of this
+        --   alone. If the target would instead recover incrementally from a log
+        --   that outlived its storage, that branch loses transactions.
+}
+
+contract ConfirmablePosition {
+    -- What we owe the upstream.
+
+    confirm: (lsn: Integer) -> Boolean
+
+    @invariant ConfirmedIsRecoverable
+        -- Every confirmed position is one the target can recover to unaided.
+        -- - After losing everything but storage, resuming there loses nothing.
+
+    @invariant SoleConfirmer
+        -- At most one party confirms a given slot.
+        -- - Two would race to a position neither could justify, each knowing
+        --   only its own durable extent.
+}
+
+---- Entities and Variants
+
+entity PgSource {
+    slot: PgSlot
+
+    -- Recovered, not chosen. Deliberately unordered against durable_lsn: it can
+    -- lead, being recovered from state a storage-only recovery would lose.
+    start_lsn: Integer
+
+    -- The furthest position the target holds, whether or not its storage has it.
+    -- Opens at start_lsn rather than at nothing, because recovery has already put
+    -- the target past it — see SourceOpensStream.
+    held_lsn: Integer
+
+    -- Advances on every record the upstream sends, so it can sit above the last
+    -- commit and below the commit of a transaction still arriving.
+    received_lsn: Integer
+
+    -- Everything the target holds is on the far side of an existing recovery point.
+    all_held_durable: xtdb.durable_lsn != null and held_lsn <= xtdb.durable_lsn
+
+    -- No recovery point exists, so there is no incremental path to protect. Per
+    -- TargetDurability.NoDurableExtentMeansResnapshot the alternative reads no WAL.
+    no_incremental_recovery: xtdb.durable_lsn = null
+
+    -- Two distinct reasons, one bound: in neither case would a recovery we would
+    -- actually take read the WAL above our durable extent.
+    may_confirm_received: all_held_durable or no_incremental_recovery
+
+    confirmable_lsn: if may_confirm_received: received_lsn else: xtdb.durable_lsn
+
+    has_unconfirmed: confirmable_lsn > slot.confirmed_lsn
+
+    invariant ConfirmedWithinReceived {
+        slot.confirmed_lsn <= received_lsn
+    }
+
+    invariant ConfirmedWithinDurableWhenBehind {
+        -- #5867: transactions above the durable extent exist only inside the
+        -- target, and only the upstream could re-supply them.
+        not may_confirm_received implies slot.confirmed_lsn <= xtdb.durable_lsn
+    }
+
+    invariant HeldWithinReceived {
+        held_lsn <= received_lsn
+    }
+
+    invariant StartWithinHeld {
+        -- The target does not give back what recovery handed it, so the WAL
+        -- below start_lsn stays unconfirmable until a block covers it.
+        start_lsn <= held_lsn
+    }
+}
+
+---- Rules
+
+rule SourceOpensStream {
+    -- The resume position comes from the target, not from the slot. The two are
+    -- recovered from different places and the slot's is normally the lower, so
+    -- nothing here licenses an inference about slot.confirmed_lsn.
+    when: StreamOpened(upstream, source, resume_lsn)
+
+    ensures:
+        source.start_lsn = resume_lsn
+
+        -- Not nothing-held: the transactions between the durable extent and
+        -- resume_lsn exist only inside the target, so confirming over them would
+        -- discard the upstream's copy of the only WAL a storage-only recovery
+        -- would need.
+        source.held_lsn = resume_lsn
+
+        source.received_lsn = resume_lsn
+}
+
+rule SourceReceivesTransaction {
+    when: PgTransactionReceived(upstream, source, tx_lsn)
+
+    ensures:
+        source.received_lsn = tx_lsn
+
+        -- Skipped below start_lsn: per ResendsFromConfirmed the upstream may
+        -- re-send what we already hold, and re-importing would record a second
+        -- version of it.
+        if tx_lsn > source.start_lsn:
+            SubmitToTarget(source, tx_lsn)
+            source.held_lsn = tx_lsn
+}
+
+rule SourceReceivesKeepalive {
+    when: PgKeepaliveReceived(upstream, source, upstream_lsn)
+    requires: upstream_lsn > source.received_lsn
+
+    ensures:
+        source.received_lsn = upstream_lsn
+}
+
+rule SourceConfirmsPosition {
+    -- The position moves when the target flushes or the upstream reports
+    -- progress, neither of which is a delivery.
+    when: source: PgSource.has_unconfirmed
+    requires: source.confirmable_lsn > source.slot.confirmed_lsn
+
+    ensures:
+        source.slot.confirmed_lsn = source.confirmable_lsn
+
+    @guidance
+        -- A tracked lower bound on slot.confirmed_lsn is enough to skip a
+        -- confirmation that would change nothing, and per
+        -- IgnoresRetrogradeConfirmations a bound that is too low costs only the
+        -- redundant call. It MUST NOT be seeded from start_lsn, which is normally
+        -- the higher of the two.
+}
+
+rule ImportFailureTearsDownStream {
+    -- Not confirmed, and not skipped: leaving the slot put makes the upstream
+    -- re-send, per ResendsFromConfirmed.
+    when: TargetImportFailed(target, source, error)
+
+    ensures:
+        StreamTornDown(source)
+}
+
+---- Invariants
+
+invariant DurableExtentIsWithinHeld {
+    for s in PgSources:
+        s.xtdb.durable_lsn != null implies s.xtdb.durable_lsn <= s.held_lsn
+}
+
+---- Actor Declarations
+
+actor Upstream {
+    identified_by: PgSlot where true
+}
+
+actor Target {
+    identified_by: XtdbTarget where true
+}
+
+---- Surfaces
+
+surface UpstreamReplication {
+    facing upstream: Upstream
+
+    context source: PgSource
+
+    provides:
+        StreamOpened(upstream, source, resume_lsn)
+        PgTransactionReceived(upstream, source, tx_lsn)
+        PgKeepaliveReceived(upstream, source, upstream_lsn)
+
+    contracts:
+        demands UpstreamWalSemantics
+        fulfils ConfirmablePosition
+
+    @guarantee ConfirmationLagsFlushNotIndexing
+        -- The confirmed position tracks the target's flush cadence, not its
+        -- indexing rate.
+        -- - An operator sizes WAL retention against the former; the latter does
+        --   not bound how much the upstream must keep.
+
+    @guarantee QuietPublicationDoesNotPinUnrelatedWal
+        -- An idle source keeps releasing WAL, so it does not retain other
+        -- databases' records on a busy server.
+        -- - This is what the caught-up branch buys, and why the rule is not
+        --   simply "confirm the durable extent".
+
+    @guarantee SlotAdvancesBeforeFirstBlock
+        -- A source confirms a position before its target has cut any block.
+        -- - So CopiesOnlyAdvancingSlots is satisfied from the start, and upstream
+        --   failover does not wait on the target's flush cadence.
+
+    @guarantee NoGapOnFailure
+        -- No failure path advances the confirmed position past a transaction the
+        -- target did not import.
+}
+
+surface TargetIngestion {
+    facing target: Target
+
+    context source: PgSource
+
+    provides:
+        TargetImportFailed(target, source, error)
+
+    contracts:
+        demands TargetDurability
+
+    @guarantee SubmissionIsOrdered
+        -- Transactions are submitted in lsn order, so submitted_lsn is a
+        -- watermark rather than a maximum.
+}
+
+---- Open Questions
+
+open question "Is ReceivedTrailsUndeliveredCommits true on the server side — can a keepalive carry a position ahead of a commit still being decoded for our publication? The client half holds: pgjdbc sets the receive position from each record's own header, which for a transaction in flight is below its commit. If the server half fails, the received branch of confirmable_lsn is unsafe; if Postgres instead recycles unrelated WAL unasked, the branch is unnecessary and confirmable_lsn collapses to the durable extent."
+
+open question "Is TargetDurability.NoDurableExtentMeansResnapshot true — with no block, does the target re-snapshot rather than recover incrementally from a log that outlived its storage? If it recovers incrementally, no_incremental_recovery loses transactions and the bound must be nothing-confirmable until the first block."

--- a/docs/src/content/docs/ops/external-sources/postgres/setup.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/setup.md
@@ -8,6 +8,7 @@ To do so we will:
 
 1. Create a role with the appropriate permissions on Postgres
 1. Create a publication on Postgres
+1. Size WAL retention on Postgres
 1. Configure Postgres credentials on the XTDB node and redeploy
 1. Run `ATTACH DATABASE` in XTDB
 
@@ -56,6 +57,40 @@ Adding a non-empty table to the publication after attaching leaves it in an inco
 Rows that existed before the `ALTER PUBLICATION` are never snapshotted, only later changes are captured.
 
 Tracked in [this ticket](https://github.com/xtdb/xtdb/issues/5497)
+:::
+
+## Size WAL retention
+
+XTDB creates a replication slot, and Postgres retains WAL for that slot until XTDB confirms it.
+XTDB confirms only as far as the last block it has written to object storage, so the WAL that Postgres must retain is sized by XTDB's *block cadence*, not by how quickly it indexes each transaction.
+
+Two [node settings](/ops/config) drive that cadence, whichever comes first:
+
+`rowsPerBlock` (default `102400`)
+
+: A busy database reaches this long before any timeout, so retention tracks throughput.
+
+`flushDuration` (default `PT4H`)
+
+: A quiet database cuts a block on this timer instead.
+  On the default it sets the worst case: up to four hours of WAL.
+
+Size `max_slot_wal_keep_size` to cover the peak WAL rate over that worst case, plus headroom:
+
+```sql
+-- e.g. 20 MB/s peak × 4h flushDuration ≈ 280 GB, plus headroom
+ALTER SYSTEM SET max_slot_wal_keep_size = '400GB';
+SELECT pg_reload_conf();
+```
+
+Lowering `flushDuration` lowers the retention floor proportionally, at the cost of more, smaller blocks.
+
+:::caution[Exceeding the limit invalidates the slot]
+`max_slot_wal_keep_size` does not apply back-pressure to XTDB — when a slot's retained WAL exceeds it, Postgres invalidates the slot and its `wal_status` becomes `lost`.
+The only recovery is to drop the XTDB database and re-attach it, which re-snapshots from scratch.
+
+Leaving it at the default of `-1` means unlimited retention, which trades that failure for the Postgres disk filling up instead.
+Either way, monitor the slot — see [troubleshooting](/ops/external-sources/postgres/troubleshooting#the-replication-slot-keeps-growing).
 :::
 
 ## Deploy the Postgres credentials

--- a/docs/src/content/docs/ops/external-sources/postgres/troubleshooting.md
+++ b/docs/src/content/docs/ops/external-sources/postgres/troubleshooting.md
@@ -67,6 +67,43 @@ Delete everything under the location set in the `storage` block of the `ATTACH` 
 
 6. Re-run the [setup guide](/ops/external-sources/postgres/setup) from the beginning
 
+## The replication slot keeps growing
+
+**Symptom:**
+Retained WAL for the XTDB slot grows steadily, while XTDB itself looks healthy — rows are queryable, and `healthz` is green.
+
+```sql
+SELECT slot_name, wal_status,
+       pg_size_pretty(pg_current_wal_lsn() - confirmed_flush_lsn) AS retained
+FROM pg_replication_slots WHERE slot_name = 'xtdb';
+```
+
+The same figure is exported as the `xtdb.postgres_source.wal_lag_bytes` gauge.
+
+**Why this happens:**
+Where a transaction has been indexed but the block carrying it is not yet in object storage, Postgres is the only place it can be re-read from, so XTDB holds `confirmed_flush_lsn` at the last durable block and the WAL behind it stays.
+Retention therefore builds up over a block, and falls back to nothing each time one lands.
+
+That makes a growing slot a signal about *blocks*, not about ingestion.
+Two causes, distinguished by whether the block index is advancing:
+
+**Resolution:**
+
+1. Check when this database last cut a block, via the `xtdb.block.last_upload_time` gauge — epoch seconds, tagged `db`.
+   A value that stops advancing while the slot keeps growing is the signal to act on.
+
+2. If blocks *are* being cut, the retention is the WAL written since the last one — up to `flushDuration`'s worth, four hours on the default.
+   This is working as intended.
+   Either size retention for it, per [Size WAL retention](/ops/external-sources/postgres/setup#size-wal-retention), or lower `flushDuration` to trade more, smaller blocks for a lower retention floor.
+
+3. If blocks are *not* being cut, block flushing is stuck and the slot will grow without bound.
+   Check the node logs for object-store write failures, and check that some node holds leadership for this database.
+
+:::caution
+Do not confirm the slot by hand with `pg_replication_slot_advance` to reclaim space.
+That tells Postgres to discard WAL that XTDB has not persisted, and any transaction in the discarded range is lost — it exists only in the replica log and the leader's in-memory index, and cannot be re-sent.
+:::
+
 ## Ingestion halted on an unchanged TOASTed column
 
 **Symptom:**

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresDriver.kt
@@ -57,18 +57,18 @@ interface PostgresDriver : AutoCloseable {
 
         /**
          * The latest server WAL position received on the stream (advances on commits and protocol keepalives), used
-         * to let Postgres recycle unrelated WAL while our slot is idle. Safe to [acknowledge] ONLY when nothing read
-         * via [poll] is still awaiting durability: this position is the physical receive LSN, always below the commit
-         * LSN of any transaction whose Commit hasn't arrived yet, and — since the caller submits a transaction the
-         * moment [poll] returns it — "nothing awaiting durability" means no already-committed change sits unimported
-         * at or below it. (Postgres also holds `restart_lsn` at the start of any in-progress transaction regardless
-         * of the confirmed-flush LSN, so an un-committed transaction is always re-sent in full.)
+         * to let Postgres recycle unrelated WAL while our slot is idle. Safe to [acknowledge] ONLY once everything at
+         * or below it is recoverable without the upstream: this position is the physical receive LSN, always below
+         * the commit LSN of any transaction whose Commit hasn't arrived yet, so the caller need only account for the
+         * transactions [poll] has already returned. (Postgres also holds `restart_lsn` at the start of any
+         * in-progress transaction regardless of the confirmed-flush LSN, so an un-committed transaction is always
+         * re-sent in full.)
          */
         val walEnd: Long
 
         /**
-         * Advances the slot's confirmed-flush LSN to [lsn] and sends a standby status update. [lsn] MUST NOT exceed
-         * the highest LSN the caller has durably imported — PG recycles WAL up to it.
+         * Advances the slot's confirmed-flush LSN to [lsn] and sends a standby status update. PG recycles WAL up to
+         * it, so [lsn] MUST NOT exceed a position the caller can recover to without the upstream.
          */
         suspend fun acknowledge(lsn: Long)
     }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -298,27 +298,38 @@ class PostgresSource(
             // indexer; `submitTx`'s bounded hand-off buffer suspends us under backpressure, keeping this bounded.
             val awaitingDurability = ArrayDeque<Pair<PostgresDriver.Transaction, Deferred<TransactionResult>>>()
 
-            // Highest LSN we've durably imported, and the highest we've confirmed to Postgres. Postgres recycles
-            // WAL up to the confirmed-flush LSN, so `confirmedFlushLsn` MUST NOT exceed `durablyImportedLsn`.
-            var durablyImportedLsn = startLsn
-            var confirmedFlushLsn = startLsn
+            // Confirmation is specified in dev/doc/pgsrc.allium; the names below are its names.
 
-            suspend fun confirmFlushUpTo(lsn: Long) {
-                if (lsn > confirmedFlushLsn) {
+            // held_lsn — opens at startLsn per SourceOpensStream, not at nothing.
+            var heldLsn = startLsn
+
+            // A lower bound on slot.confirmed_lsn, per SourceConfirmsPosition's @guidance.
+            var confirmedLsn = 0L
+
+            fun durableLsn(): Long? =
+                txIndexer.latestBlock.value?.externalSourceToken
+                    ?.let { PostgresSourceToken.parseFrom(it).latestCommittedLsn }
+
+            fun confirmableLsn(): Long {
+                val durable = durableLsn()
+                return if (durable == null || durable >= heldLsn) stream.walEnd else durable
+            }
+
+            suspend fun confirm() {
+                val lsn = confirmableLsn()
+                if (lsn > confirmedLsn) {
                     stream.acknowledge(lsn)
-                    confirmedFlushLsn = lsn
+                    confirmedLsn = lsn
                 }
             }
 
-            // Promote every awaiting tx whose durability handle has completed, in order, advancing
-            // `durablyImportedLsn`. `await()` on a completed handle returns immediately, or rethrows an ingest
-            // failure — tearing down the stream so Postgres re-sends from the confirmed-flush LSN. Metrics are
-            // recorded here, at the point the tx is durable ("successful apply"), so a replayed tx isn't double-counted.
-            suspend fun promoteDurable() {
+            // Drains the completed prefix rather than awaiting the head, so a slow tx can't stall the poll
+            // loop. `await()` rethrows an ingest failure, which unwinds past `use` — ImportFailureTearsDownStream.
+            // The metrics land here so a re-delivered tx isn't counted twice.
+            suspend fun drainApplied() {
                 while (awaitingDurability.firstOrNull()?.second?.isCompleted == true) {
                     val (tx, handle) = awaitingDurability.removeFirst()
                     handle.await()
-                    durablyImportedLsn = tx.lsn
                     eventsCounter?.increment(tx.ops.size.toDouble())
                     commitsCounter?.increment()
                     lastEventEpochSeconds.set(tx.commitTime.epochSecond)
@@ -328,15 +339,13 @@ class PostgresSource(
                 }
             }
 
-            // Everything up to `startLsn` is already durable (the recovered resume token, or the snapshot's
-            // consistent point). Postgres re-sends from its confirmed-flush LSN — which lags `startLsn` whenever a
-            // crash landed between durable import and ack — so confirm `startLsn` up front to shrink that window,
-            // and skip any tx it still re-delivers at or below it (re-importing would write a redundant
-            // system-time version).
-            stream.acknowledge(startLsn)
-
             try {
                 while (currentCoroutineContext().isActive) {
+                    // SourceConfirmsPosition. Ahead of the first poll too: per ResendsFromConfirmed the
+                    // re-delivery window is measured from the confirmed position, so the sooner the better.
+                    confirm()
+
+                    // SourceReceivesTransaction.
                     stream.poll()?.let { tx ->
                         if (tx.lsn <= startLsn) {
                             LOG.debug { "[$dbName] Skipping re-delivered tx at LSN ${LogSequenceNumber.valueOf(tx.lsn)} (<= resume LSN)" }
@@ -353,16 +362,10 @@ class PostgresSource(
                             TxResult.Committed()
                         }
                         awaitingDurability.addLast(tx to handle)
+                        heldLsn = tx.lsn
                     }
 
-                    promoteDurable()
-                    // Confirm only as far as we've durably imported — except when nothing awaits durability, when
-                    // the whole received prefix (through walEnd) is durable and idle/unrelated WAL can be recycled
-                    // (see [ChangeStream.walEnd]).
-                    confirmFlushUpTo(
-                        if (awaitingDurability.isEmpty()) maxOf(durablyImportedLsn, stream.walEnd)
-                        else durablyImportedLsn
-                    )
+                    drainApplied()
                 }
             } finally {
                 connectionState.set(0)

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import xtdb.postgres.proto.PostgresSourceToken
 import org.postgresql.replication.LogSequenceNumber
@@ -33,6 +34,7 @@ import java.time.ZonedDateTime
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import io.kotest.assertions.nondeterministic.continually
 import io.kotest.assertions.nondeterministic.eventually
 
 @Tag("integration")
@@ -256,6 +258,96 @@ class PostgresSourceIntegrationTest {
             assertEquals("Alice", rows[0]["name"])
             assertEquals("Bob", rows[1]["name"])
             assertEquals("Charlie", rows[2]["name"])
+        }
+    }
+
+    @Test
+    fun `slot advances before the first block is cut`() = runTest(timeout = 180.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_no_block (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_no_block (_id, name) VALUES (1, 'snapshot-row')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_no_block",
+        )
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresSource(node, slotName = slotName, publicationName = pubName)
+            awaitTxs(node, 2, db = "cdc")
+
+            val cdc = (node as XtdbInternal).dbCatalog["cdc"]!!
+            assertNull(cdc.blockCatalog.currentBlockIndex, "test precondition: no block cut")
+
+            val atAttach = pgSlotConfirmedFlushLsn(slotName)
+
+            pgExecute("INSERT INTO pg_no_block (_id, name) VALUES (2, 'streamed-two')")
+            eventually(30.seconds) {
+                assertEquals(2, xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_no_block").size, "streamed row applied")
+            }
+
+            eventually(30.seconds) {
+                assertTrue(
+                    pgSlotConfirmedFlushLsn(slotName) > atAttach,
+                    "slot advances with no block to gate on, so Postgres can recycle unrelated WAL and copy the slot to a standby",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `slot is confirmed only as far as the last durable block`() = runTest(timeout = 180.seconds) {
+        val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
+        val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
+        val sourceTopic = "test-topic-${UUID.randomUUID()}"
+
+        pgExecute(
+            "CREATE TABLE IF NOT EXISTS pg_confirm (_id INT PRIMARY KEY, name TEXT)",
+            "INSERT INTO pg_confirm (_id, name) VALUES (1, 'snapshot-row')",
+            "CREATE PUBLICATION $pubName FOR TABLE pg_confirm",
+        )
+
+        openNode(sourceTopic).use { node ->
+            attachPostgresSource(node, slotName = slotName, publicationName = pubName)
+            awaitTxs(node, 2, db = "cdc")
+
+            val cdc = (node as XtdbInternal).dbCatalog["cdc"]!!
+
+            cdc.sendFlushBlockMessage()
+            eventually(30.seconds) { assertTrue(cdc.blockCatalog.currentBlockIndex != null, "first block persisted") }
+            val blockLsn = PostgresSourceToken.parseFrom(cdc.blockCatalog.externalSourceToken!!).latestCommittedLsn
+
+            pgExecute(
+                "INSERT INTO pg_confirm (_id, name) VALUES (2, 'streamed-two')",
+                "INSERT INTO pg_confirm (_id, name) VALUES (3, 'streamed-three')",
+            )
+            eventually(30.seconds) {
+                assertEquals(3, xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_confirm").size, "streamed rows applied")
+            }
+
+            // Applied but unblocked, so the leader has imported past the block — which also rules out the
+            // idle walEnd advance, since that requires everything imported to be in a block. Confirming
+            // further here would tell Postgres to recycle WAL for transactions whose only copies are the
+            // replica log and the leader's live index.
+            //
+            // `continually`, not a single read: the ack reaches the slot asynchronously, so one sample taken
+            // straight after the rows apply passes whether or not the gate is there. Holding the invariant
+            // over a window is what makes it fail when confirmation tracks apply.
+            continually(5.seconds) {
+                val confirmed = pgSlotConfirmedFlushLsn(slotName)
+                assertTrue(confirmed <= blockLsn, "slot confirmed at $confirmed, past the last durable block at $blockLsn")
+            }
+
+            cdc.sendFlushBlockMessage()
+            eventually(30.seconds) {
+                val persisted = PostgresSourceToken.parseFrom(cdc.blockCatalog.externalSourceToken!!).latestCommittedLsn
+                assertTrue(persisted > blockLsn, "second block's token covers the streamed rows")
+            }
+
+            eventually(30.seconds) {
+                assertTrue(pgSlotConfirmedFlushLsn(slotName) > blockLsn, "slot advances once the block is durable")
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #5867

## tl;dr

An external-source database tells its upstream "you may discard up to here" only once that data is in object storage, rather than once it is indexed.

- **A Postgres source's replication slot now lags by block cadence, not by indexing speed**
  Up to `flushDuration` — four hours on the default — where it was seconds.

- **`max_slot_wal_keep_size` becomes a number you have to size deliberately**
  Exceeding it invalidates the slot rather than applying back-pressure, so the failure mode is a full re-snapshot, not a slowdown. The setup guide has a worked example.

- **`xtdb.block.last_upload_time` is new, and is the number that governs upstream retention**
  Tagged `db`, epoch seconds.

- **Failover slots are unaffected**
  A slot advances before the first block is cut, so Postgres copies it to a standby from the start.

- **Databases without an external source are unaffected**
  Nothing in the block path changes for them.

## Context

Confirming a resume token is a destructive instruction, not a progress report: it licenses the upstream to recycle everything behind it.

A transaction that has been indexed but not yet flushed exists in exactly two places — the replica log and the leader's live index — and Postgres cannot re-send it, because we told it not to keep it. Confirming at that point makes recovery an argument about two artefacts agreeing.

Gating on block durability collapses it to a single invariant: **recovery is the last block, plus the upstream resumed from the token that block carries.**

## The rule

Specified in `dev/doc/pgsrc.allium`, which the implementation is derived from — the code's comments cite its rule and invariant names rather than restating the argument.

- **The confirmable position is the last durable block's token**
  Below it, everything is recoverable from storage alone.

- **Except where a recovery we would actually take reads no log above it**
  Two such cases, one per way the durable extent can fail to bind. Both are in the spec with their consequences named.

  - **The extent already covers everything the database holds**
    The log above it holds nothing of ours, so idle and unrelated WAL is released. This is what stops a quiet publication pinning a busy server's WAL.

  - **There is no extent at all**
    Nothing is recoverable from storage, so recovery is a re-snapshot and withholding log protects nothing.

- **`db.allium` owns the property, `pgsrc.allium` owns the mechanism**
  `ConfirmedPositionIsRecoverable` states the obligation — everything discardable is recoverable without the upstream — rather than the mechanism, "never exceeds the token", because it is the mechanism that has exceptions. This mirrors the docs' properties-vs-mechanism split.

## Operational impact

Nothing to run. One number changes meaning for anyone operating a Postgres source.

- **Size `max_slot_wal_keep_size` against block cadence**
  Peak WAL rate over `flushDuration`, four hours on the default. `docs/ops/external-sources/postgres/setup.md` has the step and a worked example.

- **A growing slot is a signal about blocks, not ingestion**
  Retention builds between blocks and falls back each time one lands, so the diagnostic that splits the cases is whether `xtdb.block.last_upload_time` is advancing. Covered in the troubleshooting page.

- **`pg_replication_slot_advance` is the wrong way to reclaim the space**
  It discards precisely the transactions this change protects. Stated in the troubleshooting page because it is the obvious move.

## Assumptions this rests on

Both are `open question` declarations in `pgsrc.allium`, each naming what breaks if it is false. Neither is discharged here. Resolve `X2` before leaning further on the no-extent branch.

- **`assumption: X1` — the upstream never reports a position reaching the commit LSN of a transaction it has not delivered**
  The client half holds: pgjdbc sets the received position from each record's own header, which for a transaction in flight is below its commit. The server half is open — whether a keepalive can carry a position ahead of a commit still being decoded for our publication. If it fails, the received-position branch is unsafe.

- **`check: X2` — with no block, recovery re-snapshots rather than recovering incrementally from a log that outlived its storage**
  Every database takes this branch for its whole pre-first-block window, so it is a live path rather than a corner case. If it is false, the bound must be nothing-confirmable until the first block.

## Decision rationale

Decomposed by where each rejected option would have moved the cost.

- **`D1` — a `StateFlow` on `TxIndexer`, not a per-tx handle and not an `ExternalSource` callback**
  A second deferred per transaction would need a block boundary to sweep a batch of them, where a conflated latest-wins value does the job, since the confirmation position is monotonic. A callback would put a network ack on the apply loop's critical path and make ordering the leader's problem rather than the source's.

- **`D2` — carry the whole block, not just the token**
  The proto's numbers already travel together, and a value type removes the `hasX()` guard from every accessor rather than adding a single-purpose channel.

- **`D3` — `submitTx`'s deferred keeps its meaning**
  Completing it at block durability would be simplest for the source, but `executeTx` is `submitTx(...).await()`, so every caller would block for up to a block cadence.

- **`A1` — shorten block cadence for external-source databases**
  Out of scope rather than wrong: `flushDuration` is node-wide, so per-database cadence needs new config surface through `ATTACH DATABASE` and `DatabaseConfig`. It is the answer for anyone who finds four hours of retention too expensive, and wants its own card.

- **`A2` — confirm the resume position up front, unconditionally**
  Tempting, because the source skips re-delivered transactions at or below it, so the log beneath looks unusable. Rejected: if the replica log is lost, the next resume position falls back to the block's token, which is lower — so the log discarded is exactly what recovery then needs.

## Changes

Four commits, in reading order.

1. **`tidy(block-catalog)` — hold the latest block as a value behind a `StateFlow`**
   Behaviour-preserving, and reviewable as a pure refactor. `BlockCatalog.latestBlock` goes from a `@Volatile var Block?` (the protobuf) to a `MutableStateFlow<BlockDetails?>`. `BlockDetails` is a plain Kotlin value type with no proto knowledge, so a field a block may not carry becomes ordinary nullability rather than a `hasX()` guard at every accessor. The accessor surface keeps its names and types because five Clojure namespaces call them over interop.

2. **`feat(ext-source)` — expose the last durable block**
   `TxIndexer` gains `val latestBlock: StateFlow<BlockDetails?>`, delegating to the catalog. It advances only in `refresh()`, which the leader calls after `putObject(blockFilePath)` returns, so a collector observes durability rather than resolution.

3. **`feat(metrics)` — report when a database last cut a block**
   A timer records uploads that happened; `xtdb.block.last_upload_time` records their absence, which is the failure that would otherwise be silent.

4. **`fix(postgres-source)` — the rule itself**
   Plus `pgsrc.allium`, the `db.allium` reconciliation, the docs and the tests.

## Implementation notes

- **The gate is three values and one branch**
  The durable extent, the furthest position the database holds, and a lower bound on the slot's own position.

- **The held position opens at the resume LSN, not at nothing**
  The transactions between the last durable block and the resume position are held only by the replica log and the live index, so treating "nothing submitted yet" as "everything we hold is durable" would confirm over exactly the log a storage-only recovery needs.

- **The tracked slot position opens at nothing, not at the resume LSN**
  It exists only to skip a status update that would change nothing, since `acknowledge` is a network round trip and the poll loop spins. The slot's position and the resume token come from different places and the token is normally the higher, so seeding from it would swallow every real confirmation below it.

- **Safety below the extent is structural rather than checked**
  `submitTx`'s deferred completes on consume-back, in `applyRecord`'s `ResolvedTx` branch, and a `BlockBoundary` is enqueued after the transactions it covers — so the same consume-back loop completes every transaction a block covers before it reaches that block's boundary. The gate can only hold confirmation back, never push it past apply.

- **Confirming at the top of the poll loop covers the pre-first-poll case**
  pgjdbc seeds its received position to the requested start LSN, so the first iteration reproduces the up-front acknowledgement that shrinks the re-delivery window.

## Test plan

- **The upper bound is red-greened**
  With the change reverted, `slot is confirmed only as far as the last durable block` fails on `slot confirmed at …, past the last durable block at …`. It holds the invariant across a window with kotest's `continually`, because a single sample of `confirmed_flush_lsn` races the slot's asynchronous update and passes either way.

- **The progress direction has its own test**
  `slot advances before the first block is cut` covers the case where no block exists — the direction an upper-bound-only suite cannot catch. It is attributable rather than incidental: pgjdbc's periodic standby status update only resends what `acknowledge` last set, so it cannot advance the slot on its own.

- **`PostgresSourceFailoverTest` is unchanged from `main`, and passes**
  The slot advances before the first block, so the standby has something to copy.

- **Full suite green**
  `test` 2150, `integration-test` 0 failures across root/`core`/`postgres-source`/`kafka`, `property-test` 0 failures with all five simulation classes present at 100 iterations. `property-test` is required because `BlockUploader` and `BlockCatalog` sit on the simulation path `./gradlew test` cannot reach.

- **`pgsrc.allium` validates at 0 errors**
  `db.allium` retains one pre-existing reference error, `Compactor/ForDatabase` from `e59da30ce`, unrelated to this change and left alone because the fix reaches into `compaction.allium`, which has a parse error of its own.
