### PR TITLE
refactor(scan): merge by entity, then by system-time within it

### DIFF
--- a/core/src/main/kotlin/xtdb/bitemporal/PolygonCalculator.kt
+++ b/core/src/main/kotlin/xtdb/bitemporal/PolygonCalculator.kt
@@ -1,31 +1,31 @@
 package xtdb.bitemporal
 
-import org.apache.arrow.memory.util.ArrowBufPointer
 import xtdb.trie.EventRowPointer
 import xtdb.util.TemporalBounds
 
 class PolygonCalculator(private val queryBounds: TemporalBounds? = null) {
-    companion object {
-        private fun ArrowBufPointer.setFrom(src: ArrowBufPointer) = apply { set(src.buf, src.offset, src.length) }
-    }
-
-    private val skipIidPtr = ArrowBufPointer()
-    private val prevIidPtr = ArrowBufPointer()
-    val currentIidPtr = ArrowBufPointer()
-
     private val ceiling = Ceiling()
     private val polygon = Polygon()
+
+    // the iid we're currently resolving, and whether we've seen an erase for it.
+    // the initial (0, 0) needn't be distinguishable from a genuine iid: the most it can cost us is the
+    // ceiling reset on the first row, and the ceiling is constructed already reset.
+    private var iidHigh = 0L
+    private var iidLow = 0L
+    private var erased = false
 
     fun reset() = ceiling.reset()
 
     fun calculate(erp: EventRowPointer): Polygon? {
-        // after an erase, we don't process any more rows
-        if (skipIidPtr == erp.getIidPointer(currentIidPtr)) return null
-
-        if (prevIidPtr != currentIidPtr) {
+        if (erp.iidHigh != iidHigh || erp.iidLow != iidLow) {
+            iidHigh = erp.iidHigh
+            iidLow = erp.iidLow
+            erased = false
             ceiling.reset()
-            prevIidPtr.setFrom(currentIidPtr)
         }
+
+        // after an erase, we don't process any more rows
+        if (erased) return null
 
         val isErase = erp.op == "erase"
 
@@ -40,10 +40,8 @@ class PolygonCalculator(private val queryBounds: TemporalBounds? = null) {
         polygon.calculateFor(ceiling, validFrom, validTo)
         ceiling.applyLog(systemFrom, validFrom, validTo)
 
-        if (isErase) {
-            skipIidPtr.setFrom(currentIidPtr)
-        }
-        
+        if (isErase) erased = true
+
         return polygon
     }
 }

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -63,7 +63,10 @@ class ScanCursor(
         while (mergeTasks.hasNext()) {
             val task = mergeTasks.next()
             val taskPath = task.path
-            val mergeQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.comparator()))
+            // outer: one entry per page, ordered by the iid that page is currently on.
+            // inner: the pages sitting on the entity being resolved, newest system-time first.
+            val iidQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.iidComparator()))
+            val eventQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.systemFromComparator()))
             val polygonCalculator = PolygonCalculator(temporalBounds)
 
             // we're not in coroutine land here, so it's a good boundary for runBlocking
@@ -78,39 +81,52 @@ class ScanCursor(
             leafReaders.forEachIndexed { idx, leafReader ->
                 val evPtr = EventRowPointer(leafReader, taskPath)
                 if (!evPtr.isValid()) return@forEachIndexed
-                mergeQueue.add(LeafPointer(evPtr, idx))
+                iidQueue.add(LeafPointer(evPtr, idx))
             }
 
             BitemporalConsumer.open(al, leafReaders, colNames).use { bitemporalConsumer ->
                 while (true) {
-                    val leafPtr = mergeQueue.poll() ?: break
-                    val evPtr = leafPtr.evPtr
+                    val firstOfIid = iidQueue.poll() ?: break
 
-                    polygonCalculator.calculate(evPtr)
-                        ?.takeIf { evPtr.op == "put" }
-                        ?.let { polygon ->
-                            val sysFrom = evPtr.systemFrom
-                            val idx = evPtr.index
+                    // the entity we're resolving, captured before its own pointer advances past it
+                    val iidHigh = firstOfIid.evPtr.iidHigh
+                    val iidLow = firstOfIid.evPtr.iidLow
 
-                            repeat(polygon.validTimeRangeCount) { i ->
-                                val validFrom = polygon.getValidFrom(i)
-                                val validTo = polygon.getValidTo(i)
-                                val sysTo = polygon.getSystemTo(i)
+                    eventQueue.add(firstOfIid)
+                    while (iidQueue.peek()?.evPtr?.sameIidAs(iidHigh, iidLow) == true)
+                        eventQueue.add(iidQueue.poll())
 
-                                if (
-                                    temporalBounds.intersects(validFrom, validTo, sysFrom, sysTo)
-                                    && validFrom != validTo && sysFrom != sysTo
-                                ) {
-                                    val outValidFrom = if (clampValidTime) max(validFrom, vtLower) else validFrom
-                                    val outValidTo = if (clampValidTime) min(validTo, vtUpper) else validTo
-                                    bitemporalConsumer.accept(leafPtr.relIdx, idx, outValidFrom, outValidTo, sysFrom, sysTo)
+                    while (true) {
+                        val leafPtr = eventQueue.poll() ?: break
+                        val evPtr = leafPtr.evPtr
+
+                        polygonCalculator.calculate(evPtr)
+                            ?.takeIf { evPtr.op == "put" }
+                            ?.let { polygon ->
+                                val sysFrom = evPtr.systemFrom
+                                val idx = evPtr.index
+
+                                repeat(polygon.validTimeRangeCount) { i ->
+                                    val validFrom = polygon.getValidFrom(i)
+                                    val validTo = polygon.getValidTo(i)
+                                    val sysTo = polygon.getSystemTo(i)
+
+                                    if (
+                                        temporalBounds.intersects(validFrom, validTo, sysFrom, sysTo)
+                                        && validFrom != validTo && sysFrom != sysTo
+                                    ) {
+                                        val outValidFrom = if (clampValidTime) max(validFrom, vtLower) else validFrom
+                                        val outValidTo = if (clampValidTime) min(validTo, vtUpper) else validTo
+                                        bitemporalConsumer.accept(leafPtr.relIdx, idx, outValidFrom, outValidTo, sysFrom, sysTo)
+                                    }
                                 }
                             }
-                        }
 
-                    evPtr.nextIndex()
+                        evPtr.nextIndex()
 
-                    if (evPtr.isValid()) mergeQueue.add(leafPtr)
+                        if (evPtr.isValid())
+                            (if (evPtr.sameIidAs(iidHigh, iidLow)) eventQueue else iidQueue).add(leafPtr)
+                    }
                 }
 
                 val colPreds = colPreds.entries

--- a/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
+++ b/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
@@ -20,6 +20,9 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
     var iidLow: Long = -1
         private set
 
+    var systemFrom: Long = -1
+        private set
+
     private fun indexOf(path: ByteArray): Int {
         var left = 0
         var right = relReader.rowCount
@@ -39,6 +42,7 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
             if (value < relReader.rowCount) {
                 iidHigh = iidReader.getLongLongHigh(value)
                 iidLow = iidReader.getLongLongLow(value)
+                systemFrom = sysFromReader.getLong(value)
             }
         }
 
@@ -53,12 +57,13 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
 
     fun getIidPointer(reuse: ArrowBufPointer) = iidReader.getPointer(index, reuse)
 
-    val systemFrom get() = sysFromReader.getLong(index)
     val validFrom get() = validFromReader.getLong(index)
     val validTo get() = validToReader.getLong(index)
     val op get() = opReader.getLeg(index)!!
 
     fun isValid(): Boolean = index < maxIndex
+
+    fun sameIidAs(iidHigh: Long, iidLow: Long) = this.iidHigh == iidHigh && this.iidLow == iidLow
 
     companion object {
         @JvmStatic
@@ -67,5 +72,16 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
             compareUnsigned(l.iidLow, r.iidLow).takeIf { it != 0 }?.let { return@Comparator it }
             r.systemFrom.compareTo(l.systemFrom)
         }
+
+        /** Orders pages by the iid each is currently sitting on. */
+        @JvmStatic
+        fun iidComparator(): Comparator<in EventRowPointer> = Comparator { l, r ->
+            compareUnsigned(l.iidHigh, r.iidHigh).takeIf { it != 0 } ?: compareUnsigned(l.iidLow, r.iidLow)
+        }
+
+        /** Orders one entity's events, newest system-time first. */
+        @JvmStatic
+        fun systemFromComparator(): Comparator<in EventRowPointer> =
+            Comparator { l, r -> r.systemFrom.compareTo(l.systemFrom) }
     }
 }

--- a/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
+++ b/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
@@ -14,8 +14,11 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
 
     private val opReader = relReader["op"]
 
-    private var iidHigh: Long = -1
-    private var iidLow: Long = -1
+    var iidHigh: Long = -1
+        private set
+
+    var iidLow: Long = -1
+        private set
 
     private fun indexOf(path: ByteArray): Int {
         var left = 0

--- a/core/src/test/kotlin/xtdb/bitemporal/PolygonCalculatorTest.kt
+++ b/core/src/test/kotlin/xtdb/bitemporal/PolygonCalculatorTest.kt
@@ -1,0 +1,132 @@
+package xtdb.bitemporal
+
+import com.carrotsearch.hppc.LongArrayList.from as longs
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import xtdb.arrow.Relation
+import xtdb.arrow.STRUCT_TYPE
+import xtdb.arrow.VectorType.Companion.I64
+import xtdb.trie.EventRowPointer
+import xtdb.trie.Trie
+import xtdb.util.TemporalBounds
+import xtdb.util.TemporalDimension
+import java.nio.ByteBuffer
+import kotlin.Long.Companion.MAX_VALUE as MAX_LONG
+
+/**
+ * Events are written in the order bitemporal resolution sees them: iid ascending, system-from descending.
+ */
+class PolygonCalculatorTest {
+
+    private val iidA = ByteArray(16) { 1 }
+    private val iidB = ByteArray(16) { 2 }
+
+    private fun Relation.writeEvent(iid: ByteArray, sysFrom: Long, validFrom: Long, validTo: Long, op: String) {
+        this["_iid"].writeBytes(ByteBuffer.wrap(iid))
+        this["_system_from"].writeLong(sysFrom)
+        this["_valid_from"].writeLong(validFrom)
+        this["_valid_to"].writeLong(validTo)
+
+        if (op == "put") this["op"].vectorFor("put", STRUCT_TYPE, false).vectorFor("x", I64.arrowType, false).writeLong(0)
+        else this["op"][op].writeNull()
+
+        endRow()
+    }
+
+    private fun withEvents(
+        queryBounds: TemporalBounds? = null,
+        writeEvents: Relation.() -> Unit,
+        assertPolygons: (PolygonCalculator, EventRowPointer) -> Unit
+    ) =
+        RootAllocator().use { al ->
+            Trie.openLogDataWriter(al).use { rel ->
+                rel.writeEvents()
+                assertPolygons(PolygonCalculator(queryBounds), EventRowPointer(rel, ByteArray(0)))
+            }
+        }
+
+    @Test
+    fun `an earlier event resolves against only its own entity's ceiling`() {
+        withEvents(
+            writeEvents = {
+                writeEvent(iidA, sysFrom = 2, validFrom = 10, validTo = 20, op = "put")
+                writeEvent(iidA, sysFrom = 1, validFrom = 0, validTo = 100, op = "put")
+                writeEvent(iidB, sysFrom = 1, validFrom = 0, validTo = 100, op = "put")
+            },
+            assertPolygons = { calc, evPtr ->
+                calc.calculate(evPtr)
+                evPtr.nextIndex()
+
+                calc.calculate(evPtr).let { polygon ->
+                    assertEquals(longs(0, 10, 20, 100), polygon!!.validTimes)
+                    assertEquals(longs(MAX_LONG, 2, MAX_LONG), polygon.sysTimeCeilings)
+                }
+                evPtr.nextIndex()
+
+                calc.calculate(evPtr).let { polygon ->
+                    assertEquals(longs(0, 100), polygon!!.validTimes, "B's ceiling is untouched by A's events")
+                    assertEquals(longs(MAX_LONG), polygon.sysTimeCeilings)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun `an erase suppresses the entity's earlier events, and only that entity's`() {
+        withEvents(
+            writeEvents = {
+                writeEvent(iidA, sysFrom = 2, validFrom = 0, validTo = MAX_LONG, op = "erase")
+                writeEvent(iidA, sysFrom = 1, validFrom = 0, validTo = 100, op = "put")
+                writeEvent(iidB, sysFrom = 1, validFrom = 0, validTo = 100, op = "put")
+            },
+            assertPolygons = { calc, evPtr ->
+                calc.calculate(evPtr)
+                evPtr.nextIndex()
+
+                assertNull(calc.calculate(evPtr), "A's put is erased")
+                evPtr.nextIndex()
+
+                assertEquals(longs(0, 100), calc.calculate(evPtr)!!.validTimes, "B is untouched by A's erase")
+            }
+        )
+    }
+
+    @Test
+    fun `an erase after the query's system time still suppresses`() {
+        withEvents(
+            queryBounds = TemporalBounds(systemTime = TemporalDimension(1, 2)),
+            writeEvents = {
+                writeEvent(iidA, sysFrom = 5, validFrom = 0, validTo = MAX_LONG, op = "erase")
+                writeEvent(iidA, sysFrom = 1, validFrom = 0, validTo = 100, op = "put")
+            },
+            assertPolygons = { calc, evPtr ->
+                calc.calculate(evPtr)
+                evPtr.nextIndex()
+
+                assertNull(calc.calculate(evPtr))
+            }
+        )
+    }
+
+    @Test
+    fun `a put after the query's system time neither resolves nor constrains`() {
+        withEvents(
+            queryBounds = TemporalBounds(systemTime = TemporalDimension(1, 3)),
+            writeEvents = {
+                writeEvent(iidA, sysFrom = 5, validFrom = 10, validTo = 20, op = "put")
+                writeEvent(iidA, sysFrom = 1, validFrom = 0, validTo = 100, op = "put")
+            },
+            assertPolygons = { calc, evPtr ->
+                assertNull(calc.calculate(evPtr))
+                evPtr.nextIndex()
+
+                calc.calculate(evPtr).let { polygon ->
+                    assertEquals(longs(0, 100), polygon!!.validTimes, "the out-of-bounds put left no ceiling behind")
+                    assertEquals(longs(MAX_LONG), polygon.sysTimeCeilings)
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
Groundwork for #4014 and #4967. Resolves neither, and changes no observable behaviour.

## tl;dr

- **Bitemporal resolution compared a 16-byte iid on every event; it now compares one per entity per page.**
  `ScanCursor`'s single `(iid ascending, system-from descending)` priority queue becomes two — an outer queue over entities, an inner queue over one entity's events — so the comparator that runs per event is a single long rather than an iid.

- **Behaviour is intentionally unchanged, and the thing to review is the ordering argument rather than the diff.**
  The same events reach `PolygonCalculator` in the same order and the same rows come out. If that claim holds the change is invisible; if it doesn't, the failure mode is wrong query results rather than a crash.

- **The seam is the point, more than the saving.**
  "Done with this entity" is now a place in the loop. #4014 (group events under their iid on disk) and #4967 (stop at the first event covering an as-of point) both need one, and neither can express it against a flat queue.

- **Nobody has measured it.**
  The saving scales with events per entity per page, so it is a wash on a table with one version per entity and only pays on the churn-heavy shapes #4014 describes. Sizing that is a separate job, noted under Out of scope.

## Context

Events reach bitemporal resolution in `(iid ascending, system-from descending)` order, and they arrive in runs — every version of one entity, newest first, before the next entity starts. `ScanCursor` was throwing that structure away: a single priority queue over event pointers, whose comparator leads with the 16-byte iid, so every event paid `O(log pages)` iid comparisons to rediscover a boundary the data already expressed.

`PolygonCalculator` paid twice over. It has to notice when it crosses into a new entity, and it did that by re-deriving the iid as an `ArrowBufPointer` and comparing 16 bytes — twice per event — even though `EventRowPointer` has cached the iid as two longs since #4965. It also held three `ArrowBufPointer`s standing in for at most two values, with the post-erase skip encoded as "`skipIidPtr` happens to equal the entity we're on".

## Changes

1. `bfcc77ca3` — `tidy(bitemporal): one iid and an erase flag, not three ArrowBufPointers`. `PolygonCalculator`'s three pointers collapse to the entity it's on plus an `erased` flag, cleared together when the entity changes.

2. `9c114d100` — `refactor(scan): merge by entity, then by system-time within it`. The queue split, plus `sameIidAs`, the two comparators, and a cached `systemFrom` on `EventRowPointer`.

The first is a ship-class tidy that was headed for `main` independently; it rides along here because the second builds on it and it has not landed yet.

## Equivalence

The emitted order is identical to the old single queue's, and it rests on two properties rather than on the tests agreeing.

- **A priority queue yields every element tied for its minimum consecutively.**
  So the drain loop that moves pages from `iidQueue` into `eventQueue` collects exactly the pages holding the minimum entity — never a page holding a later one, and never missing a page holding this one.

- **Within a page, an entity's events are contiguous and already system-from descending.**
  So each page re-offers its next event as the inner loop consumes one, and the inner queue sees exactly that entity's events in the right order. A page that crosses into a new entity is routed back to `iidQueue`, where its new iid can only sort later than the entity being resolved.

- **The cached `systemFrom` is fresh wherever it is legal to read it.**
  `maxIndex <= rowCount` always, so a pointer that `isValid()` is a pointer whose cache has been refreshed. Every reader in the repo — `PolygonCalculator`, `ScanCursor`, `SegmentMerge.merge`, `resolveSameSystemTimeEvents`, both comparators — reads either immediately after polling a valid pointer or behind an `isValid()` short-circuit.

- **Unchanged: two pages holding both the same entity and the same system-time tie arbitrarily.**
  That was true before and is true now. It should not arise — same-transaction events for one entity are resolved within a page at load, and #5525 dedups the live table against L0 — but nothing here tightens it.

## Out of scope

Split by why each was left, rather than by what it is.

- **`SegmentMerge.merge` and `resolveSameSystemTimeEvents` keep the single comparator**, because extracting a shared merge from one worked example is how you get the wrong abstraction. They walk the same entity runs and want the same treatment; revisit when there is a second instance to generalise from.

- **`skipToNextIid()` is not here**, because nothing in this loop calls it. It is what turns the seam into an actual saving for #4967, and it should arrive with its caller rather than as dead code.

- **`Polygon.calculateFor(Ceiling, EventRowPointer)` is dead and stays dead.** It has no callers on `main` either, so removing it is a separate tidy rather than something to bundle into a refactor commit.

- **The measurement.** `scan_rows_read` against emitted rows gives the resolution amplification factor directly, which is the number that decides whether #4967 earns a second resolution algorithm. It needs a dataset with real versions-per-entity, so it is its own piece of work.

## Test plan

- `./gradlew test`, `./gradlew property-test` (100 iterations) and `./gradlew integration-test` all green on the final commit.

- `PolygonCalculatorTest` is new — the class had no unit test at all. Four cases: ceiling isolation between entities, erase suppression and its scoping to one entity, and both halves of the system-time bound (a put above it is ignored and leaves no ceiling behind; an erase above it still suppresses).

- A code-review pass over both commits, aimed at the equivalence claim rather than at style. It found no failing scenario for the ordering, confirmed the `systemFrom` cache is guarded at every reader, and flagged the dead `calculateFor` overload noted above.
