### PR TITLE
perf(scan): resolve as-of/as-of queries without the polygon

### DIFF
--- a/core/src/main/kotlin/xtdb/operator/scan/EntityMerge.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/EntityMerge.kt
@@ -33,6 +33,10 @@ internal class EntityMerge(pointers: List<LeafPointer>) : EntityEvents {
 
     /** Advances to the next entity, returning false once the task's pages are exhausted. */
     fun nextEntity(): Boolean {
+        // a resolver that stopped early leaves its entity's pointers queued, and `nextEvent` polls
+        // without an iid check, so they'd be served as this entity's events
+        skipEntity()
+
         val firstOfIid = iidQueue.poll() ?: return false
 
         iidHigh = firstOfIid.evPtr.iidHigh
@@ -53,6 +57,20 @@ internal class EntityMerge(pointers: List<LeafPointer>) : EntityEvents {
         }
 
         return eventQueue.poll()?.also { current = it }
+    }
+
+    private fun skipEntity() {
+        current?.let { leafPtr ->
+            current = null
+            leafPtr.evPtr.skipToNextIid()
+            requeue(leafPtr)
+        }
+
+        while (true) {
+            val leafPtr = eventQueue.poll() ?: break
+            leafPtr.evPtr.skipToNextIid()
+            requeue(leafPtr)
+        }
     }
 
     private fun requeue(leafPtr: LeafPointer) {

--- a/core/src/main/kotlin/xtdb/operator/scan/EntityMerge.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/EntityMerge.kt
@@ -1,0 +1,63 @@
+package xtdb.operator.scan
+
+import xtdb.trie.EventRowPointer
+import java.util.Comparator.comparing
+import java.util.PriorityQueue
+
+internal class LeafPointer(val evPtr: EventRowPointer, val relIdx: Int)
+
+/** One entity's events, newest system-time first. */
+internal interface EntityEvents {
+    fun nextEvent(): LeafPointer?
+}
+
+/**
+ * Merges one merge task's pages: an outer pass over entities in iid order, and within each entity
+ * an inner pass over its events in reverse system-time order.
+ */
+internal class EntityMerge(pointers: List<LeafPointer>) : EntityEvents {
+    // outer: one entry per page, ordered by the iid that page is currently on.
+    // inner: the pages sitting on the entity being resolved, newest system-time first.
+    private val iidQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.iidComparator()))
+    private val eventQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.systemFromComparator()))
+
+    init {
+        iidQueue.addAll(pointers)
+    }
+
+    private var iidHigh = 0L
+    private var iidLow = 0L
+
+    // advanced on the next `nextEvent` rather than eagerly, so the caller can still read the row it's on.
+    private var current: LeafPointer? = null
+
+    /** Advances to the next entity, returning false once the task's pages are exhausted. */
+    fun nextEntity(): Boolean {
+        val firstOfIid = iidQueue.poll() ?: return false
+
+        iidHigh = firstOfIid.evPtr.iidHigh
+        iidLow = firstOfIid.evPtr.iidLow
+
+        eventQueue.add(firstOfIid)
+        while (iidQueue.peek()?.evPtr?.sameIidAs(iidHigh, iidLow) == true)
+            eventQueue.add(iidQueue.poll())
+
+        return true
+    }
+
+    override fun nextEvent(): LeafPointer? {
+        current?.let { leafPtr ->
+            current = null
+            leafPtr.evPtr.nextIndex()
+            requeue(leafPtr)
+        }
+
+        return eventQueue.poll()?.also { current = it }
+    }
+
+    private fun requeue(leafPtr: LeafPointer) {
+        val evPtr = leafPtr.evPtr
+        if (evPtr.isValid())
+            (if (evPtr.sameIidAs(iidHigh, iidLow)) eventQueue else iidQueue).add(leafPtr)
+    }
+}

--- a/core/src/main/kotlin/xtdb/operator/scan/EntityResolver.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/EntityResolver.kt
@@ -10,6 +10,66 @@ internal interface EntityResolver {
     fun resolveEntity(events: EntityEvents, out: BitemporalConsumer)
 }
 
+/**
+ * Resolves a query that is `AS OF` in both dimensions, where an entity's visible row is the newest
+ * event below the system-time bound whose valid-time range covers the query's valid-time point.
+ *
+ * Nothing seen before that winner can cover the point — it would have been the winner — so every
+ * earlier event lies wholly to one side of it, and the ceiling [PolygonResolver] maintains collapses
+ * to the two scalars bracketing the gap the winner shows through. `_system_to` is null for the same
+ * reason: the ceiling only drops below `MAX_VALUE` over a covering event's range.
+ */
+internal class AsOfResolver(
+    temporalBounds: TemporalBounds, private val clampValidTime: Boolean
+) : EntityResolver {
+
+    private val vtLower = temporalBounds.validTime.lower
+    private val vtUpper = temporalBounds.validTime.upper
+    private val stUpper = temporalBounds.systemTime.upper
+
+    override fun resolveEntity(events: EntityEvents, out: BitemporalConsumer) {
+        var leftBound = Long.MIN_VALUE
+        var rightBound = Long.MAX_VALUE
+
+        while (true) {
+            val leafPtr = events.nextEvent() ?: return
+            val evPtr = leafPtr.evPtr
+            val op = evPtr.op
+
+            // an erase is exempt from the system-time bound, and suppresses only events older than
+            // itself — which, walking newest-first, are exactly the ones we have yet to reach.
+            if (op == "erase") return
+
+            if (evPtr.systemFrom >= stUpper) continue
+
+            val validFrom = evPtr.validFrom
+            val validTo = evPtr.validTo
+
+            if (validFrom <= vtLower && vtLower < validTo) {
+                if (op == "put") {
+                    val outValidFrom = max(validFrom, leftBound)
+                    val outValidTo = min(validTo, rightBound)
+
+                    out.accept(
+                        leafPtr.relIdx, evPtr.index,
+                        if (clampValidTime) max(outValidFrom, vtLower) else outValidFrom,
+                        if (clampValidTime) min(outValidTo, vtUpper) else outValidTo,
+                        evPtr.systemFrom, Long.MAX_VALUE
+                    )
+                }
+
+                return
+            }
+
+            // an empty range contributes no ceiling breakpoint, so it must not move the bounds
+            if (validFrom < validTo) {
+                if (validTo <= vtLower) leftBound = max(leftBound, validTo)
+                else rightBound = min(rightBound, validFrom)
+            }
+        }
+    }
+}
+
 internal class PolygonResolver(
     private val temporalBounds: TemporalBounds, private val clampValidTime: Boolean
 ) : EntityResolver {

--- a/core/src/main/kotlin/xtdb/operator/scan/EntityResolver.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/EntityResolver.kt
@@ -1,0 +1,51 @@
+package xtdb.operator.scan
+
+import xtdb.bitemporal.PolygonCalculator
+import xtdb.util.TemporalBounds
+import kotlin.math.max
+import kotlin.math.min
+
+/** Resolves one entity's events into the rows the query observes. */
+internal interface EntityResolver {
+    fun resolveEntity(events: EntityEvents, out: BitemporalConsumer)
+}
+
+internal class PolygonResolver(
+    private val temporalBounds: TemporalBounds, private val clampValidTime: Boolean
+) : EntityResolver {
+
+    private val polygonCalculator = PolygonCalculator(temporalBounds)
+
+    private val vtLower = temporalBounds.validTime.lower
+    private val vtUpper = temporalBounds.validTime.upper
+
+    override fun resolveEntity(events: EntityEvents, out: BitemporalConsumer) {
+        while (true) {
+            val leafPtr = events.nextEvent() ?: return
+            val evPtr = leafPtr.evPtr
+
+            val polygon = polygonCalculator.calculate(evPtr)?.takeIf { evPtr.op == "put" } ?: continue
+
+            val sysFrom = evPtr.systemFrom
+            val idx = evPtr.index
+
+            repeat(polygon.validTimeRangeCount) { i ->
+                val validFrom = polygon.getValidFrom(i)
+                val validTo = polygon.getValidTo(i)
+                val sysTo = polygon.getSystemTo(i)
+
+                if (
+                    temporalBounds.intersects(validFrom, validTo, sysFrom, sysTo)
+                    && validFrom != validTo && sysFrom != sysTo
+                ) {
+                    out.accept(
+                        leafPtr.relIdx, idx,
+                        if (clampValidTime) max(validFrom, vtLower) else validFrom,
+                        if (clampValidTime) min(validTo, vtUpper) else validTo,
+                        sysFrom, sysTo
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.runBlocking
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.ICursor
 import xtdb.arrow.RelationReader
-import xtdb.bitemporal.PolygonCalculator
 import xtdb.operator.SelectionSpec
 import xtdb.segment.MergeTask
 import xtdb.segment.Segment
@@ -16,10 +15,7 @@ import xtdb.util.TemporalBounds
 import xtdb.util.closeAll
 import xtdb.util.safeMap
 import java.util.*
-import java.util.Comparator.comparing
 import java.util.function.Consumer
-import kotlin.math.max
-import kotlin.math.min
 
 class ScanCursor(
     private val al: BufferAllocator,
@@ -35,14 +31,11 @@ class ScanCursor(
     private val metrics: ScanMetrics
 ) : ICursor {
 
-    private val vtLower = temporalBounds.validTime.lower
-    private val vtUpper = temporalBounds.validTime.upper
-
     override val cursorType get() = "scan"
     override val childCursors get() = emptyList<ICursor>()
     override val cursorAttributes get() = metrics.toMap()
 
-    private class LeafPointer(val evPtr: EventRowPointer, val relIdx: Int)
+    private fun openResolver(): EntityResolver = PolygonResolver(temporalBounds, clampValidTime)
 
     private fun RelationReader.maybeSelect(iidPred: SelectionSpec?, path: ByteArray) =
         when (iidPred) {
@@ -63,11 +56,7 @@ class ScanCursor(
         while (mergeTasks.hasNext()) {
             val task = mergeTasks.next()
             val taskPath = task.path
-            // outer: one entry per page, ordered by the iid that page is currently on.
-            // inner: the pages sitting on the entity being resolved, newest system-time first.
-            val iidQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.iidComparator()))
-            val eventQueue = PriorityQueue<LeafPointer>(comparing({ it.evPtr }, EventRowPointer.systemFromComparator()))
-            val polygonCalculator = PolygonCalculator(temporalBounds)
+            val resolver = openResolver()
 
             // we're not in coroutine land here, so it's a good boundary for runBlocking
             val loadedPages = runBlocking { task.pages.map { async { it.loadDataPage(al) } }.awaitAll() }
@@ -78,56 +67,15 @@ class ScanCursor(
 
             val leafReaders = loadedPages.map { it.maybeSelect(iidPred, taskPath) }
 
-            leafReaders.forEachIndexed { idx, leafReader ->
-                val evPtr = EventRowPointer(leafReader, taskPath)
-                if (!evPtr.isValid()) return@forEachIndexed
-                iidQueue.add(LeafPointer(evPtr, idx))
+            val pointers = leafReaders.mapIndexedNotNull { idx, leafReader ->
+                EventRowPointer(leafReader, taskPath).takeIf { it.isValid() }?.let { LeafPointer(it, idx) }
             }
 
             BitemporalConsumer.open(al, leafReaders, colNames).use { bitemporalConsumer ->
-                while (true) {
-                    val firstOfIid = iidQueue.poll() ?: break
+                val merge = EntityMerge(pointers)
 
-                    // the entity we're resolving, captured before its own pointer advances past it
-                    val iidHigh = firstOfIid.evPtr.iidHigh
-                    val iidLow = firstOfIid.evPtr.iidLow
-
-                    eventQueue.add(firstOfIid)
-                    while (iidQueue.peek()?.evPtr?.sameIidAs(iidHigh, iidLow) == true)
-                        eventQueue.add(iidQueue.poll())
-
-                    while (true) {
-                        val leafPtr = eventQueue.poll() ?: break
-                        val evPtr = leafPtr.evPtr
-
-                        polygonCalculator.calculate(evPtr)
-                            ?.takeIf { evPtr.op == "put" }
-                            ?.let { polygon ->
-                                val sysFrom = evPtr.systemFrom
-                                val idx = evPtr.index
-
-                                repeat(polygon.validTimeRangeCount) { i ->
-                                    val validFrom = polygon.getValidFrom(i)
-                                    val validTo = polygon.getValidTo(i)
-                                    val sysTo = polygon.getSystemTo(i)
-
-                                    if (
-                                        temporalBounds.intersects(validFrom, validTo, sysFrom, sysTo)
-                                        && validFrom != validTo && sysFrom != sysTo
-                                    ) {
-                                        val outValidFrom = if (clampValidTime) max(validFrom, vtLower) else validFrom
-                                        val outValidTo = if (clampValidTime) min(validTo, vtUpper) else validTo
-                                        bitemporalConsumer.accept(leafPtr.relIdx, idx, outValidFrom, outValidTo, sysFrom, sysTo)
-                                    }
-                                }
-                            }
-
-                        evPtr.nextIndex()
-
-                        if (evPtr.isValid())
-                            (if (evPtr.sameIidAs(iidHigh, iidLow)) eventQueue else iidQueue).add(leafPtr)
-                    }
-                }
+                while (merge.nextEntity())
+                    resolver.resolveEntity(merge, bitemporalConsumer)
 
                 val colPreds = colPreds.entries
                     .filterNot { it.key == "_iid" }

--- a/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
+++ b/core/src/main/kotlin/xtdb/operator/scan/ScanCursor.kt
@@ -35,7 +35,10 @@ class ScanCursor(
     override val childCursors get() = emptyList<ICursor>()
     override val cursorAttributes get() = metrics.toMap()
 
-    private fun openResolver(): EntityResolver = PolygonResolver(temporalBounds, clampValidTime)
+    private fun openResolver(): EntityResolver =
+        if (temporalBounds.validTime.isPoint && temporalBounds.systemTime.isPoint)
+            AsOfResolver(temporalBounds, clampValidTime)
+        else PolygonResolver(temporalBounds, clampValidTime)
 
     private fun RelationReader.maybeSelect(iidPred: SelectionSpec?, path: ByteArray) =
         when (iidPred) {

--- a/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
+++ b/core/src/main/kotlin/xtdb/trie/EventRowPointer.kt
@@ -4,6 +4,7 @@ import org.apache.arrow.memory.util.ArrowBufPointer
 import xtdb.arrow.LongLongVectorReader
 import xtdb.arrow.RelationReader
 import java.lang.Long.compareUnsigned
+import kotlin.math.min
 
 class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
     private val iidReader = relReader["_iid"] as LongLongVectorReader
@@ -54,6 +55,35 @@ class EventRowPointer(private val relReader: RelationReader, path: ByteArray) {
     val maxIndex: Int = Bucketer.DEFAULT.incrementPath(path)?.let { indexOf(it) } ?: relReader.rowCount
 
     fun nextIndex() = ++index
+
+    private fun sameIidAt(idx: Int, iidHigh: Long, iidLow: Long) =
+        iidReader.getLongLongHigh(idx) == iidHigh && iidReader.getLongLongLow(idx) == iidLow
+
+    /**
+     * Advances past every remaining row for the iid this pointer is on.
+     *
+     * Gallops before bisecting because an entity's run is short relative to the page: doubling finds
+     * the end of the run in log(run) reads, where bisecting `[index, maxIndex)` would take log(page).
+     */
+    fun skipToNextIid() {
+        val runIidHigh = iidHigh
+        val runIidLow = iidLow
+
+        var onRun = index
+        var step = 1
+        while (onRun + step < maxIndex && sameIidAt(onRun + step, runIidHigh, runIidLow)) {
+            onRun += step
+            step *= 2
+        }
+
+        var pastRun = min(onRun + step, maxIndex)
+        while (pastRun - onRun > 1) {
+            val mid = (onRun + pastRun) ushr 1
+            if (sameIidAt(mid, runIidHigh, runIidLow)) onRun = mid else pastRun = mid
+        }
+
+        index = pastRun
+    }
 
     fun getIidPointer(reuse: ArrowBufPointer) = iidReader.getPointer(index, reuse)
 

--- a/core/src/main/kotlin/xtdb/util/TemporalBounds.kt
+++ b/core/src/main/kotlin/xtdb/util/TemporalBounds.kt
@@ -11,6 +11,9 @@ data class TemporalDimension(
     fun intersects(other: TemporalDimension) = intersects(other.lower, other.upper)
     fun intersects(lower: Long, upper: Long) = this.lower < upper && lower < this.upper
 
+    /** True where this dimension spans a single chronon — an `AS OF`, or a `BETWEEN t AND t`. */
+    val isPoint get() = upper - lower == 1L
+
     override fun toString(): String {
         val l = Instant.ofEpochMilli(lower / 1000)
         val u = Instant.ofEpochMilli(upper / 1000)

--- a/core/src/test/kotlin/xtdb/operator/scan/AsOfResolverNodeTest.kt
+++ b/core/src/test/kotlin/xtdb/operator/scan/AsOfResolverNodeTest.kt
@@ -1,0 +1,206 @@
+package xtdb.operator.scan
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.choose
+import io.kotest.property.arbitrary.constant
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import xtdb.XtdbInternal
+import xtdb.api.Xtdb
+import xtdb.api.log.InMemoryLog
+import xtdb.tx.TxOp
+import java.time.Duration
+import java.time.Instant
+import java.time.InstantSource
+import java.time.temporal.ChronoUnit
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * The node-level counterpart to [AsOfResolverTest], which drives the resolvers directly. Here the same
+ * two resolvers are reached through a real node, so the planner's temporal defaults, the pages
+ * `filter-pages` admits and the flushed-and-compacted layout are all in the path.
+ */
+class AsOfResolverNodeTest {
+
+    companion object {
+        // a node per iteration, so this runs far fewer than the unit test's
+        private const val ITERATIONS = 25
+
+        private val VALID_TIMES = listOf("2018", "2019", "2020", "2021", "2022", "2023")
+
+        private const val COLS = "_id, v, _valid_from, _valid_to, _system_from, _system_to"
+    }
+
+    private data class Op(val kind: String, val id: Int, val validFrom: String, val validTo: String?)
+
+    /**
+     * [flushAfter] is the op index to flush and compact after, or null not to. Flushing part-way is what
+     * splits one entity's events between a flushed trie and the live index.
+     */
+    private data class Case(val ops: List<Op>, val flushAfter: Int?, val validTime: String, val systemTimeIdx: Int)
+
+    /**
+     * One instant per call, a day apart. A transaction's system time is therefore a function of how many
+     * have been submitted, not of elapsed time.
+     */
+    private fun mockClock() = object : InstantSource {
+        private var next: Instant = Instant.parse("2020-01-01T00:00:00Z")
+
+        override fun instant(): Instant = next.also { next = it.plus(1, ChronoUnit.DAYS) }
+    }
+
+    private fun openNode() = Xtdb.openNode {
+        log(InMemoryLog.Factory().instantSource(mockClock()))
+        compactor { threads = 0 }
+    }
+
+    private fun ts(t: String) = "TIMESTAMP '$t-01-01T00:00:00Z'"
+
+    private fun Op.toSql() = when (kind) {
+        "put" -> "INSERT INTO docs (_id, _valid_from, _valid_to, v) VALUES ($id, ${ts(validFrom)}, ${validTo?.let { ts(it) } ?: "NULL"}, $id)"
+        "delete" -> "DELETE FROM docs FOR PORTION OF VALID_TIME FROM ${ts(validFrom)} TO ${validTo?.let { ts(it) } ?: "NULL"} WHERE _id = $id"
+        else -> "ERASE FROM docs WHERE _id = $id"
+    }
+
+    /** Submits one transaction per op — so each gets its own system time — and returns those times. */
+    private fun Xtdb.submitOps(ops: List<Op>, flushAfter: Int?): List<Instant> {
+        // a DELETE against a table that doesn't exist yet is a planning error, so the table is seeded
+        // rather than left to whichever op the generator puts first. Entity 0 is outside the generated range.
+        val seeded = listOf(Op("put", 0, VALID_TIMES.first(), null)) + ops
+
+        return seeded.mapIndexed { idx, op ->
+            executeTx(listOf(TxOp.Sql(op.toSql()))).systemTime
+                .also { if (idx == flushAfter) flushAndCompact() }
+        }
+    }
+
+    private fun Xtdb.rows(sql: String): Set<Map<*, *>> =
+        connect().use { conn ->
+            conn.createStatement(sql).use { stmt ->
+                stmt.openQuery().use { cursor -> cursor.consume().flatten().toSet() }
+            }
+        }
+
+    private fun Xtdb.asOfRows(v: String, s: Instant) =
+        rows(
+            """SELECT $COLS FROM docs
+               FOR VALID_TIME AS OF ${ts(v)}
+               FOR SYSTEM_TIME AS OF TIMESTAMP '$s'"""
+        )
+
+    /**
+     * The same question routed through the polygon resolver: widening valid time to ALL takes it off the
+     * as-of path, while the system-time bound and the basis stay as the as-of query has them, so both see
+     * the same events and treat an erase above the bound alike.
+     *
+     * Widening system time instead would not be an oracle — the polygon resolver returns before `applyLog`
+     * for events above the system bound, so an all-system-time query cuts the same winner into more
+     * segments carrying a non-null `_system_to`.
+     */
+    private fun Xtdb.fullResolutionRows(v: String, s: Instant) =
+        rows(
+            """SELECT $COLS FROM docs
+               FOR ALL VALID_TIME
+               FOR SYSTEM_TIME AS OF TIMESTAMP '$s'
+               WHERE _valid_from <= ${ts(v)} AND (_valid_to > ${ts(v)} OR _valid_to IS NULL)"""
+        )
+
+    private fun Xtdb.flushAndCompact() {
+        val db = checkNotNull((this as XtdbInternal).dbCatalog.databaseOrNull("xtdb"))
+
+        db.sendFlushBlockMessage()
+
+        // the flush message is earlier in the log than this transaction, so a synchronous `executeTx`
+        // returning means the flush has been processed — no polling needed
+        executeTx(listOf(TxOp.Sql("INSERT INTO sentinel (_id) VALUES (1)")))
+
+        db.compactor.compactAllSync(Duration.ofSeconds(30))
+    }
+
+    private val opArb: Arb<Op> = arbitrary {
+        val vfIdx = Arb.int(0..VALID_TIMES.size - 2).bind()
+        val vtIdx = Arb.int(vfIdx + 1..VALID_TIMES.size).bind()
+
+        Op(
+            kind = Arb.choose(6 to Arb.constant("put"), 3 to Arb.constant("delete"), 1 to Arb.constant("erase")).bind(),
+            id = Arb.int(1..4).bind(),
+            validFrom = VALID_TIMES[vfIdx],
+            // one past the end stands for an open-ended range
+            validTo = VALID_TIMES.getOrNull(vtIdx)
+        )
+    }
+
+    private val caseArb: Arb<Case> = arbitrary {
+        val ops = Arb.list(opArb, 1..12).bind()
+
+        Case(
+            ops = ops,
+            flushAfter = Arb.choose(1 to Arb.constant(null), 2 to Arb.int(0..ops.size)).bind(),
+            validTime = Arb.element(VALID_TIMES).bind(),
+            systemTimeIdx = Arb.int(0..99).bind()
+        )
+    }
+
+    private fun check(case: Case) {
+        openNode().use { node ->
+            val sysTimes = node.submitOps(case.ops, case.flushAfter)
+
+            val s = sysTimes[case.systemTimeIdx % sysTimes.size]
+
+            assertEquals(node.fullResolutionRows(case.validTime, s), node.asOfRows(case.validTime, s), "$case")
+        }
+    }
+
+    @Test
+    fun `an erase above the system-time bound still hides the entity`() =
+        check(
+            Case(
+                ops = listOf(
+                    Op("put", 1, "2018", null),
+                    Op("put", 1, "2020", "2021"),
+                    Op("erase", 1, "2018", null)
+                ),
+                flushAfter = null, validTime = "2020", systemTimeIdx = 1
+            )
+        )
+
+    @Test
+    fun `neighbouring ranges bracket the winner's valid time across a block flush`() =
+        check(
+            Case(
+                ops = listOf(
+                    Op("put", 1, "2018", null),
+                    Op("put", 1, "2019", "2020"),
+                    Op("put", 1, "2022", "2023")
+                ),
+                flushAfter = 3, validTime = "2021", systemTimeIdx = 3
+            )
+        )
+
+    @Test
+    fun `one entity's events span the live index and a flushed trie`() =
+        check(
+            Case(
+                ops = listOf(
+                    Op("put", 1, "2018", null),
+                    Op("put", 1, "2019", "2020"),
+                    // flushed above this line, so the merge has to span a trie and the live index
+                    Op("put", 1, "2021", "2022")
+                ),
+                flushAfter = 2, validTime = "2019", systemTimeIdx = 3
+            )
+        )
+
+    @Tag("property")
+    @Test
+    fun `as-of resolution agrees through page filtering and compaction`() = runTest(timeout = 2.minutes) {
+        checkAll(ITERATIONS, caseArb) { case -> check(case) }
+    }
+}

--- a/core/src/test/kotlin/xtdb/operator/scan/AsOfResolverTest.kt
+++ b/core/src/test/kotlin/xtdb/operator/scan/AsOfResolverTest.kt
@@ -1,0 +1,226 @@
+package xtdb.operator.scan
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.choose
+import io.kotest.property.arbitrary.constant
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import xtdb.arrow.Relation
+import xtdb.arrow.RelationReader
+import xtdb.arrow.STRUCT_TYPE
+import xtdb.trie.EventRowPointer
+import xtdb.trie.Trie
+import xtdb.util.TemporalBounds
+import xtdb.util.TemporalDimension
+import xtdb.util.closeAll
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.time.ZonedDateTime
+import kotlin.Long.Companion.MAX_VALUE as MAX_LONG
+
+/**
+ * Both resolvers are handed the same events and the same as-of/as-of bounds, which leaves the resolver
+ * as the only variable — no page filtering and no planner in the way, and no need for an oracle that
+ * asks a differently-bounded question and then argues the difference away.
+ */
+class AsOfResolverTest {
+
+    companion object {
+        private const val ITERATIONS = 500
+
+        private val VALID_TIMES = listOf(0L, 10L, 20L, 30L, 40L)
+
+        private val COL_NAMES = listOf("_iid", "x", "_valid_from", "_valid_to", "_system_from", "_system_to")
+    }
+
+    private data class Event(
+        val iid: Int, val sysFrom: Long,
+        val validFrom: Long, val validTo: Long,
+        val op: String, val x: Long
+    )
+
+    /** `dropEvery` of 0 reads the pages directly; otherwise rows are reached through an indirection. */
+    private data class Case(
+        val events: List<Event>, val pageCount: Int,
+        val validTime: Long, val systemTime: Long,
+        val clampValidTime: Boolean, val dropEvery: Int
+    )
+
+    /** One emitted row, with the page it came from — both resolvers should agree on the copy, not just the event. */
+    private data class Row(val pageIdx: Int, val cols: Map<*, *>)
+
+    private fun Relation.writeEvent(ev: Event) {
+        this["_iid"].writeBytes(ByteBuffer.wrap(ByteArray(16) { ev.iid.toByte() }))
+        this["_system_from"].writeLong(ev.sysFrom)
+        this["_valid_from"].writeLong(ev.validFrom)
+        this["_valid_to"].writeLong(ev.validTo)
+
+        // `writeObject` rather than writing the struct's child directly: writing the grandchild leaves the
+        // struct row unfinished, so the union's leg is never set and `op` doesn't read back as "put"
+        if (ev.op == "put") this["op"].vectorFor("put", STRUCT_TYPE, false).writeObject(mapOf("x" to ev.x))
+        else this["op"][ev.op].writeNull()
+
+        endRow()
+    }
+
+    /** Splits the events across pages, each of which has to be ordered iid ascending, system-from descending. */
+    private fun pageUp(events: List<Event>, pageCount: Int): List<List<Event>> {
+        val sorted = events.sortedWith(compareBy({ it.iid }, { -it.sysFrom }))
+
+        // one entity's events at one system-time come from a single transaction, so they reach a scan
+        // through a single trie and cannot be split across pages. Splitting them would make the merge's
+        // tie-break — arbitrary between equal system-times — depend on how the pointers happened to be
+        // queued, which differs between a resolver that drains an entity and one that exits early.
+        val txGroups = sorted.groupBy { it.iid to it.sysFrom }.values.toList()
+
+        // round-robin the groups, so an entity's events still land on several pages and the cross-page
+        // merge does some work. Groups are in sorted order, so each page stays sorted.
+        return List(pageCount) { p -> txGroups.filterIndexed { idx, _ -> idx % pageCount == p }.flatten() }
+    }
+
+    private fun resolveWith(resolver: EntityResolver, al: BufferAllocator, readers: List<RelationReader>): List<Row> {
+        val pointers = readers.mapIndexedNotNull { idx, rel ->
+            EventRowPointer(rel, ByteArray(0)).takeIf { it.isValid() }?.let { LeafPointer(it, idx) }
+        }
+
+        val merge = EntityMerge(pointers)
+
+        return BitemporalConsumer.open(al, readers, COL_NAMES).use { out ->
+            while (merge.nextEntity()) resolver.resolveEntity(merge, out)
+
+            out.build().flatMapIndexed { pageIdx, rel ->
+                // `_iid` arrives as a ByteArray, which compares by reference, so it's listified
+                rel.asMaps.map { row -> Row(pageIdx, row.mapValues { (_, v) -> if (v is ByteArray) v.toList() else v }) }
+            }
+        }
+    }
+
+    private fun resolveBoth(case: Case): Pair<List<Row>, List<Row>> {
+        val pages = pageUp(case.events, case.pageCount)
+        val bounds = TemporalBounds(TemporalDimension.at(case.validTime), TemporalDimension.at(case.systemTime))
+
+        return RootAllocator().use { al ->
+            val rels = pages.map { Trie.openLogDataWriter(al) }
+
+            try {
+                rels.zip(pages).forEach { (rel, pageEvents) -> pageEvents.forEach { rel.writeEvent(it) } }
+
+                // ascending, because that's what the iid selectors emit and what keeps equal iids contiguous
+                val readers: List<RelationReader> =
+                    if (case.dropEvery == 0) rels
+                    else rels.map { rel -> rel.select((0 until rel.rowCount).filter { it % case.dropEvery != 0 }.toIntArray()) }
+
+                resolveWith(PolygonResolver(bounds, case.clampValidTime), al, readers) to
+                        resolveWith(AsOfResolver(bounds, case.clampValidTime), al, readers)
+            } finally {
+                rels.closeAll()
+            }
+        }
+    }
+
+    private val eventArb: Arb<Event> = arbitrary {
+        val vfIdx = Arb.int(VALID_TIMES.indices).bind()
+        val vtIdx = Arb.int(vfIdx..VALID_TIMES.lastIndex).bind()
+        val openEnded = vtIdx == VALID_TIMES.lastIndex && Arb.boolean().bind()
+
+        Event(
+            iid = Arb.int(0..2).bind(),
+
+            // drawn from a range narrower than the event count, so ties are common: two events sharing a
+            // system-time have to resolve the same way on either path
+            sysFrom = Arb.long(1L..8L).bind(),
+
+            validFrom = VALID_TIMES[vfIdx],
+
+            // `vtIdx == vfIdx` gives an empty range, which must not move either bracketing bound
+            validTo = if (openEnded) MAX_LONG else VALID_TIMES[vtIdx],
+
+            op = Arb.choose(
+                7 to Arb.constant("put"), 2 to Arb.constant("delete"), 1 to Arb.constant("erase")
+            ).bind(),
+
+            x = 0
+        )
+    }
+
+    // `Arb.bind`, not an `arbitrary { }` block: the block's draws don't shrink, and a counterexample of
+    // sixteen events is unreadable until the list has been shrunk. `eventArb` above has to stay a block,
+    // its valid-to being drawn from a range that depends on its valid-from.
+    private val caseArb: Arb<Case> = Arb.bind(
+        Arb.list(eventArb, 1..16).map { evs -> evs.mapIndexed { idx, ev -> ev.copy(x = idx.toLong()) } },
+        Arb.int(1..3),
+
+        // offset off the boundaries as well as onto them, so the point falls inside, between and outside
+        Arb.bind(Arb.element(VALID_TIMES), Arb.int(-5..5)) { vt, offset -> vt + offset },
+
+        Arb.long(1L..9L),
+        Arb.boolean(),
+        Arb.element(0, 0, 3, 4),
+        ::Case
+    )
+
+    // --- the anchors. A differential test proves nothing while both sides produce nothing, so these
+    // assert concrete results; the property below only ever asserts that the two agree.
+
+    /** system-time 1 puts `[40, 80)`; system-time 2 puts `[70, ∞)`. */
+    private val clippingEvents = listOf(
+        Event(iid = 0, sysFrom = 2, validFrom = 70, validTo = MAX_LONG, op = "put", x = 2),
+        Event(iid = 0, sysFrom = 1, validFrom = 40, validTo = 80, op = "put", x = 1)
+    )
+
+    private fun anchorRows(events: List<Event>, validTime: Long, systemTime: Long): List<Row> {
+        val case = Case(events, pageCount = 1, validTime, systemTime, clampValidTime = false, dropEvery = 0)
+        val (viaPolygon, viaAsOf) = resolveBoth(case)
+
+        assertEquals(viaPolygon, viaAsOf, "the two resolvers agree: $case")
+
+        return viaAsOf
+    }
+
+    private fun List<Row>.soleValidTo(): Instant {
+        assertEquals(1, size, "one visible row: $this")
+        val cols = single().cols
+        return (cols.entries.single { it.key.toString().endsWith("valid-to") }.value as ZonedDateTime).toInstant()
+    }
+
+    /**
+     * A newer event the query point can't see still clips the visible row's `_valid_to` — `[70, ∞)` is not
+     * itself visible as of valid-time 50, but it ends `[40, 80)` at 70. This is what `rightBound` is for.
+     */
+    @Test
+    fun `a newer range to the right of the query point clips the winner's valid-to`() {
+        assertEquals(Instant.EPOCH.plusNanos(70_000), anchorRows(clippingEvents, validTime = 50, systemTime = 3).soleValidTo())
+    }
+
+    /**
+     * The same two events with the system-time bound moved below the clipping one: it now contributes
+     * nothing at all, so `_valid_to` stays at the winner's own 80 rather than being pulled back to 70.
+     */
+    @Test
+    fun `an event above the system-time bound does not clip the winner`() {
+        assertEquals(Instant.EPOCH.plusNanos(80_000), anchorRows(clippingEvents, validTime = 50, systemTime = 1).soleValidTo())
+    }
+
+    @Tag("property")
+    @Test
+    fun `as-of resolution agrees with the polygon resolver`() = runTest {
+        checkAll(ITERATIONS, caseArb) { case ->
+            val (viaPolygon, viaAsOf) = resolveBoth(case)
+
+            assertEquals(viaPolygon, viaAsOf, "$case")
+        }
+    }
+}


### PR DESCRIPTION
Resolves #4967.

**tl;dr**

- **Every ordinary query now resolves bitemporally without building a polygon.**
  A query that is `AS OF` in both dimensions has at most one visible row per entity — the newest event below the system-time bound whose valid-time range covers the query's valid-time point. That needs a four-way branch per event rather than a ceiling and a valid-time segment decomposition.

- **The blast radius is wider than the card's title implies, and that is the thing to review.**
  The discriminator fires for the default query shape *and* for DML without a `FOR PORTION OF` clause, because a DML scan sets `clamp-valid-time?` unconditionally and leaves `for-valid-time` nil for `emitScan` to default. So this is the resolution path for nearly every read and every plain `UPDATE`/`DELETE`, not an opt-in fast path.

- **`AS OF now` gains the constant factor; the algorithmic win is on `AS OF <past>`.**
  Recency partitioning leaves roughly one un-superseded event per entity in the current tier, so there is no per-entity history for the early exit to skip. #4967 measured 7× resolution amplification on an as-of-past point, which is where the exit pays.

- **The gating measurement #4967 asked for has still not been taken.**
  Whether the `ScanCursor` loop is a meaningful share of scan wall-clock is unmeasured, so the size of the win is unquantified even though its shape is now clear. That is why this is an ask rather than a show.

## Context

#4967 carries the problem and the measurements; this is the part that changed the shape of the work. The restriction in that card's title — no temporal columns projected — turned out to be unnecessary, so the change covers as-of/as-of generally.

- **One lemma does all the work: under as-of/as-of, every event applied before the winner lies wholly to one side of the query point.**
  "Partially covering the point" is not representable — `validFrom <= V < validTo` either holds, in which case that event is the winner and the walk stops, or it fails, leaving `validTo <= V` or `validFrom > V`.

- **So projecting temporal columns does not force the polygon back.**
  The ceiling collapses to two scalars bracketing the gap the winner shows through: `leftBound = max(validTo)` over left-lying events, `rightBound = min(validFrom)` over right-lying ones.

- **And `_system_to` is null on the winner in every case**, because the ceiling only drops below `MAX_VALUE` over a covering event's range, and by the lemma nothing applied before the winner covers the point.

## Changes

Read the commits in order; the first is meant to behave exactly as before.

1. **`refactor(scan): resolve one entity behind a seam`** — behaviour-preserving. `EntityMerge` owns the two priority queues and hands out one entity at a time; an `EntityResolver` turns that entity's events into emitted rows. `PolygonResolver` is the only implementation and its body is the loop that was inlined in `ScanCursor.tryAdvance`.

2. **`perf(scan): resolve an as-of/as-of query without the polygon`** — adds `AsOfResolver`, the discriminator, `EventRowPointer.skipToNextIid`, and both test classes. The tests sit in the commit they test rather than in one of their own, since neither is meaningful without the resolver.

## Implementation notes

**The discriminator**

- **`upper - lower == 1` on both dimensions**, as `TemporalDimension.isPoint`.
  `at(t)` produces `(t, t+1)` and `between(t, t)` reaches the same through `to.inc()`, so one test covers `AS OF now`, `AS OF <past>` and `BETWEEN t AND t`.

- **An explicit `FOR SYSTEM_TIME AS OF s` ahead of the snapshot correctly falls back**, because the upper bound is pulled back to `snapshot + 1` while the lower stays at `s`, leaving a range rather than a point.

**The walk**

- **Four branches, and the only state carried between events is the two scalars.**
  `erase` stops the entity; `systemFrom >= S` skips; covering the point emits iff the op is `put` and then stops; anything else moves a bound. There is no per-entity reset, unlike `PolygonCalculator`.

- **The erase check deliberately precedes the bound check.**
  An erase is exempt from the system-time bound and suppresses only events older than itself — walking newest-first, exactly the ones not yet reached. So returning there is both necessary and sufficient, and needs no "greatest erase system-time" state.

- **An empty valid-time range must not move either bound**, matching `Ceiling.applyLog`, which returns early for `validFrom >= validTo` and so contributes no breakpoint.

**The early exit's cost**

- **One `skipToNextIid` per page of the merge task, not one per entity.**
  Every pointer sitting on the resolved entity has to be advanced past it. It gallops before bisecting, since an entity's run is short relative to the page; #5914's run-end encoded `_iid` would reduce each skip to an array read.

- **`nextEntity` performs that skip itself rather than trusting its caller to.**
  `nextEvent` polls the event queue without an iid check, so a caller that omitted the skip would have had one entity's leftover pointers served as the next entity's events — wrong rows, silently, with no exception. Raised in review and made structural rather than conventional.

## Out of scope

- **Lazy, system-time-stratified page loading.**
  `ScanCursor` still loads every page of a merge task up front, so an iid-restricted as-of lookup decodes one page per surviving trie where one would do — the one saving that would land as I/O rather than resolution CPU. Considered and dropped on #4967 rather than carried forward: recency prunes at both file and page level before a page is loaded, so there is little left for a system-time stratification of the survivors to skip.

- **Skipping the above-bound prefix by binary search rather than walking it.**
  Walking is correct and cheap for as-of-now, where the prefix is just the transactions committed after the query's basis. Skipping it blind would not be: the prefix is newer than everything below the bound, and an erase escapes the system-time guard in `PolygonCalculator`, so an erase hiding there suppresses the answer. That only costs an entity erased and then re-put, which is not a shape worth designing a `TrieMetadata` flag around.

- **The load/resolve split measurement**, whose instrumentation #4967 parked in favour of a profiler.

## Dead ends

- **`FOR ALL VALID_TIME FOR ALL SYSTEM_TIME` is not a valid oracle for an as-of query.**
  `PolygonCalculator` returns before `applyLog` for events above the system-time bound, so they leave no ceiling behind. An all-system-time query sees them and cuts the same winner into more segments carrying non-null `_system_to`, so it disagrees for reasons unrelated to this change. Widening *only* valid time keeps the basis and the system-time bound identical, which is what makes the differential test an oracle.

- **The inner priority queue cannot be dropped.**
  The winner is an argmax, which is why stopping at the first covering event is sound, but the early exit needs *repeated* max-extraction over the pages sitting on the entity, and that is what a heap is for. Replacing it with a linear maximum over a single-digit number of pointers is a benchmark question, not a design one.

## Test plan

The two property tests deliberately sit at different layers, because one of them cannot reach the resolvers at all.

- **`xtdb.operator.scan.AsOfResolverTest` (Kotlin) owns the resolver comparison.**
  Both resolvers get the same generated events and the same as-of/as-of bounds, so the resolver is the only variable — no page filtering and no planner in between. `PolygonResolver` under point bounds is exactly what production does for an as-of query today. 500 kotest iterations in 0.3s, plus two deterministic anchors asserting concrete `_valid_to` values — a differential test proves nothing while both sides emit nothing, and no iteration count rescues that.

  It also steers three cases the SQL route can't, each of which was otherwise resting on a read-through: two events sharing a `systemFrom`, an empty valid-time range that must not move either bracketing bound, and rows reached through an indirection as an iid-selected page does.

- **`xtdb.operator.scan.AsOfResolverNodeTest` (Kotlin) covers the stack around the resolver.**
  Its two sides still differ in valid-time bounds, so it is not the resolver comparison. What only a node reaches is the planner's temporal defaults, which pages `filter-pages` admits, and one entity's events split between a flushed trie and the live index — it flushes and compacts at a generated point mid-stream, so a run actually straddles the boundary. Three deterministic cases plus a property test over generated put/delete/erase histories, each iteration against its own node over ADBC.

- **Why the resolvers had to be compared from Kotlin.**
  They are `internal`, and Kotlin `internal` is JVM name-mangled, so Clojure interop cannot resolve them — a Clojure test can only compare two *queries*, which is what made the earlier oracle have to widen valid time and then argue the difference away.

- **Whole-suite runs:** `./gradlew test` — 1,712 tests, 0 failures. `./gradlew property-test` — 2,749 tests, 0 failures, spanning the Clojure property tests and the Kotlin simulation suites (`NodeSimulationTest`, `CompactorSimulationTest`, `CacheSimulationTest`, `LeaderDriverSimTest`, `LogProcessorSimTest`).

- **`caveat:` the DML path carries no test written for this change.**
  Plain `UPDATE`/`DELETE` now route through `AsOfResolver`, and it is the suite's existing DML coverage that stands behind that rather than anything added here.

