### PR TITLE
feat(arrow): read run-end encoded columns as the rows they encode

### DIFF
--- a/api/src/main/kotlin/xtdb/arrow/ArrowTypes.kt
+++ b/api/src/main/kotlin/xtdb/arrow/ArrowTypes.kt
@@ -66,6 +66,9 @@ val STRUCT_TYPE: ArrowType = MinorType.STRUCT.type
 @JvmField
 val UNION_TYPE: ArrowType = MinorType.DENSEUNION.type
 
+@JvmField
+val RUN_END_ENCODED_TYPE: ArrowType = ArrowType.RunEndEncoded.INSTANCE
+
 /**
  * This field, with `typeIds` declared explicitly on every union in its tree — `0 until childCount`.
  *

--- a/api/src/main/kotlin/xtdb/arrow/VectorType.kt
+++ b/api/src/main/kotlin/xtdb/arrow/VectorType.kt
@@ -36,6 +36,10 @@ const val MAP_ENTRIES_NAME = "entries"
 const val MAP_KEYS_NAME = "key"
 const val MAP_VALUES_NAME = "value"
 
+// likewise a run-end encoded vector's two children, which the spec also fixes in this order
+const val REE_RUN_ENDS_NAME = "run_ends"
+const val REE_VALUES_NAME = "values"
+
 sealed class VectorType {
     abstract val arrowType: ArrowType
     abstract val nullable: Boolean
@@ -323,6 +327,14 @@ sealed class VectorType {
                     Listy(type, children.single().asType)
                 STRUCT_TYPE -> Struct(children.associate { it.name to it.asType })
                 is ArrowType.Union -> fromLegs(children.map { it.asType })
+
+                // run-end encoding is a layout rather than a type: a column of run-encoded i64s is a
+                // column of i64s, and merging it against a plain one must not produce a union
+                is ArrowType.RunEndEncoded -> {
+                    require(children.size == 2) { "run-end encoded fields have exactly two children" }
+                    children[1].asType
+                }
+
                 else -> Scalar(type)
             }.let { maybe(it, isNullable) }
     }

--- a/core/src/main/kotlin/xtdb/arrow/RunEndEncodedVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/RunEndEncodedVector.kt
@@ -1,0 +1,301 @@
+package xtdb.arrow
+
+import org.apache.arrow.memory.ArrowBuf
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.util.ArrowBufPointer
+import org.apache.arrow.vector.ValueVector
+import org.apache.arrow.vector.ipc.message.ArrowFieldNode
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.FieldType
+import xtdb.api.query.IKeyFn
+import xtdb.util.Hasher
+import xtdb.util.safelyOpening
+import java.nio.ByteBuffer
+import org.apache.arrow.vector.complex.RunEndEncodedVector as ArrowRunEndEncodedVector
+
+/**
+ * A column stored as runs of equal values: a `run_ends` child holding each run's exclusive logical end,
+ * and a `values` child holding one value per run.
+ *
+ * Every accessor takes a **logical** index, so this reads exactly like the plain column it encodes, with
+ * [runIdx] the only place the encoding surfaces.
+ *
+ * XTDB reads this encoding but does not yet write it, so that a node on this version can read a data file
+ * a later version writes (#5914).
+ */
+class RunEndEncodedVector private constructor(
+    override var name: String,
+    private val runEndsVector: Vector,
+    private val valuesVector: Vector,
+    override var valueCount: Int
+) : Vector(), LongLongVectorReader {
+
+    init {
+        require(runEndsVector.arrowType.let { it == I16_TYPE || it == I32_TYPE || it == I64_TYPE }) {
+            "run-ends must be a signed integer vector, got ${runEndsVector.arrowType}"
+        }
+
+        require(!runEndsVector.nullable) { "run-ends must be non-nullable" }
+    }
+
+    constructor(name: String, runEndsVector: Vector, valuesVector: Vector)
+            : this(name, runEndsVector, valuesVector, 0)
+
+    constructor(al: BufferAllocator, name: String, valuesVector: Vector)
+            : this(name, IntVector.open(al, REE_RUN_ENDS_NAME, false), valuesVector)
+
+    override val arrowType get() = RUN_END_ENCODED_TYPE
+
+    override val vectors get() = listOf(runEndsVector, valuesVector)
+
+    /** The values' type: run-end encoding is a layout, not a type, so it doesn't show up here. */
+    override val type get() = valuesVector.type
+
+    // Having no validity buffer of its own, the parent is never nullable whatever its values are - while
+    // whether the *column* admits nulls is whether those values do.
+    override var nullable: Boolean
+        get() = valuesVector.nullable
+        set(value) {
+            valuesVector.nullable = value
+        }
+
+    override val fieldType get() = FieldType(false, RUN_END_ENCODED_TYPE, null)
+
+    val runEnds: VectorReader get() = runEndsVector
+
+    /** One value per run, indexed by run rather than by logical row. */
+    val runValues: VectorReader get() = valuesVector
+
+    val runCount get() = runEndsVector.valueCount
+
+    fun runEnd(runIdx: Int) = runEndsVector.getLong(runIdx).toInt()
+
+    fun runStart(runIdx: Int) = if (runIdx == 0) 0 else runEnd(runIdx - 1)
+
+    // A stale hint is harmless - [runIdx] checks one covers the index before trusting it - so this needs
+    // no synchronising, given int writes don't tear.
+    private var runIdxHint = 0
+
+    fun runIdx(idx: Int): Int {
+        val hint = runIdxHint
+
+        return when {
+            hint < runCount && idx >= runStart(hint) && idx < runEnd(hint) -> hint
+            hint + 1 < runCount && idx >= runStart(hint + 1) && idx < runEnd(hint + 1) -> hint + 1
+            else -> searchRunIdx(idx)
+        }.also { runIdxHint = it }
+    }
+
+    private fun searchRunIdx(idx: Int): Int {
+        var lo = 0
+        var hi = runCount
+
+        while (lo < hi) {
+            val mid = (lo + hi) ushr 1
+            if (runEnd(mid) <= idx) lo = mid + 1 else hi = mid
+        }
+
+        return lo
+    }
+
+    override fun isNull(idx: Int) = valuesVector.isNull(runIdx(idx))
+
+    override fun getBoolean(idx: Int) = valuesVector.getBoolean(runIdx(idx))
+    override fun getByte(idx: Int) = valuesVector.getByte(runIdx(idx))
+    override fun getShort(idx: Int) = valuesVector.getShort(runIdx(idx))
+    override fun getInt(idx: Int) = valuesVector.getInt(runIdx(idx))
+    override fun getLong(idx: Int) = valuesVector.getLong(runIdx(idx))
+    override fun getFloat(idx: Int) = valuesVector.getFloat(runIdx(idx))
+    override fun getDouble(idx: Int) = valuesVector.getDouble(runIdx(idx))
+    override fun getBytes(idx: Int): ByteBuffer = valuesVector.getBytes(runIdx(idx))
+    override fun getPointer(idx: Int, reuse: ArrowBufPointer) = valuesVector.getPointer(runIdx(idx), reuse)
+    override fun getObject(idx: Int, keyFn: IKeyFn<*>) = valuesVector.getObject(runIdx(idx), keyFn)
+
+    override fun getLongLongHigh(idx: Int) = (valuesVector as LongLongVectorReader).getLongLongHigh(runIdx(idx))
+    override fun getLongLongLow(idx: Int) = (valuesVector as LongLongVectorReader).getLongLongLow(runIdx(idx))
+
+    override fun hashCode(idx: Int, hasher: Hasher) = valuesVector.hashCode(runIdx(idx), hasher)
+
+    override fun getLeg(idx: Int) = valuesVector.getLeg(runIdx(idx))
+
+    // A child here is indexed by run, not by row, so nothing is handed out or advertised - composite
+    // values still read whole, through [getObject].
+    override val keyNames: Set<String>? get() = null
+    override val legNames: Set<String>? get() = null
+
+    override fun vectorForOrNull(name: String): VectorWriter =
+        throw UnsupportedOperationException(
+            "run-encoded columns don't expose their children - their values are indexed by run, not by row"
+        )
+
+    /** Runs cover the same distinct values as the rows they encode, so metadata is the same either way. */
+    override val metadataFlavours get() = valuesVector.metadataFlavours
+
+    override fun valueReader(): ValueReader {
+        val inner = valuesVector.valueReader()
+
+        return object : ValueReader by inner {
+            override var pos = 0
+                set(value) {
+                    field = value
+                    if (value in 0..<valueCount) inner.pos = runIdx(value)
+                }
+        }
+    }
+
+    override fun rowCopier(dest: VectorWriter): RowCopier =
+        if (dest is RunEndEncodedVector) RunCopier(valuesVector.rowCopier(dest.valuesVector), dest)
+        else valuesVector.rowCopier(dest).let { copier -> RowCopier { srcIdx -> copier.copyRow(runIdx(srcIdx)) } }
+
+    private inner class RunCopier(
+        private val valueCopier: RowCopier, private val dest: RunEndEncodedVector
+    ) : RowCopier {
+
+        override fun copyRow(srcIdx: Int) {
+            valueCopier.copyRow(runIdx(srcIdx))
+            dest.endRun(1)
+        }
+
+        override fun copyRange(startIdx: Int, len: Int) {
+            var idx = startIdx
+            val endIdx = startIdx + len
+
+            while (idx < endIdx) {
+                val run = runIdx(idx)
+                val copyTo = minOf(runEnd(run), endIdx)
+
+                valueCopier.copyRow(run)
+                dest.endRun(copyTo - idx)
+
+                idx = copyTo
+            }
+        }
+    }
+
+    /** Equal neighbours are not coalesced. */
+    @JvmOverloads
+    fun writeRun(value: Any?, runLength: Int = 1) {
+        valuesVector.writeObject(value)
+        endRun(runLength)
+    }
+
+    private inline fun writeSingletonRun(writeValue: (VectorWriter) -> Unit) {
+        writeValue(valuesVector)
+        endRun(1)
+    }
+
+    override fun writeObject(obj: Any?) = writeRun(obj)
+    override fun writeValue0(v: ValueReader) = writeSingletonRun { it.writeValue(v) }
+    override fun writeUndefined() = writeSingletonRun { it.writeUndefined() }
+
+    override fun writeBoolean(v: Boolean) = writeSingletonRun { it.writeBoolean(v) }
+    override fun writeByte(v: Byte) = writeSingletonRun { it.writeByte(v) }
+    override fun writeShort(v: Short) = writeSingletonRun { it.writeShort(v) }
+    override fun writeInt(v: Int) = writeSingletonRun { it.writeInt(v) }
+    override fun writeLong(v: Long) = writeSingletonRun { it.writeLong(v) }
+    override fun writeFloat(v: Float) = writeSingletonRun { it.writeFloat(v) }
+    override fun writeDouble(v: Double) = writeSingletonRun { it.writeDouble(v) }
+    override fun writeBytes(v: ByteBuffer) = writeSingletonRun { it.writeBytes(v) }
+
+    private fun endRun(runLength: Int) {
+        require(runLength > 0) { "run length must be positive, got $runLength" }
+
+        check(valuesVector.valueCount == runCount + 1) {
+            "expected exactly one value written for the run, got ${valuesVector.valueCount - runCount}"
+        }
+
+        val runEnd = valueCount + runLength
+
+        when (runEndsVector) {
+            is ShortVector -> {
+                require(runEnd <= Short.MAX_VALUE) { "$runEnd rows overflow int16 run-ends" }
+                runEndsVector.writeShort(runEnd.toShort())
+            }
+
+            is IntVector -> runEndsVector.writeInt(runEnd)
+            is LongVector -> runEndsVector.writeLong(runEnd.toLong())
+            else -> error("unreachable: run-ends type checked at construction")
+        }
+
+        valueCount = runEnd
+    }
+
+    // Unreachable: an unencoded source is turned away by the arrow-type check in [Vector.rowCopier] before
+    // it gets here, and an encoded one is served by the override above.
+    override fun rowCopier0(src: VectorReader) = unsupported("rowCopier0")
+
+    /** An encoded column's type is pinned by the values it already holds. */
+    override fun maybePromote(al: BufferAllocator, targetType: ArrowType, targetNullable: Boolean) =
+        unsupported("maybePromote")
+
+    // The run-ends are absolute from the start of the vector, and a slice here carries the whole vector
+    // rather than a logical offset into it, so they stay valid as they are.
+    override fun openSlice(al: BufferAllocator) = safelyOpening {
+        val runEndsSlice = open { runEndsVector.openSlice(al) }
+        val valuesSlice = open { valuesVector.openSlice(al) }
+
+        RunEndEncodedVector(name, runEndsSlice, valuesSlice, valueCount)
+    }
+
+    // An REE parent carries no buffers of its own - the encoding lives entirely in its two children.
+    override fun unloadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {
+        nodes.add(ArrowFieldNode(valueCount.toLong(), 0))
+
+        runEndsVector.unloadPage(nodes, buffers)
+        valuesVector.unloadPage(nodes, buffers)
+    }
+
+    override fun loadPage(nodes: MutableList<ArrowFieldNode>, buffers: MutableList<ArrowBuf>) {
+        val node = nodes.removeFirstOrNull() ?: error("missing node")
+        valueCount = node.length
+        runIdxHint = 0
+
+        runEndsVector.loadPage(nodes, buffers)
+        valuesVector.loadPage(nodes, buffers)
+
+        checkRuns()
+    }
+
+    override fun loadFromArrow(vec: ValueVector) {
+        require(vec is ArrowRunEndEncodedVector)
+
+        runEndsVector.loadFromArrow(vec.runEndsVector)
+        valuesVector.loadFromArrow(vec.valuesVector)
+
+        valueCount = vec.valueCount
+        runIdxHint = 0
+
+        checkRuns()
+    }
+
+    private fun checkRuns() {
+        check(runCount == valuesVector.valueCount) {
+            "$runCount runs against ${valuesVector.valueCount} values"
+        }
+
+        var prev = 0L
+
+        for (i in 0..<runCount) {
+            val end = runEndsVector.getLong(i)
+            check(end in prev + 1..Int.MAX_VALUE.toLong()) { "run end $end at run $i doesn't follow $prev" }
+            prev = end
+        }
+
+        // `>=`, because the spec allows a logical length shorter than the runs covering it.
+        check(prev >= valueCount) { "run ends cover $prev of $valueCount rows" }
+    }
+
+    override fun clear() {
+        runEndsVector.clear()
+        valuesVector.clear()
+        valueCount = 0
+        runIdxHint = 0
+    }
+
+    override fun close() {
+        runEndsVector.close()
+        valuesVector.close()
+        valueCount = 0
+        runIdxHint = 0
+    }
+}

--- a/core/src/main/kotlin/xtdb/arrow/Vector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/Vector.kt
@@ -203,7 +203,10 @@ sealed class Vector : VectorReader, VectorWriter {
 
                 override fun visit(type: Duration) = DurationVector(al, name, nullable, type.unit)
 
-                override fun visit(p0: RunEndEncoded?) = TODO("Not yet implemented")
+                override fun visit(type: RunEndEncoded): Vector {
+                    require(children.size == 2) { "run-end encoded fields have exactly two children" }
+                    return RunEndEncodedVector(name, children[0], children[1])
+                }
 
                 override fun visit(type: ExtensionType): Vector = when (type) {
                     KeywordType -> KeywordVector(Utf8Vector(al, name, nullable))
@@ -235,7 +238,7 @@ sealed class Vector : VectorReader, VectorWriter {
                 if (vec is ArrowNullVector) NullVector(vec.name, vec.field.isNullable)
                 else vec.allocator.openVector(vec.field)
 
-            return vector.apply { loadFromArrow(vec) }
+            return vector.closeOnCatch { it.apply { loadFromArrow(vec) } }
         }
 
         @JvmStatic

--- a/core/src/test/kotlin/xtdb/arrow/RunEndEncodedVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/RunEndEncodedVectorTest.kt
@@ -1,0 +1,487 @@
+package xtdb.arrow
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.ArrowFileWriter
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.arrow.Relation.Companion.loader
+import xtdb.arrow.Vector.Companion.openVector
+import xtdb.arrow.VectorType.Companion.asType
+import xtdb.arrow.metadata.MetadataFlavour
+import xtdb.bloom.BloomBuilder
+import java.io.ByteArrayOutputStream
+import java.nio.channels.Channels
+import java.util.Random
+import org.apache.arrow.vector.BigIntVector as ArrowBigIntVector
+import org.apache.arrow.vector.IntVector as ArrowIntVector
+import org.apache.arrow.vector.complex.RunEndEncodedVector as ArrowRunEndEncodedVector
+
+class RunEndEncodedVectorTest {
+
+    private lateinit var allocator: BufferAllocator
+
+    @BeforeEach
+    fun setUp() {
+        allocator = RootAllocator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        allocator.close()
+    }
+
+    /** Encodes `runs` — (value, run-length) pairs — as an i64 column. */
+    private fun openI64Runs(vararg runs: Pair<Long?, Int>) =
+        RunEndEncodedVector(allocator, "vals", LongVector(allocator, REE_VALUES_NAME, true))
+            .also { vec -> runs.forEach { (value, len) -> vec.writeRun(value, len) } }
+
+    private fun expand(vararg runs: Pair<Long?, Int>) = runs.flatMap { (value, len) -> List(len) { value } }
+
+    @Test
+    fun `reads back the rows it encodes`() {
+        val runs = arrayOf(10L to 3, 20L to 1, 30L to 4)
+
+        openI64Runs(*runs).use { vec ->
+            assertEquals(8, vec.valueCount)
+            assertEquals(expand(*runs), vec.asList)
+            assertEquals(listOf(10L, 10L, 10L, 20L, 30L, 30L, 30L, 30L), (0..<vec.valueCount).map { vec.getLong(it) })
+        }
+    }
+
+    @Test
+    fun `nulls live in the values child`() {
+        val runs = arrayOf(10L to 2, null to 3, 20L to 1)
+
+        openI64Runs(*runs).use { vec ->
+            assertEquals(expand(*runs), vec.asList)
+            assertEquals(
+                listOf(false, false, true, true, true, false),
+                (0..<vec.valueCount).map { vec.isNull(it) }
+            )
+        }
+    }
+
+    @Test
+    fun `exposes the runs themselves`() {
+        openI64Runs(10L to 3, 20L to 1, 30L to 4).use { vec ->
+            assertEquals(3, vec.runCount)
+
+            assertEquals(listOf(0, 3, 4), (0..<vec.runCount).map { vec.runStart(it) })
+            assertEquals(listOf(3, 4, 8), (0..<vec.runCount).map { vec.runEnd(it) })
+
+            assertEquals(listOf(10L, 20L, 30L), vec.runValues.asList)
+            assertEquals(listOf(3, 4, 8), vec.runEnds.asList)
+        }
+    }
+
+    @Test
+    fun `finds the run for an index from any starting point`() {
+        val runLengths = listOf(1, 4, 1, 1, 7, 2, 1, 3, 1, 1)
+        val runs = runLengths.mapIndexed { i, len -> (i * 10L) to len }.toTypedArray()
+
+        openI64Runs(*runs).use { vec ->
+            val expected = runLengths.flatMapIndexed { runIdx, len -> List(len) { runIdx } }
+            assertEquals(vec.valueCount, expected.size)
+
+            val ascending = (0..<vec.valueCount).toList()
+
+            for (order in listOf(ascending, ascending.reversed(), ascending.shuffled(Random(0)))) {
+                assertEquals(order.map { expected[it] }, order.map { vec.runIdx(it) }, "order: $order")
+            }
+        }
+    }
+
+    @Test
+    fun `an iid reads as a pair of longs`() {
+        val iids = listOf(
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2),
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4)
+        )
+
+        openIidRuns(iids[0] to 3, iids[1] to 2).use { vec ->
+            openIidPlain(iids[0], iids[0], iids[0], iids[1], iids[1]).use { plain ->
+                assertEquals(
+                    (0..<plain.valueCount).map { plain.getLongLongHigh(it) to plain.getLongLongLow(it) },
+                    (0..<vec.valueCount).map { vec.getLongLongHigh(it) to vec.getLongLongLow(it) }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the field carries the encoding, the type carries the values`() {
+        openI64Runs(10L to 3).use { vec ->
+            assertEquals(RUN_END_ENCODED_TYPE, vec.arrowType)
+            assertEquals(listOf(REE_RUN_ENDS_NAME, REE_VALUES_NAME), vec.field.children.map { it.name })
+
+            assertEquals(VectorType.maybe(VectorType.I64), vec.type)
+            assertEquals(vec.type, vec.field.asType)
+        }
+    }
+
+    @Test
+    fun `copies out as the rows it encodes`() {
+        openI64Runs(10L to 3, 20L to 1, 30L to 2).use { vec ->
+            LongVector(allocator, "out", true).use { out ->
+                out.append(vec)
+                assertEquals(vec.asList, out.asList)
+            }
+
+            LongVector(allocator, "out", true).use { out ->
+                out.appendRange(vec, 2, 3)
+                assertEquals(listOf(10L, 20L, 30L), out.asList)
+            }
+
+            LongVector(allocator, "out", true).use { out ->
+                out.appendRows(vec, intArrayOf(5, 0, 3))
+                assertEquals(listOf(30L, 10L, 20L), out.asList)
+            }
+        }
+    }
+
+    @Test
+    fun `copies into an encoded column a run at a time`() {
+        openI64Runs(10L to 3, 20L to 1, 30L to 2).use { vec ->
+            RunEndEncodedVector(allocator, "out", LongVector(allocator, REE_VALUES_NAME, true)).use { out ->
+                out.append(vec)
+
+                assertEquals(vec.asList, out.asList)
+                assertEquals(vec.runCount, out.runCount, "a whole-range copy keeps the runs")
+            }
+
+            RunEndEncodedVector(allocator, "out", LongVector(allocator, REE_VALUES_NAME, true)).use { out ->
+                out.appendRange(vec, 2, 3)
+
+                assertEquals(listOf(10L, 20L, 30L), out.asList)
+                assertEquals(3, out.runCount, "a range straddling run boundaries splits them")
+            }
+        }
+    }
+
+    @Test
+    fun `a selection materialises back to an encoded column`() {
+        openI64Runs(10L to 3, 20L to 1, 30L to 2).use { vec ->
+            vec.select(intArrayOf(0, 1, 4)).openDirectSlice(allocator).use { out ->
+                assertTrue(out is RunEndEncodedVector, "keeps the encoding: $out")
+                assertEquals(listOf(10L, 10L, 30L), out.asList)
+            }
+        }
+    }
+
+    @Test
+    fun `slices and selections read logically`() {
+        openI64Runs(10L to 3, 20L to 1, 30L to 2).use { vec ->
+            vec.openSlice(allocator).use { slice ->
+                assertEquals(vec.asList, slice.asList)
+                assertEquals(3, slice.runCount)
+            }
+
+            assertEquals(listOf(20L, 30L), vec.select(3, 2).asList)
+            assertEquals(listOf(30L, 10L), vec.select(intArrayOf(4, 1)).asList)
+        }
+    }
+
+    @Test
+    fun `runs summarise to the same metadata as the rows`() {
+        val runs = arrayOf(10L to 3, 20L to 1, 30L to 4)
+
+        openI64Runs(*runs).use { vec ->
+            LongVector(allocator, "vals", true).use { plain ->
+                expand(*runs).forEach { plain.writeObject(it) }
+
+                assertEquals(bloomOf(plain), bloomOf(vec))
+
+                val flavours = vec.metadataFlavours.filterIsInstance<MetadataFlavour.Number>()
+                assertEquals(10.0, flavours.minOf { f -> (0..<f.valueCount).minOf { f.getMetaDouble(it) } })
+                assertEquals(30.0, flavours.maxOf { f -> (0..<f.valueCount).maxOf { f.getMetaDouble(it) } })
+            }
+        }
+    }
+
+    @Test
+    fun `round-trips through Arrow IPC`() {
+        val runs = arrayOf(10L to 3, null to 2, 30L to 4)
+        val bytes = ByteArrayOutputStream()
+
+        openI64Runs(*runs).use { vec ->
+            val rel = Relation(allocator, listOf(vec), vec.valueCount)
+            rel.startUnload(Channels.newChannel(bytes)).use { unloader ->
+                unloader.writePage()
+                unloader.end()
+            }
+        }
+
+        loader(allocator, bytes.toByteArray()).use { loader ->
+            Relation(allocator, loader.schema).use { rel ->
+                loader.loadPage(0, rel)
+
+                val vec = rel["vals"]
+                assertTrue(vec is RunEndEncodedVector, "reads back run-encoded, not decoded: $vec")
+                assertEquals(3, (vec as RunEndEncodedVector).runCount)
+
+                assertEquals(9, rel.rowCount)
+                assertEquals(expand(*runs), vec.asList)
+            }
+        }
+    }
+
+    @Test
+    fun `reads run-ends of any width`() {
+        for (runEnds in listOf(
+            ShortVector(allocator, REE_RUN_ENDS_NAME, false),
+            IntVector.open(allocator, REE_RUN_ENDS_NAME, false),
+            LongVector(allocator, REE_RUN_ENDS_NAME, false)
+        )) {
+            RunEndEncodedVector("vals", runEnds, LongVector(allocator, REE_VALUES_NAME, true)).use { vec ->
+                vec.writeRun(10L, 3)
+                vec.writeRun(20L, 2)
+
+                assertEquals(listOf(10L, 10L, 10L, 20L, 20L), vec.asList, "run-ends: ${runEnds.arrowType}")
+            }
+        }
+    }
+
+    @Test
+    fun `reads a run-encoded column nested in a struct`() {
+        val reeField = Field(
+            "ree", FieldType.notNullable(RUN_END_ENCODED_TYPE),
+            listOf(
+                Field(REE_RUN_ENDS_NAME, FieldType.notNullable(I32_TYPE), null),
+                Field(REE_VALUES_NAME, FieldType.nullable(I64_TYPE), null)
+            )
+        )
+
+        val structField = Field("outer", FieldType.notNullable(STRUCT_TYPE), listOf(reeField))
+
+        allocator.openVector(structField).use { structVec ->
+            val ree = structVec.vectorFor("ree") as RunEndEncodedVector
+            ree.writeRun(10L, 2)
+            ree.writeRun(20L, 1)
+
+            assertEquals(listOf(10L, 10L, 20L), ree.asList)
+            assertEquals(structField, structVec.field)
+        }
+    }
+
+    @Test
+    fun `reads struct values whole, without offering up their children`() {
+        val reeField = Field(
+            "ree", FieldType.notNullable(RUN_END_ENCODED_TYPE),
+            listOf(
+                Field(REE_RUN_ENDS_NAME, FieldType.notNullable(I32_TYPE), null),
+                Field(
+                    REE_VALUES_NAME, FieldType.nullable(STRUCT_TYPE),
+                    listOf(Field("a", FieldType.nullable(I64_TYPE), null))
+                )
+            )
+        )
+
+        allocator.openVector(reeField).use { vec ->
+            vec as RunEndEncodedVector
+
+            vec.writeRun(mapOf("a" to 1L), 2)
+            vec.writeRun(mapOf("a" to 2L), 1)
+
+            assertEquals(listOf(1L, 1L, 2L), (0..<vec.valueCount).map { (vec.getObject(it) as Map<*, *>)["a"] })
+
+            assertNull(vec.keyNames)
+            assertThrows<UnsupportedOperationException> { vec.vectorForOrNull("a") }
+        }
+    }
+
+    /** Our own writer maintains these invariants, so a page that breaks one has to be built through Arrow's. */
+    private fun openArrowRuns(runEnds: List<Int>, values: List<Long>, valueCount: Int): ArrowRunEndEncodedVector {
+        val runEndsField = Field(REE_RUN_ENDS_NAME, FieldType.notNullable(I32_TYPE), null)
+        val valuesField = Field(REE_VALUES_NAME, FieldType.nullable(I64_TYPE), null)
+        val reeField = Field(
+            "vals", FieldType.notNullable(RUN_END_ENCODED_TYPE), listOf(runEndsField, valuesField)
+        )
+
+        return ArrowRunEndEncodedVector(reeField, allocator, null).also { arrowVec ->
+            arrowVec.initializeChildrenFromFields(listOf(runEndsField, valuesField))
+
+            (arrowVec.runEndsVector as ArrowIntVector).apply {
+                runEnds.forEachIndexed { idx, runEnd -> setSafe(idx, runEnd) }
+                this.valueCount = runEnds.size
+            }
+
+            (arrowVec.valuesVector as ArrowBigIntVector).apply {
+                values.forEachIndexed { idx, value -> setSafe(idx, value) }
+                this.valueCount = values.size
+            }
+
+            arrowVec.valueCount = valueCount
+        }
+    }
+
+    @Test
+    fun `refuses a page whose runs stop short of its rows`() {
+        openArrowRuns(runEnds = listOf(2), values = listOf(10L), valueCount = 5)
+            .use { assertThrows<IllegalStateException> { Vector.fromArrow(it).close() } }
+    }
+
+    @Test
+    fun `refuses a page with a run it has no value for`() {
+        openArrowRuns(runEnds = listOf(2, 4), values = listOf(10L), valueCount = 4)
+            .use { assertThrows<IllegalStateException> { Vector.fromArrow(it).close() } }
+    }
+
+    @Test
+    fun `refuses run-ends that don't ascend`() {
+        openArrowRuns(runEnds = listOf(4, 2, 6), values = listOf(10L, 20L, 30L), valueCount = 6)
+            .use { assertThrows<IllegalStateException> { Vector.fromArrow(it).close() } }
+    }
+
+    @Test
+    fun `refuses more rows than its run-ends can count`() {
+        RunEndEncodedVector(
+            "vals", ShortVector(allocator, REE_RUN_ENDS_NAME, false), LongVector(allocator, REE_VALUES_NAME, true)
+        ).use { vec ->
+            assertThrows<IllegalArgumentException> { vec.writeRun(10L, Short.MAX_VALUE + 1) }
+            assertEquals(0, vec.valueCount, "a rejected run doesn't count towards the rows")
+        }
+    }
+
+    @Test
+    fun `refuses a run-encoded field without both children`() {
+        val field = Field(
+            "vals", FieldType.notNullable(RUN_END_ENCODED_TYPE),
+            listOf(Field(REE_VALUES_NAME, FieldType.nullable(I64_TYPE), null))
+        )
+
+        assertThrows<IllegalArgumentException> { field.asType }
+        assertThrows<IllegalArgumentException> { allocator.openVector(field).close() }
+    }
+
+    @Test
+    fun `reads a file written by Arrow's own writer`() {
+        val bytes = ByteArrayOutputStream()
+
+        val runEndsField = Field(REE_RUN_ENDS_NAME, FieldType.notNullable(I32_TYPE), null)
+        val valuesField = Field(REE_VALUES_NAME, FieldType.nullable(I64_TYPE), null)
+        val reeField = Field(
+            "vals", FieldType.notNullable(RUN_END_ENCODED_TYPE), listOf(runEndsField, valuesField)
+        )
+
+        ArrowRunEndEncodedVector(reeField, allocator, null).use { arrowVec ->
+            arrowVec.initializeChildrenFromFields(listOf(runEndsField, valuesField))
+
+            val runEnds = arrowVec.runEndsVector as ArrowIntVector
+            val values = arrowVec.valuesVector as ArrowBigIntVector
+
+            runEnds.allocateNew(3)
+            values.allocateNew(3)
+
+            listOf(3 to 10L, 4 to null, 8 to 30L).forEachIndexed { runIdx, (runEnd, value) ->
+                runEnds.setSafe(runIdx, runEnd)
+                if (value == null) values.setNull(runIdx) else values.setSafe(runIdx, value)
+            }
+
+            runEnds.valueCount = 3
+            values.valueCount = 3
+            arrowVec.valueCount = 8
+
+            VectorSchemaRoot(listOf(reeField), listOf(arrowVec), 8).use { root ->
+                ArrowFileWriter(root, null, Channels.newChannel(bytes)).use { writer ->
+                    writer.start()
+                    writer.writeBatch()
+                    writer.end()
+                }
+            }
+        }
+
+        loader(allocator, bytes.toByteArray()).use { loader ->
+            Relation(allocator, loader.schema).use { rel ->
+                loader.loadPage(0, rel)
+
+                assertEquals(8, rel.rowCount)
+                assertEquals(
+                    listOf(10L, 10L, 10L, null, 30L, 30L, 30L, 30L),
+                    rel["vals"].asList
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `loads from an Arrow vector in memory`() {
+        val runEndsField = Field(REE_RUN_ENDS_NAME, FieldType.notNullable(I32_TYPE), null)
+        val valuesField = Field(REE_VALUES_NAME, FieldType.nullable(I64_TYPE), null)
+        val reeField = Field(
+            "vals", FieldType.notNullable(RUN_END_ENCODED_TYPE), listOf(runEndsField, valuesField)
+        )
+
+        ArrowRunEndEncodedVector(reeField, allocator, null).use { arrowVec ->
+            arrowVec.initializeChildrenFromFields(listOf(runEndsField, valuesField))
+
+            val runEnds = arrowVec.runEndsVector as ArrowIntVector
+            val values = arrowVec.valuesVector as ArrowBigIntVector
+
+            runEnds.setSafe(0, 2); values.setSafe(0, 10L)
+            runEnds.setSafe(1, 5); values.setSafe(1, 20L)
+            runEnds.valueCount = 2
+            values.valueCount = 2
+            arrowVec.valueCount = 5
+
+            Vector.fromArrow(arrowVec).use { vec ->
+                assertTrue(vec is RunEndEncodedVector, "loads as run-encoded: $vec")
+                assertEquals(listOf(10L, 10L, 20L, 20L, 20L), vec.asList)
+                assertFalse(vec.isNull(0))
+            }
+        }
+    }
+
+    @Test
+    fun `a typed write is a run of one row`() {
+        val iids = listOf(
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2),
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4)
+        )
+
+        RunEndEncodedVector(allocator, "_iid", FixedSizeBinaryVector(allocator, REE_VALUES_NAME, false, 16))
+            .use { vec ->
+                listOf(iids[0], iids[0], iids[1]).forEach { vec.writeBytes(it) }
+
+                assertEquals(3, vec.valueCount)
+                assertEquals(3, vec.runCount, "equal neighbours are not coalesced")
+
+                openIidPlain(iids[0], iids[0], iids[1]).use { plain ->
+                    assertEquals(
+                        (0..<plain.valueCount).map { plain.getLongLongHigh(it) to plain.getLongLongLow(it) },
+                        (0..<vec.valueCount).map { vec.getLongLongHigh(it) to vec.getLongLongLow(it) }
+                    )
+                }
+            }
+
+        RunEndEncodedVector(allocator, "vals", LongVector(allocator, REE_VALUES_NAME, false)).use { vec ->
+            listOf(10L, 10L, 20L).forEach { vec.writeLong(it) }
+
+            assertEquals(listOf(10L, 10L, 20L), vec.asList)
+            assertEquals(3, vec.runCount)
+        }
+    }
+
+    private fun openIidRuns(vararg runs: Pair<ByteArray, Int>) =
+        RunEndEncodedVector(allocator, "_iid", FixedSizeBinaryVector(allocator, REE_VALUES_NAME, false, 16))
+            .also { vec -> runs.forEach { (iid, len) -> vec.writeRun(iid, len) } }
+
+    private fun openIidPlain(vararg iids: ByteArray) =
+        FixedSizeBinaryVector(allocator, "_iid", false, 16).also { vec -> iids.forEach { vec.writeObject(it) } }
+
+    private fun bloomOf(vec: VectorReader) =
+        BloomBuilder().also { builder ->
+            vec.metadataFlavours.forEach { flavour ->
+                repeat(flavour.valueCount) { builder.add(flavour as VectorReader, it) }
+            }
+        }.build()
+}


### PR DESCRIPTION
Part of #5914 — `G1`, the reader on its own.

## tl;dr

- **XTDB can read run-end encoded Arrow columns, and still writes none.**
  A `RunEndEncodedVector` joins the vector hierarchy, and `openVector`'s `RunEndEncoded` branch stops being a `TODO`. Nothing in the ingest, compaction or query path emits the encoding, so no file this build produces contains one.

- **It has to land a release ahead of anything that writes runs, and that is the whole point of it.**
  Data files are shared: one upgraded compactor writing `_iid` as runs would break every node still on the previous release, and break it at `openVector`. Shipping the reader first is also what makes a rollback out of the writing release safe.

- **Above the vector, an encoded column is indistinguishable from the plain one it encodes.**
  Every accessor takes a logical row index and `type` reports the values' type, so no consumer that indexes a page by row has to change — which is the property that made run-end encoding preferable to reshaping the page in the first place (#5914 `A1`).

## Rollout / compatibility

- **This release reads; a later one writes.**
  `G2` on #5914 — compaction emitting runs — MUST NOT ship in the same release as this. By the time it has, the pages are written, and no patch release recovers a fleet that can't read them.

- **No storage-version bump, deliberately.**
  `Storage.VERSION` keys the object-store root, so bumping it means a fresh root and a full re-index — wildly disproportionate for a space optimisation, and it strands an older node against a root with nothing in it. Landing the reader early is what buys us the same safety for free (#5914 `D5`).

- **Nothing to do to adopt it.**
  No config, no migration, no flag. The capability is inert until something writes the encoding.

## Implementation notes

- **Run-end encoding is a layout, not a type.**
  `type` delegates to the values child while `arrowType` and `field` carry the encoding, so an encoded column never reaches type-level merging: it can't become a union leg, and merging it against a plain column can't produce a union. The corollary for `G2` is that `VectorType.toField` will never mint an REE field — that schema has to be built from `Field` directly.

- **`runIdx` is the only place the encoding surfaces**, memoised by a hint that every lookup validates before trusting.
  A hint left behind by another caller — or another thread, since int writes don't tear — costs a binary search rather than an answer, so the cursor needs no synchronisation and no invalidation.

- **Metadata comes out unchanged, because runs carry the same distinct values as the rows.**
  Min/max and blooms delegate to the values child and are computed per run; the non-null `count`, the one part that genuinely has to be per row, already reads from the vector itself rather than from a flavour.

- **The parent has no buffers and no validity of its own.**
  `unloadPage` emits a field node with a zero null count and no buffers, matching arrow-java's own layout (`TypeLayout` gives REE no buffers; `getNullCount()` returns 0). `fieldType` is therefore forced non-nullable, while `nullable` reports whether the *column* admits nulls — which is whether its values do.

- **Loading walks the run structure, because a page this version didn't write can't be taken on trust.**
  A header claiming N rows isn't on its own grounds to read N of them. Three ways a page can lie, all of them silent: run ends stopping short of the rows, and a run with no value behind it, both leave accessors reading past the end of the values child — bounds checking is off under `-ParrowUnsafeMemoryAccess`, so that's garbage rather than an exception; run ends that don't ascend break the binary search in `runIdx` instead, resolving the wrong run and returning the wrong value. One pass over the run-ends child on load covers all three, and pins each end inside int range while it's there, since `runEnd` narrows a long. That pass is O(runs) per page load, which is bounded by the row count and so strictly cheaper than the scan that follows it.

- **`Vector.fromArrow` now closes the vector it opened when loading rejects the buffers.**
  `loadFromArrow` takes ownership before it can check what it was given. Long-standing gap, but nothing threw from `loadFromArrow` until the checks above, so this is the commit that makes it reachable and the commit that should close it.

## Decision rationale

- **`D1` — the run is the unit of writing, and nothing coalesces equal neighbours.**
  `writeRun(value, runLength)` states the length rather than inferring it from repetition, and the typed writers — `writeObject`, `writeLong`, `writeBytes` and the rest — are the degenerate case of one row to a run. A typed write is the same call as `writeObject` carrying more type information, so accepting one while refusing the other would have been arbitrary rather than principled; `writeRun` is the route for a caller that knows its runs. Coalescing is the part left undone: it needs value equality at an index, which only pointer-comparable values vectors offer, and getting it wrong labels a whole run with the wrong value — no crash, no exception, just wrong results, which is exactly the risk #5914 `D3` flags. Leaving that decision undivided for the encoder beats half-making it here in service of no caller.

- **`D2` — an encoded column copies out to anything; nothing unencoded copies in.**
  A plain destination sees logical rows, an encoded one takes whole runs across on a range copy. The other direction isn't reachable to implement: the dispatch lives on the source, so a plain vector copying into an encoded one is turned away by `Vector.rowCopier`'s arrow-type check before `rowCopier0` is consulted. Intercepting it means a `RunEndEncodedVector` case alongside the two `DenseUnionVector` ones in the shared base class — worth doing when `G2` has a caller and is settling `D1` anyway.

- **`D3` — no child is handed out or advertised, whatever shape the values are.**
  A struct key or union leg resolves to a vector indexed by run, which would silently misalign against the logical indices everything else takes; and handing one out is unrepresentable anyway, since a dense-union child is a `VectorWriter` rather than a `Vector`. So `keyNames` and `legNames` report nothing, keeping them consistent with `vectorFor` refusing — every caller that gets an answer from the former goes straight on to the latter (`MetadataFileWriter`, `BitemporalConsumer`, `HllCalculator`). List and map navigation is refused on narrower grounds: `listElements`, `getListStartIndex`, `getListCount`, `mapKeys` and `mapValues` *would* delegate correctly, since offsets already map an element index into the elements vector, but this encoding earns its keep on the id-shaped columns and a surface claiming a shape we have no reason to encode is a surface to maintain for nobody. Values of every shape still read whole, through `getObject`.

- **`D4` — `select` decodes.**
  A selection wraps the vector itself in an `IndirectVector`, so reads are two hops: selection index to logical row, then logical row to run. Wrapping the *values* child instead would be the misalignment in `D3`. Materialising a selection back out re-encodes as runs of length 1 — correct, not compact, and only reachable from a selection.

## Out of scope

One entry per neighbouring piece of #5914, so the boundaries are explicit.

- **`G2`/`G3` — compaction writing and merging runs.** The encoder, and the coalescing decision `D1` leaves open.
- **`G7` — bitemporal resolution reading run boundaries.** This supplies the raw view (`runCount`, `runIdx`, `runStart`, `runEnd`, `runEnds`, `runValues`); nothing consumes it yet, and `skipToNextIid` still belongs with #4967's as-of resolver.
- **`sumInto`, `squareInto`, `sqrtInto` stay unsupported.** They need per-row output, so they can't delegate the way the accessors do. They'd matter only if a later release run-encoded a numeric column, and they fail loudly rather than silently.

## Test plan

- **The reader is tested against the spec, not against what we would emit.**
  #5914 `G1.4`: round-tripping through our own writer would only ever exercise int32-over-`FixedSizeBinary(16)` at the top level, and would pass a reader that rejects a page a later release writes. So: all three run-end widths, values of several types, and REE nested inside a struct as well as top-level.

- **One test reads a file written by arrow-java's own `ArrowFileWriter`**, which is the only evidence here that doesn't depend on our own encoder being right.

- **`23` tests in `xtdb.arrow.RunEndEncodedVectorTest`**, covering logical reads, nulls, the run view, `runIdx` from ascending / descending / shuffled access orders, `_iid` as a long pair, IPC round-trip, both copy directions, a typed write landing as a run of one row, slices and selections, metadata equivalence against the plain vector, and each rejection.

- **Every rejection is red-green'd against the guard it exercises.**
  The four malformed-page and malformed-field cases were run with their four guards reverted, and each failed; the guards are what turns a silent wrong read into a rejection, so a test that passes either way would be testing nothing.

- **`./gradlew test` green** — 1691 at the root aggregate and 420 in `xtdb-core`, 0 failures, no leaks, no reflection or boxed-math warnings. `property-test` not run: nothing here touches indexing, compaction or GC.
