### PR TITLE
tidy(scan): groundwork for the partition-aware read path

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -27,6 +27,7 @@
            (xtdb Bytes)
            (xtdb.api ICursor)
            (xtdb.indexer DatabaseSnapshot Snapshot Snapshot$Source TableSnapshot)
+           (xtdb.database PartitionStorage)
            (xtdb.metadata MetadataPredicate PageMetadata)
            (xtdb.operator.scan MultiIidSelector ScanCursor ScanMetrics SingleIidSelector)
            xtdb.query.IQuerySource$QueryCatalog
@@ -198,6 +199,47 @@
         (test [_ path]
           (not (.isEmpty (.filterIidsForPath bucketer iid-set path))))))))
 
+(defn- ->partition-scan-cursor
+  "Everything partition-specific arrives as an argument, so this knows nothing about which partition
+   it's been given or how many exist."
+  ^ICursor [{:keys [allocator ^TableRef table col-names col-preds iid-set metadata-pred scan-opts
+                    schema args ^ScanMetrics metrics]}
+            ^PartitionStorage storage ^Snapshot snapshot ^TemporalBounds temporal-bounds]
+
+  (let [metadata-mgr (.getMetadataManager storage)
+        buffer-pool (.getBufferPool storage)]
+
+    (util/with-close-on-catch [!segments (LinkedList.)]
+      (let [filter-opts {:query-bounds temporal-bounds
+                         :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
+                         :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
+            current-tries (cat/current-tries (.trieTableState snapshot table))
+            filtered-tries (cat/filter-tries current-tries filter-opts)]
+
+        (.addFiles metrics
+                   (long (- (count current-tries) (count filtered-tries)))
+                   (long (count filtered-tries)))
+
+        (doseq [{:keys [^String trie-key]} filtered-tries]
+          (.add !segments (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
+
+        (doseq [^TableSnapshot live-table-snap (.table snapshot table)]
+          (.add !segments (.getSegment live-table-snap)))
+
+        (let [count-pages (fn [pages]
+                            (let [survivors (trie/filter-pages pages filter-opts)]
+                              (.addPages metrics
+                                         (long (- (count pages) (count survivors)))
+                                         (long (count survivors)))
+                              survivors))
+              merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) count-pages)]
+
+          (ScanCursor. allocator (vec col-names) col-preds
+                       temporal-bounds (boolean (:clamp-valid-time? scan-opts))
+                       !segments (.iterator ^Iterable merge-tasks)
+                       schema args
+                       metrics))))))
+
 (defn scan-vec-types [snaps, scan-cols]
   (letfn [(->vec-type [[db-name ^TableRef table col-name]]
             (let [col-name (str col-name)]
@@ -219,8 +261,6 @@
             db (.databaseOrNull db-cat db-name)
             storage (.getStorage db)
             state (.getQueryState db)
-            metadata-mgr (.getMetadataManager storage)
-            buffer-pool (.getBufferPool storage)
             table-catalog (.getTableCatalog state)
             col-names (->> columns
                            (into #{} (map (fn [[col-type arg]]
@@ -305,60 +345,43 @@
                                              (update :for-valid-time
                                                      (fn [fvt]
                                                        (or fvt [:at [:now]]))))
-                               live-table-snaps (.table snapshot table)
-                               ;; TODO (#5835) each branch takes its own partition's basis slot. Wrong
-                               ;; rather than absent at N>1: every branch would apply partition 0's
+
+                               ;; EXPLAIN ANALYZE reports one set of counters per operator, and these
+                               ;; are keyed by (db, scan source) — operator identity. Built here so
+                               ;; that stays true however many cursors the operator ends up building.
+                               ^ScanMetrics metrics (ScanMetrics. db-name
+                                                                  (str (.getSchemaName table) "." (.getTableName table)))
+
+                               ;; TODO (#5835) each partition takes its own basis slot. Wrong rather
+                               ;; than absent at N>1: every partition would apply partition 0's
                                ;; temporal bound, so the scan returns wrong rows rather than failing.
                                temporal-bounds (->temporal-bounds allocator args scan-opts
                                                                   (-> (basis/<-time-basis-str snapshot-token)
-                                                                      (get-in [db-name 0])))]
+                                                                      (get-in [db-name 0])))
 
-                           (util/with-close-on-catch [!segments (LinkedList.)]
+                               trace? (or explain-analyze? (and tracer query-span))
+                               trace-attrs (when trace?
+                                             (not-empty
+                                              (merge-with merge
+                                                          (when pushdown-blooms
+                                                            (update-keys (update-vals pushdown-blooms (fn [b] {:bloom-filter b}))
+                                                                         str))
+                                                          (update-keys (update-vals (into {} (filter val) (or pushdown-iids {}))
+                                                                                    (fn [s] {:iids s}))
+                                                                       str))))]
 
-                             (let [filter-opts {:query-bounds temporal-bounds
-                                                :projects-temporal-cols? (boolean (some #{"_valid_from" "_valid_to" "_system_from" "_system_to"} col-names))
-                                                :clamp-valid-time? (boolean (:clamp-valid-time? scan-opts))}
-                                   ^ScanMetrics metrics (ScanMetrics. db-name
-                                                                      (str (.getSchemaName table) "." (.getTableName table)))
-                                   current-tries (cat/current-tries (.trieTableState snapshot table))
-                                   filtered-tries (cat/filter-tries current-tries filter-opts)]
-
-                               (.addFiles metrics
-                                          (long (- (count current-tries) (count filtered-tries)))
-                                          (long (count filtered-tries)))
-
-                               (doseq [{:keys [^String trie-key]} filtered-tries]
-                                 (.add !segments
-                                       (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
-
-                               (doseq [^TableSnapshot live-table-snap live-table-snaps]
-                                 (.add !segments (.getSegment live-table-snap)))
-
-                               (let [count-pages (fn [pages]
-                                                   (let [survivors (trie/filter-pages pages filter-opts)]
-                                                     (.addPages metrics
-                                                                (long (- (count pages) (count survivors)))
-                                                                (long (count survivors)))
-                                                     survivors))
-                                     merge-tasks (MergePlanner/planSync !segments (->path-pred iid-set) count-pages)]
-                               (cond-> (ScanCursor. allocator (vec col-names) col-preds
-                                                    temporal-bounds (boolean (:clamp-valid-time? scan-opts))
-                                                    !segments (.iterator ^Iterable merge-tasks)
-                                                    schema args
-                                                    metrics)
-                                 (or explain-analyze? (and tracer query-span)) (ICursor/wrapTracing tracer
-                                                                                                    query-span
-                                                                                                    (format "query.cursor.scan.%s" (.getTableName table))
-                                                                                                    (not-empty
-                                                                                                     (merge-with merge
-                                                                                                                 (when pushdown-blooms
-                                                                                                                   (update-keys
-                                                                                                                    (update-vals pushdown-blooms (fn [b] {:bloom-filter b}))
-                                                                                                                    str))
-                                                                                                                 (update-keys
-                                                                                                                  (update-vals (into {} (filter val) (or pushdown-iids {}))
-                                                                                                                               (fn [s] {:iids s}))
-                                                                                                                  str))))))))))))}))))
+                           ;; the cursor owns its segments from the moment it's built, and the tracing
+                           ;; wrap takes that ownership over — so it has to happen under a scope that
+                           ;; closes the cursor if the wrap itself throws.
+                           (util/with-close-on-catch [cursor (->partition-scan-cursor
+                                                              {:allocator allocator, :table table, :col-names col-names,
+                                                               :col-preds col-preds, :iid-set iid-set, :metadata-pred metadata-pred,
+                                                               :scan-opts scan-opts, :schema schema, :args args, :metrics metrics}
+                                                              storage snapshot temporal-bounds)]
+                             (cond-> cursor
+                               trace? (ICursor/wrapTracing tracer query-span
+                                                           (format "query.cursor.scan.%s" (.getTableName table))
+                                                           trace-attrs)))))))}))))
 
 (defmethod lp/emit-expr :scan [scan-expr {:keys [^IScanEmitter scan-emitter db-cat scan-vec-types, param-types]}]
   (assert db-cat)

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -351,17 +351,25 @@
                 ;; when people have 'proper' multi-tenancy, this will be a problem
                 ;; thankfully we can probably figure out what databases may be relevant to the query at parse-time
                 (util/with-close-on-catch [!snaps (HashMap.)]
-                  (doseq [db-name (.getDatabaseNames db-cat)]
-                    (.put !snaps db-name (.openSnapshot (.databaseOrNull db-cat db-name) (get min-basis db-name))))
+                  ;; `getDatabaseNames` and `databaseOrNull` are separate reads, so a concurrent
+                  ;; DETACH can drop a database between them — skip it, as Database.Catalog's own
+                  ;; iterators do. We open a snapshot for every attached database, so a query that
+                  ;; never mentions the detached one would otherwise die on its NPE.
+                  (doseq [db-name (.getDatabaseNames db-cat)
+                          :let [db (.databaseOrNull db-cat db-name)]
+                          :when db]
+                    (.put !snaps db-name (.openSnapshot db (get min-basis db-name))))
                   (into {} !snaps)))
 
               (->table-info [min-basis]
                 ;; TODO this, too, gets the schema for *every* db in the catalog
                 (->> (.getDatabaseNames db-cat)
                      (into {} (mapcat (fn [db-name]
-                                        (util/with-open [^DatabaseSnapshot snap (.openSnapshot (.databaseOrNull db-cat db-name) (get min-basis db-name))]
-                                          (->> (.tableInfo snap)
-                                               (map (fn [[table-ref cols]] [[db-name table-ref] (set cols)])))))))))
+                                        ;; same detach race as open-snaps above
+                                        (when-let [db (.databaseOrNull db-cat db-name)]
+                                          (util/with-open [^DatabaseSnapshot snap (.openSnapshot db (get min-basis db-name))]
+                                            (->> (.tableInfo snap)
+                                                 (map (fn [[table-ref cols]] [[db-name table-ref] (set cols)]))))))))))
 
               (plan-query* [table-info]
                 (-plan-query this parsed-query query-opts table-info))]

--- a/core/src/main/kotlin/xtdb/api/Xtdb.kt
+++ b/core/src/main/kotlin/xtdb/api/Xtdb.kt
@@ -943,7 +943,7 @@ interface Xtdb : DataSource, AdbcDatabase, AutoCloseable {
                     dbCat.awaitAll(awaitToken, awaitTimeout)
                     dbCat.databaseNames.flatMap { dbName ->
                         val db = dbCat.databaseOrNull(dbName) ?: return@flatMap emptyList()
-                        db.partitions.toSortedMap().map { (part, partition) ->
+                        db.partitions.mapIndexed { part, partition ->
                             mapOf("db_name" to dbName, "part" to part) + read(db, partition)
                         }
                     }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -65,7 +65,7 @@ class Database(
     override val name: DatabaseName,
     val logs: DatabaseLogs,
     val isIndexing: Boolean,
-    val partitions: Map<Int, DatabasePartition>,
+    val partitions: List<DatabasePartition>,
     private val meterRegistry: MeterRegistry?,
     private val job: Job? = null,
     private val registeredGauges: List<Gauge> = emptyList(),
@@ -73,11 +73,18 @@ class Database(
 
     init {
         require(partitions.isNotEmpty()) { "Database must have at least one partition" }
+
+        // List position *is* the partition index. The basis-token codec is positional — slot N of a
+        // database's vector is partition N — so `openSnapshot`, `currentBasis`, `latestCompletedTxs`
+        // and `awaitAll` all index partitions and basis slots against one another.
+        partitions.forEachIndexed { idx, part ->
+            require(part.partition == idx) { "partition ${part.partition} at index $idx" }
+        }
     }
 
     // Single-partition delegate. Per the stage-4 design, this becomes a per-partition
     // lookup once `partitions > 1` is enabled; for now every Database has exactly one.
-    private val partition0: DatabasePartition get() = partitions.getValue(0)
+    private val partition0: DatabasePartition get() = partitions[0]
 
     override val storage: PartitionStorage get() = partition0.storage
     override val queryState: PartitionState get() = partition0.state
@@ -85,14 +92,10 @@ class Database(
     val compactorOrNull: Compactor.ForDatabase? get() = partition0.compactorOrNull
 
     override fun openSnapshot(minBasis: List<Instant?>?): DatabaseSnapshot =
-        // Index minBasis by sorted position, matching how `currentBasis`/`snapshotToken` pack it and how
-        // `txBasis`/`validate-basis-not-before` read it back — slot N is the Nth partition in key order.
-        DatabaseSnapshot(partitions.entries.sortedBy { it.key }
-            .mapIndexed { idx, e -> e.value.openSnapshot(minBasis?.getOrNull(idx)) })
+        DatabaseSnapshot(partitions.mapIndexed { idx, part -> part.openSnapshot(minBasis?.getOrNull(idx)) })
 
     /** This database's read basis right now — latest-completed system-time per partition, in partition-index order. */
-    fun currentBasis(): List<Instant?> =
-        partitions.entries.sortedBy { it.key }.map { it.value.liveIndex.latestCompletedTx?.systemTime }
+    fun currentBasis(): List<Instant?> = partitions.map { it.liveIndex.latestCompletedTx?.systemTime }
 
     val blockCatalog: BlockCatalog get() = partition0.blockCatalog
     val tableCatalog: TableCatalog get() = partition0.tableCatalog
@@ -152,7 +155,7 @@ class Database(
         // Phase 2: the job tree has already been cancel-joined (by `cancelAndJoin` above, or by the
         // owner cancelling the catalog root). Free state, children before the database allocator.
         meterRegistry?.let { reg -> registeredGauges.forEach { reg.remove(it) } }
-        (partitions.values + listOf(logs, allocator)).closeAll()
+        (partitions + listOf(logs, allocator)).closeAll()
     }
 
     fun submitTxBlocking(ops: List<TxOp>, opts: TxOpts): Xtdb.SubmittedTx {
@@ -194,7 +197,7 @@ class Database(
      * Intended for tests and manual admin pokes; bypasses the `enabled` flag.
      */
     fun gcAll() {
-        partitions.values.forEach { it.logProcessor?.gcAll() }
+        partitions.forEach { it.logProcessor?.gcAll() }
     }
 
     companion object {
@@ -405,7 +408,7 @@ class Database(
                 name = dbName,
                 logs = logs,
                 isIndexing = indexerConfig.enabled,
-                partitions = mapOf(0 to partition),
+                partitions = listOf(partition),
                 meterRegistry = meterRegistry,
                 job = job,
                 registeredGauges = gauges,
@@ -414,13 +417,13 @@ class Database(
             if (indexerConfig.enabled && !readOnly) {
                 val listener = object : Log.SubscriptionListener<SourceMessage> {
                     override fun launchTransition(partition: Int, termId: Long) =
-                        db.partitions.getValue(partition).logProcessor!!.launchTransition(partition, termId)
+                        db.partitions[partition].logProcessor!!.launchTransition(partition, termId)
 
                     override fun commitLeader(partition: Int) =
-                        db.partitions.getValue(partition).logProcessor!!.commitLeader(partition)
+                        db.partitions[partition].logProcessor!!.commitLeader(partition)
 
                     override suspend fun demoteLeader(partition: Int) {
-                        db.partitions[partition]?.logProcessor?.demoteLeader(partition)
+                        db.partitions.getOrNull(partition)?.logProcessor?.demoteLeader(partition)
                     }
                 }
                 scope.launch { logs.sourceLog.openGroupSubscription(listener) }
@@ -516,10 +519,9 @@ class Database(
                     .map { db ->
                         launch {
                             val basisVec = basis[db.name] ?: return@launch
-                            db.partitions.entries.sortedBy { it.key }
-                                .forEach { (partIdx, part) ->
-                                    basisVec.getOrNull(partIdx)?.let { part.watchers.awaitSource(it) }
-                                }
+                            db.partitions.forEachIndexed { partIdx, part ->
+                                basisVec.getOrNull(partIdx)?.let { part.watchers.awaitSource(it) }
+                            }
                         }
                     }
                     .joinAll()
@@ -563,22 +565,21 @@ class Database(
                 .encodeTimeBasisToken()
 
         // each database's latest-completed tx per partition, surfaced through Xtdb.latestCompletedTxs and
-        // pgwire's `SHOW LATEST_COMPLETED_TXS`. Partition order is positional (sorted by partition key),
-        // so it lines up with the basis-token codec.
+        // pgwire's `SHOW LATEST_COMPLETED_TXS`. Partition order is positional, so it lines up with the
+        // basis-token codec.
         fun latestCompletedTxs(): Map<DatabaseName, List<TransactionKey?>> =
             databaseNames.mapNotNull { dbName ->
                 // databaseNames and databaseOrNull are read separately, so a concurrent detach can drop a db
                 // between them — skip it, as the sibling awaitAll0/syncAll0 do, rather than NPE.
                 databaseOrNull(dbName)?.let { db ->
-                    dbName to db.partitions.entries.sortedBy { it.key }
-                        .map { it.value.liveIndex.latestCompletedTx }
+                    dbName to db.partitions.map { it.liveIndex.latestCompletedTx }
                 }
             }.toMap()
 
         fun latestSubmittedMsgIds(): Map<DatabaseName, List<MessageId>> =
             databaseNames.mapNotNull { dbName ->
                 databaseOrNull(dbName)?.let { db ->
-                    dbName to db.partitions.keys.sorted().map { db.sourceLog.latestSubmittedMsgId(it) }
+                    dbName to db.partitions.indices.map { db.sourceLog.latestSubmittedMsgId(it) }
                 }
             }.toMap()
 

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -78,7 +78,7 @@ class Database(
         // database's vector is partition N — so `openSnapshot`, `currentBasis`, `latestCompletedTxs`
         // and `awaitAll` all index partitions and basis slots against one another.
         partitions.forEachIndexed { idx, part ->
-            require(part.partition == idx) { "partition ${part.partition} at index $idx" }
+            check(part.partition == idx) { "partitions must be in index order: partition ${part.partition} at index $idx" }
         }
     }
 

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -407,7 +407,7 @@ class ExternalSourceTest {
             name = "cdc",
             logs = DatabaseLogs(null, null),
             isIndexing = false,
-            partitions = mapOf(0 to partition),
+            partitions = listOf(partition),
             meterRegistry = null,
         )
 


### PR DESCRIPTION
Part of #5854.

## Summary

Three behaviour-preserving tidies to the read path, landed together because each is groundwork the partition-aware work rests on and none of them changes what a query returns.

The substantial one is the first. `->cursor` had grown to ~100 lines nested four deep inside a `reify` method, with its innermost code at column 128, and it takes its inputs by three routes — the options map, dynamic vars, and the enclosing closure — with several values arriving by two of them and no rule saying which. Anyone reviewing a change to that function has to reconstruct which is which before they can judge the change itself.

That is not hypothetical. The same defect was introduced into that function twice, on two different branches, while this work was being prepared — the tracing wrap escaping the segments' close scope — and caught by review both times. Reducing the function's ambient context is aimed squarely at that, and the surviving `with-close-on-catch` now says at the site why it has to be there.

## Changes

1. **`tidy(scan): lift a table's cursor construction out of the emitter`** — extracts `->partition-scan-cursor`, which takes the three things that determine what it reads (storage, snapshot, temporal bound) plus a bundle of the per-query values it applies. It knows nothing about where its inputs came from, or about how many partitions exist. Three things fall out: `metadata-mgr` and `buffer-pool` are derived inside it from the storage handle it is handed rather than bound two scopes up; `ScanMetrics` moves *up* to the emitter, since it is keyed by `(db, scan source)` and therefore identifies the operator rather than the cursor, and should stay one set of counters however many cursors get built; and the tracing attribute map becomes a named `trace-attrs` binding, which was contributing most of the remaining indentation.

2. **`fix(query): skip databases detached mid-query rather than NPEing`** — `getDatabaseNames` and `databaseOrNull` are separate reads, so a concurrent `DETACH` can drop a database between them and the second returns null. `open-snaps` and `->table-info` both dereferenced it immediately, so the query died with a bare `NullPointerException` surfaced through pgwire as an internal error. Both now skip it, as `Database.Catalog`'s `latestCompletedTxs`, `awaitAll0` and `syncAll0` already do. Since `open-snaps` opens a snapshot for *every* attached database rather than the ones the query mentions, this removes the case where detaching one database takes down concurrent queries that never referenced it.

3. **`tidy(database): index Database.partitions by list position`** — `Map<Int, DatabasePartition>` becomes a `List<DatabasePartition>` whose position *is* the partition index, with the constructor asserting that each partition's storage handle agrees with where it sits. The ordering was never incidental: the basis-token codec is positional, so `openSnapshot`, `currentBasis`, `latestCompletedTxs`, `latestSubmittedMsgIds` and `awaitAll` each re-established it for themselves with `entries.sortedBy { it.key }`. Five sites reconstructing an invariant the type can state once.

## Why these three together

They share a justification rather than a subject: each one removes ambient context or an unstated invariant from code that the partition-aware read path (#5835) is about to change substantially. Landing them separately from that work means its diff can be read as being about partitions, rather than as a restructure and a semantics change at once.

The third is the clearest case. #5835 rests on partitions, snapshot slots and basis slots being zippable positionally; this is the commit that makes that a property of the type instead of an assumption re-derived at each site.

## Provenance

These were previously #5853, opened as a draft on 6 August and left. That branch went 130 commits stale and #5855 has since rewritten three of the six files it touched, so it was `CONFLICTING`. This is the same work rebased onto current `main`, minus one commit — see below.

## Deliberately not here

- **The other half of the detach story.** A query that *names* the detached database still fails, now in `scan-vec-types` rather than `open-snaps`. Turning that into a proper anomaly means deciding what a mid-flight detach should surface as, which is a behaviour decision waiting on #5868; it is tracked on #5854.
- **The rest of #5854** — the resolve-once work proper: the `resolve-dbs`/`open-snaps` split, `->table-info` deriving from the already-open snapshots, the basis encode/decode round trip, the `IScanEmitter.emitScan` signature, and the dynamic-var-versus-argument rule.
- **#5853's `faabfdfc1`**, which pinned nullability widening in `scan_test`. Its rationale is obsolete: it documents the distinction between `Snapshot.columnType` returning nil and `TableSnapshot.columnType` returning `VectorType.Null`, and #5855 deleted both methods and made the distinction structural. Scan-level coverage of the declared types may still be worth having, but as a rewrite rather than a rebase.

## Test plan

`./gradlew test` — **2215 tests, 0 failures** across all modules, run after each cherry-pick rather than only at the tip.

Specifically confirmed: `xtdb.operator.scan_test` (31), `xtdb.query_test` (13), `xtdb.api.tx.ExternalSourceTest` (11), and the partition-related classes across storage, trie, compactor and log.

No behaviour change is intended by any of the three, so the suite passing unchanged is the assertion.

Ship/Show/Ask: **Show**.
