### PR TITLE
Prepare the database catalog for restarting databases (#5910)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ That commentary belongs in the commit body and the PR, which are read once aroun
 | Spec | Covers |
 | --- | --- |
 | `allium/live-index.allium` | In-memory staging of transactions before block flush — `LiveIndex`/`LiveTable`, transaction lifecycle, snapshot visibility, and the leader's resolve/append/consume-back/apply pipeline. |
+| `allium/database-lifecycle.allium` | The lifecycle of a database on one node — how it becomes a member of the node's set, how it stops being one, and what resolves by name in between. Node-level; treats a running database as opaque. |
 | `allium/log-processor-lifecycle.allium` | Per-database leader election in the `LogProcessor` — the Following/Prepared/Leading state machine, the term fence that keeps one confirmed leader per database, and the split between launching a transition and committing the role. |
 | `allium/memory-hash-trie.allium` | The immutable in-memory hash trie indexing rows by IID within a `LiveTable` — bucketing, leaf ordering, log compaction, splitting. |
 | `dev/doc/db.allium` | The processing model of one database end to end — submit → log processing → block flush → query, the source/replica log message types, the block and table catalogs, and the compaction message flow. |

--- a/allium/database-lifecycle.allium
+++ b/allium/database-lifecycle.allium
@@ -1,84 +1,83 @@
 -- allium: 3
 -- database-lifecycle.allium
 --
--- The lifecycle of a database on one node: how it becomes a member of the node's set,
--- how it stops being one, and what an observer can do with it in between.
+-- The lifecycle of a database on one node: how it becomes a member of the node's set, how it stops being one, and what resolves by name in between.
 --
 -- Scope: one node's set of databases, and the transitions between the states below.
--- Excludes: everything that happens INSIDE a running database -- transaction
---   processing, block flushing, query execution (db.allium), leader election
---   (log-processor-lifecycle.allium). Here a running database is opaque: it either
---   resolves by name or it does not.
+-- Excludes: everything that happens INSIDE a running database.
+-- Transaction processing, block flushing and query execution are db.allium's; leader election is log-processor-lifecycle.allium's.
+-- Here a running database is opaque: it either resolves by name or it does not.
 --
--- Three words recur. They nest, and each state below is exactly one step down them:
---   HOLD   -- a record for this name exists on this node. What `holds` tests. A held
---             name is occupied: no instruction can put a second record under it.
---   MEMBER -- the node carries this database in the set it hands to the recorder, which
---             REPLACES the durable membership record with that set, wholesale. The
---             record outlives every node, so membership is what keeps a database in
---             existence, and dropping one from the set -- deliberately, or by losing
---             track of it -- is what deletes it.
---   RUN    -- the database is working: indexing, and resolvable by name.
+-- Three words recur, and they nest.
 --
--- So: a running database is a member, and a member is held, but none of the converses
--- hold. Each of the three states drops exactly one of them, which is what distinguishes
--- them from each other and from a name that is absent altogether.
+-- - HOLD -- a record for this name exists on this node.
+--   What `holds` tests.
+--   A held name is occupied: no instruction can put a second record under it.
 --
--- The MEMBER axis only exists where a node writes the record back. `membership_source`
--- says which kind a node is: a durable_record node reads its set at startup and hands it
--- to the recorder thereafter, while a fixed node is given its whole set by the operator
--- and never writes one. HOLD and RUN apply to both; the membership instructions and the
--- membership surface exist only on the first, and a fixed node reaches only `open`.
+-- - MEMBER -- the node carries this database in the set it hands to the recorder.
+--   The recorder replaces the durable membership record with that set, wholesale.
+--   That record outlives every node, so membership is what keeps a database in existence.
+--   Dropping one from the set -- deliberately, or by losing track of it -- deletes it.
 --
--- Attach and detach are cluster-wide instructions -- every node receives them and
--- applies them to its own set independently. This spec describes what ONE node does
--- with them; how an instruction reaches the node belongs to db.allium.
+-- - RUN -- the database is working: indexing, and resolvable by name.
 --
--- Three states a held name can be in. Only the first is reachable on a fixed node:
---   open      -- held, a member, running
---   skipped   -- held and a member, not running: the operator has designated that this
---                node must not run it, and it stays in the set all the same
---   detaching -- held only: no longer a member, so already gone from the durable record,
---                but still occupying its name until its resources are released
+-- A running database is a member, and a member is held; neither converse holds.
+-- Each of the three states below drops exactly one of the three words.
 --
--- A name this node has no entry for is ABSENT, and absence is not a fourth state -- it
--- is the lack of one. The node stores nothing for an absent name, and cannot tell a name
--- it was never told to admit from one it has finished removing. Two things follow: the
--- name is FREE, so an instruction to admit it is accepted rather than refused; and it is
--- in no set the node hands over, which tells the recorder no such database exists.
+-- The MEMBER axis only exists where a node writes the record back, and `membership_source` says which kind of node this is.
+-- A durable_record node reads its set at startup and hands it to the recorder thereafter.
+-- A fixed node is given its whole set by the operator and never writes one.
+-- HOLD and RUN apply to both.
+-- The membership instructions and the membership surface exist only on the first, and a fixed node reaches only `open`.
 --
--- The two states that do not run are mirror images, and each exists for its own reason.
--- Skipped is a member though it does not run, because a node that declined to run a
--- database and dropped it from its set would delete it. Detaching is held though it is
--- no longer a member, because a database's resources have to be fully released before
--- anything may take its place -- so the record stays and keeps the name occupied for as
--- long as that takes, while the removal itself has already taken effect.
+-- Attach and detach are cluster-wide instructions -- every node receives them and applies them to its own set independently.
+-- This spec describes what ONE node does with them; how an instruction reaches the node belongs to db.allium.
+--
+-- Three states a held name can be in, of which only the first is reachable on a fixed node.
+--
+-- - open -- held, a member, running.
+--
+-- - skipped -- held and a member, not running.
+--   The operator has designated that this node must not run it, and it stays in the set all the same.
+--
+-- - detaching -- held only.
+--   No longer a member, so already gone from the durable record, but still occupying its name until its resources are released.
+--
+-- A name this node has no entry for is ABSENT.
+-- The node stores nothing for it, and cannot tell a name it was never told to admit from one it has finished removing.
+-- Two things follow.
+--
+-- - The name is free, so an instruction to admit it is accepted.
+--
+-- - It is in no set the node hands over, which tells the recorder no such database exists.
+--
+-- Each of the two states that do not run keeps one of the other two words.
+-- Skipped stays a member because a node that declined to run a database and dropped it from its set would delete it.
+-- Detaching stays held because a database's resources have to be fully released before anything may take its place.
+-- Its record keeps the name occupied for as long as that takes, while the removal itself has already taken effect.
 
 ------------------------------------------------------------
 -- External Entities
 ------------------------------------------------------------
 
 external entity DatabaseConfig {
-    -- The durable description of a database: where its log and storage live, and how
-    -- it is to be run. Opaque here -- this spec carries it from instruction to entry
-    -- and hands it back in the membership set, and never inspects it.
+    -- The durable description of a database: where its log and storage live, and how it is to be run.
+    -- Opaque here -- this spec carries it from instruction to entry and hands it back in the membership set, and never inspects it.
 }
 
 external entity Cluster {
-    -- The cluster-wide agreement about which databases exist. Instructions to admit or
-    -- to remove reach every node from here; how they travel is db.allium's.
+    -- The cluster-wide agreement about which databases exist.
+    -- Instructions to admit or to remove reach every node from here; how they travel is db.allium's.
 }
 
 external entity Caller {
-    -- Anything that asks this node to resolve a database by name: a query, a
-    -- transaction submission, an operator tool.
+    -- Anything that asks this node to resolve a database by name: a query, a transaction submission, an operator tool.
 }
 
 external entity MembershipRecord {
-    -- The cluster's durable record of which databases exist. It is rewritten wholesale
-    -- from a node's membership set rather than amended, and it is the only account of
-    -- membership that survives every node -- so it is also what a node is read back
-    -- from when it starts.
+    -- The cluster's durable record of which databases exist.
+    -- It is rewritten wholesale from a node's membership set rather than amended.
+    -- It is the only account of membership that survives every node, so it is also what a node reads its set back from when it starts.
 }
 
 ------------------------------------------------------------
@@ -104,14 +103,13 @@ given {
 ------------------------------------------------------------
 
 entity DatabaseCatalog {
-    -- The records one node holds. There is exactly one catalog per node, so a catalog
-    -- and a node are the same thing seen from two sides.
+    -- The records one node holds.
+    -- There is exactly one catalog per node.
 
-    -- Where this node's set comes from, and whether it writes one back. A durable_record
-    -- catalog reads its set when the node starts and hands it to the recorder from then
-    -- on; a fixed catalog is given its whole set at startup and never writes one, so the
-    -- MEMBER axis does not apply to it -- it cannot delete a database by omission,
-    -- because it never overwrites the record.
+    -- Where this node's set comes from, and whether it writes one back.
+    -- A durable_record catalog reads its set when the node starts and hands it to the recorder from then on.
+    -- A fixed catalog is given its whole set at startup and never writes one, so the MEMBER axis does not apply to it.
+    -- It cannot delete a database by omission, because it never overwrites the record.
     membership_source: durable_record | fixed
 
     entries: DatabaseEntry with catalog = this
@@ -121,16 +119,14 @@ entity DatabaseCatalog {
     members: entries where lifecycle in {open, skipped}
 
     -- Derived
-    -- Whether this node holds a record for a name, in any state. Its negation is the
-    -- whole of what the node knows about an absent database: nothing.
+    -- Whether this node holds a record for a name, in any state.
+    -- Its negation is the whole of what the node knows about an absent database: nothing.
     holds(db_name): entries.any(e => e.name = db_name)
 }
 
 entity DatabaseEntry {
-    -- This node's record of a database: its name, the config it would run under, and
-    -- whether it is running. A record exists whether or not anything runs behind it --
-    -- a skipped entry is a name and a config and nothing more, which is why the record
-    -- rather than the database is what carries the lifecycle.
+    -- This node's record of a database: its name, the config it would run under, and whether it is running.
+    -- A record exists whether or not anything runs behind it -- a skipped entry is a name and a config and nothing more.
 
     catalog: DatabaseCatalog
     name: String
@@ -148,15 +144,15 @@ entity DatabaseEntry {
 ------------------------------------------------------------
 
 config {
-    -- Databases the operator has designated this node must not run. Named rather than
-    -- removed, so that they stay members.
+    -- Databases the operator has designated this node must not run.
+    -- Named rather than removed, so that they stay members.
     skipped_databases: Set<String> = {}
 
     -- The database every node has as a member, and the only one that cannot be removed.
     primary_database: String = "xtdb"
 
-    -- A fixed node's whole set, supplied by the operator when the node starts. Empty on
-    -- a durable_record node, which reads its set instead.
+    -- A fixed node's whole set, supplied by the operator when the node starts.
+    -- Empty on a durable_record node, which reads its set instead.
     fixed_databases: Set<ConfiguredDatabase> = {}
 }
 
@@ -167,9 +163,9 @@ config {
 ---- Entries coming into being
 
 rule StartupCreatesFixedSet {
-    -- A fixed node's whole set arrives at once, when the node starts. There is no
-    -- instruction to respond to and no record to read: the operator supplies it, and it
-    -- does not change for as long as the node runs.
+    -- A fixed node's whole set arrives at once, when the node starts.
+    -- There is no instruction to respond to and no record to read.
+    -- The operator supplies the set, and it does not change for as long as the node runs.
     when: NodeStarted()
     requires: catalog.membership_source = fixed
 
@@ -181,10 +177,9 @@ rule StartupCreatesFixedSet {
 }
 
 rule AdmitInstructionCreatesEntry {
-    -- An instruction naming something this node does not hold makes it a member: the
-    -- record comes into being and joins the set either way. It runs too, unless the
-    -- operator has designated it as one to skip -- and a skipped name is still a member,
-    -- because membership is what keeps a database in existence and running is not.
+    -- An instruction naming something this node does not hold makes it a member: the record comes into being and joins the set either way.
+    -- It runs too, unless the operator has designated it as one to skip.
+    -- A skipped name is still a member, because membership is what keeps a database in existence.
     when: NodeInstructedToAdmit(db_name, db_config)
     requires: catalog.membership_source = durable_record
     requires: not catalog.holds(db_name)
@@ -201,10 +196,8 @@ rule AdmitInstructionCreatesEntry {
 }
 
 rule AdmitRefusedWhenAlreadyHeld {
-    -- A name identifies at most one database per node, so an instruction naming one
-    -- this node already holds is refused rather than replacing it. This holds however
-    -- the held database is faring: one that has already ceased to be a member still
-    -- occupies its name until it is gone.
+    -- A name identifies at most one database per node, so an instruction naming one this node already holds is refused rather than replacing it.
+    -- This holds however the held database is faring: one that has already ceased to be a member still occupies its name until it is gone.
     when: NodeInstructedToAdmit(db_name, db_config)
     requires: catalog.membership_source = durable_record
     requires: catalog.holds(db_name)
@@ -215,8 +208,8 @@ rule AdmitRefusedWhenAlreadyHeld {
 ---- Entries going away
 
 rule PrimaryCannotBeRemoved {
-    -- Every node has the primary as a member, and no instruction removes it. It is the
-    -- one entry whose presence anything reading this node may assume.
+    -- Every node has the primary as a member, and no instruction removes it.
+    -- It is the one entry whose presence anything reading this node may assume.
     when: NodeInstructedToRemove(db_name)
     requires: catalog.membership_source = durable_record
     requires: db_name = config.primary_database
@@ -226,8 +219,7 @@ rule PrimaryCannotBeRemoved {
 
 rule RemoveRefusedForAbsentName {
     -- An instruction naming something this node does not hold has nothing to act on.
-    -- The node cannot tell whether it never held the name or has already finished
-    -- removing it, and does not need to: either way there is nothing here to remove.
+    -- The node cannot tell whether it never held the name or has already finished removing it; either way there is nothing here to remove.
     when: NodeInstructedToRemove(db_name)
     requires: catalog.membership_source = durable_record
     requires: db_name != config.primary_database
@@ -237,9 +229,9 @@ rule RemoveRefusedForAbsentName {
 }
 
 rule RemoveBeginsTeardown {
-    -- A running database is torn down before it goes. It stops running and stops being
-    -- a member the moment the instruction arrives -- so it is already out of the durable
-    -- record -- and goes on being held while its resources are released.
+    -- A running database is torn down before it goes.
+    -- It stops running and stops being a member the moment the instruction arrives, so it is already out of the durable record.
+    -- It goes on being held while its resources are released.
     when: NodeInstructedToRemove(db_name)
     let entry = DatabaseEntry{catalog, name: db_name}
     requires: catalog.membership_source = durable_record
@@ -251,8 +243,7 @@ rule RemoveBeginsTeardown {
 }
 
 rule RemoveDropsSkippedEntry {
-    -- A skipped database is running nothing, so it has nothing to release and goes
-    -- straight out.
+    -- A skipped database is running nothing, so it has nothing to release and goes straight out.
     when: NodeInstructedToRemove(db_name)
     let entry = DatabaseEntry{catalog, name: db_name}
     requires: catalog.membership_source = durable_record
@@ -276,8 +267,8 @@ rule RemoveRefusedWhileTearingDown {
 }
 
 rule TeardownCompletesRemoval {
-    -- The record goes only once the database has released its resources. Until then it
-    -- occupies its name, which is what stops a re-admission racing its own teardown.
+    -- The record goes only once the database has released its resources.
+    -- Until then it occupies its name, which is what stops a re-admission racing its own teardown.
     when: TeardownCompleted(entry)
     requires: entry.lifecycle = detaching
 
@@ -289,9 +280,8 @@ rule TeardownCompletesRemoval {
 ------------------------------------------------------------
 
 invariant OneEntryPerNamePerNode {
-    -- Within a node a name identifies at most one record. ACROSS nodes the same name
-    -- recurs by design -- every node holds the primary, and a database is normally a
-    -- member everywhere -- so the constraint is per catalog, not global.
+    -- Within a node a name identifies at most one record.
+    -- Across nodes the same name recurs by design: every node holds the primary, and a database is normally a member everywhere.
     for a in DatabaseEntries:
         for b in DatabaseEntries:
             a != b and a.catalog = b.catalog implies a.name != b.name
@@ -325,18 +315,15 @@ surface MembershipInstructions {
         NodeInstructedToRemove(cluster, db_name)
 
     @guarantee OnlyRecordBackedNodesTakeInstructions
-        -- This boundary exists only where `membership_source` is durable_record. A fixed
-        -- node is given its set at startup and takes no instructions, which every rule
-        -- below the surface enforces in its own right.
+        -- Instructions reach only a catalog whose `membership_source` is durable_record.
+        -- A fixed node is given its set at startup and takes none.
 
     @guarantee EveryNodeDecidesForItself
-        -- An instruction reaches every node and each applies it to its own set. A node
-        -- that refuses one -- because it already holds the name, or because the name is
-        -- the primary -- does not thereby refuse it on any other node's behalf.
+        -- An instruction reaches every node and each applies it to its own set.
+        -- A node that refuses one does not thereby refuse it on any other node's behalf.
 
-    @guarantee RefusalIsNotFailure
-        -- Refusing an instruction leaves this node's set exactly as it was. There is no
-        -- partial application to undo.
+    @guarantee RefusalLeavesTheSetUnchanged
+        -- Refusing an instruction leaves this node's set exactly as it was.
 }
 
 surface DatabaseResolution {
@@ -352,9 +339,9 @@ surface DatabaseResolution {
         ResolveDatabase(caller, db_name)
 
     @guarantee OnlyRunningDatabasesResolve
-        -- A name resolves only while the database behind it runs. A caller sees nothing
-        -- at all of a detaching or skipped one -- not its name, not that it exists -- so
-        -- it cannot tell either from a name this node never held.
+        -- A name resolves only while the database behind it runs.
+        -- A caller sees nothing at all of a detaching or skipped one: not its name, not that it exists.
+        -- It therefore cannot tell either from a name this node never held.
 }
 
 surface Membership {
@@ -367,22 +354,17 @@ surface Membership {
             entry.name
             entry.config
 
-    @guarantee DecliningToRunIsNotForgetting
-        -- The membership set carries every database this node knows of and has not been
-        -- told to remove, including ones it has declined to run. The recorder takes it
-        -- as the whole truth and replaces the previous record with it, so a database
-        -- omitted while it still exists is forgotten rather than merely absent.
+    @guarantee DeclinedDatabasesStayMembers
+        -- The membership set carries every database this node knows of and has not been told to remove, including ones it has declined to run.
 
     @guarantee AbsenceAssertsNonExistence
         -- Handing over a set without a name in it asserts that no such database exists.
-        -- A node that has merely lost track of one -- rather than been told to remove it
-        -- -- erases it by doing so, and nothing later restores it, because the record it
-        -- overwrote is the only one that survives the node.
+        -- The recorder takes the set as the whole truth and replaces the previous record with it.
+        -- A node that has merely lost track of one -- rather than been told to remove it -- erases it by doing so.
+        -- Nothing later restores it, because the record it overwrote is the only one that survives the node.
 
-    @guarantee RemovalLeavesImmediately
-        -- A database under instruction to be removed leaves the membership set when the
-        -- instruction arrives, not when its teardown finishes. The instruction is what
-        -- decides membership; how long this node then takes to release resources is
-        -- local to it, and must not decide what the durable record says.
+    @guarantee MembershipEndsOnInstruction
+        -- A database under instruction to be removed leaves the membership set when the instruction arrives, not when its teardown finishes.
+        -- The instruction is what decides membership.
+        -- How long this node then takes to release resources is local to it, and does not reach the durable record.
 }
-

--- a/allium/database-lifecycle.allium
+++ b/allium/database-lifecycle.allium
@@ -24,11 +24,17 @@
 -- hold. Each of the three states drops exactly one of them, which is what distinguishes
 -- them from each other and from a name that is absent altogether.
 --
+-- The MEMBER axis only exists where a node writes the record back. `membership_source`
+-- says which kind a node is: a durable_record node reads its set at startup and hands it
+-- to the recorder thereafter, while a fixed node is given its whole set by the operator
+-- and never writes one. HOLD and RUN apply to both; the membership instructions and the
+-- membership surface exist only on the first, and a fixed node reaches only `open`.
+--
 -- Attach and detach are cluster-wide instructions -- every node receives them and
 -- applies them to its own set independently. This spec describes what ONE node does
 -- with them; how an instruction reaches the node belongs to db.allium.
 --
--- Three states a held name can be in:
+-- Three states a held name can be in. Only the first is reachable on a fixed node:
 --   open      -- held, a member, running
 --   skipped   -- held and a member, not running: the operator has designated that this
 --                node must not run it, and it stays in the set all the same
@@ -76,6 +82,16 @@ external entity MembershipRecord {
 }
 
 ------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value ConfiguredDatabase {
+    -- One entry in the set an operator hands a fixed node when it starts.
+    name: String
+    config: DatabaseConfig
+}
+
+------------------------------------------------------------
 -- Given
 ------------------------------------------------------------
 
@@ -90,6 +106,13 @@ given {
 entity DatabaseCatalog {
     -- The records one node holds. There is exactly one catalog per node, so a catalog
     -- and a node are the same thing seen from two sides.
+
+    -- Where this node's set comes from, and whether it writes one back. A durable_record
+    -- catalog reads its set when the node starts and hands it to the recorder from then
+    -- on; a fixed catalog is given its whole set at startup and never writes one, so the
+    -- MEMBER axis does not apply to it -- it cannot delete a database by omission,
+    -- because it never overwrites the record.
+    membership_source: durable_record | fixed
 
     entries: DatabaseEntry with catalog = this
 
@@ -131,13 +154,31 @@ config {
 
     -- The database every node has as a member, and the only one that cannot be removed.
     primary_database: String = "xtdb"
+
+    -- A fixed node's whole set, supplied by the operator when the node starts. Empty on
+    -- a durable_record node, which reads its set instead.
+    fixed_databases: Set<ConfiguredDatabase> = {}
 }
 
 ------------------------------------------------------------
 -- Rules
 ------------------------------------------------------------
 
----- Becoming a member
+---- Entries coming into being
+
+rule StartupCreatesFixedSet {
+    -- A fixed node's whole set arrives at once, when the node starts. There is no
+    -- instruction to respond to and no record to read: the operator supplies it, and it
+    -- does not change for as long as the node runs.
+    when: NodeStarted()
+    requires: catalog.membership_source = fixed
+
+    for configured in config.fixed_databases:
+        ensures: DatabaseEntry.created(
+            catalog: catalog, name: configured.name, config: configured.config,
+            lifecycle: open
+        )
+}
 
 rule AdmitInstructionCreatesEntry {
     -- An instruction naming something this node does not hold makes it a member: the
@@ -145,6 +186,7 @@ rule AdmitInstructionCreatesEntry {
     -- operator has designated it as one to skip -- and a skipped name is still a member,
     -- because membership is what keeps a database in existence and running is not.
     when: NodeInstructedToAdmit(db_name, db_config)
+    requires: catalog.membership_source = durable_record
     requires: not catalog.holds(db_name)
 
     ensures:
@@ -164,17 +206,19 @@ rule AdmitRefusedWhenAlreadyHeld {
     -- the held database is faring: one that has already ceased to be a member still
     -- occupies its name until it is gone.
     when: NodeInstructedToAdmit(db_name, db_config)
+    requires: catalog.membership_source = durable_record
     requires: catalog.holds(db_name)
 
     ensures: AdmitRefused(db_name: db_name)
 }
 
----- Ceasing to be a member
+---- Entries going away
 
 rule PrimaryCannotBeRemoved {
     -- Every node has the primary as a member, and no instruction removes it. It is the
     -- one entry whose presence anything reading this node may assume.
     when: NodeInstructedToRemove(db_name)
+    requires: catalog.membership_source = durable_record
     requires: db_name = config.primary_database
 
     ensures: RemoveRefused(db_name: db_name)
@@ -185,6 +229,7 @@ rule RemoveRefusedForAbsentName {
     -- The node cannot tell whether it never held the name or has already finished
     -- removing it, and does not need to: either way there is nothing here to remove.
     when: NodeInstructedToRemove(db_name)
+    requires: catalog.membership_source = durable_record
     requires: db_name != config.primary_database
     requires: not catalog.holds(db_name)
 
@@ -197,6 +242,7 @@ rule RemoveBeginsTeardown {
     -- record -- and goes on being held while its resources are released.
     when: NodeInstructedToRemove(db_name)
     let entry = DatabaseEntry{catalog, name: db_name}
+    requires: catalog.membership_source = durable_record
     requires: db_name != config.primary_database
     requires: exists entry
     requires: entry.lifecycle = open
@@ -209,6 +255,7 @@ rule RemoveDropsSkippedEntry {
     -- straight out.
     when: NodeInstructedToRemove(db_name)
     let entry = DatabaseEntry{catalog, name: db_name}
+    requires: catalog.membership_source = durable_record
     requires: db_name != config.primary_database
     requires: exists entry
     requires: entry.lifecycle = skipped
@@ -220,6 +267,7 @@ rule RemoveRefusedWhileTearingDown {
     -- Already on its way out; a second instruction has nothing left to do.
     when: NodeInstructedToRemove(db_name)
     let entry = DatabaseEntry{catalog, name: db_name}
+    requires: catalog.membership_source = durable_record
     requires: db_name != config.primary_database
     requires: exists entry
     requires: entry.lifecycle = detaching
@@ -276,6 +324,11 @@ surface MembershipInstructions {
         NodeInstructedToAdmit(cluster, db_name, db_config)
         NodeInstructedToRemove(cluster, db_name)
 
+    @guarantee OnlyRecordBackedNodesTakeInstructions
+        -- This boundary exists only where `membership_source` is durable_record. A fixed
+        -- node is given its set at startup and takes no instructions, which every rule
+        -- below the surface enforces in its own right.
+
     @guarantee EveryNodeDecidesForItself
         -- An instruction reaches every node and each applies it to its own set. A node
         -- that refuses one -- because it already holds the name, or because the name is
@@ -307,7 +360,7 @@ surface DatabaseResolution {
 surface Membership {
     facing recorder: Recorder
 
-    context node_catalog: DatabaseCatalog
+    context node_catalog: DatabaseCatalog where membership_source = durable_record
 
     exposes:
         for entry in node_catalog.members:
@@ -333,8 +386,3 @@ surface Membership {
         -- local to it, and must not decide what the durable record says.
 }
 
-------------------------------------------------------------
--- Open Questions
-------------------------------------------------------------
-
-open question "Ingest nodes hold databases without a catalog and never receive admit or remove instructions -- their whole set is fixed when the node starts. Does that belong in this spec as a restricted set of transitions, or in its own?"

--- a/allium/database-lifecycle.allium
+++ b/allium/database-lifecycle.allium
@@ -1,0 +1,340 @@
+-- allium: 3
+-- database-lifecycle.allium
+--
+-- The lifecycle of a database on one node: how it becomes a member of the node's set,
+-- how it stops being one, and what an observer can do with it in between.
+--
+-- Scope: one node's set of databases, and the transitions between the states below.
+-- Excludes: everything that happens INSIDE a running database -- transaction
+--   processing, block flushing, query execution (db.allium), leader election
+--   (log-processor-lifecycle.allium). Here a running database is opaque: it either
+--   resolves by name or it does not.
+--
+-- Three words recur. They nest, and each state below is exactly one step down them:
+--   HOLD   -- a record for this name exists on this node. What `holds` tests. A held
+--             name is occupied: no instruction can put a second record under it.
+--   MEMBER -- the node carries this database in the set it hands to the recorder, which
+--             REPLACES the durable membership record with that set, wholesale. The
+--             record outlives every node, so membership is what keeps a database in
+--             existence, and dropping one from the set -- deliberately, or by losing
+--             track of it -- is what deletes it.
+--   RUN    -- the database is working: indexing, and resolvable by name.
+--
+-- So: a running database is a member, and a member is held, but none of the converses
+-- hold. Each of the three states drops exactly one of them, which is what distinguishes
+-- them from each other and from a name that is absent altogether.
+--
+-- Attach and detach are cluster-wide instructions -- every node receives them and
+-- applies them to its own set independently. This spec describes what ONE node does
+-- with them; how an instruction reaches the node belongs to db.allium.
+--
+-- Three states a held name can be in:
+--   open      -- held, a member, running
+--   skipped   -- held and a member, not running: the operator has designated that this
+--                node must not run it, and it stays in the set all the same
+--   detaching -- held only: no longer a member, so already gone from the durable record,
+--                but still occupying its name until its resources are released
+--
+-- A name this node has no entry for is ABSENT, and absence is not a fourth state -- it
+-- is the lack of one. The node stores nothing for an absent name, and cannot tell a name
+-- it was never told to admit from one it has finished removing. Two things follow: the
+-- name is FREE, so an instruction to admit it is accepted rather than refused; and it is
+-- in no set the node hands over, which tells the recorder no such database exists.
+--
+-- The two states that do not run are mirror images, and each exists for its own reason.
+-- Skipped is a member though it does not run, because a node that declined to run a
+-- database and dropped it from its set would delete it. Detaching is held though it is
+-- no longer a member, because a database's resources have to be fully released before
+-- anything may take its place -- so the record stays and keeps the name occupied for as
+-- long as that takes, while the removal itself has already taken effect.
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity DatabaseConfig {
+    -- The durable description of a database: where its log and storage live, and how
+    -- it is to be run. Opaque here -- this spec carries it from instruction to entry
+    -- and hands it back in the membership set, and never inspects it.
+}
+
+external entity Cluster {
+    -- The cluster-wide agreement about which databases exist. Instructions to admit or
+    -- to remove reach every node from here; how they travel is db.allium's.
+}
+
+external entity Caller {
+    -- Anything that asks this node to resolve a database by name: a query, a
+    -- transaction submission, an operator tool.
+}
+
+external entity MembershipRecord {
+    -- The cluster's durable record of which databases exist. It is rewritten wholesale
+    -- from a node's membership set rather than amended, and it is the only account of
+    -- membership that survives every node -- so it is also what a node is read back
+    -- from when it starts.
+}
+
+------------------------------------------------------------
+-- Given
+------------------------------------------------------------
+
+given {
+    catalog: DatabaseCatalog
+}
+
+------------------------------------------------------------
+-- Entities and Variants
+------------------------------------------------------------
+
+entity DatabaseCatalog {
+    -- The records one node holds. There is exactly one catalog per node, so a catalog
+    -- and a node are the same thing seen from two sides.
+
+    entries: DatabaseEntry with catalog = this
+
+    -- Projections
+    resolvable: entries where lifecycle = open
+    members: entries where lifecycle in {open, skipped}
+
+    -- Derived
+    -- Whether this node holds a record for a name, in any state. Its negation is the
+    -- whole of what the node knows about an absent database: nothing.
+    holds(db_name): entries.any(e => e.name = db_name)
+}
+
+entity DatabaseEntry {
+    -- This node's record of a database: its name, the config it would run under, and
+    -- whether it is running. A record exists whether or not anything runs behind it --
+    -- a skipped entry is a name and a config and nothing more, which is why the record
+    -- rather than the database is what carries the lifecycle.
+
+    catalog: DatabaseCatalog
+    name: String
+    config: DatabaseConfig
+    lifecycle: open | detaching | skipped
+
+    transitions lifecycle {
+        open -> detaching
+        terminal: detaching, skipped
+    }
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    -- Databases the operator has designated this node must not run. Named rather than
+    -- removed, so that they stay members.
+    skipped_databases: Set<String> = {}
+
+    -- The database every node has as a member, and the only one that cannot be removed.
+    primary_database: String = "xtdb"
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+---- Becoming a member
+
+rule AdmitInstructionCreatesEntry {
+    -- An instruction naming something this node does not hold makes it a member: the
+    -- record comes into being and joins the set either way. It runs too, unless the
+    -- operator has designated it as one to skip -- and a skipped name is still a member,
+    -- because membership is what keeps a database in existence and running is not.
+    when: NodeInstructedToAdmit(db_name, db_config)
+    requires: not catalog.holds(db_name)
+
+    ensures:
+        if db_name in config.skipped_databases:
+            DatabaseEntry.created(
+                catalog: catalog, name: db_name, config: db_config, lifecycle: skipped
+            )
+        else:
+            DatabaseEntry.created(
+                catalog: catalog, name: db_name, config: db_config, lifecycle: open
+            )
+}
+
+rule AdmitRefusedWhenAlreadyHeld {
+    -- A name identifies at most one database per node, so an instruction naming one
+    -- this node already holds is refused rather than replacing it. This holds however
+    -- the held database is faring: one that has already ceased to be a member still
+    -- occupies its name until it is gone.
+    when: NodeInstructedToAdmit(db_name, db_config)
+    requires: catalog.holds(db_name)
+
+    ensures: AdmitRefused(db_name: db_name)
+}
+
+---- Ceasing to be a member
+
+rule PrimaryCannotBeRemoved {
+    -- Every node has the primary as a member, and no instruction removes it. It is the
+    -- one entry whose presence anything reading this node may assume.
+    when: NodeInstructedToRemove(db_name)
+    requires: db_name = config.primary_database
+
+    ensures: RemoveRefused(db_name: db_name)
+}
+
+rule RemoveRefusedForAbsentName {
+    -- An instruction naming something this node does not hold has nothing to act on.
+    -- The node cannot tell whether it never held the name or has already finished
+    -- removing it, and does not need to: either way there is nothing here to remove.
+    when: NodeInstructedToRemove(db_name)
+    requires: db_name != config.primary_database
+    requires: not catalog.holds(db_name)
+
+    ensures: RemoveRefused(db_name: db_name)
+}
+
+rule RemoveBeginsTeardown {
+    -- A running database is torn down before it goes. It stops running and stops being
+    -- a member the moment the instruction arrives -- so it is already out of the durable
+    -- record -- and goes on being held while its resources are released.
+    when: NodeInstructedToRemove(db_name)
+    let entry = DatabaseEntry{catalog, name: db_name}
+    requires: db_name != config.primary_database
+    requires: exists entry
+    requires: entry.lifecycle = open
+
+    ensures: entry.lifecycle = detaching
+}
+
+rule RemoveDropsSkippedEntry {
+    -- A skipped database is running nothing, so it has nothing to release and goes
+    -- straight out.
+    when: NodeInstructedToRemove(db_name)
+    let entry = DatabaseEntry{catalog, name: db_name}
+    requires: db_name != config.primary_database
+    requires: exists entry
+    requires: entry.lifecycle = skipped
+
+    ensures: not exists entry
+}
+
+rule RemoveRefusedWhileTearingDown {
+    -- Already on its way out; a second instruction has nothing left to do.
+    when: NodeInstructedToRemove(db_name)
+    let entry = DatabaseEntry{catalog, name: db_name}
+    requires: db_name != config.primary_database
+    requires: exists entry
+    requires: entry.lifecycle = detaching
+
+    ensures: RemoveRefused(db_name: db_name)
+}
+
+rule TeardownCompletesRemoval {
+    -- The record goes only once the database has released its resources. Until then it
+    -- occupies its name, which is what stops a re-admission racing its own teardown.
+    when: TeardownCompleted(entry)
+    requires: entry.lifecycle = detaching
+
+    ensures: not exists entry
+}
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant OneEntryPerNamePerNode {
+    -- Within a node a name identifies at most one record. ACROSS nodes the same name
+    -- recurs by design -- every node holds the primary, and a database is normally a
+    -- member everywhere -- so the constraint is per catalog, not global.
+    for a in DatabaseEntries:
+        for b in DatabaseEntries:
+            a != b and a.catalog = b.catalog implies a.name != b.name
+}
+
+------------------------------------------------------------
+-- Actor Declarations
+------------------------------------------------------------
+
+actor Client {
+    identified_by: Caller where true
+}
+
+actor ClusterControl {
+    identified_by: Cluster where true
+}
+
+actor Recorder {
+    identified_by: MembershipRecord where true
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface MembershipInstructions {
+    facing cluster: ClusterControl
+
+    provides:
+        NodeInstructedToAdmit(cluster, db_name, db_config)
+        NodeInstructedToRemove(cluster, db_name)
+
+    @guarantee EveryNodeDecidesForItself
+        -- An instruction reaches every node and each applies it to its own set. A node
+        -- that refuses one -- because it already holds the name, or because the name is
+        -- the primary -- does not thereby refuse it on any other node's behalf.
+
+    @guarantee RefusalIsNotFailure
+        -- Refusing an instruction leaves this node's set exactly as it was. There is no
+        -- partial application to undo.
+}
+
+surface DatabaseResolution {
+    facing caller: Client
+
+    context node_catalog: DatabaseCatalog
+
+    exposes:
+        for entry in node_catalog.resolvable:
+            entry.name
+
+    provides:
+        ResolveDatabase(caller, db_name)
+
+    @guarantee OnlyRunningDatabasesResolve
+        -- A name resolves only while the database behind it runs. A caller sees nothing
+        -- at all of a detaching or skipped one -- not its name, not that it exists -- so
+        -- it cannot tell either from a name this node never held.
+}
+
+surface Membership {
+    facing recorder: Recorder
+
+    context node_catalog: DatabaseCatalog
+
+    exposes:
+        for entry in node_catalog.members:
+            entry.name
+            entry.config
+
+    @guarantee DecliningToRunIsNotForgetting
+        -- The membership set carries every database this node knows of and has not been
+        -- told to remove, including ones it has declined to run. The recorder takes it
+        -- as the whole truth and replaces the previous record with it, so a database
+        -- omitted while it still exists is forgotten rather than merely absent.
+
+    @guarantee AbsenceAssertsNonExistence
+        -- Handing over a set without a name in it asserts that no such database exists.
+        -- A node that has merely lost track of one -- rather than been told to remove it
+        -- -- erases it by doing so, and nothing later restores it, because the record it
+        -- overwrote is the only one that survives the node.
+
+    @guarantee RemovalLeavesImmediately
+        -- A database under instruction to be removed leaves the membership set when the
+        -- instruction arrives, not when its teardown finishes. The instruction is what
+        -- decides membership; how long this node then takes to release resources is
+        -- local to it, and must not decide what the durable record says.
+}
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "Ingest nodes hold databases without a catalog and never receive admit or remove instructions -- their whole set is fixed when the node starts. Does that belong in this spec as a restricted set of transitions, or in its own?"

--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -30,10 +30,6 @@
     (max 0 (- (or latest-available -1)
               (or current-block -1)))))
 
-(defn- critical? [^Database db]
-  (or (= "xtdb" (.getName db))
-      (.getCritical (.getConfig db))))
-
 (defn- all-databases
   "Returns all currently attached databases from the catalog."
   [^Database$Catalog db-cat]
@@ -88,7 +84,7 @@
                                           (let [dbs (all-databases db-cat)
                                                 problems (for [^Database db dbs
                                                                :let [db-name (.getName db)
-                                                                     critical (critical? db)
+                                                                     critical (.isCritical db)
                                                                      ingestion-error (get-ingestion-error db)
                                                                      block-lag (->block-lag db)
                                                                      block-lag-healthy? (<= block-lag 5)]

--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -37,7 +37,7 @@
 (defn- all-databases
   "Returns all currently attached databases from the catalog."
   [^Database$Catalog db-cat]
-  (into [] (map (fn [^String db-name] (.databaseOrNull db-cat db-name)))
+  (into [] (keep (fn [^String db-name] (.databaseOrNull db-cat db-name)))
         (.getDatabaseNames db-cat)))
 
 (def index-html-str

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -246,9 +246,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
         var defaultAccessMode: ParsedStatement.AccessMode? = null
             private set
 
-        private fun db(dbName: DatabaseName): Database =
-            dbCat.databaseOrNull(dbName)
-                ?: throw Incorrect("Unknown database: $dbName", "xtdb/unknown-db", mapOf("db-name" to dbName))
+        private fun db(dbName: DatabaseName): Database = dbCat.databaseOrThrow(dbName)
 
         private fun recordTx(dbName: DatabaseName, txId: MessageId) {
             awaitToken = mergeTxBasisTokens(awaitToken, mapOf(dbName to listOf(txId)).encodeTxBasisToken())

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -122,6 +122,9 @@ class Database(
     val latestProcessedMsgId: MessageId get() = watchers.latestSourceMsgId
     val ingestionError: IngestionStoppedException? get() = watchers.exception
 
+    /** Whether an ingestion error here should take the whole node out of service. */
+    val isCritical: Boolean get() = name == "xtdb" || config.critical
+
     fun awaitTxBlocking(txId: Long, timeout: Duration? = null): TransactionResult? =
         runBlocking {
             check(isIndexing) { "log processor not initialised" }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -551,6 +551,10 @@ class Database(
         override val databaseNames: Collection<DatabaseName>
         override fun databaseOrNull(dbName: DatabaseName): Database?
 
+        fun databaseOrThrow(dbName: DatabaseName): Database =
+            databaseOrNull(dbName)
+                ?: throw Incorrect("Unknown database: $dbName", "xtdb/unknown-db", mapOf("db-name" to dbName))
+
         operator fun get(dbName: DatabaseName) = databaseOrNull(dbName)
 
         val primary: Database get() = databaseOrNull("xtdb")!!

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -54,7 +54,6 @@ import io.micrometer.core.instrument.MeterRegistry
 import java.time.Duration
 import java.time.Instant
 import java.util.*
-import kotlin.concurrent.Volatile
 import xtdb.api.tx.ExternalSource
 
 private val LOG = Database::class.logger
@@ -122,10 +121,6 @@ class Database(
 
     val latestProcessedMsgId: MessageId get() = watchers.latestSourceMsgId
     val ingestionError: IngestionStoppedException? get() = watchers.exception
-
-    @Volatile
-    var isClosing: Boolean = false
-        internal set
 
     fun awaitTxBlocking(txId: Long, timeout: Duration? = null): TransactionResult? =
         runBlocking {

--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -33,8 +33,23 @@ class DatabaseCatalog @JvmOverloads constructor(
     closerDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Database.Catalog, AutoCloseable {
 
-    private val databases = ConcurrentHashMap<DatabaseName, Database>()
-    private val dormantDatabases = ConcurrentHashMap<DatabaseName, DatabaseConfig>()
+    // A block records the whole secondary list and replaces the previous one, so an entry left out
+    // of `serialisedSecondaryDatabases` while a block is cut is erased rather than skipped.
+    private sealed interface Entry {
+        val config: Database.Config
+
+        class Open(val db: Database) : Entry {
+            override val config get() = db.config
+        }
+
+        class Skipped(override val config: Database.Config) : Entry
+
+        class Detaching(val db: Database) : Entry {
+            override val config get() = db.config
+        }
+    }
+
+    private val entries = ConcurrentHashMap<DatabaseName, Entry>()
 
     // Parent of every database's job tree. A SupervisorJob so one database's failure is contained
     // here (on the common parent) rather than cancelling its siblings; node shutdown cancels this
@@ -42,46 +57,44 @@ class DatabaseCatalog @JvmOverloads constructor(
     private val dbJob = SupervisorJob()
     private val dbScope = CoroutineScope(dbJob)
 
-    // Detaching databases tear down off the caller's thread on this scope, and stay in `databases`
+    // Detaching databases tear down off the caller's thread on this scope, and keep their entry
     // until that completes — see #5613. Nested under `dbJob` so node shutdown's single cancel covers it.
     private val closerJob = SupervisorJob(dbJob)
     private val closerScope = CoroutineScope(closerJob + closerDispatcher)
 
     override val databaseNames: Collection<DatabaseName>
-        get() = databases.entries.asSequence().filter { !it.value.isClosing }.map { it.key }.toSet()
+        get() = entries.entries.asSequence().filter { it.value is Entry.Open }.map { it.key }.toSet()
 
     override val txScoped = false
 
-    override fun databaseOrNull(dbName: DatabaseName): Database? =
-        databases[dbName]?.takeUnless { it.isClosing }
+    override fun databaseOrNull(dbName: DatabaseName): Database? = (entries[dbName] as? Entry.Open)?.db
 
     override val serialisedSecondaryDatabases: Map<DatabaseName, DatabaseConfig>
-        get() {
-            val active = this.filterNot { it.name == "xtdb" }
-                .associate { db -> db.name to db.config.serializedConfig }
-            return active + dormantDatabases
-        }
+        get() = entries.entries
+            .filter { it.key != "xtdb" && it.value !is Entry.Detaching }
+            .associate { (dbName, entry) -> dbName to entry.config.serializedConfig }
 
     private val skipDbs: Set<String> get() = base.config.skipDbs
 
     override fun attach(dbName: DatabaseName, config: Database.Config?) {
-        databases[dbName]?.let { existing ->
-            if (existing.isClosing)
-                throw Conflict(
-                    "Database is still being detached — retry once the previous detach has completed",
-                    "xtdb/db-being-detached",
-                    mapOf("db-name" to dbName)
-                )
-            throw Conflict("Database already exists", "xtdb/db-exists", mapOf("db-name" to dbName))
+        when (entries[dbName]) {
+            is Entry.Detaching -> throw Conflict(
+                "Database is still being detached — retry once the previous detach has completed",
+                "xtdb/db-being-detached",
+                mapOf("db-name" to dbName)
+            )
+
+            is Entry.Open, is Entry.Skipped ->
+                throw Conflict("Database already exists", "xtdb/db-exists", mapOf("db-name" to dbName))
+
+            null -> {}
         }
-        if (dormantDatabases.containsKey(dbName))
-            throw Conflict("Database already exists", "xtdb/db-exists", mapOf("db-name" to dbName))
 
         val dbConfig = config ?: Database.Config()
 
         if (dbName in skipDbs) {
             LOG.warn { "Skipping database '$dbName' (XTDB_SKIP_DBS) — database is dormant. Remove from XTDB_SKIP_DBS and restart to re-enable, or DETACH DATABASE to remove permanently." }
-            dormantDatabases[dbName] = dbConfig.serializedConfig
+            entries[dbName] = Entry.Skipped(dbConfig)
             return
         }
 
@@ -97,7 +110,7 @@ class DatabaseCatalog @JvmOverloads constructor(
         }
 
         db.closeOnCatch {
-            databases[dbName] = db
+            entries[dbName] = Entry.Open(db)
         }
     }
 
@@ -105,30 +118,35 @@ class DatabaseCatalog @JvmOverloads constructor(
         if (dbName == "xtdb")
             throw Incorrect("Cannot detach the primary 'xtdb' database", "xtdb/cannot-detach-primary", mapOf("db-name" to dbName))
 
-        if (dormantDatabases.remove(dbName) != null) return
+        val open = when (val entry = entries[dbName]) {
+            is Entry.Skipped -> {
+                entries.remove(dbName, entry); return
+            }
 
-        val db = databases[dbName]
-            ?: throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
+            is Entry.Open -> entry
 
-        if (db.isClosing)
-            throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
+            is Entry.Detaching, null ->
+                throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
+        }
 
         // Close off the persister's stack — see #5613. `cancelAndJoin` suspends rather than parking a
         // thread in `runBlocking`, so the detach can't deadlock against another thread-parking
         // teardown on a constrained dispatcher.
-        db.isClosing = true
+        val detaching = Entry.Detaching(open.db)
+        entries[dbName] = detaching
+
         closerScope.launch {
             // NonCancellable: once teardown starts it must run to completion. Node shutdown cancels
             // `dbJob` (this coroutine's ancestor); without the shield a detach caught mid-cancelAndJoin
-            // would skip `db.close()` yet still remove the database from the map — leaking its state.
+            // would skip `db.close()` yet still drop the entry — leaking its state.
             withContext(NonCancellable) {
                 try {
-                    db.cancelAndJoin()
-                    db.close()
+                    open.db.cancelAndJoin()
+                    open.db.close()
                 } catch (t: Throwable) {
                     LOG.error(t) { "Failed to close detaching database '$dbName'" }
                 } finally {
-                    databases.remove(dbName, db)
+                    entries.remove(dbName, detaching)
                 }
             }
         }
@@ -147,7 +165,13 @@ class DatabaseCatalog @JvmOverloads constructor(
             throw Fault("database catalog did not shut down in time", "xtdb/db-close-timeout")
         }
 
-        databases.values.closeAll()
+        entries.values.mapNotNull {
+            when (it) {
+                is Entry.Open -> it.db
+                is Entry.Detaching -> it.db
+                is Entry.Skipped -> null
+            }
+        }.closeAll()
     }
 
     companion object {

--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -118,22 +118,25 @@ class DatabaseCatalog @JvmOverloads constructor(
         if (dbName == "xtdb")
             throw Incorrect("Cannot detach the primary 'xtdb' database", "xtdb/cannot-detach-primary", mapOf("db-name" to dbName))
 
+        fun noSuchDb(): Nothing =
+            throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
+
         val open = when (val entry = entries[dbName]) {
             is Entry.Skipped -> {
-                entries.remove(dbName, entry); return
+                if (!entries.remove(dbName, entry)) noSuchDb()
+                return
             }
 
             is Entry.Open -> entry
 
-            is Entry.Detaching, null ->
-                throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
+            is Entry.Detaching, null -> noSuchDb()
         }
 
         // Close off the persister's stack — see #5613. `cancelAndJoin` suspends rather than parking a
         // thread in `runBlocking`, so the detach can't deadlock against another thread-parking
         // teardown on a constrained dispatcher.
         val detaching = Entry.Detaching(open.db)
-        entries[dbName] = detaching
+        if (!entries.replace(dbName, open, detaching)) noSuchDb()
 
         closerScope.launch {
             // NonCancellable: once teardown starts it must run to completion. Node shutdown cancels

--- a/core/src/test/kotlin/xtdb/database/DatabaseCatalogTest.kt
+++ b/core/src/test/kotlin/xtdb/database/DatabaseCatalogTest.kt
@@ -21,9 +21,9 @@ class DatabaseCatalogTest {
     fun `reattach during detach returns transient conflict (#5613)`() {
         NodeBase.openBase(openMeterRegistry = false).use { base ->
             // Pin the closer to a single-thread dispatcher whose one thread we hold with `gate`, so the
-            // detaching database is held mid-teardown (isClosing, not yet removed) for as long as we need
-            // to observe the conflict. The teardown otherwise completes on a background thread and would
-            // race the re-attach to win the observation.
+            // detaching database is held mid-teardown for as long as we need to observe the conflict.
+            // The teardown otherwise completes on a background thread and would race the re-attach to
+            // win the observation.
             val gate = CountDownLatch(1)
             val closerExecutor = Executors.newSingleThreadExecutor()
             try {
@@ -34,8 +34,8 @@ class DatabaseCatalogTest {
                 DatabaseCatalog.open(base, closerExecutor.asCoroutineDispatcher()).use { catalog ->
                     catalog.attach("test_db", Database.Config())
                     try {
-                        // The teardown coroutine is queued behind the gate, so the database stays in
-                        // `databases` with isClosing = true and the re-attach sees the transient conflict.
+                        // The teardown coroutine is queued behind the gate, so the entry stays Detaching
+                        // and the re-attach sees the transient conflict.
                         catalog.detach("test_db")
 
                         val ex = assertThrows<Conflict> {

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -1652,8 +1652,10 @@ deferred ResolveFailedDbOp           -- tx_resolver.indexFailedDbOp: resolve an 
                                      -- mutation failed with a caller fault, as an ABORTED ResolvedTx
                                      -- carrying that error
 deferred ApplyAttachToCatalog        -- dbCatalog.attach(dbName, config), returning the caller fault if it
-                                     -- failed. Runs on the resolve side, before the tx is resolved
-deferred ApplyDetachToCatalog        -- dbCatalog.detach(dbName), as above
+                                     -- failed. Runs on the resolve side, before the tx is resolved.
+                                     -- See: database-lifecycle.allium AdmitInstructionCreatesEntry
+deferred ApplyDetachToCatalog        -- dbCatalog.detach(dbName), as above.
+                                     -- See: database-lifecycle.allium RemoveBeginsTeardown
 deferred TakeResolvedHead            -- tx_resolver.removeHead(): remove and return the OLDEST staged tx,
                                      -- passing ownership to the caller — which must then import it and
                                      -- close it, or fail its durability handle and free it, on every path.

--- a/src/test/clojure/xtdb/healthz_test.clj
+++ b/src/test/clojure/xtdb/healthz_test.clj
@@ -215,6 +215,13 @@
                 (t/is (= 503 (:status resp)))
                 (t/is (re-find #"critical-db" (:body resp)))))))))))
 
+(t/deftest test-listed-but-unresolvable-database-is-skipped
+  (let [db-cat (reify Database$Catalog
+                 (getDatabaseNames [_] #{"vanished"})
+                 (databaseOrNull [_ _] nil))]
+    (t/is (= [] (#'healthz/all-databases db-cat))
+          "a name that no longer resolves must not reach the callers that dereference it")))
+
 (t/deftest test-alive-primary-always-critical
   (util/with-tmp-dirs #{local-path}
     (with-open [node (tu/->local-node {:node-dir local-path})]

--- a/src/test/kotlin/xtdb/ConnectionTest.kt
+++ b/src/test/kotlin/xtdb/ConnectionTest.kt
@@ -40,6 +40,7 @@ class ConnectionTest {
 
         dbCat = mockk(relaxed = true)
         every { dbCat.databaseOrNull(any()) } returns db
+        every { dbCat.databaseOrThrow(any()) } returns db
         every { dbCat.primary } returns db
 
         return Xtdb.Connection(


### PR DESCRIPTION
Part of #5910.

## tl;dr

- **Groundwork for auto-restarting databases that stop ingesting — no restart behaviour yet**
  The catalog and the specs are put in a shape that can express a database being temporarily absent; the supervisor that uses it comes next.

- **One real bug: `/healthz/alive` could return 500 and get your node killed**
  A database listed but no longer resolvable produced an NPE, and a liveness probe fails on any non-2xx — so a routine detach could turn into a container restart.

- **Plus a latent one: `detach` was a read-then-write, so two callers could both win**
  Unreachable today because there is only ever one writer; fixed now because the restart supervisor is about to be the second.

- **Everything else is behaviour-preserving**
  Three refactors, each verified against the tests that already pinned the behaviour.

- **The node-level database lifecycle now has a spec, which it never had**
  `db.allium` scopes itself to a single database and defers the catalog; that deferral had nowhere to point.

## Context

#5910 has the problem statement: a non-critical database whose ingestion fails is never restarted, so a transient fault costs the same as a permanent one, and both recovery paths available today — restart the node, or `DETACH` and re-`ATTACH` — are disproportionate to the fault.

None of that is fixed here. This is the part that has to land first: the catalog could not represent "this database exists but has no live `Database` right now" without a third map, and nothing described the lifecycle it would be extending.

## Changes

Read in order:

1. **`docs(allium)`: specify the node-level database lifecycle** — today's three states only (`open`, `detaching`, `skipped`), plus the `hold` ⊃ `member` ⊃ `run` nesting that distinguishes them.
2. **`docs(allium)`: model where a node's database set comes from** — resolves the spec's own open question about ingest nodes, which hold databases with no catalog and never receive attach or detach instructions.
3. **`fix(healthz)`: skip a database that no longer resolves** — the 500.
4. **`refactor(db-catalog)`: one entry per database, not two maps and a flag**.
5. **`refactor(healthz)`: put criticality on the database** — `Database.isCritical`.
6. **`refactor(db-catalog)`: let the catalog say why a lookup failed** — `databaseOrThrow`.
7. **`fix(db-catalog)`: make the detach transition atomic** — the one thing here the sealed entry made a one-liner.
8. **`docs(allium)`: write the lifecycle spec in the chalk voice** — a voice pass over 1 and 2 against the newly-released `chalk:allium-voice`: three obligations renamed off "what it is not", the passages arguing for the design rather than obliging anything cut, sentence-per-line throughout. No obligation changed — stripping every comment from both revisions leaves three `@guarantee` identifiers and nothing else.

## Implementation notes

### The healthz bug

- **The nil was always reachable, and the window is about to get much wider**
  `databaseNames` and `databaseOrNull` each filter on the same flag, so a detach landing between them leaves a name that resolves to nothing. `.getName` on it throws, the exception interceptor turns that into a 500, and the liveness probe fails. Today that window is microseconds; a restart widens it to a whole teardown plus backoff.

- **Four siblings on `Database$Catalog` already guarded this and one didn't**
  `awaitAll`, `syncAll`, `latestCompletedTxs` and `iterator` all skip a name that fails to resolve, and `latestCompletedTxs` carries a comment saying why. `/healthz/started` guards it too.

- **dead end: `(into [] db-cat)` looks like the better fix and is wrong**
  `Database$Catalog` is both `Iterable<Database>` and `Seqable`, and `RT.seq` prefers the `Seqable` — whose elements are `[name database]` pairs, not databases. The duplicated guard stays, and a test would catch anyone reaching for the shortcut.

### The catalog's entry model

- **Three states were encoded across two maps and a volatile boolean**
  Nothing structurally stopped a name being in both maps; the guard was two `if`s a reader had to find and trust. `Database.isClosing` described the catalog's opinion of a database rather than the database, which is why the catalog was its only reader.

- **Only the state holding no `Database` stores a config**
  `Open` and `Detaching` delegate to the one they already hold. `Skipped` stores its own because there is nothing to ask — and that is why an entry carries a config at all: a block records the whole secondary list and replaces the previous one, so an entry omitted while a block is cut is erased rather than skipped.

- **Removal got stricter as a side effect**
  Teardown ended with `databases.remove(dbName, db)`, whose value comparison runs through `Database.equals` — which is by name, so it would have matched any database under that name. `Entry` has no `equals`, so the same call now means what it looks like.

### `databaseOrThrow`

- **Scoped to one of four call sites, deliberately**
  Only `Xtdb.kt` already raised the canonical `xtdb/unknown-db`, so only it could move without changing behaviour. `export` and `compactor.reset` raise tool-namespaced `::db-not-found` codes and pgwire raises a protocol-level error with a playground attach-on-demand path in front of it; folding those in would have changed three user-visible error codes inside a behaviour-preserving commit.

- **One caller is enough because the argument isn't reuse**
  `Entry` is private to `DatabaseCatalog`, so a caller cannot distinguish "restarting" from "never existed" — `databaseOrNull` collapses both to null. This is the seam that lets the catalog answer that without exposing its state machine.

### `detach` atomicity

- **Reading the entry and writing `Detaching` were separate steps**
  Two callers could both observe `Open`, both install their own `Detaching`, and both launch a teardown — tearing the same `Database` down twice, with the second failure swallowed by the teardown's catch-all into a log line. Pre-existing: the old `isClosing` test-and-set had the identical window.

- **Unreachable today, which is why it survived**
  Every caller of `attach`/`detach` is the primary's log processor, whose leader, follower and transition forms are mutually exclusive by construction. It becomes reachable with the restart supervisor, which mutates the map concurrently with log processing by design — and the guards that change needs are only worth anything if the transitions underneath them are atomic.

- **`replace(key, expected, new)` is the whole fix**
  `Entry` has no `equals`, so the compare is by reference. Losing it means someone else moved the entry on, which is indistinguishable from arriving after they finished — so the loser gets the same `NotFound` it would have got a moment later.

- **No test, deliberately**
  A two-thread test only catches a regression when the threads interleave inside a window of tens of nanoseconds, so it would pass most of the time against the broken code. For a race that cannot currently happen, code that is correct by construction beats a detector that usually misses.

## Known and deliberate

- **A pre-existing config asymmetry is preserved rather than tidied**
  The skip check runs before the `readOnlyDatabases` override, so a skipped database records its raw config while an open one reports the overridden one. Harmless — the override is reapplied from node config at startup — but whether it is intended is a separate question.

- **`"xtdb"` is hardcoded in eight places** in the database package while `RoleMembership.PRIMARY_DB` holds exactly that constant in authz. Its own tidy.

- **`FixedDbCatalog` inherits `databaseOrThrow`'s default**, so an ingest node will report a restarting database as "unknown" until that step overrides it.

- **A default method on `Database.Catalog` is invisible to a mockk double**
  `jvmDefault = NO_COMPATIBILITY` makes it a real JVM default, which mockk intercepts rather than running — so the double keeps compiling and starts answering wrong. That is how `ConnectionTest` went red on this branch, and it will catch the next person who extends this interface.

## Test plan

- `xtdb.healthz-test` (10), `xtdb.sql.multi-db-test` (16), `xtdb.database-test` (3), `xtdb.api-test` (35), `xtdb.api-flight-sql-test` (15), `ConnectionTest` (9), `DatabaseCatalogTest` (1) — all passing, and re-run after every edit that followed a green run.
- The tests that carry the weight are the ones already there: `DatabaseCatalogTest`'s gated re-attach-during-detach, `skip-dbs-on-startup` and `detach-dormant-database` (which exercise an entry's config reaching the persisted secondary list), and `unknown-db-is-rejected-at-open`.
- One test added, for the healthz bug: a catalog listing a name that resolves to nothing must not reach the code that dereferences it.
- **The full suite has not been run locally**, and neither have the integration or property suites. Nothing here touches indexing, compaction or GC.

