### PR TITLE
fix(postgres-source): default to DirectMirror when a persisted config has no indexer

### DIFF
--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -165,7 +165,11 @@ class PostgresSource(
                     remote = config.remote,
                     slotName = config.slotName,
                     publicationName = config.publicationName,
-                    indexer = PgIndexer.Factory.fromProto(config.indexer),
+                    // Configs persisted before `indexer` was a required field were all effectively using
+                    // DirectMirror, so we default to it here — new databases must say which indexer they want.
+                    indexer =
+                        if (config.hasIndexer()) PgIndexer.Factory.fromProto(config.indexer)
+                        else DirectMirror.Factory(),
                 )
             }
 

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceFactoryTest.kt
@@ -30,13 +30,25 @@ class PostgresSourceFactoryTest {
         assertTrue(restored.indexer is DirectMirror.Factory)
     }
 
-    // fix: DETACH the database, then re-ATTACH with an indexer in the config
     @Test
-    fun `config persisted without an indexer is rejected`() {
+    fun `config persisted without an indexer defaults to DirectMirror`() {
         val legacy = xtdb.postgres.proto.postgresSourceConfig {
             remote = "pg"; slotName = "s"; publicationName = "p"
         }
         val any = com.google.protobuf.Any.pack(legacy, "proto.xtdb.com")
+
+        val factory = PostgresSource.Factory.Registration().fromProto(any)
+
+        assertTrue(factory.indexer is DirectMirror.Factory)
+    }
+
+    @Test
+    fun `unknown persisted indexer is still rejected`() {
+        val config = xtdb.postgres.proto.postgresSourceConfig {
+            remote = "pg"; slotName = "s"; publicationName = "p"
+            indexer = com.google.protobuf.Any.newBuilder().setTypeUrl("proto.xtdb.com/nope.Nope").build()
+        }
+        val any = com.google.protobuf.Any.pack(config, "proto.xtdb.com")
 
         assertThrows(IllegalStateException::class.java) {
             PostgresSource.Factory.Registration().fromProto(any)
@@ -60,6 +72,18 @@ class PostgresSourceFactoryTest {
         assertEquals("my_slot", factory.slotName)
         assertEquals("my_pub", factory.publicationName)
         assertTrue(factory.indexer is DirectMirror.Factory)
+    }
+
+    @Test
+    fun `YAML without an indexer is rejected`() {
+        val yaml = """
+            externalSource: !Postgres
+              remote: pg
+              slotName: my_slot
+              publicationName: my_pub
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) { Database.Config.fromYaml(yaml) }
     }
 
     @Test


### PR DESCRIPTION
tl;dr

- **A Postgres-source database attached on v2.2.0-beta1 stops a v2.2.0-rc0+ node from starting at all.**
  Its persisted config predates the `indexer` field, and decoding it throws during catalog open — before the node has attached anything.

- **An absent `indexer` now decodes to `!DirectMirror`**, which is the only thing the source did before the field existed.

- **The YAML surface is unchanged.**
  A new `ATTACH` must still name an indexer; only the persisted-config read path got more lenient.

## Context

`indexer` became a field on `PostgresSourceConfig` in 5f673a873 (`feat(postgres-source): pluggable indexer SPI with !DirectMirror default`), which landed between **v2.2.0-beta1** and **v2.2.0-rc0**. A database attached while running beta1 has a serialised config written before that field existed, and there is no migration for it.

## Root cause

- **Protobuf gives an unset message field a default rather than an absence**, and the decode path couldn't tell the two apart.
  `fromProto` passed `config.indexer` — an empty `Any` with a blank `typeUrl` — straight to `PgIndexer.Factory.fromProto`, which looked the blank tag up in the registration table, missed, and threw `unknown pg indexer:`.

- **The throw lands in `DatabaseCatalog.open()`, so it tanks the whole node, not just the one database.**
  `Database.Config.fromProto` is called in an unguarded loop over every secondary in the block catalog (`DatabaseCatalog.kt:174`), inside a `closeOnCatch`.

- **`XTDB_SKIP_DBS` can't rescue it.**
  The skip check lives in `attach` (`DatabaseCatalog.kt:82`), which the decode at line 174 never reaches — so the documented escape hatch for a bad secondary doesn't apply, and recovering meant a `DETACH`, which needs a node that starts.

## Decision rationale

- **D1: DirectMirror is a reconstruction, not a guess.**
  Mirroring the upstream as-is was the entire behaviour of the source before the SPI existed, so a beta1 config decoding to `DirectMirror.Factory()` resumes doing exactly what that database was already doing. There is no other indexer it could have meant.

- **D2: the default lives in the decode path, not on `Factory.indexer`.**
  Rejected giving the constructor parameter a Kotlin default: that would also make the YAML key optional, and a fresh `ATTACH` should still have to state its indexer. The field is missing from these configs because it predates the choice existing — not because omitting it carries meaning.

- **D3: only absence defaults; an unrecognised `typeUrl` still throws.**
  `hasIndexer()` separates the two cases, so a config naming an indexer this build doesn't carry keeps failing loudly rather than silently falling back to mirroring — which would be the one way to turn a startup failure into wrong data.

## Out of scope

- **kafka-connect-source has the same decode shape and is left alone.**
  `KafkaConnectSourceConfig.indexer` is also an `Any` with the same missing-field behaviour, but its `!Docs` indexer requires a `table`, so there's no zero-config indexer to fall back to. Nothing to reconstruct, so no fix to make.

- **No docs or changelog entry.**
  The user-facing config surface is unchanged, and the behaviour being repaired only ever existed on a beta.

## Test plan

`./gradlew :modules:xtdb-postgres-source:test` — 8 pass, 0 fail. Three cases carry the change:

- `config persisted without an indexer defaults to DirectMirror` — packs a `PostgresSourceConfig` with no `indexer` set, the beta1 shape, and asserts it decodes.
- `unknown persisted indexer is still rejected` — pins D3, so the fix can't erode into a blanket fallback.
- `YAML without an indexer is rejected` — pins D2, so the config surface can't loosen unnoticed.

The module's testcontainers-backed suites weren't run; they exercise the `ATTACH … WITH` YAML path, which this branch doesn't touch.
