### PR TITLE
ai: milestone at creation only for release blockers, otherwise at close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,9 @@ Treat a hit from another project as "already tracked, leave it alone".
 
 When you open an issue *or* PR, work out whether it's standalone or part of a surrounding issue, then:
 
-- **There's a surrounding issue** (the PR closes, advances, or is otherwise scoped by an open issue): the **issue** carries the board card and, if the work is end-user-visible, the milestone.
+- **There's a surrounding issue** (the PR closes, advances, or is otherwise scoped by an open issue): the **issue** carries the board card, and the milestone if it passes both tests in [Milestones](#milestones) below.
   The PR does not go on the board and does not get a milestone — it inherits them through the issue.
-- **It's a standalone PR** (no surrounding issue, e.g. a small fix, cleanup, or dependency bump worth noting in release notes): the **PR** goes on the board and on the milestone directly.
+- **It's a standalone PR** (no surrounding issue, e.g. a small fix, cleanup, or dependency bump worth noting in release notes): the **PR** goes on the board directly, and takes the milestone on the same two tests.
 
 This mirrors how the release notes are written — one entry per issue-or-standalone-PR, never both.
 Applies to docs-only and meta/repo-admin work too (1.x work is the only category that doesn't go on the 2.x board, and there's very little of that these days).
@@ -148,9 +148,40 @@ Flattening everything onto the umbrella out of habit loses the dependency struct
 
 ### Milestones
 
-A milestone is the release-notes scope, so it carries a narrower test than the board does: set one only when the work is **end-user-visible**.
-Internal refactors, module-author-facing SPI tightening, test-infra and infrastructure cleanup go on the board with an appropriate `Stream` but MUST NOT go on `2-NEXT` or any other milestone, however large they are.
-End users don't read about interface tightening; putting it on the milestone clutters the release notes with internal noise.
+A milestone means two different things depending on the card's state, and both readings have to keep working:
+
+- **Open on the milestone** means *the release is waiting for this* — the open list is the "what's left before we can ship?" queue.
+- **Closed on the milestone** means *this shipped in the release* — the closed list is the release-notes scope.
+
+So setting a milestone **when you create a card** requires it to pass two tests, not one:
+
+- **End-user-visible.**
+  Internal refactors, module-author-facing SPI tightening, test-infra and infrastructure cleanup go on the board with an appropriate `Stream` but MUST NOT go on `2-NEXT` or any other milestone, however large they are — not at creation, and not at close either.
+  End users don't read about interface tightening; putting it on the milestone clutters the release notes with internal noise.
+- **Blocking the next release** — would we hold the release for this?
+  If not, leave the milestone off at creation and **set it when you close the card**.
+  By then it has definitely landed in the release, so it earns its release-notes entry without ever having claimed to be a blocker.
+
+You MAY add the milestone to an open card mid-flight, once it's decided the work is going into this release after all.
+That is the same move as setting it at close, just earlier, and it is the only reason an open card should gain one.
+
+The rule follows from what the open list is for.
+Every card on it asserts the release is waiting, so a non-blocker dilutes exactly the signal the list exists to carry, and "is this milestone still accurate?" stops being answerable at a glance.
+
+**Bugs are not automatically blockers.**
+It is tempting to treat every bug as a showstopper.
+Most are not, and reaching for the milestone by reflex is how the open list fills up with work nobody intends to hold the release for.
+
+- **A pre-existing bug is presumptively not a blocker**: if the last release shipped with it, this one can too.
+  What overrides that is a change in the bug's *situation* rather than its existence — it got worse, it became reachable on a path this release adds, or something else shipping this release makes it materially more likely to be hit.
+- **Severity is the test, not the issue type.**
+  A `Bug` type and a `fix:` prefix say nothing about whether the release waits for it.
+  Silent data loss or corruption usually does qualify, as does wedging a node or a database with no operator route out; a wrong error message on a narrow edge case usually doesn't.
+- **Wrong observability can be load-bearing for something else on the milestone.**
+  A metric that reads healthy when it knows nothing is ordinarily its own card, and becomes a blocker when a change already in the release makes that metric the signal an operator is told to rely on.
+
+When you can't tell, ask rather than defaulting.
+Defaulting *on* is the more expensive mistake here: an absent milestone is caught when the card closes, whereas a wrong one quietly misrepresents the release scope until someone audits it.
 
 The open milestone is always named `2-NEXT`.
 Look up its current REST number by name+state rather than caching it:
@@ -159,7 +190,8 @@ Look up its current REST number by name+state rather than caching it:
 gh api '/repos/xtdb/xtdb/milestones?state=open' --jq '.[] | select(.title=="2-NEXT") | .number'
 ```
 
-Set it on an issue or PR with `gh issue edit N --milestone 2-NEXT` / `gh pr edit N --milestone 2-NEXT`.
+Set it on an issue or PR with `gh issue edit N --milestone 2-NEXT` / `gh pr edit N --milestone 2-NEXT`, and take it off with `gh issue edit N --remove-milestone` / `gh pr edit N --remove-milestone`.
+Removing a milestone leaves the board card and its fields untouched, so it is the right move for a card that turned out not to be blocking — it drops out of the release scope and stays tracked.
 
 ### Labels
 


### PR DESCRIPTION
tl;dr

- **`2-NEXT`'s open list becomes the ship-blocker queue** — "what's left before we can ship?" — rather than everything user-visible that might land in the release.
- **A user-visible non-blocker now takes the milestone when it closes**, not when it's created, because by then it has definitely shipped.
- **Bugs get guidance of their own**, since "it's a bug, so it blocks" is the reflex that fills the list up.
- **Agent-instructions only** — no code, no behaviour change.

## Context

No surrounding issue: this came out of auditing `2-NEXT` during the 2.2 run-up, with rc1 already cut.

The milestone had 17 open cards, of which eight were things we would actually hold the release for. The remainder were a mix of `tidy:`/`test:`-prefixed internals, cards gated on a feature 2.2 doesn't ship (multi-partition), and a refactor whose own stated motivation was reviewer burden. Every one of them satisfied the rule as written, which is the point — the rule had a single test, **end-user-visible**, and that test is about release-notes scope rather than about whether the release is waiting.

The consequence is that the open milestone couldn't answer the question people actually open it to ask. Reading it told you what might be in 2.2, not what was left to do before 2.2 could ship, and there was no way to tell the two apart without re-triaging every card.

## What changed in the rule

- **The milestone is named as carrying two readings**, split by card state: open means the release is waiting for this, closed means this shipped in the release.
  The old rule governed only the second, which is why a card could be correctly milestoned and still misrepresent the release scope for months.

- **Setting it at creation now takes both tests** — end-user-visible *and* blocking the release.
  End-user-visible keeps its full force and is unchanged, including the prohibition on internal work ever taking a milestone.

- **Failing the blocking test defers rather than disqualifies.**
  The card takes the milestone when it closes, which is stronger evidence than a prediction made at creation, and it can be added mid-flight once it's decided the work is going into the release.

- **Bugs are called out explicitly**, with a pre-existing bug presumptively not a blocker: if the last release shipped with it, this one can too, and what overrides that is a change in the bug's *situation* rather than its existence.

- **`--remove-milestone` is documented** alongside setting one, with the note that it leaves the board card and its fields untouched — so taking a card out of release scope doesn't cost its tracking.

## Already applied

The audit that prompted this took nine items off `2-NEXT` ahead of the rule being written down: #5834, #5833, #5884, #5849, #5734, #5854, #5871, #5868, and PR #5853. All nine remain on the board with `Status` and `Stream` untouched, and #5887 was raised under the new rule with no milestone. `2-NEXT` currently has 8 open.

## Out of scope

- **A label-name error in the same file**, left alone to keep this commit focused: the component-label list names `docs`, which is not a label in this repo — the real one is `documentation`. Worth a separate one-word fix.
- **Which cards belong on the milestone.** This changes the rule for deciding, not any particular decision; the nine above were agreed case by case.
