### PR TITLE
fix(types): join the historical and live halves of a column's type

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -168,6 +168,15 @@ external entity MemorySegment {}
     -- unaffected by subsequent writes to the source relation.
     -- See: xtdb.segment.MemorySegment, memory-hash-trie.allium.
 
+external entity TrieCatalogSnap {}
+    -- Frozen per-table trie-catalog state: which tries exist on disk, and the
+    -- highest L0 block index per table. See: xtdb.trie.TrieCatalog.Snap.
+
+external entity TableCatalogSnap {}
+    -- Frozen per-table metadata for everything already flushed: each table's
+    -- column types and its count of rows ever written. The historical half of
+    -- a column's declared type. See: xtdb.catalog.TableCatalog.Snap.
+
 -- A per-tx durability handle: a deferred completed with the tx's result once the tx
 -- has been CONSUMED BACK and imported into the durable live tables (durably replicated
 -- AND confirmed unfenced — Raft's ReadIndex). Carried by external-source txs only
@@ -391,16 +400,30 @@ entity LiveTableTx {
 ------------------------------------------------------------
 -- Snapshots (visibility)
 --
--- A Snapshot is a point-in-time view over the live index. It is composed of
+-- A Snapshot is a point-in-time view over one partition. It is composed of
 -- per-table TableSnapshots, each holding a MemorySegment: a sliced live
 -- relation plus the MemoryHashTrie indexing it. When opened from within an
 -- active transaction, a TableSnapshot also layers an optional tx segment
 -- (sliced from the OpenTx.Table's txRelation) on top of the live segment, so
 -- queries inside the tx see committed rows + their own uncommitted rows.
 --
+-- A Snapshot also pins the two catalogs a reader needs alongside those
+-- segments: the trie catalog, which locates the historical tries on disk, and
+-- the table catalog's per-table metadata (column types and row counts for
+-- everything already flushed). All three are captured together, so a reader
+-- sees one vintage of the whole partition rather than pinned data combined
+-- with catalog state read live at the moment it happens to ask.
+--
+-- That matters for a column's declared type, which is the join of what the
+-- table catalog knows (flushed blocks) with what the segments know
+-- (unflushed). Both halves must come from the same capture, or the column set
+-- and the types resolving it can disagree.
+--
 -- Consistency guarantees:
 --   - A snapshot's underlying segments are sliced at creation and do not
 --     observe later writes
+--   - Its captured catalogs are likewise frozen: writes landing afterwards
+--     have no effect on it
 --   - Commits are atomic: all tx rows become visible together, or none
 --   - Multiple snapshots can be held concurrently without interference
 --   - Writes don't block reads: a shared external snapshot is rebuilt lazily on
@@ -419,6 +442,12 @@ entity Snapshot {
     basis_tx: TransactionKey?
 
     table_snapshots: TableSnapshot with snapshot = this
+
+    -- Frozen catalog state, captured with the segments above. The trie catalog
+    -- locates the historical tries; the table catalog carries their column
+    -- types and row counts.
+    trie_catalog_snap: TrieCatalogSnap
+    table_catalog_snap: TableCatalogSnap
 
     -- External snapshots are shared and reference-counted; concurrent
     -- readers each hold one retention on the current shared snapshot.

--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -410,20 +410,47 @@ entity LiveTableTx {
 -- A Snapshot also pins the two catalogs a reader needs alongside those
 -- segments: the trie catalog, which locates the historical tries on disk, and
 -- the table catalog's per-table metadata (column types and row counts for
--- everything already flushed). All three are captured together, so a reader
--- sees one vintage of the whole partition rather than pinned data combined
--- with catalog state read live at the moment it happens to ask.
+-- everything already flushed). Pinning them is what stops a reader combining
+-- pinned data with catalog state read live at the moment it happens to ask.
+--
+-- The three captures are NOT atomic with respect to one another. They are
+-- taken in order — trie catalog, then segments, then table catalog — so a
+-- block landing concurrently can fall between them. The table catalog is taken
+-- last deliberately: a type view newer than the data view over-approximates,
+-- which is always safe, whereas an older one would declare a narrower type
+-- than the rows being scanned, which is not.
 --
 -- That matters for a column's declared type, which is the join of what the
--- table catalog knows (flushed blocks) with what the segments know
--- (unflushed). Both halves must come from the same capture, or the column set
--- and the types resolving it can disagree.
+-- table catalog knows (flushed blocks), what the segments know (unflushed),
+-- and what the superseded live tables know. The column set and the types
+-- resolving it come from one capture, or they can disagree.
+--
+-- L0 supersession:
+--   After a block is flushed its rows exist twice — in the live table that
+--   produced them, and in the L0 trie written from it. A snapshot therefore
+--   excludes any live table the trie catalog's L0 watermark has reached, so
+--   those rows are read once, from the L0.
+--
+--   Their column TYPES are retained regardless. A block becomes visible in
+--   two steps: the L0 reaches the trie catalog first, the block's column types
+--   reach the table catalog second. A snapshot taken between the two would
+--   otherwise have no source for those types at all — declaring a narrower
+--   type than the rows it is about to scan, and failing to resolve a
+--   brand-new table entirely. Retaining the types bridges that gap, and is
+--   safe because the join is idempotent: once the catalog catches up the
+--   answer is unchanged, whatever order the writers ran in.
+--
+--   The live table outlives the gap in both directions — it is cleared only
+--   after the table catalog has been updated — so a source is always
+--   available while the gap is open.
 --
 -- Consistency guarantees:
 --   - A snapshot's underlying segments are sliced at creation and do not
 --     observe later writes
 --   - Its captured catalogs are likewise frozen: writes landing afterwards
 --     have no effect on it
+--   - Those captures are ordered, not simultaneous: a concurrently-landing block
+--     can fall between them, which is what "L0 supersession" above covers
 --   - Commits are atomic: all tx rows become visible together, or none
 --   - Multiple snapshots can be held concurrently without interference
 --   - Writes don't block reads: a shared external snapshot is rebuilt lazily on
@@ -453,8 +480,27 @@ entity Snapshot {
     -- readers each hold one retention on the current shared snapshot.
     ref_count: Integer
 
-    -- Derived: which tables are visible in this snapshot
-    visible_tables: table_snapshots.map(ts => ts.table_ref)
+    -- Tables the pinned table catalog knows about: everything already flushed,
+    -- plus the data-backed system tables seeded when the partition opens
+    -- (xt.txs, xt.role_membership). A table here resolves with no segment at all.
+    catalog_tables: Set<TableRef>
+
+    -- Live tables kept out of table_snapshots because a published L0 already
+    -- covers their rows, but whose column types are still needed until the table
+    -- catalog records them. See "L0 supersession" above.
+    --
+    -- Supersession applies to the DURABLE live table only, so this does not
+    -- partition against segment_tables: a superseded table that the resolving tx
+    -- or a staged tx also writes to appears in both, and contributes through both.
+    superseded_tables: Set<TableRef>
+
+    -- The tables carrying a segment in this snapshot.
+    segment_tables: table_snapshots -> table_ref
+
+    -- Derived: which tables resolve in this snapshot. Base-table resolution reads
+    -- this, and a table can resolve without a segment — via the catalog, or via
+    -- supersession — so the segments alone do not answer it.
+    visible_tables: catalog_tables + superseded_tables + segment_tables
 }
 
 entity TableSnapshot {

--- a/api/src/main/kotlin/xtdb/arrow/VectorType.kt
+++ b/api/src/main/kotlin/xtdb/arrow/VectorType.kt
@@ -164,6 +164,36 @@ sealed class VectorType {
 
     companion object {
 
+        /**
+         * What a source contributes for a column it does not record — the input to the join that produces
+         * the column's declared type.
+         *
+         * A source states only the columns it has values for, but a scan needs an answer for every column
+         * it projects, so a source's map is read as a total function: its recorded type where there is one,
+         * and this everywhere else. Callers index [recorded] themselves and hold this alongside it, because
+         * it is constant for a fixed [recorded] while the lookup is per column.
+         *
+         * The question is not "do you hold this column" but "what will your rows read for it", so it turns
+         * on whether the source has any *put* rows: put rows lacking the column read as null, and no put
+         * rows means no cells at all.
+         *
+         * Derived from [recorded] rather than carried alongside it, because nothing carries a put-row count:
+         * every row count we keep includes deletes and erases, which is the distinction being drawn. Nor
+         * does put-leg presence answer it — declaring a column materialises the leg without writing a row.
+         * What does: `CREATE TABLE` records its declared columns as `Nothing` (`declareColumns` writes
+         * `NULL_TYPE, nullable = false`), deletes and erases never materialise a put leg at all, and any
+         * value written through a put makes its column non-`Nothing`. So a non-`Nothing` entry means some
+         * put wrote a value.
+         *
+         * That direction is unconditional. The converse holds only while every put leaves at least one
+         * non-`Nothing` doc column — true of SQL, XTQL and `writePut`, which all fold `_id` into the doc,
+         * but not of a hand-built put with an empty doc struct. #5919 records the count rather than
+         * inferring it, which reduces this to a comparison and retires the caveat.
+         */
+        @JvmStatic
+        fun absentContribution(recorded: Map<String, VectorType>): VectorType =
+            if (recorded.values.any { it != Nothing }) Null else Nothing
+
         @JvmStatic
         @JvmOverloads
         fun maybe(type: VectorType, nullable: Boolean = true): VectorType {

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -522,12 +522,11 @@
             db-state (.getQueryState db)
             db-name (.getName db)
             trie-catalog (.getTrieCatalog db-state)
-            ->table-ref (fn [k] (cond (instance? TableRef k) k, (symbol? k) (table/->ref k)))
 
             ;; Same key set `schema-info` has, without deriving a single type: `allColumnTypes` is
             ;; `tableInfo.keys.associateWith { … }`, so their key sets are equal by construction.
             table-refs (into (set (keys (.getTableInfo ^Snapshot snap)))
-                             (map ->table-ref)
+                             (map table/->ref)
                              (keys meta-table-schemas))
 
             ;; delayed: only `columns` and `pg_attribute` need types, and this is bound ahead of the
@@ -536,7 +535,7 @@
             ;; entry seqs, and only the outer map has to be Clojure for `merge` to take a `conj`.
             schema-info (delay (-> (into {} (.getAllColumnTypes ^Snapshot snap))
                                    (merge meta-table-schemas)
-                                   (update-keys ->table-ref)))]
+                                   (update-keys table/->ref)))]
 
         (util/with-close-on-catch [out-rel (Relation. ^BufferAllocator allocator
                                                       ^Map (update-keys derived-table-schema str))]

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -516,17 +516,14 @@
     (->cursor [_ allocator db db-cat query-source snap derived-table-schema
                table col-names col-preds
                schema params]
-      ;; TODO should use the schema passed to it, but also regular merge is insufficient here for colFields
-      ;; should be types/merge-types as per scan-vec-types
+      ;; TODO should use the schema passed to it
       (let [^IQuerySource$QueryDatabase db db
             ^IQuerySource$QueryCatalog db-cat db-cat
             db-state (.getQueryState db)
             db-name (.getName db)
-            table-catalog (.getTableCatalog db-state)
             trie-catalog (.getTrieCatalog db-state)
-            schema-info (-> (merge-with merge
-                                        (update-vals (into {} (.getTypes table-catalog)) #(into {} %))
-                                        (.getAllColumnTypes ^Snapshot snap))
+            schema-info (-> (into {} (map (fn [[table col-types]] [table (into {} col-types)]))
+                                  (.getAllColumnTypes ^Snapshot snap))
                             (merge meta-table-schemas)
                             (update-keys (fn [k]
                                            (cond

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -234,23 +234,23 @@
                   :schema-name schema-name
                   :schema-owner "xtdb"})))))
 
-(defn tables [db-name schema-info]
-  (for [^TableRef table (keys schema-info)]
+(defn tables [db-name table-refs]
+  (for [^TableRef table table-refs]
     {:table-catalog db-name
      :table-name (.getTableName table)
      :table-schema (.getSchemaName table)
      :table-type (if (views (table/ref->schema+table table)) "VIEW" "BASE TABLE")}))
 
-(defn pg-tables [schema-info]
-  (for [^TableRef table (keys schema-info)
+(defn pg-tables [table-refs]
+  (for [^TableRef table table-refs
         :let [schema-name (.getSchemaName table)]]
     {:schemaname schema-name
      :tablename (.getTableName table)
      :tableowner "xtdb"
      :tablespace nil}))
 
-(defn pg-class [schema-info]
-  (for [^TableRef table (keys schema-info)]
+(defn pg-class [table-refs]
+  (for [^TableRef table table-refs]
     {:oid (name->oid (table/ref->schema+table table))
      :relname (.denormalize ^IKeyFn (identity #xt/key-fn :snake-case-string) (.getTableName table))
      :relnamespace (name->oid (.getSchemaName table))
@@ -376,8 +376,8 @@
      :datallowconn true
      :datistemplate false}))
 
-(defn pg-stat-user-tables [schema-info]
-  (for [^TableRef table (keys schema-info)]
+(defn pg-stat-user-tables [table-refs]
+  (for [^TableRef table table-refs]
     {:relid (name->oid (table/ref->schema+table table))
      :relname (.getTableName table)
      :schemaname (.getSchemaName table)
@@ -522,35 +522,43 @@
             db-state (.getQueryState db)
             db-name (.getName db)
             trie-catalog (.getTrieCatalog db-state)
-            schema-info (-> (into {} (map (fn [[table col-types]] [table (into {} col-types)]))
-                                  (.getAllColumnTypes ^Snapshot snap))
-                            (merge meta-table-schemas)
-                            (update-keys (fn [k]
-                                           (cond
-                                             (instance? TableRef k) k
-                                             (symbol? k) (table/->ref k)))))]
+            ->table-ref (fn [k] (cond (instance? TableRef k) k, (symbol? k) (table/->ref k)))
+
+            ;; Same key set `schema-info` has, without deriving a single type: `allColumnTypes` is
+            ;; `tableInfo.keys.associateWith { … }`, so their key sets are equal by construction.
+            table-refs (into (set (keys (.getTableInfo ^Snapshot snap)))
+                             (map ->table-ref)
+                             (keys meta-table-schemas))
+
+            ;; delayed: only `columns` and `pg_attribute` need types, and this is bound ahead of the
+            ;; dispatch — eagerly, the other 32 tables would each derive every column of every table.
+            ;; Values stay as the Kotlin maps `allColumnTypes` returns; every consumer reads them as
+            ;; entry seqs, and only the outer map has to be Clojure for `merge` to take a `conj`.
+            schema-info (delay (-> (into {} (.getAllColumnTypes ^Snapshot snap))
+                                   (merge meta-table-schemas)
+                                   (update-keys ->table-ref)))]
 
         (util/with-close-on-catch [out-rel (Relation. ^BufferAllocator allocator
                                                       ^Map (update-keys derived-table-schema str))]
 
           (.writeRows out-rel (->> (case (table/ref->schema+table table)
-                                     information_schema/tables (tables db-name schema-info)
-                                     information_schema/columns (columns db-name (schema-info->col-rows schema-info))
+                                     information_schema/tables (tables db-name table-refs)
+                                     information_schema/columns (columns db-name (schema-info->col-rows @schema-info))
                                      information_schema/schemata (schemas db-name)
                                      information_schema/table_constraints nil
                                      information_schema/key_column_usage nil
                                      information_schema/constraint_column_usage nil
-                                     pg_catalog/pg_tables (pg-tables schema-info)
+                                     pg_catalog/pg_tables (pg-tables table-refs)
                                      pg_catalog/pg_type (pg-type)
-                                     pg_catalog/pg_class (pg-class schema-info)
+                                     pg_catalog/pg_class (pg-class table-refs)
                                      pg_catalog/pg_description nil
                                      pg_catalog/pg_views nil
                                      pg_catalog/pg_matviews nil
-                                     pg_catalog/pg_attribute (pg-attribute (schema-info->col-rows schema-info))
+                                     pg_catalog/pg_attribute (pg-attribute (schema-info->col-rows @schema-info))
                                      pg_catalog/pg_namespace (pg-namespace)
                                      pg_catalog/pg_proc (pg-proc)
                                      pg_catalog/pg_database (pg-database (.getDatabaseNames db-cat))
-                                     pg_catalog/pg_stat_user_tables (pg-stat-user-tables schema-info)
+                                     pg_catalog/pg_stat_user_tables (pg-stat-user-tables table-refs)
                                      pg_catalog/pg_settings (pg-settings)
                                      pg_catalog/pg_range (pg-range)
                                      pg_catalog/pg_am (pg-am)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -198,20 +198,17 @@
         (test [_ path]
           (not (.isEmpty (.filterIidsForPath bucketer iid-set path))))))))
 
-(defn scan-vec-types [^IQuerySource$QueryCatalog db-catalog, snaps, scan-cols]
+(defn scan-vec-types [snaps, scan-cols]
   (letfn [(->vec-type [[db-name ^TableRef table col-name]]
             (let [col-name (str col-name)]
               (or (types/temporal-vec-types col-name)
                   (-> (info-schema/derived-table table)
                       (get (symbol col-name)))
-                  (let [state (.getQueryState (.databaseOrNull db-catalog db-name))
-                        table-catalog (.getTableCatalog state)
-                        ^DatabaseSnapshot db-snap (get snaps db-name)
-                        ;; TODO (#5835) reduce types/merge-types over per-partition live
-                        ;; types here; for now we only allow single-partition databases.
+                  (let [^DatabaseSnapshot db-snap (get snaps db-name)
+                        ;; TODO (#5835) join across every partition's snapshot;
+                        ;; for now we only allow single-partition databases.
                         ^Snapshot snap (first (.getPartitions db-snap))]
-                    (types/merge-types (.getType table-catalog table col-name)
-                                       (.columnType snap table col-name))))))]
+                    (get (.columnTypes snap table [col-name]) col-name)))))]
     (->> scan-cols
          (into {} (map (juxt identity ->vec-type))))))
 

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -185,7 +185,7 @@
 (defn- emit-query [{:keys [conformed-plan scan-cols col-names ^Cache emit-cache, explain-analyze?]},
                    scan-emitter, db-cat, snaps
                    param-types, {:keys [default-tz]}]
-  (.get emit-cache {:scan-vec-types (scan/scan-vec-types db-cat snaps scan-cols)
+  (.get emit-cache {:scan-vec-types (scan/scan-vec-types snaps scan-cols)
 
                     ;; this one is just to reset the cache for up-to-date stats
                     ;; probably over-zealous

--- a/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
@@ -71,7 +71,8 @@ data class MergeTypes(
          * [mergeTypes] with `Nothing` restored as the identity.
          *
          * `⊔` is not idempotent at the bottom today - `mergeTypes(Nothing, Nothing)` returns `Null` (#5871) -
-         * so a join over sources that all have nothing to say reports a dataless column as nullable.
+         * so a join over sources that all have nothing to say reports a dataless column as nullable. Both the
+         * read path and the block merge need the law to hold, hence one repair rather than a copy at each.
          *
          * Delete this and call [mergeTypes] directly once `fromLegs(∅)` returns the bottom.
          */

--- a/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
@@ -2,6 +2,7 @@ package xtdb.arrow
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.apache.arrow.vector.types.pojo.ArrowType
+import xtdb.api.error.Fault
 import xtdb.arrow.VectorType.*
 import xtdb.arrow.VectorType.Companion.structOf
 import xtdb.arrow.VectorType.Companion.fromLegs
@@ -78,10 +79,35 @@ data class MergeTypes(
         fun joinContributions(types: Collection<VectorType>): VectorType =
             if (types.all { it == Nothing }) Nothing else mergeTypes(types)
 
+        /**
+         * A source with nothing to say contributes [VectorType.Nothing], the lattice bottom - never a Kotlin
+         * null. A null is rejected rather than discarded, because discarding one drops a contribution from
+         * the join without trace: that is how #5855 stayed hidden, an accessor returning null for "no such
+         * column" looking like a legitimate argument.
+         *
+         * The signature holds Kotlin callers to that. It cannot hold Clojure ones - erasure means there is no
+         * per-element check on a generic collection - hence the explicit rejection below.
+         */
         @JvmStatic
-        fun mergeTypes(types: Collection<VectorType?>): VectorType = cache[types.mapNotNullTo(mutableSetOf()) { it }]
+        fun mergeTypes(types: Collection<VectorType>): VectorType {
+            val set = mutableSetOf<VectorType>()
 
-        fun mergeTypes(vararg types: VectorType?): VectorType = mergeTypes(types.toList())
+            for (type in types) {
+                // The compiler calls this comparison senseless because the element type is non-null; it is
+                // reachable anyway, from Clojure through erasure. Do not delete it. Without it a nil falls
+                // through `merge`'s exhaustive `when` as a bare NoWhenBranchMatchedException - no anomaly
+                // category, no indication of which argument was bad. Checking here rather than inside the
+                // cache loader also keeps the offending caller's frame directly above the throw.
+                @Suppress("SENSELESS_COMPARISON")
+                if (type == null) throw Fault("null passed to mergeTypes - a source with nothing to say contributes Nothing", "xtdb/merge-types-null")
+
+                set.add(type)
+            }
+
+            return cache[set]
+        }
+
+        fun mergeTypes(vararg types: VectorType): VectorType = mergeTypes(types.toList())
     }
 }
 

--- a/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
@@ -66,6 +66,18 @@ data class MergeTypes(
             .maximumSize(4096)
             .build<Set<VectorType>, VectorType> { mergeTypes0(it) }
 
+        /**
+         * [mergeTypes] with `Nothing` restored as the identity.
+         *
+         * `⊔` is not idempotent at the bottom today - `mergeTypes(Nothing, Nothing)` returns `Null` (#5871) -
+         * so a join over sources that all have nothing to say reports a dataless column as nullable.
+         *
+         * Delete this and call [mergeTypes] directly once `fromLegs(∅)` returns the bottom.
+         */
+        @JvmStatic
+        fun joinContributions(types: Collection<VectorType>): VectorType =
+            if (types.all { it == Nothing }) Nothing else mergeTypes(types)
+
         @JvmStatic
         fun mergeTypes(types: Collection<VectorType?>): VectorType = cache[types.mapNotNullTo(mutableSetOf()) { it }]
 

--- a/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
+++ b/core/src/main/kotlin/xtdb/authz/RoleMembership.kt
@@ -45,8 +45,8 @@ object RoleMembership {
         val primary = dbCat.databaseOrNull(PRIMARY_DB) ?: return emptyList()
         val tableRef = TableRef("xt", "role_membership")
 
-        val exists = primary.queryState.tableCatalog.getTypes(tableRef) != null ||
-                primary.openSnapshot(null).use { it.tableInfo().containsKey(tableRef) }
+        // tableInfo already unions the catalog's tables with the live ones, so it answers this on its own
+        val exists = primary.openSnapshot(null).use { it.tableInfo().containsKey(tableRef) }
         if (!exists) return emptyList()
 
         val now = Instant.now()

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -2,11 +2,10 @@ package xtdb.catalog
 
 import com.google.protobuf.ByteString
 import org.apache.arrow.vector.types.pojo.Schema
-import xtdb.arrow.MergeTypes.Companion.mergeTypes
+import xtdb.arrow.MergeTypes.Companion.joinContributions
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.asType
 import xtdb.arrow.VectorType.Companion.field
-import xtdb.arrow.VectorType.Null
 import xtdb.block.proto.Partition
 import xtdb.block.proto.TableBlock
 import xtdb.indexer.LiveTable
@@ -155,6 +154,15 @@ class TableCatalog(
             }
         }
 
+        /**
+         * Folds a block's types into the accumulated catalog.
+         *
+         * Each side is a partial map read as a total function - its recorded type where it has one, and its
+         * [VectorType.absentContribution] everywhere else. Substituting `Null` unconditionally would be right
+         * only for a side that holds put rows; for one with none (delete-only, or a `CREATE TABLE` declaring
+         * a column and writing nothing) it widens every column that side failed to mention, and since types
+         * only ever widen and this result is serialised into the block file, that would never heal (#5911).
+         */
         internal fun mergeVecTypes(
             old: Map<ColumnName, VectorType>?, new: Map<ColumnName, VectorType>?
         ): Map<ColumnName, VectorType> =
@@ -162,8 +170,12 @@ class TableCatalog(
                 old == null -> new.orEmpty()
                 new == null -> old
                 else -> {
-                    val allCols = old.keys + new.keys
-                    allCols.associateWith { col -> mergeTypes(old[col] ?: Null, new[col] ?: Null) }
+                    val oldAbsent = VectorType.absentContribution(old)
+                    val newAbsent = VectorType.absentContribution(new)
+
+                    (old.keys + new.keys).associateWith { col ->
+                        joinContributions(listOf(old[col] ?: oldAbsent, new[col] ?: newAbsent))
+                    }
                 }
             }
 

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -28,7 +28,10 @@ class TableCatalog(
         val vecTypes: Map<ColumnName, VectorType>,
         val rowCount: Long,
         val hlls: Map<ColumnName, HLL>
-    )
+    ) {
+        /** @see xtdb.indexer.TableSnapshot.contributedType — the historical side of the same memo. */
+        val absentContribution by lazy { VectorType.absentContribution(vecTypes) }
+    }
 
     private data class State(
         val blockIdx: Long?,
@@ -40,14 +43,30 @@ class TableCatalog(
 
     fun rowCount(table: TableRef): Long? = state.tables[table]?.rowCount
 
-    fun getType(table: TableRef, columnName: ColumnName): VectorType? =
-        state.tables[table]?.vecTypes?.get(columnName)
+    /**
+     * A pinned read surface over one version of the per-table metadata.
+     *
+     * The freezing is the map's doing, not the [Snap]'s: `state` is replaced wholesale on every write and the
+     * map it holds is immutable, so this is a single reference copy and later writes cannot affect it. What
+     * [Snap] adds is one `state` read rather than one per accessor call, so two reads a query apart cannot
+     * see two versions - which is the guarantee its callers actually need.
+     */
+    fun snapshot(): Snap = Snap(state.tables)
 
-    fun getTypes(table: TableRef): Map<ColumnName, VectorType>? =
-        state.tables[table]?.vecTypes
+    /** @see snapshot */
+    class Snap internal constructor(private val tables: Map<TableRef, TableMeta>) {
+        // Copies the outer map on each read - the per-table maps are shared references, not copies. Cheap
+        // where it is used: `buildTableInfo` reads it once per `Snapshot.open`. Worth knowing before
+        // reaching for it per column.
+        val types: Map<TableRef, Map<ColumnName, VectorType>>
+            get() = tables.mapValues { (_, meta) -> meta.vecTypes }
 
-    val types: Map<TableRef, Map<ColumnName, VectorType>>
-        get() = state.tables.mapValues { (_, meta) -> meta.vecTypes }
+        fun rowCount(table: TableRef): Long? = tables[table]?.rowCount
+
+        /** The historical half's contribution — an unknown table has written nothing. */
+        fun contributedType(table: TableRef, col: ColumnName): VectorType =
+            tables[table]?.let { it.vecTypes[col] ?: it.absentContribution } ?: VectorType.Nothing
+    }
 
     /**
      * Seeds a data-backed system table (e.g. `xt.txs`) so it's present from startup, as if an empty

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -98,13 +98,14 @@ class Database(
     val tableCatalog: TableCatalog get() = partition0.tableCatalog
 
     internal fun getColumnTypes(table: TableRef): Map<ColumnName, VectorType>? {
-        val historical = tableCatalog.getTypes(table)
-        // TODO (#5835) iterate the snapshot's partitions and merge per-partition live types;
-        // for now single-partition is the only allowed shape, so pick the only Snapshot.
         // gate on the current basis so a just-committed table's columns are visible (getTableSchema awaits first).
-        val live = openSnapshot(currentBasis()).use { it.partitions.first().allColumnTypes[table] }
-        return if (historical == null && live == null) null
-        else (historical ?: emptyMap()) + (live ?: emptyMap())
+        return openSnapshot(currentBasis()).use { dbSnap ->
+            // TODO (#5835) join across every partition's snapshot, not just partition 0's.
+            val snap = dbSnap.partitions.first()
+
+            // null means "no such table" - distinct from a known table with no columns yet
+            if (table in snap.tableInfo) snap.columnTypes(table) else null
+        }
     }
     val trieCatalog: TrieCatalog get() = partition0.trieCatalog
     val liveIndex: LiveIndex get() = partition0.liveIndex

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -2,7 +2,7 @@ package xtdb.indexer
 
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
-import xtdb.arrow.MergeTypes.Companion.mergeTypes
+import xtdb.arrow.MergeTypes.Companion.joinContributions
 import xtdb.arrow.VectorType
 import xtdb.catalog.TableCatalog
 import xtdb.api.TableRef
@@ -19,9 +19,17 @@ import kotlin.collections.component2
 import kotlin.collections.iterator
 import xtdb.api.tx.OpenTx
 
+/**
+ * A frozen view of **one partition** at a point in time — see [DatabaseSnapshot] for the whole database.
+ *
+ * It pins the in-memory segments, the trie catalog and the historical table metadata, so a reader is not
+ * combining pinned data with a catalog read live at call time. The two catalog captures are not atomic with
+ * respect to each other, though — see [open].
+ */
 class Snapshot(
     val txBasis: TransactionKey?,
     val trieCatSnap: TrieCatalog.Snap,
+    val tableCatSnap: TableCatalog.Snap,
     // A table already has several of these on a transaction snapshot - the live-index segment, one
     // per staged tx that touched it, and the tx's own writes. Those are all tx-visibility layers,
     // so an external snapshot still sees one segment per table. Dual-slot LiveTable (#4495) is what
@@ -36,16 +44,34 @@ class Snapshot(
     fun table(table: TableRef): List<TableSnapshot> = tableSnaps[table].orEmpty()
     val tables get() = tableSnaps.keys
 
-    fun columnType(table: TableRef, column: ColumnName): VectorType? {
-        val snaps = table(table)
-        if (snaps.isEmpty()) return null
-        return mergeTypes(snaps.map { it.columnType(column) })
-    }
-
-    val allColumnTypes by lazy { tableSnaps.mapValues { (_, snaps) -> snaps.mergeTypes() } }
-
     /** The frozen per-table trie-cat state for [table], for downstream `current-tries` planning. */
     fun trieTableState(table: TableRef): Any? = trieCatSnap.tableState(table)
+
+    /**
+     * The declared type of each of [cols] in [table] - the historical half joined with the live half.
+     *
+     * Takes the columns it is asked about rather than returning whatever it finds. A column can belong to the
+     * table while being absent from one half — recorded historically, missing from a live segment — and that
+     * half still has an answer: its rows read null for it. Indexing into a found-columns map would make that
+     * a lookup miss, and the caller would have to invent what a miss means.
+     */
+    fun columnTypes(table: TableRef, cols: Iterable<ColumnName>): Map<ColumnName, VectorType> {
+        val liveSnaps = table(table)
+
+        return cols.associateWith { col ->
+            joinContributions(
+                liveSnaps.map { it.contributedType(col) } + tableCatSnap.contributedType(table, col)
+            )
+        }
+    }
+
+    /** [tableInfo] is the one enumeration of a table's columns - typing whatever it lists keeps them agreeing. */
+    fun columnTypes(table: TableRef): Map<ColumnName, VectorType> =
+        columnTypes(table, tableInfo[table].orEmpty())
+
+    val allColumnTypes: Map<TableRef, Map<ColumnName, VectorType>> by lazy {
+        tableInfo.keys.associateWith { columnTypes(it) }
+    }
 
     private val refCount = AtomicInteger(1)
 
@@ -58,27 +84,18 @@ class Snapshot(
     }
 
     companion object {
-        private fun List<TableSnapshot>.mergeTypes(): Map<ColumnName, VectorType> =
-            when {
-                isEmpty() -> emptyMap()
-                size == 1 -> first().types
-                else -> {
-                    val allCols = flatMapTo(mutableSetOf()) { it.types.keys }
-                    allCols.associateWith { col -> mergeTypes(map { it.columnType(col) }) }
-                }
-            }
-
+        /** Column *names* only - [tableInfo] answers which columns a table has; [columnTypes] answers their types. */
         @JvmStatic
-        private fun TableCatalog.buildTableInfo(
-            allColumnTypes: Map<TableRef, Map<ColumnName, VectorType>>?
+        private fun TableCatalog.Snap.buildTableInfo(
+            liveColumnNames: Map<TableRef, Set<ColumnName>>
         ): Map<TableRef, Set<ColumnName>> {
             val tableInfo = HashMap<TableRef, MutableSet<ColumnName>>()
 
             for ((table, types) in types)
                 tableInfo.getOrPut(table) { mutableSetOf() }.addAll(types.keys)
 
-            for ((table, types) in allColumnTypes.orEmpty())
-                tableInfo.getOrPut(table) { mutableSetOf() }.addAll(types.keys)
+            for ((table, colNames) in liveColumnNames)
+                tableInfo.getOrPut(table) { mutableSetOf() }.addAll(colNames)
 
             return tableInfo
         }
@@ -126,13 +143,21 @@ class Snapshot(
             // must carry every staged table's declared columns *including* 0-row ones (e.g. `CREATE TABLE`),
             // which openSnapshot drops from `byTable` (empty relation), so a tx resolving behind a freshly
             // created empty table in the same batch still sees it exists.
-            val colTypes = LinkedHashMap<TableRef, MutableMap<ColumnName, VectorType>>()
-            for ((table, snaps) in byTable) colTypes.getOrPut(table) { LinkedHashMap() }.putAll(snaps.mergeTypes())
-            for (t in stagedTables) colTypes.getOrPut(t.ref) { LinkedHashMap() }.putAll(t.columnTypes)
+            val liveColumnNames = LinkedHashMap<TableRef, MutableSet<ColumnName>>()
+            for ((table, snaps) in byTable)
+                snaps.flatMapTo(liveColumnNames.getOrPut(table) { linkedSetOf() }) { it.types.keys }
+            for (t in stagedTables) liveColumnNames.getOrPut(t.ref) { linkedSetOf() }.addAll(t.columnTypes.keys)
 
-            val tableInfo = tableCat.buildTableInfo(colTypes)
+            // Captured last, deliberately: a block lands as `addTries` then `finishBlock`, and a table is
+            // invisible to both halves only if the trie-cat capture falls after the first and this one
+            // before the second, so the wider the gap the narrower that window. Pinning still widens the
+            // exposure overall - consumers used to read the catalog live at query time, strictly later
+            // than here. See #5873.
+            val tableCatSnap = tableCat.snapshot()
 
-            Snapshot(ownTx?.txKey ?: liveIndex.latestCompletedTx, trieCatSnap, byTable, tableInfo)
+            val tableInfo = tableCatSnap.buildTableInfo(liveColumnNames)
+
+            Snapshot(ownTx?.txKey ?: liveIndex.latestCompletedTx, trieCatSnap, tableCatSnap, byTable, tableInfo)
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -5,6 +5,7 @@ import xtdb.api.TransactionKey
 import xtdb.arrow.MergeTypes.Companion.joinContributions
 import xtdb.arrow.VectorType
 import xtdb.catalog.TableCatalog
+import xtdb.indexer.LiveTable.Companion.logRelTypes
 import xtdb.api.TableRef
 import xtdb.trie.ColumnName
 import xtdb.trie.TrieCatalog
@@ -35,6 +36,10 @@ class Snapshot(
     // so an external snapshot still sees one segment per table. Dual-slot LiveTable (#4495) is what
     // changes that, adding a second *durable* slot for as long as block N is uploading.
     private val tableSnaps: Map<TableRef, List<TableSnapshot>>,
+    // Live tables whose rows a published L0 already covers — see [open] for why their types outlive
+    // their rows. A type map rather than the TableSnapshot itself, so the excluded rows stay
+    // unreachable from here.
+    private val supersededLiveTypes: Map<TableRef, Map<ColumnName, VectorType>>,
     val tableInfo: Map<TableRef, Set<ColumnName>>,
 ) : AutoCloseable {
     interface Source {
@@ -57,10 +62,17 @@ class Snapshot(
      */
     fun columnTypes(table: TableRef, cols: Iterable<ColumnName>): Map<ColumnName, VectorType> {
         val liveSnaps = table(table)
+        val superseded = supersededLiveTypes[table]
+        // Hoisted for the same reason TableSnapshot and TableMeta hold theirs: constant for a fixed map,
+        // and this loop asks once per column. Doubles as the no-superseded-table answer, since a table
+        // that never had one contributes the bottom too.
+        val supersededAbsent = superseded?.let { VectorType.absentContribution(it) } ?: VectorType.Nothing
 
         return cols.associateWith { col ->
             joinContributions(
-                liveSnaps.map { it.contributedType(col) } + tableCatSnap.contributedType(table, col)
+                liveSnaps.map { it.contributedType(col) }
+                        + (superseded?.get(col) ?: supersededAbsent)
+                        + tableCatSnap.contributedType(table, col)
             )
         }
     }
@@ -113,17 +125,23 @@ class Snapshot(
         ): Snapshot = safelyOpening {
             val trieCatSnap = trieCatalog.snapshot()
 
-            val liveIndexSnaps = openAll {
-                liveIndex.tableRefs
-                    .mapNotNull { liveIndex.table(it) }
+            // Live-tables already covered by a published L0 contribute no *rows* — they'd duplicate the
+            // L0's data. The watermark is monotonic, so once L0_N exists we drop the live-table-N entry
+            // for good (its rows are now in L0_N).
+            //
+            // Their *types* we keep. `addTries` and `tableCatalog.finishBlock` are separate steps, and
+            // between them the L0 is readable while the catalog still holds the pre-block types — so
+            // dropping the live half outright would leave nobody able to answer, declaring a narrower
+            // type than the rows about to be scanned. The write path keeps both copies alive across that
+            // gap (`nextBlock` runs after the catalog update on the leader and follower paths alike);
+            // this keeps the read path inside it. See #5873.
+            val (liveTables, supersededTables) = liveIndex.tableRefs
+                .mapNotNull { liveIndex.table(it) }
+                .partition { it.blockIdx > trieCatSnap.l0MaxBlockIdx(it.table) }
 
-                    // Skip live-tables already covered by a published L0 — they'd duplicate the
-                    // L0's data. The watermark is monotonic, so once L0_N exists we drop the
-                    // live-table-N entry from this snapshot for good (its rows are now in L0_N).
-                    .filter { it.blockIdx > trieCatSnap.l0MaxBlockIdx(it.table) }
+            val liveIndexSnaps = openAll { liveTables.safeMap { TableSnapshot.open(al, it) } }
 
-                    .safeMap { TableSnapshot.open(al, it) }
-            }
+            val supersededLiveTypes = supersededTables.associate { it.table to it.liveRelation.logRelTypes.orEmpty() }
 
             val stagedTables = resolvedTxs.flatMap { it.allTables }
 
@@ -147,17 +165,19 @@ class Snapshot(
             for ((table, snaps) in byTable)
                 snaps.flatMapTo(liveColumnNames.getOrPut(table) { linkedSetOf() }) { it.types.keys }
             for (t in stagedTables) liveColumnNames.getOrPut(t.ref) { linkedSetOf() }.addAll(t.columnTypes.keys)
+            for ((table, types) in supersededLiveTypes) liveColumnNames.getOrPut(table) { linkedSetOf() }.addAll(types.keys)
 
-            // Captured last, deliberately: a block lands as `addTries` then `finishBlock`, and a table is
-            // invisible to both halves only if the trie-cat capture falls after the first and this one
-            // before the second, so the wider the gap the narrower that window. Pinning still widens the
-            // exposure overall - consumers used to read the catalog live at query time, strictly later
-            // than here. See #5873.
+            // Captured after the trie-cat and the live tables, deliberately: the type view must not lag the
+            // data view. A declared type narrower than the rows being scanned is unsound; a wider one is
+            // always safe, so a catalog read that's newer than the tries it covers errs in the safe direction.
             val tableCatSnap = tableCat.snapshot()
 
             val tableInfo = tableCatSnap.buildTableInfo(liveColumnNames)
 
-            Snapshot(ownTx?.txKey ?: liveIndex.latestCompletedTx, trieCatSnap, tableCatSnap, byTable, tableInfo)
+            Snapshot(
+                ownTx?.txKey ?: liveIndex.latestCompletedTx, trieCatSnap, tableCatSnap,
+                byTable, supersededLiveTypes, tableInfo
+            )
         }
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -22,8 +22,10 @@ import xtdb.api.tx.OpenTx
 class Snapshot(
     val txBasis: TransactionKey?,
     val trieCatSnap: TrieCatalog.Snap,
-    // Each table can have multiple TableSnapshots once dual-slot LiveTable lands;
-    // for now the list is always size 0 or 1, but readers must iterate.
+    // A table already has several of these on a transaction snapshot - the live-index segment, one
+    // per staged tx that touched it, and the tx's own writes. Those are all tx-visibility layers,
+    // so an external snapshot still sees one segment per table. Dual-slot LiveTable (#4495) is what
+    // changes that, adding a second *durable* slot for as long as block N is uploading.
     private val tableSnaps: Map<TableRef, List<TableSnapshot>>,
     val tableInfo: Map<TableRef, Set<ColumnName>>,
 ) : AutoCloseable {

--- a/core/src/main/kotlin/xtdb/indexer/TableSnapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TableSnapshot.kt
@@ -12,14 +12,27 @@ import xtdb.api.tx.OpenTx
 
 class TableSnapshot(
     val table: TableRef,
-    val columnTypes: Map<ColumnName, VectorType>,
+    private val columnTypes: Map<ColumnName, VectorType>,
     val segment: MemorySegment
 ) : AutoCloseable {
     val relation get() = segment.rel
     val trie get() = segment.trie
 
-    fun columnType(col: ColumnName): VectorType = columnTypes[col] ?: VectorType.Null
+    // A constant of the segment: `columnTypes` is fixed at construction, so what this segment
+    // contributes for a column it doesn't hold is fixed too. Held rather than recomputed because
+    // `Snapshot.columnTypes` asks per column, and a wide table asks many times.
+    private val absentContribution by lazy { VectorType.absentContribution(columnTypes) }
 
+    /** The live half's contribution — its recorded type for [col], or [VectorType.absentContribution]. */
+    fun contributedType(col: ColumnName): VectorType = columnTypes[col] ?: absentContribution
+
+    /**
+     * The raw record of what this one segment physically holds — no rule applied and nothing joined in.
+     * A column's *declared* type is [xtdb.indexer.Snapshot.columnTypes]; this is only an input to it.
+     *
+     * Public for `xt.live_columns`, which reports the live index as it stands and would be defeated by
+     * merging — the merged question is what `information_schema.columns` answers.
+     */
     val types: Map<ColumnName, VectorType> get() = columnTypes
 
     override fun close() {

--- a/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveIndexTest.kt
@@ -6,6 +6,7 @@ import clojure.lang.Keyword
 import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNotSame
@@ -32,6 +33,7 @@ import xtdb.storage.MemoryStorage
 import xtdb.api.TableRef
 import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation
+import xtdb.arrow.VectorType.Companion.I64
 import xtdb.api.error.Incorrect
 import xtdb.trie.Bucketer
 import java.nio.ByteBuffer
@@ -282,6 +284,49 @@ class LiveIndexTest {
             db.liveIndex.nextBlock()
 
             assertNull(db.liveIndex.table(table))
+        }
+    }
+
+    /**
+     * Stops between `BlockUploader`'s two steps — `trieCatalog.addTries` has run, `tableCatalog.finishBlock`
+     * deliberately has not. The L0's rows are scannable by then and the catalog can't yet type them, which
+     * leaves the live table as the only source that can. See #5873.
+     */
+    @Test
+    fun `a live table superseded by its L0 still declares its column types`() {
+        TestDb().use { db ->
+            val table = TableRef("public", "docs")
+
+            db.openTx(0, Instant.parse("2020-01-01T00:00:00Z")).use { tx ->
+                tx.table(table).writePut(mapOf("_id" to UUID.randomUUID(), "v" to 1L))
+                db.commitTx(tx)
+            }
+
+            val writtenTrie = runBlocking { db.liveIndex.finishBlock(db.bp, 0L) }.getValue(table).writtenTrie!!
+
+            db.trieCatalog.addTries(
+                table,
+                listOf(
+                    TrieDetails.newBuilder()
+                        .setTableName(table.schemaAndTable)
+                        .setTrieKey(writtenTrie.trieKey)
+                        .setDataFileSize(writtenTrie.dataFileSize)
+                        .setTrieMetadata(writtenTrie.trieMetadata)
+                        .build()
+                ),
+                Instant.parse("2020-01-01T00:00:00Z")
+            )
+
+            db.openTx(1, Instant.parse("2020-01-02T00:00:00Z")).use { tx ->
+                db.liveIndex.openSnapshot(emptyList(), tx).use { snap ->
+                    // the two symptoms are independent - assertAll so a regression in either is reported,
+                    // rather than the table-level one masking the column-level one
+                    assertAll(
+                        { assertTrue(table in snap.tableInfo, "the table is still resolvable") },
+                        { assertEquals(mapOf("v" to I64), snap.columnTypes(table, listOf("v"))) }
+                    )
+                }
+            }
         }
     }
 

--- a/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
@@ -50,7 +50,7 @@ class LiveTableTest {
 
                 TableSnapshot.open(allocator, liveTable).use { snap ->
                     assertEquals(2, snap.relation.rowCount)
-                    assertTrue(snap.columnType("foo").toString().isNotEmpty())
+                    assertTrue(snap.contributedType("foo").toString().isNotEmpty())
                 }
             }
         }

--- a/src/test/clojure/xtdb/create_table_test.clj
+++ b/src/test/clojure/xtdb/create_table_test.clj
@@ -157,3 +157,35 @@ $$"])
                  (xt/q secondary "SELECT table_name FROM information_schema.tables WHERE table_name = 'foo'"
                        {:database :shared_db}))
               "an empty table created on the primary propagates to the read-only follower")))))
+
+(defn- col-type [node table col]
+  (xt/q node ["SELECT data_type, is_nullable FROM information_schema.columns
+               WHERE table_name = ? AND column_name = ?" table col]))
+
+;; `TableCatalog/mergeVecTypes` folds each block's types into the catalog, reading each side as a total
+;; function: its recorded type where it has one, and what it contributes for a column it lacks elsewhere.
+;; A block with no put rows carries no columns, so it must widen nothing. Getting that wrong is durable -
+;; types only ever widen, and the result is serialised into the block file - hence a test per trigger (#5911).
+(t/deftest delete-only-block-does-not-widen-column-types
+  (with-open [node (xtn/start-node)]
+    (xt/execute-tx node [[:sql "INSERT INTO foo (_id, v) VALUES (1, 42)"]])
+    (tu/flush-block! node)
+
+    (t/is (= [{:data-type ":i64", :is-nullable "NO"}] (col-type node "foo" "v"))
+          "baseline: one non-null i64")
+
+    (xt/execute-tx node [[:sql "DELETE FROM foo WHERE _id = 1"]])
+    (tu/flush-block! node)
+
+    (t/is (= [{:data-type ":i64", :is-nullable "NO"}] (col-type node "foo" "v"))
+          "a delete ends a version rather than producing one, so it carries no columns and must not widen `v`")))
+
+(t/deftest declaring-a-column-does-not-widen-the-others
+  (with-open [node (xtn/start-node)]
+    (xt/execute-tx node [[:sql "INSERT INTO foo (_id, v) VALUES (1, 42)"]])
+    (tu/flush-block! node)
+    (xt/execute-tx node [[:sql "CREATE TABLE foo (w)"]])
+    (tu/flush-block! node)
+
+    (t/is (= [{:data-type ":i64", :is-nullable "NO"}] (col-type node "foo" "v"))
+          "declaring `w` writes no rows, so it must not widen `v`")))

--- a/src/test/clojure/xtdb/indexer_test.clj
+++ b/src/test/clojure/xtdb/indexer_test.clj
@@ -218,18 +218,18 @@
           (cpb/check-pbuf (.toPath (io/file expected-dir "pbuf")) node-dir))
 
         (let [db (db/primary-db node)
-              tc (.getTableCatalog db)]
+              tc-types (.getTypes (.snapshot (.getTableCatalog db)))]
           (t/is (= #xt/type #{:utf8 :keyword :i64}
-                   (.getType tc #xt/table xt_docs "_id")))
+                   (get-in tc-types [#xt/table xt_docs "_id"])))
 
           (t/is (= #xt/type [:? :list #{:f64 :utf8 :instant :bool}]
-                   (.getType tc #xt/table xt_docs "list")))
+                   (get-in tc-types [#xt/table xt_docs "list"])))
 
           (t/is (= #xt/type [:? :struct {"a" #{:i64 :bool},
                                          "b" #{:utf8
                                                ;; TODO these shouldn't be optional strings, really. #4988
                                                [:struct {"c" [:? :utf8], "d" [:? :utf8]}]}}]
-                   (.getType tc #xt/table xt_docs "struct"))))))))
+                   (get-in tc-types [#xt/table xt_docs "struct"]))))))))
 
 (t/deftest drops-nils-on-round-trip
   (xt/submit-tx tu/*node* [[:put-docs :xt_docs {:xt/id "nil-bar", :foo "foo", :bar nil}]
@@ -415,7 +415,7 @@
                                                                 (t/is (= 5 (count (filter #(re-matches #"tables/xt\$txs/meta/l00.+?\.arrow" %) objs))))))
 
                                                             (t/is (= #xt/type :utf8
-                                                                     (.getType tc #xt/table device_readings "_id")))
+                                                                     (get-in (.getTypes (.snapshot tc)) [#xt/table device_readings "_id"])))
 
                                                             (let [{second-half-tx-id :tx-id} (->> (partition-all 100 second-half-tx-ops)
                                                                                                   (reduce (fn [_ tx-ops]
@@ -428,7 +428,7 @@
                                                                         second-half-tx-id))
 
                                                               (t/is (= #xt/type :utf8
-                                                                       (.getType tc #xt/table device_info "_id")))
+                                                                       (get-in (.getTypes (.snapshot tc)) [#xt/table device_info "_id"])))
 
                                                               [second-half-tx-id second-half-await-token])))]
 
@@ -456,7 +456,7 @@
               (t/is (= 11 (count (filter #(re-matches #"tables/xt\$txs/meta/l00-.+.arrow" %) objs)))))
 
             (t/is (= #xt/type :utf8
-                     (.getType tc #xt/table device_info "_id")))))))))
+                     (get-in (.getTypes (.snapshot tc)) [#xt/table device_info "_id"])))))))))
 
 
 (t/deftest merges-column-fields-on-restart
@@ -472,7 +472,7 @@
         (tu/flush-block! node1)
 
         (t/is (= #xt/type :utf8
-                 (.getType tc1 #xt/table xt_docs "v")))
+                 (get-in (.getTypes (.snapshot tc1)) [#xt/table xt_docs "v"])))
 
         (xt/execute-tx node1 [[:put-docs :xt_docs {:xt/id 1, :v :bar}]
                               [:put-docs :xt_docs {:xt/id 2, :v #uuid "8b190984-2196-4144-9fa7-245eb9a82da8"}]
@@ -481,7 +481,7 @@
         (tu/flush-block! node1)
 
         (t/is (= #xt/type #{:utf8 :keyword :uuid :transit}
-                 (.getType tc1 #xt/table xt_docs "v")))))
+                 (get-in (.getTypes (.snapshot tc1)) [#xt/table xt_docs "v"])))))
 
     (with-open [node2 (tu/->local-node (assoc node-opts :buffers-dir "objects-1"))]
       (let [tc2 (.getTableCatalog (db/primary-db node2))]
@@ -491,7 +491,7 @@
         ;; very annoying.
         ;; so we render the type to compare.
         (t/is (= #{:utf8 :keyword :uuid :transit}
-                 (st/render-type (.getType tc2 #xt/table xt_docs "v"))))))))
+                 (st/render-type (get-in (.getTypes (.snapshot tc2)) [#xt/table xt_docs "v"]))))))))
 
 (t/deftest test-indexes-sql-insert
   (binding [c/*ignore-signal-block?* true]

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -85,3 +85,14 @@
            (types/field->col-type #xt/field {"a" [:? :list]})))
   (t/is (= [:union #{[:set :null] :null}]
            (types/field->col-type #xt/field {"b" [:? :set]}))))
+
+;; Kotlin's non-null signature can't hold Clojure callers - erasure means nil reaches `mergeTypes`
+;; as a null element. It must land as an anomaly, not a bare NoWhenBranchMatchedException.
+(t/deftest merge-types-rejects-nil
+  (t/is (thrown? xtdb.api.error.Fault (types/merge-types nil)))
+  (t/is (thrown? xtdb.api.error.Fault (types/merge-types #xt/type :i64 nil)))
+
+  ;; `#xt/type :nothing` doesn't read - `render-type` emits `:nothing` but the reader has no clause for it
+  (t/testing "the lattice bottom is how a source says it has nothing to contribute"
+    (t/is (= #xt/type :i64
+             (types/merge-types #xt/type :i64 xtdb.arrow.VectorType$Nothing/INSTANCE)))))

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -19,10 +19,16 @@ import org.junit.jupiter.api.Test
 import xtdb.api.Xtdb
 import xtdb.api.query.IKeyFn.KeyFn.SNAKE_CASE_STRING
 import xtdb.arrow.Relation
+import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.I64
+import xtdb.arrow.VectorType.Companion.UTF8
+import xtdb.arrow.VectorType.Companion.asType
+import xtdb.arrow.VectorType.Companion.fromLegs
+import xtdb.arrow.VectorType.Companion.maybe
 import xtdb.arrow.VectorType.Companion.ofType
 import xtdb.database.Database
 import xtdb.database.encodeTimeBasisToken
+import xtdb.test.flushBlock
 import java.time.Instant
 import java.util.UUID
 
@@ -943,6 +949,117 @@ class InProcessAdbcTest {
                 assertEquals(0, rdr.vectorSchemaRoot.rowCount)
             }
         }
+    }
+
+    private fun advertisedType(table: String, col: String) =
+        xtdb.connect().use { conn ->
+            conn.getTableSchema(null, "public", table).fields.single { it.name == col }.asType
+        }
+
+    /**
+     * The type the query's own result schema reports. A separate client-visible answer from
+     * [advertisedType]'s, reached through `scan-vec-types` rather than `getColumnTypes` — so a client that
+     * reads the table schema and then executes against it sees both, and they have to agree.
+     */
+    private fun queriedType(table: String, col: String) =
+        xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT $col FROM $table")
+                stmt.prepare()
+                stmt.executeSchema().fields.single { it.name == col }.asType
+            }
+        }
+
+    @Test
+    fun `getTableSchema admits null for a column only the historical rows have`() {
+        insertData("INSERT INTO w1 RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        insertData("INSERT INTO w1 RECORDS {_id: 2}")
+
+        assertEquals(
+            maybe(I64), advertisedType("w1", "v"),
+            "row 2 has no `v` and so reads as null - advertising a non-nullable i64 licenses a consumer to omit the validity buffer"
+        )
+
+        assertEquals(
+            advertisedType("w1", "v"), queriedType("w1", "v"),
+            "getTableSchema and the query's result schema must agree - a client reads one then executes against the other"
+        )
+    }
+
+    /**
+     * `Nothing.toField` is a NULL field marked non-nullable, which looks like the hazard the tests above
+     * guard against and isn't: the bottom is reached only when no source has put rows, so no rows are
+     * emitted and there are no cells to describe. `declares-bare-columns` pins that companion half.
+     */
+    @Test
+    fun `a declared but unwritten column is the bottom on every surface`() {
+        insertData("CREATE TABLE decl (v)")
+
+        assertEquals(VectorType.Nothing, queriedType("decl", "v"))
+        assertEquals(advertisedType("decl", "v"), queriedType("decl", "v"))
+    }
+
+    /** But once the table has rows, they read null for it — the bottom is for a column with no cells. */
+    @Test
+    fun `a column declared on a populated table is advertised nullable`() {
+        insertData("INSERT INTO pop RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        insertData("CREATE TABLE pop (w)")
+
+        assertEquals(VectorType.Null, advertisedType("pop", "w"))
+    }
+
+    @Test
+    fun `a delete-only segment does not widen the advertised type`() {
+        insertData("INSERT INTO del RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        insertData("DELETE FROM del WHERE _id = 1")
+
+        assertEquals(
+            I64, advertisedType("del", "v"),
+            "a delete carries no columns, so it cannot make `v` nullable"
+        )
+    }
+
+    @Test
+    fun `getTableSchema unions a column's historical and live types`() {
+        insertData("INSERT INTO baz RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        insertData("INSERT INTO baz RECORDS {_id: 2, v: 'hello'}")
+
+        assertEquals(
+            fromLegs(I64, UTF8), advertisedType("baz", "v"),
+            "the table holds both an i64 and a utf8; advertising either alone is a type the other row isn't"
+        )
+
+        assertEquals(
+            advertisedType("baz", "v"), queriedType("baz", "v"),
+            "getTableSchema and the query's result schema must agree - a client reads one then executes against the other"
+        )
+    }
+
+    /**
+     * `[:list :null]` rather than the more accurate `[:list :nothing]` is #5871 — `mergeTypes` rewrites a
+     * nested lattice bottom. What this pins is that all three surfaces say the *same* thing; the value they
+     * agree on gets more accurate when that lands.
+     */
+    @Test
+    fun `an empty list column reports the same type on every surface`() {
+        insertData("INSERT INTO el RECORDS {_id: 1, v: []}")
+
+        val advertised = advertisedType("el", "v")
+
+        assertEquals(advertised, queriedType("el", "v"), "getTableSchema and the query's result schema must agree")
+
+        val infoSchema = xtdb.connect().use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.setSqlQuery("SELECT data_type FROM information_schema.columns WHERE table_name = 'el' AND column_name = 'v'")
+                queryRows(stmt).single()["data_type"].toString()
+            }
+        }
+
+        assertEquals("[:list :null]", infoSchema, "information_schema must agree with both")
     }
 
     @Test

--- a/src/test/kotlin/xtdb/catalog/ColumnTypesTest.kt
+++ b/src/test/kotlin/xtdb/catalog/ColumnTypesTest.kt
@@ -1,0 +1,176 @@
+package xtdb.catalog
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import xtdb.XtdbInternal
+import xtdb.api.TableRef
+import xtdb.api.Xtdb
+import xtdb.arrow.VectorType
+import xtdb.arrow.VectorType.Companion.I64
+import xtdb.arrow.VectorType.Companion.UTF8
+import xtdb.arrow.VectorType.Companion.fromLegs
+import xtdb.arrow.VectorType.Companion.maybe
+import xtdb.test.flushBlock
+import xtdb.trie.ColumnName
+
+/**
+ * The historical⊔live join, asserted directly rather than through a query.
+ *
+ * A query can't catch a defect on either side, because the two halves cover for each other - and nils drop
+ * out of Clojure row maps, so the emitted rows look right while the declared type is wrong.
+ */
+class ColumnTypesTest {
+
+    private lateinit var xtdb: Xtdb
+
+    @BeforeEach
+    fun setUp() {
+        xtdb = Xtdb.openNode { server { port = 0 } }
+    }
+
+    @AfterEach
+    fun tearDown() = xtdb.close()
+
+    private fun exec(sql: String) =
+        xtdb.connect().use { conn -> conn.createStatement().use { it.setSqlQuery(sql); it.executeUpdate() } }
+
+    private fun typeOf(table: String, vararg cols: ColumnName): Map<ColumnName, VectorType> {
+        val db = (xtdb as XtdbInternal).dbCatalog.primary
+        return db.openSnapshot(db.currentBasis()).use { dbSnap ->
+            dbSnap.partitions.first().columnTypes(TableRef("public", table), cols.toList())
+        }
+    }
+
+    @Test
+    fun `unions types that disagree across the boundary`() {
+        exec("INSERT INTO t RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        exec("INSERT INTO t RECORDS {_id: 2, v: 'hello'}")
+
+        assertEquals(
+            mapOf("v" to fromLegs(I64, UTF8)), typeOf("t", "v"),
+            "both legs are real; neither side may overwrite the other"
+        )
+    }
+
+    @Test
+    fun `widens when the live rows lack a column the historical rows have`() {
+        exec("INSERT INTO t RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        exec("INSERT INTO t RECORDS {_id: 2}")
+
+        assertEquals(mapOf("v" to maybe(I64)), typeOf("t", "v"))
+    }
+
+    @Test
+    fun `widens when the historical rows lack a column the live rows have`() {
+        exec("INSERT INTO t RECORDS {_id: 1}")
+        xtdb.flushBlock()
+        exec("INSERT INTO t RECORDS {_id: 2, v: 1}")
+
+        assertEquals(
+            mapOf("v" to maybe(I64)), typeOf("t", "v"),
+            "the mirror of the above - the historical side has rows that read null, so it contributes Null, not nothing"
+        )
+    }
+
+    @Test
+    fun `a column present nowhere still has a type`() {
+        exec("INSERT INTO t RECORDS {_id: 1}")
+
+        assertEquals(
+            mapOf("nope" to VectorType.Null), typeOf("t", "nope"),
+            "every row of a non-empty table reads null for it - asking is not a lookup miss"
+        )
+    }
+
+    /**
+     * `CREATE TABLE` on a populated table leaves a live segment holding only the newly-declared column and
+     * no rows. It contributes nothing about `v`, so it must contribute `Nothing` — a segment with no rows
+     * has no row that reads null.
+     */
+    @Test
+    fun `a zero-row live segment does not make other columns nullable`() {
+        exec("INSERT INTO t RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        exec("CREATE TABLE t (w)")
+
+        assertEquals(
+            mapOf("v" to I64), typeOf("t", "v"),
+            "`v` is non-null in every block and segment; an empty segment lacking it must not widen it"
+        )
+    }
+
+    /** The declaring segment holds no rows, but the table does, and they read null for `w`. */
+    @Test
+    fun `a column declared on a populated table is nullable, not the bottom`() {
+        exec("INSERT INTO t RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        exec("CREATE TABLE t (w)")
+
+        assertEquals(mapOf("w" to VectorType.Null), typeOf("t", "w"))
+    }
+
+    @Test
+    fun `a column declared on an empty table is the bottom`() {
+        exec("CREATE TABLE t (w)")
+
+        assertEquals(mapOf("w" to VectorType.Nothing), typeOf("t", "w"))
+    }
+
+    /**
+     * The op-type axis. Every case above is built from puts, which is how a source's row count came to stand
+     * in for "rows that could carry a column" - `delete` and `erase` are rows too, and they carry none, so a
+     * source made only of them contributes `Nothing`. They also never materialise a put leg, which is what
+     * lets [xtdb.arrow.VectorType.absentContribution] tell them apart from a source that does have puts.
+     */
+    @Test
+    fun `a delete-only live segment does not make columns nullable`() {
+        exec("INSERT INTO t RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        exec("DELETE FROM t WHERE _id = 1")
+
+        assertEquals(
+            mapOf("v" to I64), typeOf("t", "v"),
+            "the segment holds one delete and no put, so it has no row that could carry `v`"
+        )
+    }
+
+    @Test
+    fun `an erase-only live segment does not make columns nullable`() {
+        exec("INSERT INTO t RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        exec("ERASE FROM t WHERE _id = 1")
+
+        assertEquals(mapOf("v" to I64), typeOf("t", "v"))
+    }
+
+    /**
+     * `v` is in the put's doc, so the lookup hits and the absent-column rule never runs — unlike the
+     * delete-only case above, which is where [xtdb.arrow.VectorType.absentContribution] earns its keep.
+     * Worth pinning even so: a delete sharing the segment must not disturb a recorded type. Note the
+     * catalog could not narrow one in any case — types only ever widen, and the deleted row's `v` stays
+     * queryable through history.
+     */
+    @Test
+    fun `a put alongside a delete keeps the recorded type`() {
+        exec("INSERT INTO t RECORDS {_id: 1, v: 1}")
+        xtdb.flushBlock()
+        exec("INSERT INTO t RECORDS {_id: 2, v: 2}")
+        exec("DELETE FROM t WHERE _id = 1")
+
+        assertEquals(mapOf("v" to I64), typeOf("t", "v"))
+    }
+
+    @Test
+    fun `a table nobody has written is the lattice bottom`() {
+        exec("INSERT INTO t RECORDS {_id: 1}")
+
+        assertEquals(
+            mapOf("v" to VectorType.Nothing), typeOf("no_such_table", "v"),
+            "no rows anywhere, so nothing to contribute - Nothing is absorbed by any join it takes part in"
+        )
+    }
+}

--- a/src/testFixtures/kotlin/xtdb/test/FlushBlock.kt
+++ b/src/testFixtures/kotlin/xtdb/test/FlushBlock.kt
@@ -1,0 +1,20 @@
+package xtdb.test
+
+import xtdb.XtdbInternal
+import xtdb.api.Xtdb
+import java.time.Duration
+
+/**
+ * Finishes a block on every attached database and waits for it, so a test can put data on the far side of
+ * the historical/live boundary. Rows written before the flush are read from tries; rows written after are
+ * read from the live index, and several behaviours differ across that line.
+ *
+ * The Clojure counterpart is `tu/flush-block!`.
+ */
+@JvmOverloads
+fun Xtdb.flushBlock(timeout: Duration = Duration.ofSeconds(5)) {
+    (this as XtdbInternal).dbCatalog.let { cat ->
+        cat.databaseNames.mapNotNull { cat.databaseOrNull(it) }.forEach { it.sendFlushBlockMessage() }
+        cat.syncAll(timeout)
+    }
+}


### PR DESCRIPTION
Resolves #5855 and #5911. Advances #5873.

## Summary

XTDB advertised Arrow schemas that its own data contradicted — `getTableSchema` reporting `v: Int(64, true) not null` for a table whose second row reads null for `v`, and `Utf8` for a column holding both a `utf8` and an `i64`. Arrow's non-nullable flag licenses a consumer to omit the validity buffer entirely, so that is a contract being broken rather than a hint being fudged. It bites the Arrow-typed surfaces (ADBC, Flight SQL) and `information_schema.columns`; pgwire is unaffected, since a DataRow carries NULL regardless of OID.

Neither half of the type derivation was broken on its own. The live half null-fills within a block; the historical half null-fills and unions across blocks. The defect was entirely at the seam — and that seam was crossed in four places by four different operators, only one of which was a join.

## Changes

1. `tidy(indexer): correct what gives a table several TableSnapshots` — a comment that described a shape the code no longer had.
2. `fix(types): join the historical and live halves of a column's type` — the substance. One derivation, one rule, four call sites repointed, four accessors deleted.
3. `tidy(types): mergeTypes rejects nulls rather than dropping them` — with the 24-site Clojure audit behind it.
4. `tidy(info-schema): keep the metadata tables off the type derivation` — 32 of 34 metadata tables no longer derive types they never needed.
5. `fix(catalog): a block widens only the columns its rows could carry` — a pre-existing `main` bug (#5911) the new rule exposed.
6. `fix(indexer): keep live column types once an L0 supersedes their rows` — #5873's mechanism.
7. `docs(allium): realign snapshot visibility on what a snapshot actually pins`.

## The rule

A source's contribution for a column is its recorded type where it has one, and otherwise what its rows would read for that column: `Null` if it holds put rows, since an absent column reads as null in XT, or `Nothing` — the lattice bottom, which the join absorbs — if it holds none.

The discriminator is **put** rows, not rows. `delete` and `erase` are rows in the log relation but they end a version rather than producing one, so they carry no columns and emit no cells; counting them reports a column as nullable on the strength of rows that never read it. Both put-less shapes are reachable and neither is exotic: a delete-only transaction never materialises a put leg at all, and `CREATE TABLE` on an already-populated table leaves a segment with a put leg and no rows.

That distinction is derived from the recorded types rather than carried alongside them, and it is exact rather than approximate: every put records `_id` with a real type, `declareColumns` records declared-but-unwritten columns as `Nothing`, and a delete-only source records nothing at all. So a non-`Nothing` entry exists precisely when some put wrote a value. Confirmed against both shapes rather than assumed — a `CREATE TABLE`-only segment reads back as `{w=Nothing}` with a present-but-empty put leg, a delete-only segment as `{}` with no put leg, which is also why neither the row count nor put-leg-presence alone can separate them.

## Implementation notes

**A `Snapshot` was not previously a snapshot of everything.** Three components were captured at construction while the historical types were read live off a volatile at call time, so a query saw data as of one moment and types as of another. Pinning the fourth costs a single reference copy, because `TableCatalog.state` is replaced wholesale and the map it holds is immutable. `tableInfo` then becomes the single enumeration of a table's columns, and the derivation types whatever it lists — so the planner and `information_schema` can no longer disagree about which columns exist.

**Four accessors are deleted rather than fixed.** Two were defect sites, so they go by construction rather than by patch. The other two were the remaining ways to read the historical half *without* pinning it, which is the thing that caused this bug. Historical types are now unreachable except through a `Snap`.

**The derivation takes the columns it is asked about** rather than returning whatever it finds. A column can belong to a table while being absent from one half, and that half still has an answer — its rows read null for it. Returning a found-columns map would make that a lookup miss, and the caller would have to invent what a miss means, reinstating exactly the nil-at-a-boundary handling this change exists to delete.

**Commit 5 is a `main` bug, not a branch regression.** `mergeVecTypes` substituted `Null` unconditionally for a column one side failed to mention. That is right only for a side holding put rows; for one with none it widens every unmentioned column, and since types only ever widen and the result is serialised into the block file, it never heals. Reproduced in isolation on `main` first, so the behaviour was pinned independently of this branch.

**Commit 6 is a read-path fix, not a sequencing one.** Once `addTries` publishes an L0, the filter in `Snapshot.open` drops the block's live table — correct for its rows, which the L0 now duplicates, but it discarded the column types too, and `tableCatalog` does not carry them until `finishBlock`. Between those two steps the types were visible in neither half. The write path already holds both copies across the gap (`nextBlock` runs after the catalog update on the leader and follower paths alike); it was the read path leaving that overlap early, on a signal meaning "these rows are readable from disk" rather than "these types are in the catalog". So the block-finish sequencing is untouched.

## Decisions

**The lattice bottom is repaired locally rather than at source.** `mergeTypes` collapses an all-`Nothing` merge to `Null` (#5871), so `⊔` is not idempotent at `⊥` and `T` is not yet a join-semilattice. `joinContributions` restores the law at the two sites that need it. Both it and the unconditional merge become unnecessary once `fromLegs(∅)` returns the bottom.

**Every column goes through `mergeTypes` even where there is a single contribution.** Skipping looks free and is not: the merge also rewrites a *nested* bottom, turning `[:list :nothing]` into `[:list :null]`, so a short-circuit would make a column's declared type depend on whether its rows had been flushed — the exact inconsistency this change removes. An earlier revision did that and was caught in review.

**`rowCount` is left out of type derivation entirely.** It is a statistics field, which is what it was before this work, and it counts deletes and erases — the two op types the rule must exclude.

## User-visible change beyond the fix

For a column whose type contains a nested bottom (an empty list literal is enough), `getTableSchema` and `information_schema` previously reported the raw `[:list :nothing]` while the query's result schema reported the merged `[:list :null]`. They now all report `[:list :null]`. The value they agree on becomes the more accurate `[:list :nothing]` when #5871 lands.

A `CREATE TABLE`-declared, never-written column's ADBC field also goes from nullable to non-nullable NULL. That is the accurate statement — no rows means no values, not even nulls — and what #4467 intended.

## Test plan

- `./gradlew test` — 2182 tests, 0 failures.
- `./gradlew property-test` — 2747 tests, 0 failures, 100 iterations across all five simulation classes (`NodeSimulationTest`, `CompactorSimulationTest`, `LogProcessorSimTest`, `CacheSimulationTest`, `LeaderDriverSimTest`), since this touches indexing.
- The ADBC tests assert that `getTableSchema` and a query's result schema **agree**, rather than checking each against a known-good type. They are two independently-derived client-visible answers, and a client typically reads one then executes against the other; on the way in only the first was wrong, so the observable failure was less "the schema is wrong" than "the same client gets two answers depending on how it asks".
- `ColumnTypesTest` asserts the join directly rather than through a query — a query cannot catch a defect on either side, because the two halves cover for each other and nils drop out of Clojure row maps.
- Commit 6's test was verified to fail without its fix, reporting both symptoms independently via `assertAll`: `expected: <true> but was: <false>` for table resolution, and `expected: <{v=<Int(64, true)>}> but was: <{v=Nothing}>` for the column type.
- Four `/code-review high` rounds over the branch. The last round's three findings resolved as: allium spec drift (fixed, commit 7); a `RoleMembership` regression (invalid — `PartitionState.open` seeds `xt.role_membership` into the catalog *before* the first snapshot is built, so the removed disjunct was an always-true operand of an always-true `||`); and an `absentContribution` cost concern (actioned, folded into commit 2 — see below).

On that last one: the finding's stated cost was wrong, since `absentContribution` is `values.any { it != Nothing }` and every put records `_id` with a real type, so it short-circuits immediately. But the underlying point held. The absent contribution is a *constant of the source* — `TableSnapshot.columnTypes` and `TableMeta.vecTypes` are both fixed at construction — so recomputing it per column asked about is pure waste, and a wide table asks many times. It is now memoised on each, which is also better modelling than hoisting at the call site would have been: the property belongs to the source, not to each question put to it. `VectorType.contributedType` remains the rule's canonical statement and says so in its kdoc.

## Out of scope

- **Cross-partition semantics** (#5835, #5837). The cross-partition type is this same join widened from 2 sources to 2N, so this is the thing that gets extended; `Database.getColumnTypes` still reads `partitions.first()` behind a TODO. Worth noting `DatabaseSnapshot.tableInfo()` already unions across partitions while `getColumnTypes` does not, so those two disagree under p > 1 — recorded on #5835.
- **Recording the put-row count instead of inferring it** (#5919, blocked on this). `absentContribution` decides a source's contribution by asking whether any recorded type is non-`Nothing`, which is an inference standing in for "does this source have put rows". It is correct for everything reachable — SQL, XTQL and `writePut` all fold `_id` into the doc — but a hand-built put with an empty doc struct would defeat it. The inference exists because L0s are sparse across columns: a column no put row wrote occupies zero bytes, so an empty column and an absent one become indistinguishable, and that is exactly the bit being recovered. Carrying it is additive rather than a format break (the block proto is `edition = "2023"`, so an absent field is detectable and falls back to today's behaviour), but it is a separable change with its own test surface.
- **Basis-scoping the historical side.** `TableCatalog` takes no basis, so it contributes every type ever written; only the live half is snapshot-exact. Tightening it needs per-block type metadata, i.e. a storage-format change.
- **Whether the advertised schema is fixed at prepare or per execution** (#5854).
- **#5873 stays open.** Commit 6 fixes the mechanism and pins it with a deterministic test, but the flake it was filed for was never reproduced in isolation, so there is no before/after on the reported symptom — and whether the same window explains #4640 / #4638 is unchecked.

## Note for the reviewer

`allium check` could not be run (CLI not installed locally), so commit 7 was validated against the language reference. One line is uncertain — `segment_tables: table_snapshots -> table_ref`, a projection that maps without filtering. The reference documents `-> field` extraction as its own feature but pairs it with `where` in every example. If the checker rejects it, `is_visible(t)` as a parameterised derived value over `table_snapshots.any(ts => ts.table_ref = t)` says the same thing with constructs that are definitely in the grammar.
