### PR TITLE
refactor(indexer): the log processor owns the leader term's concurrency

### DIFF
--- a/allium/log-processor-lifecycle.allium
+++ b/allium/log-processor-lifecycle.allium
@@ -45,10 +45,8 @@ external entity FollowerTerm {
     -- catch-up (await up to a target msg id) is the launched transition's only
     -- unbounded step. See: live-index.allium.
     --
-    -- Reading the replica log is the Listener's rather than a role's: one read feeds
-    -- whichever role is live, a follower building state and a leader confirming its
-    -- own writes alike. The position it has reached is the partition's, so a role
-    -- change continues from it rather than restarting.
+    -- Reading the replica log is the Listener's: one read feeds whichever role is live, a follower building state and a leader confirming its own writes alike.
+    -- The position it has reached is the partition's, so a role change continues from it rather than restarting.
     replica_pos: MessageId
     mid_block: Boolean   -- true if an old leader died before uploading its block
 }
@@ -122,10 +120,8 @@ contract DurableTotalOrder {
 
     @invariant AppendReturnsItsOwnPosition
         -- An accepted append tells its author which position the record now occupies.
-        --   The launched transition stamps a no-op with its term and uses that record's
-        --   own position as its replay target, which the follower catches up to. Without
-        --   the position coming back from the append, the transition would need a second
-        --   handshake to learn where its own marker landed.
+        --   The launched transition stamps a no-op with its term and uses that record's own position as its replay target, which the follower catches up to.
+        --   Without the position coming back from the append, the transition would need a second handshake to learn where its own marker landed.
 
     @invariant OneAcceptedAppendYieldsOneRecord
         -- An accepted append puts exactly one record in the log, a refused one puts
@@ -375,8 +371,7 @@ rule LaunchTransition {
             DanglingBlockFinished(follower_term: listener.follower_term)
 
         -- Step 5: build the leader term (uncommitted), carrying the fencing term.
-        -- Replica records reach it from the Listener's read, continuing from where the
-        -- follower left off.
+        -- Replica records reach it from the Listener's read, continuing from where the follower left off.
         listener.prepared_leader = LeaderTerm.created(
             term: term,
             replay_target: target

--- a/allium/log-processor-lifecycle.allium
+++ b/allium/log-processor-lifecycle.allium
@@ -443,9 +443,8 @@ rule DemoteLeader {
 }
 
 rule AbandonPreparedLeader {
-    -- Abandon an uncommitted leader: same teardown, reached from Prepared. The
-    -- prepared leader term is torn down (its pumps + persister cancelled); leadership
-    -- is non-resumable, so a later promotion builds a fresh term at a higher term id.
+    -- Abandon an uncommitted leader: same teardown, reached from Prepared.
+    -- The prepared leader term is torn down; leadership is non-resumable, so a later promotion builds a fresh term at a higher term id.
     when: DemoteLeaderRequested(transport, listener)
 
     requires: listener.state = prepared

--- a/allium/log-processor-lifecycle.allium
+++ b/allium/log-processor-lifecycle.allium
@@ -45,11 +45,10 @@ external entity FollowerTerm {
     -- catch-up (await up to a target msg id) is the launched transition's only
     -- unbounded step. See: live-index.allium.
     --
-    -- Replica-log consumption belongs to whichever role is live rather than to the
-    -- follower alone: this is the sole consumer while the node follows, and the
-    -- leader's consume-back (LeaderTerm) is the sole consumer while it leads.
-    -- Ownership passes at the cutover, which is why the read position is handed from
-    -- one to the other rather than either starting afresh.
+    -- Reading the replica log is the Listener's rather than a role's: one read feeds
+    -- whichever role is live, a follower building state and a leader confirming its
+    -- own writes alike. The position it has reached is the partition's, so a role
+    -- change continues from it rather than restarting.
     replica_pos: MessageId
     mid_block: Boolean   -- true if an old leader died before uploading its block
 }
@@ -124,10 +123,9 @@ contract DurableTotalOrder {
     @invariant AppendReturnsItsOwnPosition
         -- An accepted append tells its author which position the record now occupies.
         --   The launched transition stamps a no-op with its term and uses that record's
-        --   own position as its replay target: the follower catches up to it, and the
-        --   leader consumes back from it. Without the position coming back from the
-        --   append, the transition would need a second handshake to learn where its own
-        --   marker landed.
+        --   own position as its replay target, which the follower catches up to. Without
+        --   the position coming back from the append, the transition would need a second
+        --   handshake to learn where its own marker landed.
 
     @invariant OneAcceptedAppendYieldsOneRecord
         -- An accepted append puts exactly one record in the log, a refused one puts
@@ -376,8 +374,9 @@ rule LaunchTransition {
         if listener.follower_term.mid_block:
             DanglingBlockFinished(follower_term: listener.follower_term)
 
-        -- Step 5: build the leader term (uncommitted), carrying the fencing term and
-        -- the replay target its consume pump will tail from.
+        -- Step 5: build the leader term (uncommitted), carrying the fencing term.
+        -- Replica records reach it from the Listener's read, continuing from where the
+        -- follower left off.
         listener.prepared_leader = LeaderTerm.created(
             term: term,
             replay_target: target

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -195,7 +195,7 @@ class Database(
      * Intended for tests and manual admin pokes; bypasses the `enabled` flag.
      */
     fun gcAll() {
-        partitions.forEach { it.logProcessor?.gcAll() }
+        partitions.forEach { it.logProcessor?.awaitNoGarbageBlocking() }
     }
 
     companion object {

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -36,8 +36,6 @@ private const val DEFAULT_DELETE_PARALLELISM = 64
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class BlockGarbageCollector(
-    /** The owner's scope: supplies this collector's lifetime and the thread its loop runs on. Cancelling it stops the loop. */
-    scope: CoroutineScope,
     private val bufferPool: BufferPool,
     private val blockCatalog: BlockCatalog,
     private val blocksToKeep: Int,
@@ -46,7 +44,7 @@ class BlockGarbageCollector(
     private val meterRegistry: MeterRegistry? = null,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
-    /** Base for the parallel delete fan-out pools; the loop itself runs on [scope]. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
+    /** Base for the parallel delete fan-out pools; the loop itself runs on its caller's thread. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     dbName: DatabaseName,
 ) {
@@ -77,36 +75,37 @@ class BlockGarbageCollector(
 
     init {
         require(blocksToKeep >= 1) { "blocksToKeep must be >= 1, got $blocksToKeep" }
+    }
 
+    /** Collect on every trigger until cancelled. [signal] and [awaitNoGarbage] do nothing until this is running. */
+    suspend fun run(): Unit = coroutineScope {
         LOGGER.debug("Starting BlockGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep)")
 
-        scope.launch {
-            while (isActive) {
-                val pending = mutableListOf<CompletableDeferred<Unit>>()
+        while (isActive) {
+            val pending = mutableListOf<CompletableDeferred<Unit>>()
 
-                // Wait for any trigger. Drain both channels each cycle so waiters arriving while
-                // a cycle is running see a cycle that *started* after their suspension — not just
-                // one that finished after it.
-                select {
-                    if (enabled) signalCh.onReceive { }
-                    awaitCh.onReceive { pending += it }
-                }
+            // Wait for any trigger. Drain both channels each cycle so waiters arriving while
+            // a cycle is running see a cycle that *started* after their suspension — not just
+            // one that finished after it.
+            select {
+                if (enabled) signalCh.onReceive { }
+                awaitCh.onReceive { pending += it }
+            }
 
-                try {
-                    do {
-                        signalCh.tryReceive()
-                        while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
-                        garbageCollectBlocks()
-                    } while (drainTriggers(pending))
+            try {
+                do {
+                    signalCh.tryReceive()
+                    while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
+                    garbageCollectBlocks()
+                } while (drainTriggers(pending))
 
-                    pending.forEach { it.complete(Unit) }
-                } catch (e: CancellationException) {
-                    pending.forEach { it.cancel() }
-                    throw e
-                } catch (e: Exception) {
-                    LOGGER.warn(e, "Block garbage collection cycle failed")
-                    pending.forEach { it.completeExceptionally(e) }
-                }
+                pending.forEach { it.complete(Unit) }
+            } catch (e: CancellationException) {
+                pending.forEach { it.cancel() }
+                throw e
+            } catch (e: Exception) {
+                LOGGER.warn(e, "Block garbage collection cycle failed")
+                pending.forEach { it.completeExceptionally(e) }
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -77,7 +77,7 @@ class BlockGarbageCollector(
         require(blocksToKeep >= 1) { "blocksToKeep must be >= 1, got $blocksToKeep" }
     }
 
-    /** Collect on every trigger until cancelled. [signal] and [awaitNoGarbage] do nothing until this is running. */
+    /** Collect on every trigger until cancelled. Nothing is serviced until this is running: [signal] queues, and [awaitNoGarbage] suspends. */
     suspend fun run(): Unit = coroutineScope {
         LOGGER.debug("Starting BlockGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep)")
 

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -87,7 +87,7 @@ class TrieGarbageCollector(
             .register(it)
     }
     
-    /** Collect on every trigger until cancelled. [signal] and [awaitNoGarbage] do nothing until this is running. */
+    /** Collect on every trigger until cancelled. Nothing is serviced until this is running: [signal] queues, and [awaitNoGarbage] suspends. */
     suspend fun run(): Unit = coroutineScope {
         LOGGER.debug("Starting TrieGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep, garbageLifetime=$garbageLifetime)")
 

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -51,8 +51,6 @@ private const val TRIES_DELETED_CHUNK_SIZE = 1024
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TrieGarbageCollector(
-    /** The owner's scope: supplies this collector's lifetime and the thread its loop runs on. Cancelling it stops the loop. */
-    scope: CoroutineScope,
     private val bufferPool: BufferPool,
     partitionState: PartitionState,
     dbName: DatabaseName,
@@ -68,7 +66,7 @@ class TrieGarbageCollector(
     private val meterRegistry: MeterRegistry? = null,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
-    /** Base for the parallel delete fan-out pools; the loop itself runs on [scope]. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
+    /** Base for the parallel delete fan-out pools; the loop itself runs on its caller's thread. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
@@ -89,33 +87,32 @@ class TrieGarbageCollector(
             .register(it)
     }
     
-    init {
+    /** Collect on every trigger until cancelled. [signal] and [awaitNoGarbage] do nothing until this is running. */
+    suspend fun run(): Unit = coroutineScope {
         LOGGER.debug("Starting TrieGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep, garbageLifetime=$garbageLifetime)")
 
-        scope.launch {
-            while (isActive) {
-                val pending = mutableListOf<CompletableDeferred<Unit>>()
+        while (isActive) {
+            val pending = mutableListOf<CompletableDeferred<Unit>>()
 
-                select<Unit> {
-                    if (enabled) signalCh.onReceive { }
-                    awaitCh.onReceive { pending += it }
-                }
+            select<Unit> {
+                if (enabled) signalCh.onReceive { }
+                awaitCh.onReceive { pending += it }
+            }
 
-                try {
-                    do {
-                        signalCh.tryReceive()
-                        while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
-                        garbageCollectTries()
-                    } while (drainTriggers(pending))
+            try {
+                do {
+                    signalCh.tryReceive()
+                    while (true) pending.add(awaitCh.tryReceive().getOrNull() ?: break)
+                    garbageCollectTries()
+                } while (drainTriggers(pending))
 
-                    pending.forEach { it.complete(Unit) }
-                } catch (e: CancellationException) {
-                    pending.forEach { it.cancel() }
-                    throw e
-                } catch (e: Exception) {
-                    LOGGER.warn(e, "Trie garbage collection cycle failed")
-                    pending.forEach { it.completeExceptionally(e) }
-                }
+                pending.forEach { it.complete(Unit) }
+            } catch (e: CancellationException) {
+                pending.forEach { it.cancel() }
+                throw e
+            } catch (e: Exception) {
+                LOGGER.warn(e, "Trie garbage collection cycle failed")
+                pending.forEach { it.completeExceptionally(e) }
             }
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
@@ -1,0 +1,118 @@
+package xtdb.indexer
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.channels.Channel
+import xtdb.api.TransactionResult
+import xtdb.api.log.Watchers
+import xtdb.api.tx.ExternalSource
+import xtdb.api.tx.ExternalSourceToken
+import xtdb.api.tx.OpenTx
+import xtdb.api.tx.TxIndexer
+import xtdb.api.tx.TxIndexer.TxResult
+import xtdb.catalog.BlockCatalog
+import java.time.Instant
+
+/**
+ * The external source's side of a leader term: the adapter, the queue its transactions arrive on, and the
+ * [TxIndexer] it submits them through.
+ *
+ * Appending stays with the term, via [appendTx] — the row gauge it feeds and the block boundary it may cut
+ * are shared with the source log, and ordering between the two is what the term is for.
+ */
+internal class ExternalSourceProcessor(
+    private val extSource: ExternalSource,
+    private val partition: Int,
+    private val blockCatalog: BlockCatalog,
+    private val watchers: Watchers,
+    private val txResolver: TxResolver,
+    private val appendTx: suspend (ResolvedTx) -> Unit,
+) : TxIndexer, AutoCloseable {
+
+    override val latestBlock get() = blockCatalog.latestBlock
+
+    class Task(val msg: ExtSourceMessage) {
+        val onComplete = CompletableDeferred<Unit>()
+
+        /**
+         * Fail this task's awaiting caller, because the term is going away without finishing it.
+         *
+         * With the term's real cause, not a cancellation: this is an ext-source caller's own transaction
+         * awaiting its own result, and it isn't on the transport's poll thread — so it both wants and can
+         * safely see why the term died.
+         */
+        fun abandon(cause: Throwable) {
+            onComplete.completeExceptionally(cause)
+            msg.pending.completeExceptionally(cause)
+        }
+    }
+
+    // capacity 1 so a fire-and-forget `submitTx` caller can queue one tx ahead while the persister works
+    // the current one. `executeTx` still blocks on the result regardless of capacity.
+    //
+    // Undelivered — a cancelled send, or a cancelled channel — is a term-teardown failure like any other,
+    // so it goes through the task's own `abandon` rather than a second, hand-rolled policy here.
+    private val tasks = Channel<Task>(
+        capacity = 1,
+        onUndeliveredElement = { it.abandon(CancellationException("leader term closed")) }
+    )
+
+    val onTask get() = tasks.onReceive
+
+    suspend fun handleTask(task: Task) {
+        appendTx(txResolver.indexTx(task.msg))
+        task.onComplete.complete(Unit)
+    }
+
+    override suspend fun executeTx(
+        externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
+        writer: suspend (OpenTx) -> TxResult,
+    ): TransactionResult =
+        submitTx(externalSourceToken, systemTime, writer).await()
+
+    override suspend fun submitTx(
+        externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
+        writer: suspend (OpenTx) -> TxResult,
+    ): Deferred<TransactionResult> {
+        val task = Task(ExtSourceMessage(externalSourceToken, systemTime, writer))
+
+        // The send throws if the channel is closed (dead indexer) — the early-exit signal. The returned
+        // handle is the message's `pending`, completed on consume-back once the tx is durably replicated
+        // AND confirmed unfenced (ReadIndex); an unrecoverable failure also closes the channel with its
+        // cause, so the next send throws it.
+        tasks.send(task)
+        return task.msg.pending
+    }
+
+    /** Run the source adapter against this term until cancelled. */
+    suspend fun run() {
+        try {
+            extSource.onPartitionAssigned(partition, watchers.externalSourceToken, this)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            watchers.notifyError(e)
+        }
+    }
+
+    /**
+     * Shut the queue down and fail everyone still waiting on it: senders (via the close cause) and
+     * whatever is still queued (via each task's [Task.abandon]).
+     *
+     * Close and drain are bundled because both are needed and the order matters — `close` alone doesn't
+     * visit buffered elements (only `cancel` does), so a queued task's caller would wait forever; and
+     * closing *first* means no send can slip into a buffer we've already drained.
+     *
+     * Only safe on the persister's own exit path: it is the sole receiver, so nothing competes with these
+     * `tryReceive`s.
+     */
+    fun shutdown(cause: Throwable) {
+        tasks.close(cause)
+        while (true) (tasks.tryReceive().getOrNull() ?: break).abandon(cause)
+    }
+
+    override fun close() {
+        extSource.close()
+    }
+}

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -44,7 +44,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val hasExternalSource: Boolean,
     private val meterRegistry: MeterRegistry? = null,
     private val maxBufferedRecords: Int = 1024,
-) : LogProcessor.Processor<ReplicaMessage>, Role {
+) : AutoCloseable {
 
     private fun processTimer(msgType: String): Timer? = meterRegistry?.let {
         Timer.builder("xtdb.replica.process.timer")
@@ -272,11 +272,11 @@ class FollowerLogProcessor @JvmOverloads constructor(
     /** Hand a batch read off the replica log to whoever is driving this follower. */
     suspend fun queueRecords(records: List<Log.Record<ReplicaMessage>>) = inbound.send(records)
 
-    override fun SelectBuilder<Unit>.selectWork() {
+    fun SelectBuilder<Unit>.selectWork() {
         inbound.onReceive { records -> processRecords(records) }
     }
 
-    override suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
+    suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
         for (record in records) {
             try {
                 val term = record.message.termId

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -3,10 +3,8 @@ package xtdb.indexer
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.SelectBuilder
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.DatabaseName
 import xtdb.api.TransactionKey
@@ -36,7 +34,6 @@ private val LOG = FollowerLogProcessor::class.logger
 
 class FollowerLogProcessor @JvmOverloads constructor(
     allocator: BufferAllocator,
-    replicaLog: PartitionLog<ReplicaMessage>,
     private val bufferPool: BufferPool,
     private val partitionState: PartitionState,
     private val dbName: DatabaseName,
@@ -44,11 +41,10 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
     pendingBlock: PendingBlock?,
-    scope: CoroutineScope,
     private val hasExternalSource: Boolean,
     private val meterRegistry: MeterRegistry? = null,
     private val maxBufferedRecords: Int = 1024,
-) : LogProcessor.Processor<ReplicaMessage> {
+) : LogProcessor.Processor<ReplicaMessage>, Role {
 
     private fun processTimer(msgType: String): Timer? = meterRegistry?.let {
         Timer.builder("xtdb.replica.process.timer")
@@ -268,6 +264,23 @@ class FollowerLogProcessor @JvmOverloads constructor(
         if (msg.stale) watchers.notifyApplied(replicaMsgId) else processRecord(record, replicaMsgId)
     }
 
+    // Batches read off the replica log, awaiting application. Rendezvous, so the read runs no further
+    // ahead than the loop has applied — a follower's consume position is what a transition's catch-up
+    // awaits, and buffering here would advance the read without advancing that.
+    private val inbound = Channel<List<Log.Record<ReplicaMessage>>>()
+
+    /** Hand a batch read off the replica log to whoever is driving this follower. */
+    suspend fun queueRecords(records: List<Log.Record<ReplicaMessage>>) = inbound.send(records)
+
+    override fun armWork(select: SelectBuilder<suspend () -> Unit>) {
+        with(select) {
+            inbound.onReceive { records -> { processRecords(records) } }
+        }
+    }
+
+    // `processRecords` has already logged and notified by the time it throws.
+    override fun workFailed(cause: Throwable) = Unit
+
     override suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
         for (record in records) {
             try {
@@ -295,19 +308,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
             }
         }
     }
-
-    // Launched last so every field the tail touches is initialised before the first record.
-    private val job = scope.launch {
-        try {
-            replicaLog.tailAll(watchers.latestReplicaMsgId, this@FollowerLogProcessor)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            watchers.notifyError(e); throw e
-        }
-    }
-
-    suspend fun cancelAndJoin() = job.cancelAndJoin()
 
     override fun close() {
         allocator.close()

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -269,7 +269,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
     // awaits, and buffering here would advance the read without advancing that.
     private val inbound = Channel<List<Log.Record<ReplicaMessage>>>()
 
-    /** Hand a batch read off the replica log to whoever is driving this follower. */
     suspend fun queueRecords(records: List<Log.Record<ReplicaMessage>>) = inbound.send(records)
 
     fun SelectBuilder<Unit>.selectWork() {

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -276,9 +276,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
         inbound.onReceive { records -> processRecords(records) }
     }
 
-    // `processRecords` has already logged and notified by the time it throws.
-    override fun workFailed(cause: Throwable) = Unit
-
     override suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
         for (record in records) {
             try {

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -272,10 +272,8 @@ class FollowerLogProcessor @JvmOverloads constructor(
     /** Hand a batch read off the replica log to whoever is driving this follower. */
     suspend fun queueRecords(records: List<Log.Record<ReplicaMessage>>) = inbound.send(records)
 
-    override fun armWork(select: SelectBuilder<suspend () -> Unit>) {
-        with(select) {
-            inbound.onReceive { records -> { processRecords(records) } }
-        }
+    override fun SelectBuilder<Unit>.selectWork() {
+        inbound.onReceive { records -> processRecords(records) }
     }
 
     // `processRecords` has already logged and notified by the time it throws.

--- a/core/src/main/kotlin/xtdb/indexer/GarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/indexer/GarbageCollector.kt
@@ -1,0 +1,119 @@
+package xtdb.indexer
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import xtdb.NodeBase
+import xtdb.api.DatabaseName
+import xtdb.api.TableRef
+import xtdb.api.log.ReplicaMessage.TriesDeleted
+import xtdb.database.PartitionState
+import xtdb.database.PartitionStorage
+import xtdb.garbage_collector.BlockGarbageCollector
+import xtdb.garbage_collector.TrieGarbageCollector
+import xtdb.trie.TrieKey
+
+internal class GarbageCollector(
+    private val nodeBase: NodeBase,
+    partitionStorage: PartitionStorage,
+    private val partitionState: PartitionState,
+    private val dbName: DatabaseName,
+    private val leaderTerm: Long,
+    private val replicaAppender: ReplicaLogAppender,
+
+    // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
+    gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+
+    private val bufferPool = partitionStorage.bufferPool
+    private val blockCatalog = partitionState.blockCatalog
+    private val trieCatalog = partitionState.trieCatalog
+
+    private val blockGc = nodeBase.config.garbageCollector.let { cfg ->
+        BlockGarbageCollector(
+            bufferPool, blockCatalog,
+            blocksToKeep = cfg.blocksToKeep,
+            enabled = cfg.enabled,
+            meterRegistry = nodeBase.meterRegistry,
+            dispatcher = gcDispatcher,
+            dbName = dbName
+        )
+    }
+
+    internal val gcCh = Channel<GcTask>(
+        Channel.UNLIMITED,
+        onUndeliveredElement = { it.abandon(CancellationException("leader term closed")) }
+    )
+
+    private val trieGc = nodeBase.config.garbageCollector.let { cfg ->
+        // Routed through the persister rather than applied inline: the catalog removal has to be serialised
+        // against block cuts, and this await must not return until the catalog reflects it — which is the
+        // GC's contract, since it has already deleted the files. See [handleTask].
+        val commitTriesDeleted: suspend (TableRef, Set<TrieKey>) -> Unit = { tableName, trieKeys ->
+            val task = GcTask.TriesDeleted(tableName, trieKeys)
+            gcCh.send(task)
+            task.onComplete.await()
+        }
+
+        TrieGarbageCollector(
+            bufferPool, partitionState, dbName,
+            commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
+            cfg.enabled,
+            nodeBase.meterRegistry,
+            dispatcher = gcDispatcher,
+        )
+    }
+
+    sealed class GcTask {
+        val onComplete = CompletableDeferred<Unit>()
+
+        fun abandon(cause: Throwable) {
+            onComplete.completeExceptionally(cause)
+        }
+
+        data class TriesDeleted(val tableName: TableRef, val trieKeys: Set<TrieKey>) : GcTask()
+    }
+
+    suspend fun handleTask(task: GcTask) {
+        when (task) {
+            is GcTask.TriesDeleted -> {
+                // Remove from the local catalog here, then replicate for followers — eager on the resolve side so
+                // the GC's `commitTriesDeleted` await returns with the catalog already updated (its contract; the
+                // GC has already deleted the files). Safe as a fenced-log projection for the same reason as
+                // TriesAdded: the block-cut pause serialises this against any boundary, and gcCh is excluded while a
+                // block is in progress. Skipped on our own consume-back (see applyRecord); the follower applies it.
+                trieCatalog.deleteTries(task.tableName, task.trieKeys)
+
+                replicaAppender.append(
+                    ControlItem(TriesDeleted(task.tableName.schemaAndTable, task.trieKeys, termId = leaderTerm))
+                )
+
+                task.onComplete.complete(Unit)
+            }
+        }
+    }
+
+    fun signal() {
+        blockGc.signal()
+        trieGc.signal()
+    }
+
+    suspend fun runGc() = supervisorScope {
+        launch { blockGc.run() }
+        launch { trieGc.run() }
+    }
+
+    fun awaitNoGarbageBlocking() {
+        blockGc.awaitNoGarbageBlocking()
+        trieGc.awaitNoGarbageBlocking()
+    }
+
+    fun shutdown(cause: Throwable) {
+        gcCh.close(cause)
+        while (true) (gcCh.tryReceive().getOrNull() ?: break).abandon(cause)
+    }
+}

--- a/core/src/main/kotlin/xtdb/indexer/GarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/indexer/GarbageCollector.kt
@@ -44,10 +44,12 @@ internal class GarbageCollector(
         )
     }
 
-    internal val gcCh = Channel<GcTask>(
+    private val gcCh = Channel<GcTask>(
         Channel.UNLIMITED,
         onUndeliveredElement = { it.abandon(CancellationException("leader term closed")) }
     )
+
+    val onTask get() = gcCh.onReceive
 
     private val trieGc = nodeBase.config.garbageCollector.let { cfg ->
         // Routed through the persister rather than applied inline: the catalog removal has to be serialised

--- a/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
@@ -23,7 +23,7 @@ import xtdb.types.MessageId
  * CancellationException unwinds `processRecords` as cancellation, while anything else reaches the Database
  * scope's `CoroutineExceptionHandler`, which calls `watchers.notifyError`.
  */
-private fun Throwable?.asCancellation(): CancellationException =
+internal fun Throwable?.asCancellation(): CancellationException =
     this as? CancellationException
         ?: CancellationException("leader term closed").also { c -> this?.let { c.initCause(it) } }
 
@@ -72,19 +72,14 @@ internal interface SourceBatches {
 /**
  * The leader term's observable external effects, behind one seam.
  *
- * The [LeaderLogProcessor] keeps the concurrency that drives these — the persister select loop, the
- * background append, the staging resolver — and reaches the outside world only through here. That
- * makes the leader simulable: a mock driver can stall an upload, fail an append, or feed back a
- * record from a newer term, none of which the real logs express in memory.
+ * These are driven from the log processor's work loop, and reach the outside world only through
+ * here. That makes a leader simulable: a mock driver can stall an upload or fail an append, neither
+ * of which the real logs express in memory.
  *
  * Deliberately narrow. In-memory state mutations that happen to sit on the leader's path —
  * `trieCatalog`, `dbCatalog`, `watchers`, the GC signals — stay on the processor, as do reads of
  * in-memory state (`liveIndex.isFull()`, `blockCatalog.currentBlockIndex`). A mock holds real state
  * objects, so those reads stay consistent with what the driver has applied.
- *
- * The replica-log tail ([tailReplica]) is here despite being a read: since #5817 it is how the leader
- * learns its own writes landed, and where the term fence bites, so a sim has to be able to feed it a
- * superseding record that the real in-memory log would never produce on its own.
  */
 internal interface LeaderDriver : AutoCloseable {
 
@@ -98,13 +93,6 @@ internal interface LeaderDriver : AutoCloseable {
      * an append that fails.
      */
     suspend fun appendToReplica(msg: ReplicaMessage): Log.MessageMetadata
-
-    /**
-     * Tail our own replica log from [afterMsgId], handing each batch of records back for application.
-     * Suspends until cancelled — a plain tail, independent of the source-log group subscription that
-     * drives leader election.
-     */
-    suspend fun tailReplica(afterMsgId: MessageId, process: suspend (List<Log.Record<ReplicaMessage>>) -> Unit)
 
     /** Commit a resolved tx's writes into the durable live index. */
     suspend fun applyTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>)
@@ -157,10 +145,6 @@ internal class RealLeaderDriver(
 
     override suspend fun appendToReplica(msg: ReplicaMessage): Log.MessageMetadata =
         replicaLog.appendMessage(msg)
-
-    override suspend fun tailReplica(
-        afterMsgId: MessageId, process: suspend (List<Log.Record<ReplicaMessage>>) -> Unit,
-    ) = replicaLog.tailAll(afterMsgId) { records -> process(records) }
 
     override suspend fun applyTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>) =
         liveIndex.commitTx(txKey, tables)

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -3,32 +3,20 @@
 package xtdb.indexer
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.SelectBuilder
-import kotlinx.coroutines.supervisorScope
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.api.DatabaseName
-import xtdb.api.TransactionResult
 import xtdb.api.log.*
 import xtdb.api.log.ReplicaMessage.BlockBoundary
-import xtdb.api.log.ReplicaMessage.TriesAdded
-import xtdb.api.storage.Storage
 import xtdb.database.*
-import xtdb.api.error.Anomaly
-import xtdb.garbage_collector.BlockGarbageCollector
-import xtdb.garbage_collector.TrieGarbageCollector
-import xtdb.api.tx.TxIndexer.TxResult
-import xtdb.api.TableRef
-import xtdb.table.fromSchemaAndTable
-import xtdb.trie.TrieKey
+import xtdb.api.log.ReplicaMessage
 import xtdb.util.*
 import java.time.*
-import xtdb.api.tx.OpenTx
-import xtdb.api.tx.TxIndexer
 import xtdb.api.tx.ExternalSource
-import xtdb.api.tx.ExternalSourceToken
 import xtdb.types.MessageId
 
 private val LOG = LeaderLogProcessor::class.logger
@@ -42,13 +30,16 @@ private class LeaderSupersededException(message: String) : RuntimeException(mess
 
 internal class LeaderLogProcessor(
     allocator: BufferAllocator,
-    private val nodeBase: NodeBase,
-    private val partitionStorage: PartitionStorage,
+    nodeBase: NodeBase,
+    partitionStorage: PartitionStorage,
     crashLogger: CrashLogger,
-    private val partitionState: PartitionState,
+    partitionState: PartitionState,
     private val dbName: DatabaseName,
     private val driver: LeaderDriver,
     private val watchers: Watchers,
+
+    private val replicaAppender: ReplicaLogAppender,
+
     private val extSource: ExternalSource?,
     skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
@@ -57,7 +48,7 @@ internal class LeaderLogProcessor(
     flushTimeout: Duration,
     // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
     gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : LogProcessor.Processor<SourceMessage>, Role, TxIndexer {
+) : LogProcessor.Processor<SourceMessage>, Role {
 
     init {
         require((dbCatalog != null) == (dbName == "xtdb")) {
@@ -66,25 +57,23 @@ internal class LeaderLogProcessor(
     }
 
     private val partition = partitionStorage.partition
-    private val bufferPool = partitionStorage.bufferPool
     private val liveIndex = partitionState.liveIndex
 
     private val blockCatalog = partitionState.blockCatalog
-    private val trieCatalog = partitionState.trieCatalog
-
-    override val latestBlock get() = blockCatalog.latestBlock
 
     // Resolves each source-log / attach-detach / ext-source tx and holds it — with every other
     // resolved-but-not-yet-applied tx — until we've read it back off our own replica log and committed it
     // into the live index. Driven only from the persister coroutine, and freed in close() once that job is
     // joined; see TxResolver.
     private val txResolver =
-        TxResolver(allocator, nodeBase, partitionStorage, partitionState, dbName, crashLogger, skipTxs, instantSource)
+        TxResolver(
+            allocator, nodeBase, partitionStorage, partitionState, dbName, crashLogger, skipTxs,
+            resolvedSrcMsgId = watchers.latestSourceMsgId, resolvedExtToken = watchers.externalSourceToken,
+            instantSource
+        )
 
     var pendingBlock: PendingBlock? = null
         private set
-
-    private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
 
     // From the live index, not the node config: the two agree in production, but they are one value and
     // the live index is what owns the block being filled — `blockRowCount` below seeds the gauge from it.
@@ -97,51 +86,31 @@ internal class LeaderLogProcessor(
     // across restarts — the #5817 stop/start off-by-one). Reset when a boundary is injected.
     private var rowsSinceBlock: Long = liveIndex.blockRowCount
 
-    // The source-log watermark and ext-source token as of the last-resolved tx — the boundary is now cut
-    // on the resolve side, ahead of the watchers (which advance on apply), so its `latestProcessedMsgId`
-    // and token come from here rather than `watchers.*`.
-    private var lastResolvedSrcMsgId: MessageId = watchers.latestSourceMsgId
-    private var lastResolvedExtToken: ExternalSourceToken? = watchers.externalSourceToken
-
     // A block cut is in progress: the BlockBoundary has been appended but its BlockUploaded has not yet
     // been produced. Resolution (source/ext/gc) is paused — excluded from the select — so no tx interleaves
     // between the boundary and its upload, keeping the follower's bounded pending-block buffer empty.
     private var blockInProgress: Boolean = false
 
-    // ---- append pump ----
+    val gc = GarbageCollector(
+        nodeBase, partitionStorage, partitionState, dbName, leaderTerm, replicaAppender, gcDispatcher
+    )
 
-    // What the append pump serializes-and-appends, in resolution order. A tx borrows its [ResolvedTx]
-    // (the resolver owns and frees it); a control message is appended verbatim.
-    private sealed interface AppendItem
-    private class TxItem(val resolvedTx: ResolvedTx) : AppendItem
-    private class ControlItem(val message: ReplicaMessage) : AppendItem
+    val srcLogProc = SourceLogProcessor(
+        driver, txResolver, partitionStorage, partitionState, watchers, dbCatalog, dbName, leaderTerm,
+        replicaAppender, flushTimeout, ::appendTx, ::cutBlock
+    )
 
-    // Unbounded, on purpose:
-    //  - the persister sends here from the same coroutine that services `replicaMsgs`;
-    //  - a bounded channel could block that send, stalling the apply loop;
-    //  - but apply is what drains the queue and makes progress → single-coroutine deadlock.
-    // Backpressure comes from the block pause + the resolve-side row gauge, not channel capacity.
-    private val awaitingAppend = Channel<AppendItem>(Channel.UNLIMITED)
+    // An ext-source tx that fills a block cuts it like any other, but there is no batch mid-flight to
+    // stop, so the processor is handed the append alone.
+    val extSrcProc =
+        extSource?.let { source ->
+            ExternalSourceProcessor(source, partition, blockCatalog, watchers, txResolver) { appendTx(it) }
+        }
 
     // Records read back off the replica log, awaiting application. The partition's reader fills it
     // through [queueReplicaMessage]; its capacity is what bounds how far that reader may run ahead.
     private val replicaMsgs = Channel<Log.Record<ReplicaMessage>>(capacity = 128)
 
-    // Serialize each ResolvedTx (the costly Arrow-IPC step, kept off the resolver) and append it, in
-    // order, through the driver. Plain (non-transactional) appends: the sole fence on a zombie leader is
-    // now the term check on consume-back — a higher-term record read back means we've been superseded and
-    // resign (see applyRecord) — replacing the Kafka transactional producer that fenced at commit (#5817).
-    // An append failure propagates and tears the term down. Never frees a borrowed ResolvedTx — the
-    // resolver owns it.
-    private suspend fun appendPump() {
-        for (item in awaitingAppend) {
-            val msg = when (item) {
-                is TxItem -> item.resolvedTx.toReplicaMessage(leaderTerm)
-                is ControlItem -> item.message
-            }
-            driver.appendToReplica(msg)
-        }
-    }
 
     /**
      * Hand a record read back off the replica log to the apply loop, suspending while the loop is behind.
@@ -210,11 +179,10 @@ internal class LeaderLogProcessor(
                 // the block's covered source position, as the follower does
                 watchers.notifyApplied(record.msgId, msg.latestProcessedMsgId)
 
-                blockGc.signal()
-                trieGc.signal()
+                gc.signal()
 
                 blockInProgress = false
-                resumeCh.trySend(Unit) // resume a source batch stashed by the pause, if any
+                srcLogProc.blockUploaded()
             }
 
             // Our own BlockUploaded, read back after uploadBlock already rolled the index — nothing to do
@@ -223,7 +191,7 @@ internal class LeaderLogProcessor(
 
             is ReplicaMessage.NoOp -> watchers.notifyApplied(record.msgId, msg.srcMsgId)
 
-            // Catalog already updated on the resolve side (see handleTriesDeleted); nothing to do here.
+            // Catalog already updated on the resolve side (see GarbageCollector.handleTask); nothing to do.
             is ReplicaMessage.TriesDeleted -> watchers.notifyApplied(record.msgId)
         }
     }
@@ -232,318 +200,62 @@ internal class LeaderLogProcessor(
 
     // Cut a block: inject the boundary (in resolution order, so it lands after this block's txs and before
     // the next block's) and pause resolution until it is read back and uploaded. Reset the row gauge.
-    private suspend fun cutBlock(latestProcessedMsgId: MessageId, externalSourceToken: ExternalSourceToken?) {
+    private suspend fun cutBlock(latestProcessedMsgId: MessageId) {
         val boundary = BlockBoundary(
-            (blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, externalSourceToken, termId = leaderTerm
+            (blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, txResolver.resolvedExtToken,
+            termId = leaderTerm
         )
-        awaitingAppend.send(ControlItem(boundary))
+        replicaAppender.append(ControlItem(boundary))
         blockInProgress = true
         rowsSinceBlock = 0
     }
 
-    // Hand a freshly-resolved tx to the append pump, and cut a block if this tx filled one.
-    //
-    // [srcMsgId] is the source-log position this tx sits at. A source-log tx advances it; an ext-source tx
-    // passes the current one back, because it has no source-log position of its own — which is exactly what
-    // gets stamped on its replica record.
-    private suspend fun appendTx(resolvedTx: ResolvedTx, srcMsgId: MessageId) {
-        lastResolvedSrcMsgId = srcMsgId
+    // Hand a freshly-resolved tx to the append pump, cutting a block if this tx filled one — which the
+    // caller is told about, because a source batch mid-flight has to stop where that happens.
+    private suspend fun appendTx(resolvedTx: ResolvedTx): Boolean {
         rowsSinceBlock += resolvedTx.allTables.sumOf { it.relation.rowCount.toLong() }
-        awaitingAppend.send(TxItem(resolvedTx))
-        if (rowsSinceBlock >= rowsPerBlock) cutBlock(lastResolvedSrcMsgId, lastResolvedExtToken)
+        replicaAppender.append(TxItem(resolvedTx, leaderTerm))
+
+        if (rowsSinceBlock < rowsPerBlock) return false
+
+        cutBlock(txResolver.resolvedSrcMsgId)
+        return true
     }
 
-    private suspend fun handleSourceLogRecord(record: Log.Record<SourceMessage>) {
-        val msgId = record.msgId
-        val msg = record.message
-        LOG.trace { "[$dbName] leader: message $msgId (${msg::class.simpleName})" }
+    // ---- work loop ----
 
-        when (msg) {
-            is SourceMessage.Tx -> appendTx(txResolver.indexTx(msgId, record.logTimestamp, msg), msgId)
+    override fun SelectBuilder<Unit>.selectWork() {
+        // supersession fails the term, not the database — rationale on the outer ladder
+        replicaMsgs.onReceive { rec ->
+            try {
+                applyRecord(rec)
+            } catch (e: Throwable) {
+                if (!e.isShutdownSignal && e !is LeaderSupersededException) watchers.notifyError(e)
+                throw e
+            }
+        }
 
-            is SourceMessage.LegacyTx -> appendTx(txResolver.indexTx(msgId, record.logTimestamp, msg), msgId)
+        if (!blockInProgress) {
+            with(srcLogProc) { selectWork() }
 
-            is SourceMessage.FlushBlock -> {
-                val expectedBlockIdx = msg.expectedBlockIdx
-                if (expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L)) {
-                    cutBlock(msgId, lastResolvedExtToken)
-                } else {
-                    // see #5680
-                    awaitingAppend.send(ControlItem(ReplicaMessage.NoOp(srcMsgId = msgId, termId = leaderTerm)))
+            extSrcProc?.onTask { task ->
+                watchers.runTaskGuarded(task.onComplete, extResult = task.msg.pending) {
+                    extSrcProc.handleTask(task)
                 }
-                lastResolvedSrcMsgId = msgId
             }
 
-            is SourceMessage.AttachDatabase -> {
-                val error = if (dbCatalog != null) {
-                    try {
-                        dbCatalog.attach(msg.dbName, msg.config)
-                        null
-                    } catch (e: Anomaly.Caller) {
-                        LOG.debug(e) { "[$dbName] leader: attach database '${msg.dbName}' failed at $msgId" }
-                        e
-                    }
-                } else null
-
-                val resolvedTx =
-                    if (error == null)
-                        txResolver.indexDbOp(msgId, record.logTimestamp, DbOp.Attach(msg.dbName, msg.config))
-                    else
-                        txResolver.indexFailedDbOp(msgId, record.logTimestamp, error)
-
-                appendTx(resolvedTx, msgId)
-            }
-
-            is SourceMessage.DetachDatabase -> {
-                val error = if (dbCatalog != null) {
-                    try {
-                        dbCatalog.detach(msg.dbName)
-                        null
-                    } catch (e: Anomaly.Caller) {
-                        LOG.debug(e) { "[$dbName] leader: detach database '${msg.dbName}' failed at $msgId" }
-                        e
-                    }
-                } else null
-
-                val resolvedTx =
-                    if (error == null)
-                        txResolver.indexDbOp(msgId, record.logTimestamp, DbOp.Detach(msg.dbName))
-                    else
-                        txResolver.indexFailedDbOp(msgId, record.logTimestamp, error)
-
-                appendTx(resolvedTx, msgId)
-            }
-
-            is SourceMessage.TriesAdded -> {
-                // Mutate the local trie catalog here (as the leader did pre-rewrite), then replicate for
-                // followers. Eager on the resolve side, not deferred to our own consume-back, because:
-                //  - callers see the effect promptly (the compactor/GC read the catalog synchronously);
-                //  - it stays a projection of the fenced log anyway — the block-cut pause serialises trie
-                //    mutations against boundaries, so no block snapshot straddles this add.
-                // We skip re-applying it on our own consume-back (see applyRecord); the follower applies it.
-                if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
-                    msg.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
-                        trieCatalog.addTries(fromSchemaAndTable(tableName), tries, record.logTimestamp)
-                    }
-                awaitingAppend.send(
-                    ControlItem(TriesAdded(msg.storageVersion, msg.storageEpoch, msg.tries, sourceMsgId = msgId, termId = leaderTerm))
-                )
-                lastResolvedSrcMsgId = msgId
-            }
-
-            // TODO this one's going after 2.2
-            is SourceMessage.BlockUploaded -> {
-                watchers.notifyApplied(null, msgId)
-                // Keep the resolve-side gauge in step with the watermark we just advanced, or a following
-                // block cut would carry a lower latestProcessedMsgId and regress it on apply.
-                lastResolvedSrcMsgId = msgId
-            }
-        }
-    }
-
-    private suspend fun handleIndexTx(task: ExtSourceTask.IndexTx) {
-        // The stamped watermark must be the RESOLVE-side one (`lastResolvedSrcMsgId`), not `watchers.*`:
-        // watchers advance on consume-back (apply), which lags resolution, so a source tx
-        // resolved-and-appended ahead of this ext tx would apply first and push the watermark past a stale
-        // stamp — `notifyApplied`'s monotonicity check would then fire (#5817).
-        val resolvedTx = txResolver.indexTx(task.msg, srcMsgId = lastResolvedSrcMsgId)
-
-        task.msg.externalSourceToken?.let { lastResolvedExtToken = it }
-        appendTx(resolvedTx, lastResolvedSrcMsgId)
-    }
-
-    private suspend fun handleTriesDeleted(task: GcTask.TriesDeleted) {
-        // Remove from the local catalog here, then replicate for followers — eager on the resolve side so
-        // the GC's `commitTriesDeleted` await returns with the catalog already updated (its contract; the
-        // GC has already deleted the files). Safe as a fenced-log projection for the same reason as
-        // TriesAdded: the block-cut pause serialises this against any boundary, and gcCh is excluded while a
-        // block is in progress. Skipped on our own consume-back (see applyRecord); the follower applies it.
-        trieCatalog.deleteTries(task.tableName, task.trieKeys)
-        awaitingAppend.send(
-            ControlItem(ReplicaMessage.TriesDeleted(task.tableName.schemaAndTable, task.trieKeys, termId = leaderTerm))
-        )
-    }
-
-    // ---- persister channels & loop ----
-
-    private sealed interface PersisterTask {
-        val onComplete: CompletableDeferred<Unit>
-
-        /**
-         * Fail this task's awaiting caller, because the term is going away without finishing it.
-         *
-         * The *kind* of failure — cancellation vs the term's real cause — depends on who awaits the handle,
-         * so it belongs here, on the task, rather than being re-decided at each teardown site. Callers just
-         * abandon whatever they hold.
-         */
-        fun abandon(cause: Throwable)
-    }
-
-    private sealed interface ExtSourceTask : PersisterTask {
-        class IndexTx(val msg: ExtSourceMessage) : ExtSourceTask {
-            override val onComplete = CompletableDeferred<Unit>()
-
-            // The real cause: this is an ext-source caller's own tx, awaiting its own result, and it isn't
-            // on the transport's poll thread — so it both wants and can safely see why the term died.
-            override fun abandon(cause: Throwable) {
-                onComplete.completeExceptionally(cause)
-                msg.pending.completeExceptionally(cause)
-            }
-        }
-    }
-
-    private sealed interface GcTask : PersisterTask {
-        data class TriesDeleted(val tableName: TableRef, val trieKeys: Set<TrieKey>) : GcTask {
-            override val onComplete = CompletableDeferred<Unit>()
-
-            override fun abandon(cause: Throwable) {
-                onComplete.completeExceptionally(cause)
-            }
-        }
-    }
-
-    // Undelivered — a cancelled send, or a cancelled channel — is a term-teardown failure like any other,
-    // so it goes through the task's own `abandon` rather than a second, hand-rolled policy here.
-    private fun <T : PersisterTask> persisterChannel(capacity: Int) =
-        Channel<T>(capacity, onUndeliveredElement = { it.abandon(CancellationException("leader term closed")) })
-
-    // capacity 1 so a fire-and-forget `submitTx` caller can queue one tx ahead while the persister works
-    // the current one. `executeTx` still blocks on the result regardless of capacity.
-    private val extSourceCh = persisterChannel<ExtSourceTask>(capacity = 1)
-
-    private val gcCh = persisterChannel<GcTask>(Channel.UNLIMITED)
-
-    /**
-     * Shut this channel down and fail everyone still waiting on it: senders (via the close cause) and
-     * whatever is still queued (via each task's [PersisterTask.abandon]).
-     *
-     * Close and drain are bundled because both are needed and the order matters — `close` alone doesn't
-     * visit buffered elements (only `cancel` does), so a queued task's caller would wait forever; and
-     * closing *first* means no send can slip into a buffer we've already drained.
-     *
-     * Only safe on the persister's own exit path: it is the sole receiver, so nothing competes with these
-     * `tryReceive`s.
-     */
-    private fun <T : PersisterTask> Channel<T>.shutdown(cause: Throwable) {
-        close(cause)
-        while (true) (tryReceive().getOrNull() ?: break).abandon(cause)
-    }
-
-    // A source batch paused mid-way by a block cut: the task, and where to pick it up again. At most one —
-    // the poll thread awaits each batch before sending the next, so only one is ever in flight; a nullable
-    // field makes that structural. Holds the *task*, so its failure policy stays the task's own.
-    private class PausedBatch(val task: SourceBatch, val nextIdx: Int)
-
-    private var pausedBatch: PausedBatch? = null
-
-    // Poked when a stashed [pausedBatch] becomes resumable (the block finished uploading). Conflated: at
-    // most one resume is pending, and the select clause is gated on `pausedBatch != null && !blockInProgress`.
-    private val resumeCh = Channel<Unit>(Channel.CONFLATED)
-
-    // Process a source batch from `startIdx`, stopping if a block cut pauses us — stashing the remainder on
-    // [pausedBatch] so the loop resumes it after the upload. Completes the task only when fully drained.
-    private suspend fun runSourceBatch(task: SourceBatch, startIdx: Int) {
-        var i = startIdx
-        while (i < task.records.size) {
-            handleSourceLogRecord(task.records[i])
-            i++
-            if (blockInProgress) {
-                pausedBatch = PausedBatch(task, i)
-                return
-            }
-        }
-        task.onComplete.complete(Unit)
-    }
-
-    private sealed interface Work
-    private class Apply(val record: Log.Record<ReplicaMessage>) : Work
-    private class SourceWork(val batch: SourceBatch) : Work
-    private class RunTask(val task: PersisterTask) : Work
-    private data object Resume : Work
-
-    internal val blockGc = nodeBase.config.garbageCollector.let { cfg ->
-        BlockGarbageCollector(
-            bufferPool, blockCatalog,
-            blocksToKeep = cfg.blocksToKeep,
-            enabled = cfg.enabled,
-            meterRegistry = nodeBase.meterRegistry,
-            dispatcher = gcDispatcher,
-            dbName = dbName
-        )
-    }
-
-    internal val trieGc = nodeBase.config.garbageCollector.let { cfg ->
-        // Routed through the persister rather than applied inline: the catalog removal has to be serialised
-        // against block cuts, and this await must not return until the catalog reflects it — which is the
-        // GC's contract, since it has already deleted the files. See handleTriesDeleted.
-        val commitTriesDeleted: suspend (TableRef, Set<TrieKey>) -> Unit = { tableName, trieKeys ->
-            enqueue(GcTask.TriesDeleted(tableName, trieKeys)).await()
-        }
-
-        TrieGarbageCollector(
-            bufferPool, partitionState, dbName,
-            commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
-            cfg.enabled,
-            nodeBase.meterRegistry,
-            dispatcher = gcDispatcher,
-        )
-    }
-
-    override fun armWork(select: SelectBuilder<suspend () -> Unit>) {
-        with(select) {
-            replicaMsgs.onReceive { r -> { runWork(Apply(r)) } }
-            if (!blockInProgress) {
-                if (pausedBatch != null) resumeCh.onReceive { { runWork(Resume) } }
-                driver.sourceBatches.onBatch { b -> { runWork(SourceWork(b)) } }
-                extSourceCh.onReceive { t -> { runWork(RunTask(t)) } }
-                gcCh.onReceive { t -> { runWork(RunTask(t)) } }
-            }
-        }
-    }
-
-    private suspend fun runWork(work: Work) {
-        when (work) {
-            // supersession fails the term, not the database — rationale on the outer ladder
-            is Apply ->
-                try {
-                    applyRecord(work.record)
-                } catch (e: Throwable) {
-                    if (!e.isShutdownSignal && e !is LeaderSupersededException) watchers.notifyError(e)
-                    throw e
-                }
-
-            is Resume -> {
-                val pb = pausedBatch ?: return
-                pausedBatch = null
-                runTaskGuarded(pb.task.onComplete) { runSourceBatch(pb.task, pb.nextIdx) }
-            }
-
-            // The batch completes its own onComplete (deferred, if a block cut pauses it).
-            is SourceWork ->
-                runTaskGuarded(work.batch.onComplete) { runSourceBatch(work.batch, 0) }
-
-            is RunTask -> {
-                val task = work.task
-                runTaskGuarded(task.onComplete, extResult = (task as? ExtSourceTask.IndexTx)?.msg?.pending) {
-                    when (task) {
-                        is ExtSourceTask.IndexTx -> {
-                            handleIndexTx(task); task.onComplete.complete(Unit)
-                        }
-                        is GcTask.TriesDeleted -> {
-                            handleTriesDeleted(task); task.onComplete.complete(Unit)
-                        }
-                    }
-                }
+            gc.gcCh.onReceive { task ->
+                watchers.runTaskGuarded(task.onComplete) { gc.handleTask(task) }
             }
         }
     }
 
     // Completed by [workFailed] with the cause. Write-once, and the only thing the term learns about the
-    // loop it no longer runs.
+    // work it no longer runs.
     private val termFailure = CompletableDeferred<Throwable>()
 
     /**
-     * End this term, because the work loop it no longer runs has failed with [cause].
+     * End this term, because work it no longer runs has failed with [cause].
      *
      * The logging, the watchers and the sweep of everything staged are still the term's, and so is the
      * distinction they turn on — a supersession is a clean resignation where an append fault is not — so
@@ -554,153 +266,57 @@ internal class LeaderLogProcessor(
     }
 
     /**
-     * Run this term until it is cancelled or fails: the append pump, the collectors and the ext source.
-     * Cancelling the caller is what ends the term.
+     * Wait for this term to end, then fail everything staged on it.
+     *
+     * Cancelling the caller is what ends the term otherwise.
      */
-    suspend fun runTerm(): Unit = coroutineScope {
-        launch {
-            supervisorScope {
-                launch { blockGc.run() }
-                launch { trieGc.run() }
-            }
-        }
-
-        // Core: the append pump, and the term's own end. Structured together so a pump failure and a
-        // loop failure both arrive here, and either cancels the other.
-        launch {
-            var cause: Throwable? = null
-            try {
-                coroutineScope {
-                    launch(CoroutineName("$dbName-append-pump")) { appendPump() }
-                    throw termFailure.await()
-                }
-            } catch (_: CancellationException) {
-                // term cancellation
-            } catch (e: LeaderSupersededException) {
-                // superseded by a newer leader — expected, not a query-facing fault; the transport
-                // re-follows on the next rebalance. Don't poison the watchers.
-                LOG.info("[$dbName] ${e.message}")
-                cause = e
-            } catch (t: Throwable) {
-                // A genuine term fault (e.g. an append-pump commit fault) surfaces to queries as a
-                // failed term. Idempotent — the apply arm may already have notified for its own faults.
-                LOG.error(t) { "[$dbName] leader term failed" }
-                cause = t
-                watchers.notifyError(t)
-            } finally {
-                val pendingCause = cause ?: CancellationException("leader term closed")
-
-                // Nothing may be left awaiting the persister once it has gone: whatever is staged,
-                // paused, or still queued gets failed here. Each task's own `abandon` picks the failure
-                // *kind*, so this is a flat sweep with no per-caller special-casing.
-                //
-                // Miss anything and the symptom is a hang, not an error — and for a source-log batch
-                // that hang is on the transport's poll thread (inside `processRecords`), which is also
-                // the sole servicer of the transport's unregister. So it wedges the whole subscription
-                // teardown and blows DatabaseCatalog.close's bound (#5711 / #5817).
-                txResolver.failPending(pendingCause)
-                pausedBatch?.task?.abandon(pendingCause)
-
-                // The source-log pipe lives on the driver; its shutdown applies the same close-and-drain,
-                // and owns the must-be-a-cancellation rule (SourceBatch.abandon) because the poll thread
-                // both awaits and sends there.
-                driver.sourceBatches.shutdown(pendingCause)
-                extSourceCh.shutdown(pendingCause)
-                gcCh.shutdown(pendingCause)
-
-                // The partition's reader is suspended on a send here rather than awaiting a task, so a
-                // close is all it needs — as a cancellation, since it is the reader's own coroutine that
-                // sees it and a benign teardown must not poison the watchers.
-                replicaMsgs.close(pendingCause.asCancellation())
-            }
-        }
-
-        extSource?.let { source ->
-            supervisorScope {
-                launch {
-                    try {
-                        source.onPartitionAssigned(partition, watchers.externalSourceToken, this@LeaderLogProcessor)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Throwable) {
-                        watchers.notifyError(e)
-                    }
-                }
-            }
-        }
-    }
-
-    // Run a resolution task, routing failures onto its completion handle (and any ext-source result) so no
-    // caller hangs. Interrupts are shutdown signals, not ingestion faults, so they don't poison the watchers.
-    // A successful source batch completes its onComplete itself (possibly deferred, if paused).
-    private suspend inline fun runTaskGuarded(
-        onComplete: CompletableDeferred<Unit>,
-        extResult: CompletableDeferred<TransactionResult>? = null,
-        block: () -> Unit,
-    ) {
+    suspend fun runTerm() {
+        var cause: Throwable? = null
         try {
-            block()
-        } catch (e: CancellationException) {
-            if (!onComplete.isCompleted) onComplete.cancel(e)
-            throw e
-        } catch (e: Throwable) {
-            if (!e.isShutdownSignal) {
-                watchers.notifyError(e)
-                extResult?.let { if (!it.isCompleted) it.completeExceptionally(e) }
-            }
-            if (!onComplete.isCompleted) onComplete.completeExceptionally(e)
-            throw e
+            throw termFailure.await()
+        } catch (_: CancellationException) {
+            // term cancellation
+        } catch (e: LeaderSupersededException) {
+            // superseded by a newer leader — expected, not a query-facing fault; the transport
+            // re-follows on the next rebalance. Don't poison the watchers.
+            LOG.info("[$dbName] ${e.message}")
+            cause = e
+        } catch (t: Throwable) {
+            // A genuine term fault (e.g. an append fault) surfaces to queries as a failed term.
+            // Idempotent — the apply arm may already have notified for its own faults.
+            LOG.error(t) { "[$dbName] leader term failed" }
+            cause = t
+            watchers.notifyError(t)
+        } finally {
+            val pendingCause = cause ?: CancellationException("leader term closed")
+
+            // Nothing may be left awaiting the term once it has gone: whatever is staged, paused, or
+            // still queued gets failed here. Each task's own `abandon` picks the failure *kind*, so this
+            // is a flat sweep with no per-caller special-casing.
+            //
+            // Miss anything and the symptom is a hang, not an error — and for a source-log batch that
+            // hang is on the transport's poll thread (inside `processRecords`), which is also the sole
+            // servicer of the transport's unregister. So it wedges the whole subscription teardown and
+            // blows DatabaseCatalog.close's bound (#5711 / #5817).
+            txResolver.failPending(pendingCause)
+            srcLogProc.shutdown(pendingCause)
+            extSrcProc?.shutdown(pendingCause)
+            gc.shutdown(pendingCause)
+
+            replicaAppender.shutdown(pendingCause)
+
+            // The partition's reader is suspended on a send here rather than awaiting a task, so a
+            // close is all it needs — as a cancellation, since it is the reader's own coroutine that
+            // sees it and a benign teardown must not poison the watchers.
+            replicaMsgs.close(pendingCause.asCancellation())
         }
     }
 
-    // Hand the task to the persister and return its completion handle. The caller decides whether to await
-    // it: `executeTx`, GC and `processRecords` await; `submitTx` doesn't. Suspends only on the channel send.
-    private suspend fun enqueue(task: PersisterTask): Deferred<Unit> {
-        when (task) {
-            is ExtSourceTask -> extSourceCh.send(task)
-            is GcTask -> gcCh.send(task)
-        }
-        return task.onComplete
-    }
-
-    override suspend fun executeTx(
-        externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
-        writer: suspend (OpenTx) -> TxResult,
-    ): TransactionResult =
-        submitTx(externalSourceToken, systemTime, writer).await()
-
-    override suspend fun submitTx(
-        externalSourceToken: ExternalSourceToken?, systemTime: Instant?,
-        writer: suspend (OpenTx) -> TxResult,
-    ): Deferred<TransactionResult> {
-        val task = ExtSourceTask.IndexTx(ExtSourceMessage(externalSourceToken, systemTime, writer))
-        // enqueue's send throws if the channel is closed (dead indexer) — the early-exit signal. The
-        // returned handle is the message's `pending`, completed on consume-back once the tx is durably
-        // replicated AND confirmed unfenced (ReadIndex); an unrecoverable failure also closes the channel
-        // with its cause, so the next `enqueue` throws it.
-        enqueue(task)
-        return task.msg.pending
-    }
-
-    private suspend fun maybeFlushBlock() {
-        if (blockFlusher.checkBlockTimeout(blockCatalog))
-            driver.requestFlushBlock(blockCatalog.currentBlockIndex ?: -1)
-    }
-
-    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
-        maybeFlushBlock()
-
-        // Await the batch through the persister rather than firing and returning:
-        //  - the persister resolves + hands off to the append pump on its own thread (heavy work off the
-        //    poll thread);
-        //  - blocking here until the batch is resolved keeps the poll loop and the persister roughly in
-        //    step (channel cap 1 → ~2 batches of lookahead);
-        //  - so a rebalance/transition under runBlocking doesn't pile up behind unbounded resolution (#5741).
-        if (records.isNotEmpty()) driver.sourceBatches.submit(records).await()
-    }
+    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) =
+        srcLogProc.processRecords(records)
 
     override fun close() {
-        extSource?.close()
+        extSrcProc?.close()
         driver.close()
         // Frees every resolved-but-not-applied tx — safe only once the term's job has been joined, so the
         // persister and the pumps are gone.

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -4,7 +4,9 @@ package xtdb.indexer
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.selects.selectUnbiased
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.SelectBuilder
+import kotlinx.coroutines.supervisorScope
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.api.DatabaseName
@@ -50,14 +52,12 @@ internal class LeaderLogProcessor(
     private val extSource: ExternalSource?,
     skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
-    afterReplicaMsgId: MessageId,
     private val leaderTerm: Long = 0,
     instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration,
-    scope: CoroutineScope,
     // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
     gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : LogProcessor.Processor<SourceMessage>, TxIndexer {
+) : LogProcessor.Processor<SourceMessage>, Role, TxIndexer {
 
     init {
         require((dbCatalog != null) == (dbName == "xtdb")) {
@@ -83,11 +83,6 @@ internal class LeaderLogProcessor(
 
     var pendingBlock: PendingBlock? = null
         private set
-
-    // Where the consume pump starts tailing: the transition's replay target, which can sit below where
-    // the outgoing follower had read. Everything in between is the superseded leader's, written after
-    // our own claim and therefore fenced, so re-reading it applies nothing.
-    private val replayFrom: MessageId = afterReplicaMsgId
 
     private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
 
@@ -128,7 +123,8 @@ internal class LeaderLogProcessor(
     // Backpressure comes from the block pause + the resolve-side row gauge, not channel capacity.
     private val awaitingAppend = Channel<AppendItem>(Channel.UNLIMITED)
 
-    // Records the consume pump has tailed back off the replica log, awaiting application.
+    // Records read back off the replica log, awaiting application. The partition's reader fills it
+    // through [queueReplicaMessage]; its capacity is what bounds how far that reader may run ahead.
     private val replicaMsgs = Channel<Log.Record<ReplicaMessage>>(capacity = 128)
 
     // Serialize each ResolvedTx (the costly Arrow-IPC step, kept off the resolver) and append it, in
@@ -147,12 +143,13 @@ internal class LeaderLogProcessor(
         }
     }
 
-    // Tail our own replica log from the replay target and post everything back to the apply loop. The
-    // same plain tail the follower uses — a separate consumer from the source-log group subscription that
-    // drives leader election, so this doesn't interfere with it.
-    private suspend fun consumePump() {
-        driver.tailReplica(replayFrom) { records -> records.forEach { replicaMsgs.send(it) } }
-    }
+    /**
+     * Hand a record read back off the replica log to the apply loop, suspending while the loop is behind.
+     *
+     * Confirmation, not delivery: a leader learns its own writes landed by reading them back (#5817), so
+     * every record reaches this — its own, and a superseding leader's alike.
+     */
+    suspend fun queueReplicaMessage(record: Log.Record<ReplicaMessage>) = replicaMsgs.send(record)
 
     // ---- apply loop (consume-back) ----
 
@@ -464,18 +461,8 @@ internal class LeaderLogProcessor(
     private class RunTask(val task: PersisterTask) : Work
     private data object Resume : Work
 
-    // The term handle: a supervisor child of the Database scope, owning the pumps + persister loop
-    // (launched in `init`) and the GCs. A term-internal failure surfaces via `notifyError` rather than
-    // cancelling the source-log subscription; `cancelAndJoin` reaps the whole term. See dev/doc/coroutines.adoc.
-    private val termJob = SupervisorJob(scope.coroutineContext.job)
-
-    // The GCs run under a SupervisorJob child of `termJob`, so one GC's failure cancels neither its sibling
-    // nor the persister; cancelling `termJob` reaps them all.
-    private val gcScope = scope + SupervisorJob(termJob)
-
     internal val blockGc = nodeBase.config.garbageCollector.let { cfg ->
         BlockGarbageCollector(
-            gcScope,
             bufferPool, blockCatalog,
             blocksToKeep = cfg.blocksToKeep,
             enabled = cfg.enabled,
@@ -494,7 +481,6 @@ internal class LeaderLogProcessor(
         }
 
         TrieGarbageCollector(
-            gcScope,
             bufferPool, partitionState, dbName,
             commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
             cfg.enabled,
@@ -503,65 +489,48 @@ internal class LeaderLogProcessor(
         )
     }
 
-    // Launched last so every field the body reaches — e.g. blockGc/trieGc via the boundary path — is
-    // initialised before the first record. Runs under `termJob`, so `cancelAndJoin` reaps it.
-    init {
-        CoroutineScope(scope.coroutineContext + termJob).launch {
-            // Core: the append pump, the consume pump and the persister loop, structured together so any
-            // one failing cancels the others and surfaces the cause.
-            launch {
-                var cause: Throwable? = null
+    override fun armWork(select: SelectBuilder<suspend () -> Unit>) {
+        with(select) {
+            replicaMsgs.onReceive { r -> { runWork(Apply(r)) } }
+            if (!blockInProgress) {
+                if (pausedBatch != null) resumeCh.onReceive { { runWork(Resume) } }
+                driver.sourceBatches.onBatch { b -> { runWork(SourceWork(b)) } }
+                extSourceCh.onReceive { t -> { runWork(RunTask(t)) } }
+                gcCh.onReceive { t -> { runWork(RunTask(t)) } }
+            }
+        }
+    }
+
+    private suspend fun runWork(work: Work) {
+        when (work) {
+            // supersession fails the term, not the database — rationale on the outer ladder
+            is Apply ->
                 try {
-                    coroutineScope {
-                        launch(CoroutineName("$dbName-append-pump")) { appendPump() }
-                        launch(CoroutineName("$dbName-consume-pump")) { consumePump() }
-                        persisterLoop()
-                    }
-                } catch (_: CancellationException) {
-                    // term cancellation
-                } catch (e: LeaderSupersededException) {
-                    // superseded by a newer leader — expected, not a query-facing fault; the transport
-                    // re-follows on the next rebalance. Don't poison the watchers.
-                    LOG.info("[$dbName] ${e.message}")
-                    cause = e
-                } catch (t: Throwable) {
-                    // A genuine term fault (e.g. an append-pump commit fault) surfaces to queries as a
-                    // failed term. Idempotent — the apply arm may already have notified for its own faults.
-                    LOG.error(t) { "[$dbName] leader term failed" }
-                    cause = t
-                    watchers.notifyError(t)
-                } finally {
-                    val pendingCause = cause ?: CancellationException("leader term closed")
-
-                    // Nothing may be left awaiting the persister once it has gone: whatever is staged,
-                    // paused, or still queued gets failed here. Each task's own `abandon` picks the failure
-                    // *kind*, so this is a flat sweep with no per-caller special-casing.
-                    //
-                    // Miss anything and the symptom is a hang, not an error — and for a source-log batch
-                    // that hang is on the transport's poll thread (inside `processRecords`), which is also
-                    // the sole servicer of the transport's unregister. So it wedges the whole subscription
-                    // teardown and blows DatabaseCatalog.close's bound (#5711 / #5817).
-                    txResolver.failPending(pendingCause)
-                    pausedBatch?.task?.abandon(pendingCause)
-
-                    // The source-log pipe lives on the driver; its shutdown applies the same close-and-drain,
-                    // and owns the must-be-a-cancellation rule (SourceBatch.abandon) because the poll thread
-                    // both awaits and sends there.
-                    driver.sourceBatches.shutdown(pendingCause)
-                    extSourceCh.shutdown(pendingCause)
-                    gcCh.shutdown(pendingCause)
+                    applyRecord(work.record)
+                } catch (e: Throwable) {
+                    if (!e.isShutdownSignal && e !is LeaderSupersededException) watchers.notifyError(e)
+                    throw e
                 }
+
+            is Resume -> {
+                val pb = pausedBatch ?: return
+                pausedBatch = null
+                runTaskGuarded(pb.task.onComplete) { runSourceBatch(pb.task, pb.nextIdx) }
             }
 
-            extSource?.let { source ->
-                supervisorScope {
-                    launch {
-                        try {
-                            source.onPartitionAssigned(partition, watchers.externalSourceToken, this@LeaderLogProcessor)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Throwable) {
-                            watchers.notifyError(e)
+            // The batch completes its own onComplete (deferred, if a block cut pauses it).
+            is SourceWork ->
+                runTaskGuarded(work.batch.onComplete) { runSourceBatch(work.batch, 0) }
+
+            is RunTask -> {
+                val task = work.task
+                runTaskGuarded(task.onComplete, extResult = (task as? ExtSourceTask.IndexTx)?.msg?.pending) {
+                    when (task) {
+                        is ExtSourceTask.IndexTx -> {
+                            handleIndexTx(task); task.onComplete.complete(Unit)
+                        }
+                        is GcTask.TriesDeleted -> {
+                            handleTriesDeleted(task); task.onComplete.complete(Unit)
                         }
                     }
                 }
@@ -569,49 +538,92 @@ internal class LeaderLogProcessor(
         }
     }
 
-    private suspend fun persisterLoop() {
-        while (true) {
-            val work = selectUnbiased<Work> {
-                replicaMsgs.onReceive { Apply(it) }
-                if (!blockInProgress) {
-                    if (pausedBatch != null) resumeCh.onReceive { Resume }
-                    driver.sourceBatches.onBatch { SourceWork(it) }
-                    extSourceCh.onReceive { RunTask(it) }
-                    gcCh.onReceive { RunTask(it) }
-                }
+    // Completed by [workFailed] with the cause. Write-once, and the only thing the term learns about the
+    // loop it no longer runs.
+    private val termFailure = CompletableDeferred<Throwable>()
+
+    /**
+     * End this term, because the work loop it no longer runs has failed with [cause].
+     *
+     * The logging, the watchers and the sweep of everything staged are still the term's, and so is the
+     * distinction they turn on — a supersession is a clean resignation where an append fault is not — so
+     * the cause has to come back here to reach them.
+     */
+    override fun workFailed(cause: Throwable) {
+        termFailure.complete(cause)
+    }
+
+    /**
+     * Run this term until it is cancelled or fails: the append pump, the collectors and the ext source.
+     * Cancelling the caller is what ends the term.
+     */
+    suspend fun runTerm(): Unit = coroutineScope {
+        launch {
+            supervisorScope {
+                launch { blockGc.run() }
+                launch { trieGc.run() }
             }
+        }
 
-            when (work) {
-                // supersession fails the term, not the database — rationale on the outer ladder
-                is Apply ->
-                    try {
-                        applyRecord(work.record)
-                    } catch (e: Throwable) {
-                        if (!e.isShutdownSignal && e !is LeaderSupersededException) watchers.notifyError(e)
-                        throw e
-                    }
-
-                is Resume -> {
-                    val pb = pausedBatch ?: continue
-                    pausedBatch = null
-                    runTaskGuarded(pb.task.onComplete) { runSourceBatch(pb.task, pb.nextIdx) }
+        // Core: the append pump, and the term's own end. Structured together so a pump failure and a
+        // loop failure both arrive here, and either cancels the other.
+        launch {
+            var cause: Throwable? = null
+            try {
+                coroutineScope {
+                    launch(CoroutineName("$dbName-append-pump")) { appendPump() }
+                    throw termFailure.await()
                 }
+            } catch (_: CancellationException) {
+                // term cancellation
+            } catch (e: LeaderSupersededException) {
+                // superseded by a newer leader — expected, not a query-facing fault; the transport
+                // re-follows on the next rebalance. Don't poison the watchers.
+                LOG.info("[$dbName] ${e.message}")
+                cause = e
+            } catch (t: Throwable) {
+                // A genuine term fault (e.g. an append-pump commit fault) surfaces to queries as a
+                // failed term. Idempotent — the apply arm may already have notified for its own faults.
+                LOG.error(t) { "[$dbName] leader term failed" }
+                cause = t
+                watchers.notifyError(t)
+            } finally {
+                val pendingCause = cause ?: CancellationException("leader term closed")
 
-                // The batch completes its own onComplete (deferred, if a block cut pauses it).
-                is SourceWork ->
-                    runTaskGuarded(work.batch.onComplete) { runSourceBatch(work.batch, 0) }
+                // Nothing may be left awaiting the persister once it has gone: whatever is staged,
+                // paused, or still queued gets failed here. Each task's own `abandon` picks the failure
+                // *kind*, so this is a flat sweep with no per-caller special-casing.
+                //
+                // Miss anything and the symptom is a hang, not an error — and for a source-log batch
+                // that hang is on the transport's poll thread (inside `processRecords`), which is also
+                // the sole servicer of the transport's unregister. So it wedges the whole subscription
+                // teardown and blows DatabaseCatalog.close's bound (#5711 / #5817).
+                txResolver.failPending(pendingCause)
+                pausedBatch?.task?.abandon(pendingCause)
 
-                is RunTask -> {
-                    val task = work.task
-                    runTaskGuarded(task.onComplete, extResult = (task as? ExtSourceTask.IndexTx)?.msg?.pending) {
-                        when (task) {
-                            is ExtSourceTask.IndexTx -> {
-                                handleIndexTx(task); task.onComplete.complete(Unit)
-                            }
-                            is GcTask.TriesDeleted -> {
-                                handleTriesDeleted(task); task.onComplete.complete(Unit)
-                            }
-                        }
+                // The source-log pipe lives on the driver; its shutdown applies the same close-and-drain,
+                // and owns the must-be-a-cancellation rule (SourceBatch.abandon) because the poll thread
+                // both awaits and sends there.
+                driver.sourceBatches.shutdown(pendingCause)
+                extSourceCh.shutdown(pendingCause)
+                gcCh.shutdown(pendingCause)
+
+                // The partition's reader is suspended on a send here rather than awaiting a task, so a
+                // close is all it needs — as a cancellation, since it is the reader's own coroutine that
+                // sees it and a benign teardown must not poison the watchers.
+                replicaMsgs.close(pendingCause.asCancellation())
+            }
+        }
+
+        extSource?.let { source ->
+            supervisorScope {
+                launch {
+                    try {
+                        source.onPartitionAssigned(partition, watchers.externalSourceToken, this@LeaderLogProcessor)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        watchers.notifyError(e)
                     }
                 }
             }
@@ -687,13 +699,11 @@ internal class LeaderLogProcessor(
         if (records.isNotEmpty()) driver.sourceBatches.submit(records).await()
     }
 
-    suspend fun cancelAndJoin() = termJob.cancelAndJoin()
-
     override fun close() {
         extSource?.close()
         driver.close()
-        // Frees every resolved-but-not-applied tx — safe now that cancelAndJoin has joined the persister
-        // and the pumps.
+        // Frees every resolved-but-not-applied tx — safe only once the term's job has been joined, so the
+        // persister and the pumps are gone.
         txResolver.close()
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -253,7 +253,6 @@ internal class LeaderLogProcessor(
         return true
     }
 
-    /** A record read back off the replica log, for [applyRecord]. */
     val onReplicaMsg get() = replicaMsgs.onReceive
 
     /**

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.SelectBuilder
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.api.DatabaseName
@@ -48,7 +47,7 @@ internal class LeaderLogProcessor(
     flushTimeout: Duration,
     // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
     gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : LogProcessor.Processor<SourceMessage>, Role {
+) : AutoCloseable {
 
     init {
         require((dbCatalog != null) == (dbName == "xtdb")) {
@@ -153,7 +152,7 @@ internal class LeaderLogProcessor(
     //      - ResolvedTx  → import from the resolver's head (we still hold its relations — no re-materialisation).
     //      - BlockBoundary → trigger the block upload (liveIndex now holds exactly this block's txs).
     //      - everything else mirrors the follower.
-    private suspend fun applyRecord(record: Log.Record<ReplicaMessage>) {
+    suspend fun applyRecord(record: Log.Record<ReplicaMessage>) {
         val msg = record.message
         val term = msg.termId
 
@@ -254,33 +253,16 @@ internal class LeaderLogProcessor(
         return true
     }
 
-    // ---- work loop ----
+    /** A record read back off the replica log, for [applyRecord]. */
+    val onReplicaMsg get() = replicaMsgs.onReceive
 
-    override fun SelectBuilder<Unit>.selectWork() {
-        // supersession fails the term, not the database — rationale on the outer ladder
-        replicaMsgs.onReceive { rec ->
-            try {
-                applyRecord(rec)
-            } catch (e: Throwable) {
-                if (!e.isShutdownSignal && e !is LeaderSupersededException) watchers.notifyError(e)
-                throw e
-            }
-        }
-
-        if (blockState is Filling) {
-            with(srcLogProc) { selectWork() }
-
-            extSrcProc?.onTask { task ->
-                watchers.runTaskGuarded(task.onComplete, extResult = task.msg.pending) {
-                    extSrcProc.handleTask(task)
-                }
-            }
-
-            gc.gcCh.onReceive { task ->
-                watchers.runTaskGuarded(task.onComplete) { gc.handleTask(task) }
-            }
-        }
-    }
+    /**
+     * Whether this term will take resolution work right now.
+     *
+     * False for the length of a block cut, so nothing interleaves between the boundary and its upload —
+     * which is what keeps the follower's bounded pending-block buffer empty.
+     */
+    val acceptingResolution get() = blockState is Filling
 
     /**
      * Fail everything staged on this term, because it has ended with [cause].
@@ -307,9 +289,6 @@ internal class LeaderLogProcessor(
         // benign teardown must not poison the watchers.
         replicaMsgs.close(cause.asCancellation())
     }
-
-    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) =
-        srcLogProc.processRecords(records)
 
     override fun close() {
         extSrcProc?.close()

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -26,7 +26,7 @@ private val LOG = LeaderLogProcessor::class.logger
  * the apply loop to fail the term cleanly (not a query-facing fault, so it doesn't poison the watchers);
  * the transport re-follows on the next rebalance. See #5817.
  */
-private class LeaderSupersededException(message: String) : RuntimeException(message)
+internal class LeaderSupersededException(message: String) : RuntimeException(message)
 
 internal class LeaderLogProcessor(
     allocator: BufferAllocator,
@@ -72,24 +72,48 @@ internal class LeaderLogProcessor(
             instantSource
         )
 
-    var pendingBlock: PendingBlock? = null
-        private set
+    /**
+     * Where this term is in the block it is filling: `Filling` → `Cut` → `Uploading` → `Filling`.
+     *
+     * Resolution is armed only in [Filling], so no tx can interleave between a boundary and its upload —
+     * which keeps the follower's bounded pending-block buffer empty. That is also why the row gauge is
+     * [Filling]'s alone: outside it, nothing can move the gauge.
+     */
+    private sealed interface BlockState
 
-    // From the live index, not the node config: the two agree in production, but they are one value and
-    // the live index is what owns the block being filled — `blockRowCount` below seeds the gauge from it.
+    /**
+     * Accumulating rows towards the cut, [rows] of them so far.
+     *
+     * The boundary is cut off this rather than `liveIndex.isFull()`, which lags — it reflects only APPLIED
+     * (consume-back) txs. Seeded from the rows already applied into the open block, because a new leader
+     * inherits a partially-filled block from replay and must cut it where the old leader would have, or
+     * block sizes drift across restarts (the #5817 stop/start off-by-one).
+     */
+    private class Filling(val rows: Long) : BlockState
+
+    /** The boundary is queued for append, and has not been read back yet. */
+    private data object Cut : BlockState
+
+    /** The boundary has been applied and the upload is in flight. */
+    private class Uploading(val pendingBlock: PendingBlock) : BlockState
+
+    private var blockState: BlockState = Filling(liveIndex.blockRowCount)
+
+    /**
+     * The block this term would have to hand on, were it demoted right now.
+     *
+     * Read from the transport's serialization point rather than from the work loop, and after this term has
+     * been cancelled and closed — so it must not touch anything allocator-backed.
+     */
+    val pendingBlock: PendingBlock?
+        get() = when (val state = blockState) {
+            is Filling, Cut -> null
+            is Uploading -> state.pendingBlock
+        }
+
+    // From the live index, not the node config: the two agree in production, but they are one value and the
+    // live index is what owns the block being filled.
     private val rowsPerBlock = liveIndex.rowsPerBlock
-
-    // Rows in the current block so far (resolve-side gauge). The boundary is cut off this rather than
-    // liveIndex.isFull(), which lags (it only reflects APPLIED — consume-back — txs). Seeded from the rows
-    // already applied into the open block: on a leadership change the new leader inherits a partially-filled
-    // block from replay, and must cut it at the same point the old leader would have (else block sizes drift
-    // across restarts — the #5817 stop/start off-by-one). Reset when a boundary is injected.
-    private var rowsSinceBlock: Long = liveIndex.blockRowCount
-
-    // A block cut is in progress: the BlockBoundary has been appended but its BlockUploaded has not yet
-    // been produced. Resolution (source/ext/gc) is paused — excluded from the select — so no tx interleaves
-    // between the boundary and its upload, keeping the follower's bounded pending-block buffer empty.
-    private var blockInProgress: Boolean = false
 
     val gc = GarbageCollector(
         nodeBase, partitionStorage, partitionState, dbName, leaderTerm, replicaAppender, gcDispatcher
@@ -170,18 +194,18 @@ internal class LeaderLogProcessor(
             is ReplicaMessage.TriesAdded -> watchers.notifyApplied(record.msgId, msg.sourceMsgId)
 
             is BlockBoundary -> {
-                pendingBlock = PendingBlock(record.msgId, msg)
+                blockState = Uploading(PendingBlock(record.msgId, msg))
                 // liveIndex now holds exactly this block's txs (by log order); snapshot, upload the files,
                 // append BlockUploaded and roll the index — all inside uploadBlock.
                 driver.uploadBlock(record.msgId, leaderTerm, msg)
-                pendingBlock = null
+                // Straight after the upload, so a demote landing here hands on nothing: the block is done.
+                blockState = Filling(0)
 
                 // the block's covered source position, as the follower does
                 watchers.notifyApplied(record.msgId, msg.latestProcessedMsgId)
 
                 gc.signal()
 
-                blockInProgress = false
                 srcLogProc.blockUploaded()
             }
 
@@ -199,24 +223,32 @@ internal class LeaderLogProcessor(
     // ---- resolution ----
 
     // Cut a block: inject the boundary (in resolution order, so it lands after this block's txs and before
-    // the next block's) and pause resolution until it is read back and uploaded. Reset the row gauge.
+    // the next block's) and pause resolution until it is read back and uploaded.
     private suspend fun cutBlock(latestProcessedMsgId: MessageId) {
         val boundary = BlockBoundary(
             (blockCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, txResolver.resolvedExtToken,
             termId = leaderTerm
         )
         replicaAppender.append(ControlItem(boundary))
-        blockInProgress = true
-        rowsSinceBlock = 0
+        blockState = Cut
     }
 
     // Hand a freshly-resolved tx to the append pump, cutting a block if this tx filled one — which the
     // caller is told about, because a source batch mid-flight has to stop where that happens.
     private suspend fun appendTx(resolvedTx: ResolvedTx): Boolean {
-        rowsSinceBlock += resolvedTx.allTables.sumOf { it.relation.rowCount.toLong() }
+        val rows = when (val state = blockState) {
+            is Filling -> state.rows + resolvedTx.allTables.sumOf { it.relation.rowCount.toLong() }
+            // Only reachable from clauses this term arms in Filling alone, so getting here means the
+            // arm-set and this state have come apart — and the gauge it would feed no longer exists.
+            Cut, is Uploading -> error("[$dbName] tx resolved during a block cut")
+        }
+
         replicaAppender.append(TxItem(resolvedTx, leaderTerm))
 
-        if (rowsSinceBlock < rowsPerBlock) return false
+        if (rows < rowsPerBlock) {
+            blockState = Filling(rows)
+            return false
+        }
 
         cutBlock(txResolver.resolvedSrcMsgId)
         return true
@@ -235,7 +267,7 @@ internal class LeaderLogProcessor(
             }
         }
 
-        if (!blockInProgress) {
+        if (blockState is Filling) {
             with(srcLogProc) { selectWork() }
 
             extSrcProc?.onTask { task ->
@@ -250,66 +282,30 @@ internal class LeaderLogProcessor(
         }
     }
 
-    // Completed by [workFailed] with the cause. Write-once, and the only thing the term learns about the
-    // work it no longer runs.
-    private val termFailure = CompletableDeferred<Throwable>()
-
     /**
-     * End this term, because work it no longer runs has failed with [cause].
+     * Fail everything staged on this term, because it has ended with [cause].
      *
-     * The logging, the watchers and the sweep of everything staged are still the term's, and so is the
-     * distinction they turn on — a supersession is a clean resignation where an append fault is not — so
-     * the cause has to come back here to reach them.
-     */
-    override fun workFailed(cause: Throwable) {
-        termFailure.complete(cause)
-    }
-
-    /**
-     * Wait for this term to end, then fail everything staged on it.
+     * Nothing may be left awaiting the term once it has gone: whatever is staged, paused, or still queued
+     * gets failed here. Each task's own `abandon` picks the failure *kind*, so this is a flat sweep with no
+     * per-caller special-casing.
      *
-     * Cancelling the caller is what ends the term otherwise.
+     * Miss anything and the symptom is a hang, not an error — and for a source-log batch that hang is on
+     * the transport's poll thread (inside `processRecords`), which is also the sole servicer of the
+     * transport's unregister. So it wedges the whole subscription teardown and blows
+     * `DatabaseCatalog.close`'s bound (#5711 / #5817).
      */
-    suspend fun runTerm() {
-        var cause: Throwable? = null
-        try {
-            throw termFailure.await()
-        } catch (_: CancellationException) {
-            // term cancellation
-        } catch (e: LeaderSupersededException) {
-            // superseded by a newer leader — expected, not a query-facing fault; the transport
-            // re-follows on the next rebalance. Don't poison the watchers.
-            LOG.info("[$dbName] ${e.message}")
-            cause = e
-        } catch (t: Throwable) {
-            // A genuine term fault (e.g. an append fault) surfaces to queries as a failed term.
-            // Idempotent — the apply arm may already have notified for its own faults.
-            LOG.error(t) { "[$dbName] leader term failed" }
-            cause = t
-            watchers.notifyError(t)
-        } finally {
-            val pendingCause = cause ?: CancellationException("leader term closed")
+    fun shutdown(cause: Throwable) {
+        txResolver.failPending(cause)
+        srcLogProc.shutdown(cause)
+        extSrcProc?.shutdown(cause)
+        gc.shutdown(cause)
 
-            // Nothing may be left awaiting the term once it has gone: whatever is staged, paused, or
-            // still queued gets failed here. Each task's own `abandon` picks the failure *kind*, so this
-            // is a flat sweep with no per-caller special-casing.
-            //
-            // Miss anything and the symptom is a hang, not an error — and for a source-log batch that
-            // hang is on the transport's poll thread (inside `processRecords`), which is also the sole
-            // servicer of the transport's unregister. So it wedges the whole subscription teardown and
-            // blows DatabaseCatalog.close's bound (#5711 / #5817).
-            txResolver.failPending(pendingCause)
-            srcLogProc.shutdown(pendingCause)
-            extSrcProc?.shutdown(pendingCause)
-            gc.shutdown(pendingCause)
+        replicaAppender.shutdown(cause)
 
-            replicaAppender.shutdown(pendingCause)
-
-            // The partition's reader is suspended on a send here rather than awaiting a task, so a
-            // close is all it needs — as a cancellation, since it is the reader's own coroutine that
-            // sees it and a benign teardown must not poison the watchers.
-            replicaMsgs.close(pendingCause.asCancellation())
-        }
+        // The partition's reader is suspended on a send here rather than awaiting a task, so a close is
+        // all it needs — as a cancellation, since it is the reader's own coroutine that sees it and a
+        // benign teardown must not poison the watchers.
+        replicaMsgs.close(cause.asCancellation())
     }
 
     override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) =

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -6,8 +6,13 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.SelectBuilder
+import kotlinx.coroutines.selects.selectUnbiased
 import kotlinx.coroutines.withContext
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
@@ -33,6 +38,45 @@ private val LOG = LogProcessor::class.logger
 // revoke or a node teardown would leave the database unqueryable until the process restarts.
 internal val Throwable.isShutdownSignal
     get() = this is CancellationException || this is InterruptedException || this is Interrupted
+
+/**
+ * A live role, as the partition's loop sees it.
+ *
+ * The split is between what the role decides and what it doesn't. Which work it will take *right now* is
+ * the role's own — a leader arms fewer clauses mid-block-cut, so nothing interleaves between a boundary
+ * and its upload — where running one unit at a time is the partition's.
+ */
+internal interface Role {
+    /**
+     * Arm the work this role will take right now, each clause yielding that work as a thunk.
+     *
+     * A thunk rather than a description of the work, so what the work *is* never leaves the role.
+     */
+    fun armWork(select: SelectBuilder<suspend () -> Unit>)
+
+    /** Work threw, so this role is finished. Report it however this role reports a failure. */
+    fun workFailed(cause: Throwable)
+}
+
+/**
+ * Run a role's work, one unit at a time, until cancelled or until the role fails.
+ *
+ * A failure returns rather than propagating: it is the role's to report, and for a leader it may be a
+ * clean resignation, which reaching the database scope's handler would turn into a poisoned watcher over
+ * a node that is merely no longer the leader (#5817).
+ */
+internal suspend fun Role.drive() {
+    try {
+        while (true) {
+            val work = selectUnbiased<suspend () -> Unit> { armWork(this) }
+            work()
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        workFailed(e)
+    }
+}
 
 class LogProcessor(
     private val allocator: BufferAllocator,
@@ -65,32 +109,50 @@ class LogProcessor(
     // *committed* role change still happens only at the serialization point.
     //
     // The leader and the follower process different message types, so the only thing a state can offer
-    // without narrowing to its variant is the teardown.
+    // without narrowing to its variant is the teardown: a role is stopped by cancelling its job and freed
+    // by closing its processor, in that order (dev/doc/coroutines.adoc).
     private sealed interface State {
         val proc: AutoCloseable
+        val job: Job
     }
 
-    private class Following(override val proc: FollowerLogProcessor) : State
-    private class Prepared(override val proc: LeaderLogProcessor, val resumeAfterMsgId: MessageId) : State
-    private class Leading(override val proc: LeaderLogProcessor) : State
+    private class Following(override val proc: FollowerLogProcessor, override val job: Job) : State
 
-    private fun openLeader(
-        afterReplicaMsgId: MessageId,
-        termId: Long,
-    ): LeaderLogProcessor =
+    // A built leader, committed or not.
+    private sealed interface Leader : State {
+        override val proc: LeaderLogProcessor
+    }
+
+    private class Prepared(
+        override val proc: LeaderLogProcessor, override val job: Job, val resumeAfterMsgId: MessageId,
+    ) : Leader
+
+    private class Leading(override val proc: LeaderLogProcessor, override val job: Job) : Leader
+
+    private fun openLeader(termId: Long, resumeAfterMsgId: MessageId): Prepared {
         // The leader term owns (and frees) its driver and its ext source.
-        LeaderLogProcessor(
+        val proc = LeaderLogProcessor(
             allocator, base, partitionStorage, crashLogger, partitionState, dbName,
             RealLeaderDriver(partitionStorage, partitionState, blockUploader),
             watchers,
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
             skipTxs, dbCatalog,
-            afterReplicaMsgId,
             leaderTerm = termId,
             flushTimeout = flushTimeout,
-            scope = scope,
             gcDispatcher = gcDispatcher,
         )
+
+        // Reading is the partition's for a leader too — the term's own writes are confirmed by arriving
+        // back here. One job over all three, so a read that fails cancels the term: consume-back is the
+        // only thing that acks a write, so a term outliving its reader hangs whatever is staged on it.
+        val termJob = scope.launch {
+            launch { tailReplica { records -> records.forEach { proc.queueReplicaMessage(it) } } }
+            launch { proc.drive() }
+            proc.runTerm()
+        }
+
+        return Prepared(proc, termJob, resumeAfterMsgId)
+    }
 
     private fun openTransition(termId: Long): TransitionLogProcessor =
         TransitionLogProcessor(
@@ -100,7 +162,20 @@ class LogProcessor(
             termId = termId,
         )
 
-    private fun openFollower(pendingBlock: PendingBlock? = null): FollowerLogProcessor {
+    // Read the partition's replica log into [apply] until cancelled. The reader belongs to the partition
+    // rather than to a role: a follower and a leader consume the same log from the same position, and what
+    // differs between them is only what a record does when it arrives.
+    private suspend fun tailReplica(apply: suspend (List<Log.Record<ReplicaMessage>>) -> Unit) {
+        try {
+            replicaLog.tailAll(watchers.latestReplicaMsgId, apply)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            watchers.notifyError(e); throw e
+        }
+    }
+
+    private fun openFollower(pendingBlock: PendingBlock? = null): Following {
         LOG.info {
             buildString {
                 append("[$dbName] starting follower: ")
@@ -110,16 +185,21 @@ class LogProcessor(
             }
         }
 
-        return FollowerLogProcessor(
-            allocator, partitionStorage.replicaLog, partitionStorage.bufferPool, partitionState, dbName, compactor, watchers,
-            dbCatalog, pendingBlock, scope,
+        val proc = FollowerLogProcessor(
+            allocator, partitionStorage.bufferPool, partitionState, dbName, compactor, watchers,
+            dbCatalog, pendingBlock,
             hasExternalSource = hasExternalSource,
             meterRegistry = base.meterRegistry,
         )
+
+        return Following(proc, scope.launch {
+            launch { tailReplica(proc::queueRecords) }
+            proc.drive()
+        })
     }
 
     @Volatile
-    private var state: State = Following(openFollower())
+    private var state: State = openFollower()
 
     init {
         base.meterRegistry?.let { reg ->
@@ -133,28 +213,31 @@ class LogProcessor(
     override fun launchTransition(partition: Int, termId: Long): Deferred<Unit> {
         // Transport contract: transition only from Following (see SubscriptionListener). A raw cast
         // would surface an out-of-order call as a cryptic ClassCastException; name it instead.
-        val followerProc = (state as? Following)?.proc
-            ?: throw Fault("[$dbName] launchTransition while not following (${state::class.simpleName})", "xtdb/log-prepare-not-following")
+        val following = (state as? Following)
+            ?: throw Fault(
+                "[$dbName] launchTransition while not following (${state::class.simpleName})",
+                "xtdb/log-prepare-not-following"
+            )
 
         // Launched on the database scope (not the caller's): the transition is a child of the db job
         // tree, so the transport joins/cancels this handle while db teardown cancels-and-joins it
         // before close(). See dev/doc/coroutines.adoc and allium/log-processor-lifecycle.allium.
-        return scope.async { runTransition(followerProc, termId) }
+        return scope.async { runTransition(following, termId) }
     }
 
-    private suspend fun runTransition(followerProc: FollowerLogProcessor, termId: Long) {
+    private suspend fun runTransition(following: Following, termId: Long) {
         try {
             // Append a NoOp stamped with the new term as the replay target: the follower catches up to it
-            // before we cut over, and the leader's consume pump tails from it. A plain append now — the
-            // term on read-back is the fence, replacing the transactional producer (#5817).
+            // before we cut over, which is what proves our own claim has been read back. A plain append
+            // now — the term on read-back is the fence, replacing the transactional producer (#5817).
             val replayTarget = replicaLog.appendMessage(ReplicaMessage.NoOp(termId = termId)).msgId
             LOG.debug("[$dbName] transition: awaiting replica catch-up to $replayTarget")
             watchers.awaitReplicaMsg(replayTarget)
             LOG.debug("[$dbName] transition: replica caught up to $replayTarget")
             // Our own claim is now read back, so the follower's max term is the log's — anything above
             // it fences us, and leading would index nothing. Refuse loudly instead (#5817).
-            followerProc.checkTermUnfenced(termId)
-            cutoverToLeader(followerProc, replayTarget, termId)
+            following.proc.checkTermUnfenced(termId)
+            cutoverToLeader(following, termId)
         } catch (e: Throwable) {
             // Cutover already restored a live `state` if it had to; here we only report.
             if (!e.isShutdownSignal) {
@@ -174,17 +257,13 @@ class LogProcessor(
     // is needed. NonCancellable guards only the resource release — the follower's allocator must close
     // cleanly once teardown begins, whatever the cancellation (bounded: the follower's coroutines just
     // unwind). Watermark/pendingBlock stay readable after close (not allocator-backed).
-    private suspend fun cutoverToLeader(
-        followerProc: FollowerLogProcessor,
-        replayTarget: MessageId,
-        termId: Long,
-    ) {
-        val pendingBlock = followerProc.pendingBlock
+    private suspend fun cutoverToLeader(following: Following, termId: Long) {
+        val pendingBlock = following.proc.pendingBlock
         try {
             LOG.debug("[$dbName] transition: closing follower")
             withContext(NonCancellable) {
-                followerProc.cancelAndJoin()
-                followerProc.close()
+                following.job.cancelAndJoin()
+                following.proc.close()
             }
 
             openTransition(termId).use { transition ->
@@ -203,17 +282,20 @@ class LogProcessor(
 
             // Built, not committed: `state` moves to Prepared but no records flow as leader until
             // commitLeader installs it at the serialization point.
-            state = Prepared(openLeader(replayTarget, termId), resumeAfterMsgId)
+            state = openLeader(termId, resumeAfterMsgId)
         } catch (e: Throwable) {
-            state = Following(openFollower(pendingBlock))
+            state = openFollower(pendingBlock)
             throw e
         }
     }
 
     override fun commitLeader(partition: Int): Log.TailSpec<SourceMessage> {
         val prepared = (state as? Prepared)
-            ?: throw Fault("[$dbName] commitLeader without a prepared leader (${state::class.simpleName})", "xtdb/log-commit-not-prepared")
-        state = Leading(prepared.proc)
+            ?: throw Fault(
+                "[$dbName] commitLeader without a prepared leader (${state::class.simpleName})",
+                "xtdb/log-commit-not-prepared"
+            )
+        state = Leading(prepared.proc, prepared.job)
         LOG.info("[$dbName] leader startup complete, resuming after ${prepared.resumeAfterMsgId}")
         return Log.TailSpec(prepared.resumeAfterMsgId, prepared.proc)
     }
@@ -221,22 +303,21 @@ class LogProcessor(
     override suspend fun demoteLeader(partition: Int) {
         // Genuine revoke (Leading) and abandoning an uncommitted leader (Prepared) tear down the
         // same way; an already-following listener is a no-op.
-        val leaderProc = when (val s = state) {
+        val leader = when (val s = state) {
             is Following -> {
                 LOG.debug("[$dbName] demote — already follower, no transition needed")
                 return
             }
 
-            is Prepared -> s.proc
-            is Leading -> s.proc
+            is Leader -> s
         }
 
         LOG.info("[$dbName] demote — tearing down leader, re-opening follower")
         // Cancel first: `pendingBlock` stays readable after the cancel/close — it isn't allocator-backed
         // — so we free the old term before reading it to seed the follower.
-        leaderProc.cancelAndJoin()
-        leaderProc.close()
-        state = Following(openFollower(leaderProc.pendingBlock))
+        leader.job.cancelAndJoin()
+        leader.proc.close()
+        state = openFollower(leader.proc.pendingBlock)
     }
 
     override fun close() = state.proc.close()

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.SelectBuilder
 import kotlinx.coroutines.selects.selectUnbiased
@@ -73,32 +74,70 @@ internal inline fun Watchers.runTaskGuarded(
  *
  * The split is between what the role decides and what it doesn't. Which work it will take *right now* is
  * the role's own — a leader arms fewer clauses mid-block-cut, so nothing interleaves between a boundary
- * and its upload — where running one unit at a time is the partition's.
+ * and its upload — where running one unit at a time, and what a failure means, are the partition's.
  */
 internal interface Role {
     /** Arm the work this role will take right now — one clause per kind, each doing that work when taken. */
     fun SelectBuilder<Unit>.selectWork()
+}
 
-    /** Work threw, so this role is finished. Report it however this role reports a failure. */
-    fun workFailed(cause: Throwable)
+/** Run a role's work, one unit at a time, until cancelled or until a unit of it throws. */
+internal suspend fun Role.drive() {
+    while (true) {
+        selectUnbiased { this.selectWork() }
+    }
 }
 
 /**
- * Run a role's work, one unit at a time, until cancelled or until the role fails.
+ * Run a leader term until it ends, then fail everything staged on it.
  *
- * A failure returns rather than propagating: it is the role's to report, and for a leader it may be a
- * clean resignation, which reaching the database scope's handler would turn into a poisoned watcher over
- * a node that is merely no longer the leader (#5817).
+ * The term's work and its append pump are structured together, so whichever fails first cancels the other
+ * and arrives here as the cause. Cancelling the caller is what ends a term that hasn't failed.
+ *
+ * Which failures reach the watchers is decided here rather than in the term, because the term is not the
+ * thing that knows a resignation from a fault: a supersession means this node is merely no longer the
+ * leader, and poisoning the watchers over it would leave a healthy database unqueryable (#5817).
  */
-internal suspend fun Role.drive() {
+internal suspend fun runLeaderTerm(
+    dbName: DatabaseName, watchers: Watchers, term: LeaderLogProcessor, appender: ReplicaLogAppender,
+) {
+    var cause: Throwable? = null
     try {
-        while (true) {
-            selectUnbiased { this.selectWork() }
+        coroutineScope {
+            launch(CoroutineName("$dbName-append-pump")) { appender.run() }
+            term.drive()
         }
+    } catch (_: CancellationException) {
+        // term cancellation
+    } catch (e: LeaderSupersededException) {
+        // superseded by a newer leader — expected, not a query-facing fault; the transport re-follows on
+        // the next rebalance.
+        LOG.info("[$dbName] ${e.message}")
+        cause = e
+    } catch (t: Throwable) {
+        // A genuine term fault (e.g. an append fault) surfaces to queries as a failed term. Idempotent —
+        // the apply arm may already have notified for its own faults.
+        LOG.error(t) { "[$dbName] leader term failed" }
+        cause = t
+        watchers.notifyError(t)
+    } finally {
+        term.shutdown(cause ?: CancellationException("leader term closed"))
+    }
+}
+
+/**
+ * Run a follower's work until it ends.
+ *
+ * A failure is already logged and on the watchers by the time it arrives — `FollowerLogProcessor` applies
+ * records inside `processRecords`, which reports before it throws — so there is nothing left to decide.
+ */
+internal suspend fun runFollower(follower: FollowerLogProcessor) {
+    try {
+        follower.drive()
     } catch (e: CancellationException) {
         throw e
-    } catch (e: Throwable) {
-        workFailed(e)
+    } catch (_: Throwable) {
+        // already reported
     }
 }
 
@@ -173,11 +212,9 @@ class LogProcessor(
         // only thing that acks a write, so a term outliving its reader hangs whatever is staged on it.
         val termJob = scope.launch {
             launch { tailReplica { records -> records.forEach { proc.queueReplicaMessage(it) } } }
-            launch { proc.drive() }
             launch { proc.gc.runGc() }
             proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
-            launch(CoroutineName("$dbName-append-pump")) { replicaAppender.run(proc::workFailed) }
-            proc.runTerm()
+            runLeaderTerm(dbName, watchers, proc, replicaAppender)
         }
 
         return Prepared(proc, termJob, resumeAfterMsgId)
@@ -224,7 +261,7 @@ class LogProcessor(
 
         return Following(proc, scope.launch {
             launch { tailReplica(proc::queueRecords) }
-            proc.drive()
+            runFollower(proc)
         })
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -98,7 +98,7 @@ private fun SelectBuilder<Unit>.selectLeaderWork(watchers: Watchers, term: Leade
             }
         }
 
-        term.gc.gcCh.onReceive { task ->
+        term.gc.onTask { task ->
             watchers.runTaskGuarded(task.onComplete) { term.gc.handleTask(task) }
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -2,9 +2,12 @@ package xtdb.indexer
 
 import io.micrometer.core.instrument.Gauge
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -16,6 +19,7 @@ import kotlinx.coroutines.selects.selectUnbiased
 import kotlinx.coroutines.withContext
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
+import xtdb.api.TransactionResult
 import xtdb.api.log.*
 import xtdb.compactor.Compactor
 import xtdb.api.DatabaseName
@@ -40,6 +44,31 @@ internal val Throwable.isShutdownSignal
     get() = this is CancellationException || this is InterruptedException || this is Interrupted
 
 /**
+ * Run a resolution task, routing failures onto its completion handle (and any external-source result) so
+ * that no caller hangs. Interrupts are shutdown signals, not ingestion faults, so they don't poison the
+ * watchers. A successful source batch completes its own handle, possibly deferred if a block cut paused it.
+ */
+internal inline fun Watchers.runTaskGuarded(
+    onComplete: CompletableDeferred<Unit>,
+    extResult: CompletableDeferred<TransactionResult>? = null,
+    block: () -> Unit,
+) {
+    try {
+        block()
+    } catch (e: CancellationException) {
+        if (!onComplete.isCompleted) onComplete.cancel(e)
+        throw e
+    } catch (e: Throwable) {
+        if (!e.isShutdownSignal) {
+            notifyError(e)
+            extResult?.let { if (!it.isCompleted) it.completeExceptionally(e) }
+        }
+        if (!onComplete.isCompleted) onComplete.completeExceptionally(e)
+        throw e
+    }
+}
+
+/**
  * A live role, as the partition's loop sees it.
  *
  * The split is between what the role decides and what it doesn't. Which work it will take *right now* is
@@ -47,12 +76,8 @@ internal val Throwable.isShutdownSignal
  * and its upload — where running one unit at a time is the partition's.
  */
 internal interface Role {
-    /**
-     * Arm the work this role will take right now, each clause yielding that work as a thunk.
-     *
-     * A thunk rather than a description of the work, so what the work *is* never leaves the role.
-     */
-    fun armWork(select: SelectBuilder<suspend () -> Unit>)
+    /** Arm the work this role will take right now — one clause per kind, each doing that work when taken. */
+    fun SelectBuilder<Unit>.selectWork()
 
     /** Work threw, so this role is finished. Report it however this role reports a failure. */
     fun workFailed(cause: Throwable)
@@ -68,8 +93,7 @@ internal interface Role {
 internal suspend fun Role.drive() {
     try {
         while (true) {
-            val work = selectUnbiased<suspend () -> Unit> { armWork(this) }
-            work()
+            selectUnbiased { this.selectWork() }
         }
     } catch (e: CancellationException) {
         throw e
@@ -131,10 +155,12 @@ class LogProcessor(
 
     private fun openLeader(termId: Long, resumeAfterMsgId: MessageId): Prepared {
         // The leader term owns (and frees) its driver and its ext source.
+        val driver = RealLeaderDriver(partitionStorage, partitionState, blockUploader)
+        val replicaAppender = ReplicaLogAppender(driver)
+
         val proc = LeaderLogProcessor(
-            allocator, base, partitionStorage, crashLogger, partitionState, dbName,
-            RealLeaderDriver(partitionStorage, partitionState, blockUploader),
-            watchers,
+            allocator, base, partitionStorage, crashLogger, partitionState, dbName, driver, watchers,
+            replicaAppender,
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
             skipTxs, dbCatalog,
             leaderTerm = termId,
@@ -143,16 +169,20 @@ class LogProcessor(
         )
 
         // Reading is the partition's for a leader too — the term's own writes are confirmed by arriving
-        // back here. One job over all three, so a read that fails cancels the term: consume-back is the
+        // back here. One job over all of them, so a read that fails cancels the term: consume-back is the
         // only thing that acks a write, so a term outliving its reader hangs whatever is staged on it.
         val termJob = scope.launch {
             launch { tailReplica { records -> records.forEach { proc.queueReplicaMessage(it) } } }
             launch { proc.drive() }
+            launch { proc.gc.runGc() }
+            proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
+            launch(CoroutineName("$dbName-append-pump")) { replicaAppender.run(proc::workFailed) }
             proc.runTerm()
         }
 
         return Prepared(proc, termJob, resumeAfterMsgId)
     }
+
 
     private fun openTransition(termId: Long): TransitionLogProcessor =
         TransitionLogProcessor(
@@ -327,9 +357,5 @@ class LogProcessor(
      * both. No-op unless leading — GC only runs on the leader. Bypasses the collectors'
      * `enabled` flag (which gates the auto-signal from the block-boundary path, not direct calls).
      */
-    fun gcAll() {
-        val proc = (state as? Leading)?.proc ?: return
-        proc.blockGc.awaitNoGarbageBlocking()
-        proc.trieGc.awaitNoGarbageBlocking()
-    }
+    fun awaitNoGarbageBlocking() = (state as? Leading)?.proc?.gc?.awaitNoGarbageBlocking()
 }

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -70,21 +70,37 @@ internal inline fun Watchers.runTaskGuarded(
 }
 
 /**
- * A live role, as the partition's loop sees it.
+ * Arm the work a leader term will take right now.
  *
- * The split is between what the role decides and what it doesn't. Which work it will take *right now* is
- * the role's own — a leader arms fewer clauses mid-block-cut, so nothing interleaves between a boundary
- * and its upload — where running one unit at a time, and what a failure means, are the partition's.
+ * Consume-back stays armed throughout: it is the only thing that acks a write, so a term that stopped
+ * applying while a block cut was in flight would never see the boundary land. Resolution is the part that
+ * pauses, which [LeaderLogProcessor.acceptingResolution] answers for.
  */
-internal interface Role {
-    /** Arm the work this role will take right now — one clause per kind, each doing that work when taken. */
-    fun SelectBuilder<Unit>.selectWork()
-}
+private fun SelectBuilder<Unit>.selectLeaderWork(watchers: Watchers, term: LeaderLogProcessor) {
+    // supersession fails the term, not the database — rationale on the outer ladder
+    term.onReplicaMsg { record ->
+        try {
+            term.applyRecord(record)
+        } catch (e: Throwable) {
+            if (!e.isShutdownSignal && e !is LeaderSupersededException) watchers.notifyError(e)
+            throw e
+        }
+    }
 
-/** Run a role's work, one unit at a time, until cancelled or until a unit of it throws. */
-internal suspend fun Role.drive() {
-    while (true) {
-        selectUnbiased { this.selectWork() }
+    if (term.acceptingResolution) {
+        with(term.srcLogProc) { selectWork() }
+
+        term.extSrcProc?.let { extSrcProc ->
+            extSrcProc.onTask { task ->
+                watchers.runTaskGuarded(task.onComplete, extResult = task.msg.pending) {
+                    extSrcProc.handleTask(task)
+                }
+            }
+        }
+
+        term.gc.gcCh.onReceive { task ->
+            watchers.runTaskGuarded(task.onComplete) { term.gc.handleTask(task) }
+        }
     }
 }
 
@@ -105,7 +121,7 @@ internal suspend fun runLeaderTerm(
     try {
         coroutineScope {
             launch(CoroutineName("$dbName-append-pump")) { appender.run() }
-            term.drive()
+            while (true) selectUnbiased { selectLeaderWork(watchers, term) }
         }
     } catch (_: CancellationException) {
         // term cancellation
@@ -133,7 +149,7 @@ internal suspend fun runLeaderTerm(
  */
 internal suspend fun runFollower(follower: FollowerLogProcessor) {
     try {
-        follower.drive()
+        while (true) selectUnbiased { with(follower) { selectWork() } }
     } catch (e: CancellationException) {
         throw e
     } catch (_: Throwable) {
@@ -158,8 +174,6 @@ class LogProcessor(
     private val flushTimeout: Duration,
     private val gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Log.SubscriptionListener<SourceMessage>, AutoCloseable {
-
-    interface Processor<M> : Log.RecordProcessor<M>, AutoCloseable
 
     private val replicaLog = partitionStorage.replicaLog
     private val hasExternalSource = externalSourceFactory != null
@@ -364,7 +378,7 @@ class LogProcessor(
             )
         state = Leading(prepared.proc, prepared.job)
         LOG.info("[$dbName] leader startup complete, resuming after ${prepared.resumeAfterMsgId}")
-        return Log.TailSpec(prepared.resumeAfterMsgId, prepared.proc)
+        return Log.TailSpec(prepared.resumeAfterMsgId, prepared.proc.srcLogProc)
     }
 
     override suspend fun demoteLeader(partition: Int) {

--- a/core/src/main/kotlin/xtdb/indexer/ReplicaLogAppender.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ReplicaLogAppender.kt
@@ -1,0 +1,69 @@
+package xtdb.indexer
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import xtdb.api.log.ReplicaMessage
+
+/**
+ * One item queued for append to the replica log.
+ *
+ * The term is stamped where the item is made, because it is the *resolving* term's claim over the record
+ * rather than a property of whoever drains the queue. Serialization is what stays deferred: [TxItem]
+ * renders its relations to Arrow IPC when appended, which is why the queue carries items and not messages.
+ */
+internal sealed interface AppendItem {
+    fun toReplicaMessage(): ReplicaMessage
+}
+
+/** A resolved tx, borrowed — the resolver owns its relations and frees them. */
+internal class TxItem(private val resolvedTx: ResolvedTx, private val termId: Long) : AppendItem {
+    override fun toReplicaMessage() = resolvedTx.toReplicaMessage(termId)
+}
+
+internal class ControlItem(private val message: ReplicaMessage) : AppendItem {
+    override fun toReplicaMessage() = message
+}
+
+/**
+ * The replica log's write end for one leader term: everything the term resolves is queued here and appended
+ * in that order.
+ *
+ * Appending is its own coroutine so that the serialization and the log round-trip stay off the term's work
+ * loop — which is what releases the transport's poll thread at "resolved" rather than at "durable" (#5741).
+ */
+internal class ReplicaLogAppender(private val driver: LeaderDriver) {
+
+    // Unbounded: the term queues here from the same coroutine that services its consume-back, so a bounded
+    // channel could block that send — and consume-back is what makes the progress the send would be
+    // waiting on. Backpressure comes from the block-cut pause and the term's row gauge.
+    private val queue = Channel<AppendItem>(Channel.UNLIMITED)
+
+    suspend fun append(item: AppendItem) = queue.send(item)
+
+    /**
+     * Append until the queue is shut down.
+     *
+     * Plain, non-transactional appends: the sole fence on a zombie leader is the term its records carry,
+     * checked when it reads them back — a higher term means it has been superseded, and it resigns (#5817).
+     *
+     * A fault goes to [termFailed] rather than up, because it has to reach the term's own sweep as the
+     * cause: whatever is staged should fail with the append fault and not a bare cancellation.
+     */
+    suspend fun run(termFailed: (Throwable) -> Unit) {
+        try {
+            for (item in queue) driver.appendToReplica(item.toReplicaMessage())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            termFailed(e)
+        }
+    }
+
+    /**
+     * Stop appending, which is what keeps a resigned term from writing on.
+     *
+     * A close rather than a cancel, so an append already in flight lands rather than tearing. Whatever is
+     * still queued is dropped: its `ResolvedTx` is borrowed, and the resolver frees it.
+     */
+    fun shutdown(cause: Throwable) = queue.close(cause.asCancellation())
+}

--- a/core/src/main/kotlin/xtdb/indexer/ReplicaLogAppender.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ReplicaLogAppender.kt
@@ -45,18 +45,9 @@ internal class ReplicaLogAppender(private val driver: LeaderDriver) {
      *
      * Plain, non-transactional appends: the sole fence on a zombie leader is the term its records carry,
      * checked when it reads them back — a higher term means it has been superseded, and it resigns (#5817).
-     *
-     * A fault goes to [termFailed] rather than up, because it has to reach the term's own sweep as the
-     * cause: whatever is staged should fail with the append fault and not a bare cancellation.
      */
-    suspend fun run(termFailed: (Throwable) -> Unit) {
-        try {
-            for (item in queue) driver.appendToReplica(item.toReplicaMessage())
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            termFailed(e)
-        }
+    suspend fun run() {
+        for (item in queue) driver.appendToReplica(item.toReplicaMessage())
     }
 
     /**

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -1,0 +1,227 @@
+package xtdb.indexer
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.SelectBuilder
+import xtdb.api.DatabaseName
+import xtdb.api.error.Anomaly
+import xtdb.api.log.DbOp
+import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.ReplicaMessage.TriesAdded
+import xtdb.api.log.SourceMessage
+import xtdb.api.log.Watchers
+import xtdb.api.storage.Storage
+import xtdb.database.Database
+import xtdb.database.PartitionState
+import xtdb.database.PartitionStorage
+import xtdb.table.fromSchemaAndTable
+import xtdb.types.MessageId
+import xtdb.util.debug
+import xtdb.util.logger
+import xtdb.util.trace
+import java.time.Duration
+
+private val LOG = SourceLogProcessor::class.logger
+
+/**
+ * The source log's side of a leader term: the flush timer, the batches the transport hands over, and what
+ * each record in one resolves to.
+ *
+ * A batch is processed a record at a time and stops where a record cuts a block, because nothing may
+ * interleave between a boundary and its upload. Both [appendTx] and [cutBlock] report a cut back, so the
+ * pause is this processor's own state rather than a read of the term's.
+ */
+internal class SourceLogProcessor(
+    private val driver: LeaderDriver,
+    private val txResolver: TxResolver,
+    partitionStorage: PartitionStorage,
+    partitionState: PartitionState,
+    private val watchers: Watchers,
+    private val dbCatalog: Database.Catalog?,
+    private val dbName: DatabaseName,
+    private val leaderTerm: Long,
+    private val replicaAppender: ReplicaLogAppender,
+    flushTimeout: Duration,
+
+    /** Stage a resolved tx for append, answering whether it filled the block. */
+    private val appendTx: suspend (ResolvedTx) -> Boolean,
+
+    /** Inject a block boundary covering the source log up to [MessageId], pausing resolution behind it. */
+    private val cutBlock: suspend (MessageId) -> Unit,
+) {
+
+    private val bufferPool = partitionStorage.bufferPool
+    private val blockCatalog = partitionState.blockCatalog
+    private val trieCatalog = partitionState.trieCatalog
+
+    private val blockFlusher = BlockFlusher(flushTimeout, blockCatalog)
+
+    // A source batch paused mid-way by a block cut: the task, and where to pick it up again. At most one —
+    // the poll thread awaits each batch before sending the next, so only one is ever in flight; a nullable
+    // field makes that structural. Holds the *task*, so its failure policy stays the task's own.
+    private class PausedBatch(val task: SourceBatch, val nextIdx: Int)
+
+    private var pausedBatch: PausedBatch? = null
+
+    // Poked when a stashed [pausedBatch] becomes resumable. Conflated: at most one resume is pending, and
+    // the select clause is gated on `pausedBatch != null` (and, by the term, on the block having landed).
+    private val resumeCh = Channel<Unit>(Channel.CONFLATED)
+
+    /** The block a cut was waiting on has landed, so anything stashed behind it may run on. */
+    fun blockUploaded() {
+        resumeCh.trySend(Unit)
+    }
+
+    // Resolve one source-log record, answering whether it cut a block.
+    private suspend fun handleRecord(record: Log.Record<SourceMessage>): Boolean {
+        val msgId = record.msgId
+        val msg = record.message
+        LOG.trace { "[$dbName] leader: message $msgId (${msg::class.simpleName})" }
+
+        return when (msg) {
+            is SourceMessage.Tx -> appendTx(txResolver.indexTx(msgId, record.logTimestamp, msg))
+
+            is SourceMessage.LegacyTx -> appendTx(txResolver.indexTx(msgId, record.logTimestamp, msg))
+
+            is SourceMessage.FlushBlock -> {
+                val expectedBlockIdx = msg.expectedBlockIdx
+                val cut = expectedBlockIdx != null && expectedBlockIdx == (blockCatalog.currentBlockIndex ?: -1L)
+
+                if (cut) cutBlock(msgId)
+                // see #5680
+                else replicaAppender.append(ControlItem(ReplicaMessage.NoOp(srcMsgId = msgId, termId = leaderTerm)))
+
+                txResolver.advanceSrcMsgId(msgId)
+                cut
+            }
+
+            is SourceMessage.AttachDatabase -> {
+                val error = if (dbCatalog != null) {
+                    try {
+                        dbCatalog.attach(msg.dbName, msg.config)
+                        null
+                    } catch (e: Anomaly.Caller) {
+                        LOG.debug(e) { "[$dbName] leader: attach database '${msg.dbName}' failed at $msgId" }
+                        e
+                    }
+                } else null
+
+                appendTx(
+                    if (error == null)
+                        txResolver.indexDbOp(msgId, record.logTimestamp, DbOp.Attach(msg.dbName, msg.config))
+                    else
+                        txResolver.indexFailedDbOp(msgId, record.logTimestamp, error)
+                )
+            }
+
+            is SourceMessage.DetachDatabase -> {
+                val error = if (dbCatalog != null) {
+                    try {
+                        dbCatalog.detach(msg.dbName)
+                        null
+                    } catch (e: Anomaly.Caller) {
+                        LOG.debug(e) { "[$dbName] leader: detach database '${msg.dbName}' failed at $msgId" }
+                        e
+                    }
+                } else null
+
+                appendTx(
+                    if (error == null)
+                        txResolver.indexDbOp(msgId, record.logTimestamp, DbOp.Detach(msg.dbName))
+                    else
+                        txResolver.indexFailedDbOp(msgId, record.logTimestamp, error)
+                )
+            }
+
+            is SourceMessage.TriesAdded -> {
+                // Mutate the local trie catalog here (as the leader did pre-rewrite), then replicate for
+                // followers. Eager on the resolve side, not deferred to our own consume-back, because:
+                //  - callers see the effect promptly (the compactor/GC read the catalog synchronously);
+                //  - it stays a projection of the fenced log anyway — the block-cut pause serialises trie
+                //    mutations against boundaries, so no block snapshot straddles this add.
+                // We skip re-applying it on our own consume-back (see applyRecord); the follower applies it.
+                if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
+                    msg.tries.groupBy { it.tableName }.forEach { (tableName, tries) ->
+                        trieCatalog.addTries(fromSchemaAndTable(tableName), tries, record.logTimestamp)
+                    }
+
+                replicaAppender.append(
+                    ControlItem(
+                        TriesAdded(
+                            msg.storageVersion, msg.storageEpoch, msg.tries,
+                            sourceMsgId = msgId, termId = leaderTerm
+                        )
+                    )
+                )
+                txResolver.advanceSrcMsgId(msgId)
+                false
+            }
+
+            // TODO this one's going after 2.2
+            is SourceMessage.BlockUploaded -> {
+                watchers.notifyApplied(null, msgId)
+                // Keep the resolve-side watermark in step with the one we just advanced, or a following
+                // block cut would carry a lower latestProcessedMsgId and regress it on apply.
+                txResolver.advanceSrcMsgId(msgId)
+                false
+            }
+        }
+    }
+
+    // Process a batch from `startIdx`, stopping where a record cuts a block — stashing the remainder on
+    // [pausedBatch] so the loop resumes it after the upload. Completes the task only when fully drained.
+    private suspend fun runBatch(task: SourceBatch, startIdx: Int) {
+        var i = startIdx
+        while (i < task.records.size) {
+            val cutBlock = handleRecord(task.records[i])
+            i++
+            if (cutBlock) {
+                pausedBatch = PausedBatch(task, i)
+                return
+            }
+        }
+        task.onComplete.complete(Unit)
+    }
+
+    /** Arm this processor's clauses. The term arms them only while no block cut is in progress. */
+    fun SelectBuilder<Unit>.selectWork() {
+        if (pausedBatch != null) resumeCh.onReceive {
+            val pb = pausedBatch ?: return@onReceive
+            pausedBatch = null
+            watchers.runTaskGuarded(pb.task.onComplete) { runBatch(pb.task, pb.nextIdx) }
+        }
+
+        driver.sourceBatches.onBatch { batch ->
+            watchers.runTaskGuarded(batch.onComplete) { runBatch(batch, 0) }
+        }
+    }
+
+    private suspend fun maybeFlushBlock() {
+        if (blockFlusher.checkBlockTimeout(blockCatalog))
+            driver.requestFlushBlock(blockCatalog.currentBlockIndex ?: -1)
+    }
+
+    /** The transport's edge: hand a poll batch over and await its resolution. */
+    suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+        maybeFlushBlock()
+
+        // Await the batch through the persister rather than firing and returning:
+        //  - the persister resolves + hands off to the append pump on its own thread (heavy work off the
+        //    poll thread);
+        //  - blocking here until the batch is resolved keeps the poll loop and the persister roughly in
+        //    step (channel cap 1 → ~2 batches of lookahead);
+        //  - so a rebalance/transition under runBlocking doesn't pile up behind unbounded resolution (#5741).
+        if (records.isNotEmpty()) driver.sourceBatches.submit(records).await()
+    }
+
+    /**
+     * Fail everyone still waiting on the source log: whatever a block cut stashed, and the pipe itself.
+     *
+     * The pipe's own shutdown owns the must-be-a-cancellation rule ([SourceBatch.abandon]), because the
+     * transport's poll thread both awaits and sends there.
+     */
+    fun shutdown(cause: Throwable) {
+        pausedBatch?.task?.abandon(cause)
+        driver.sourceBatches.shutdown(cause)
+    }
+}

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -48,7 +48,7 @@ internal class SourceLogProcessor(
 
     /** Inject a block boundary covering the source log up to [MessageId], pausing resolution behind it. */
     private val cutBlock: suspend (MessageId) -> Unit,
-) {
+) : Log.RecordProcessor<SourceMessage> {
 
     private val bufferPool = partitionStorage.bufferPool
     private val blockCatalog = partitionState.blockCatalog
@@ -202,7 +202,7 @@ internal class SourceLogProcessor(
     }
 
     /** The transport's edge: hand a poll batch over and await its resolution. */
-    suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
+    override suspend fun processRecords(records: List<Log.Record<SourceMessage>>) {
         maybeFlushBlock()
 
         // Await the batch through the persister rather than firing and returning:

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -67,7 +67,6 @@ internal class SourceLogProcessor(
     // the select clause is gated on `pausedBatch != null` (and, by the term, on the block having landed).
     private val resumeCh = Channel<Unit>(Channel.CONFLATED)
 
-    /** The block a cut was waiting on has landed, so anything stashed behind it may run on. */
     fun blockUploaded() {
         resumeCh.trySend(Unit)
     }

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -32,7 +32,7 @@ class TransitionLogProcessor(
     private val dbCatalog: Database.Catalog?,
     private val hasExternalSource: Boolean,
     private val termId: Long = 0,
-) : LogProcessor.Processor<ReplicaMessage> {
+) : AutoCloseable {
 
     private val blockCatalog = partitionState.blockCatalog
     private val trieCatalog = partitionState.trieCatalog
@@ -127,7 +127,7 @@ class TransitionLogProcessor(
         }
     }
 
-    override suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
+    suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
         LOG.debug("[$dbName] transition: processing ${records.size} records")
 
         for (record in records) {

--- a/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
@@ -77,9 +77,15 @@ internal class ExtSourceMessage(
  * Everything still queued is a read-your-writes predecessor for the next tx to resolve, which is why the
  * queue and resolution sit together: a tx resolving now must see every predecessor not yet applied.
  *
- * Two heads: [latestCompletedTx] here is the RESOLVED head (it drives resolution — the next external-source
- * tx-id and system-time smoothing), and it leads [LiveIndex.latestCompletedTx] (the durable/query basis) by
- * everything queued but not yet applied.
+ * ## The resolve-side watermarks
+ *
+ * [latestCompletedTx], [resolvedSrcMsgId] and [resolvedExtToken] are `Watchers`' triple as of the
+ * last-resolved tx. They lead the watchers' own — which advance on apply — by everything queued but not yet
+ * applied, so resolution reads them and not the watchers: the next external-source tx-id and its system-time
+ * smoothing come off [latestCompletedTx], and a block boundary cut on the resolve side carries
+ * [resolvedSrcMsgId] and [resolvedExtToken]. Stamping a boundary or an ext-source record from the watchers
+ * instead would let a tx resolved ahead of it apply first and push the watermark past the stamp, tripping
+ * `notifyApplied`'s monotonicity check (#5817).
  */
 internal class TxResolver(
     allocator: BufferAllocator,
@@ -89,6 +95,8 @@ internal class TxResolver(
     private val dbName: DatabaseName,
     crashLogger: CrashLogger,
     private val skipTxs: Set<MessageId>,
+    resolvedSrcMsgId: MessageId,
+    resolvedExtToken: ExternalSourceToken?,
     private val instantSource: InstantSource,
 ) : AutoCloseable {
 
@@ -104,6 +112,20 @@ internal class TxResolver(
 
     var latestCompletedTx: TransactionKey? = partitionState.liveIndex.latestCompletedTx
         private set
+
+    var resolvedSrcMsgId: MessageId = resolvedSrcMsgId
+        private set
+
+    var resolvedExtToken: ExternalSourceToken? = resolvedExtToken
+        private set
+
+    /**
+     * Move the source watermark on for a source message that resolves to something other than a tx — a block
+     * boundary, a trie add, a no-op — so the next boundary cut carries a position that covers it.
+     */
+    fun advanceSrcMsgId(srcMsgId: MessageId) {
+        this.resolvedSrcMsgId = srcMsgId
+    }
 
     private val queue = ArrayDeque<ResolvedTx>()
 
@@ -121,14 +143,20 @@ internal class TxResolver(
 
     /**
      * Take ownership of [openTx]'s written tables (a reference move — see `OpenTx.sealTables`), enqueue them,
-     * and advance the resolved head. The caller closes the (now table-less) [openTx].
+     * and advance every resolve-side watermark this tx implies. The caller closes the (now table-less)
+     * [openTx].
      */
     private fun stage(
         openTx: OpenTx, srcMsgId: MessageId, txResult: TransactionResult,
         dbOp: DbOp?, pending: CompletableDeferred<TransactionResult>?,
     ): ResolvedTx =
         ResolvedTx.stage(openTx, srcMsgId, txResult, dbOp, pending)
-            .also { queue.addLast(it); latestCompletedTx = openTx.txKey }
+            .also {
+                queue.addLast(it)
+                latestCompletedTx = openTx.txKey
+                resolvedSrcMsgId = srcMsgId
+                openTx.externalSourceToken?.let { token -> resolvedExtToken = token }
+            }
 
     private fun openTx(txKey: TransactionKey, externalSourceToken: ExternalSourceToken?) =
         OpenTx(allocator, nodeBase, partitionStorage, partitionState, dbName, txKey, externalSourceToken, tracer, resolvedTxs)
@@ -286,12 +314,12 @@ internal class TxResolver(
     /**
      * Run an external source's writer and stage the tx it produces.
      *
-     * [srcMsgId] is the source-log watermark to stamp on the replicated record. Ext-source txs carry no
-     * source-log position of their own — they track progress via `externalSourceToken` — but without the
-     * stamp a follower's `latestSourceMsgId` lags between block boundaries, and on promotion it resumes the
-     * source log from a stale point and replays an already-covered block boundary.
+     * The staged tx carries [resolvedSrcMsgId] unchanged. An ext-source tx has no source-log position of its
+     * own — it tracks progress via `externalSourceToken` — but stamping the replicated record with the
+     * current one anyway keeps a follower's `latestSourceMsgId` up to date between block boundaries, so on
+     * promotion it resumes the source log where the leader was rather than replaying a covered boundary.
      */
-    suspend fun indexTx(msg: ExtSourceMessage, srcMsgId: MessageId): ResolvedTx {
+    suspend fun indexTx(msg: ExtSourceMessage): ResolvedTx {
         val txKey = TransactionKey(
             (latestCompletedTx?.txId ?: -1) + 1,
             smoothSystemTime(msg.systemTime ?: instantSource.instant())
@@ -319,7 +347,7 @@ internal class TxResolver(
                     }
                 }
 
-                stage(openTx, srcMsgId, txResult, dbOp = null, pending = msg.pending)
+                stage(openTx, resolvedSrcMsgId, txResult, dbOp = null, pending = msg.pending)
             } catch (e: Throwable) {
                 // Writer, writeTxRow, or stage threw before the tx reached the queue, so nothing will ever
                 // settle it — complete the handle here, or a caller awaiting it hangs until the term closes.

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -125,7 +125,6 @@ class NodeSimulationTest : SimulationTestBase() {
             val compactorForDb = compactor.openForDatabase(compactorScope, allocator, partitionStorage, partitionState, Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1))
             val gcScope = CoroutineScope(dispatcher)
             val garbageCollector = TrieGarbageCollector(
-                gcScope,
                 sharedBufferPool, partitionState, "xtdb",
                 commitTriesDeleted = { tableName, trieKeys ->
                     // No replica log in the mock — apply the catalog mutation directly so the
@@ -136,7 +135,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 garbageLifetime = garbageLifetime,
                 enabled = false,
                 dispatcher = dispatcher,
-            )
+            ).also { gcScope.launch { it.run() } }
             MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector, gcScope, compactorScope)
         }
     }

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -35,6 +35,7 @@ import xtdb.indexer.LeaderDriver
 import xtdb.indexer.LeaderLogProcessor
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.RealLeaderDriver
+import xtdb.indexer.ReplicaLogAppender
 import xtdb.indexer.drive
 import xtdb.storage.MemoryStorage
 import xtdb.tx.TxOpts
@@ -127,10 +128,11 @@ class ExternalSourceTest {
         )
 
         val crashLogger = mockk<CrashLogger>(relaxed = true)
+        val replicaAppender = ReplicaLogAppender(driver)
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, crashLogger,
-            partitionState, "test", driver, watchers, extSource,
+            partitionState, "test", driver, watchers, replicaAppender, extSource,
             skipTxs = emptySet(), dbCatalog = null,
             flushTimeout = IndexerConfig().flushDuration,
         ).also { proc ->
@@ -142,6 +144,9 @@ class ExternalSourceTest {
                     }
                 }
                 launch { proc.drive() }
+                launch { proc.gc.runGc() }
+                proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
+                launch { replicaAppender.run(proc::workFailed) }
                 proc.runTerm()
             }
         }

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -35,6 +35,7 @@ import xtdb.indexer.LeaderDriver
 import xtdb.indexer.LeaderLogProcessor
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.RealLeaderDriver
+import xtdb.indexer.drive
 import xtdb.storage.MemoryStorage
 import xtdb.tx.TxOpts
 import xtdb.util.closeAll
@@ -131,10 +132,19 @@ class ExternalSourceTest {
             allocator, nodeBase, partitionStorage, crashLogger,
             partitionState, "test", driver, watchers, extSource,
             skipTxs = emptySet(), dbCatalog = null,
-            afterReplicaMsgId = -1,
             flushTimeout = IndexerConfig().flushDuration,
-            scope = backgroundScope
-        ).also(leadersToClose::add)
+        ).also { proc ->
+            leadersToClose += proc
+            backgroundScope.launch {
+                launch {
+                    partitionStorage.replicaLog.tailAll(-1) { records ->
+                        records.forEach { proc.queueReplicaMessage(it) }
+                    }
+                }
+                launch { proc.drive() }
+                proc.runTerm()
+            }
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -210,7 +210,7 @@ class ExternalSourceTest {
 
         val now = Instant.now()
 
-        lp.processRecords(
+        lp.srcLogProc.processRecords(
             listOf(
                 Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
             )

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -36,7 +36,7 @@ import xtdb.indexer.LeaderLogProcessor
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.RealLeaderDriver
 import xtdb.indexer.ReplicaLogAppender
-import xtdb.indexer.drive
+import xtdb.indexer.runLeaderTerm
 import xtdb.storage.MemoryStorage
 import xtdb.tx.TxOpts
 import xtdb.util.closeAll
@@ -143,11 +143,9 @@ class ExternalSourceTest {
                         records.forEach { proc.queueReplicaMessage(it) }
                     }
                 }
-                launch { proc.drive() }
                 launch { proc.gc.runGc() }
                 proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
-                launch { replicaAppender.run(proc::workFailed) }
-                proc.runTerm()
+                runLeaderTerm("test", watchers, proc, replicaAppender)
             }
         }
     }

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -3,11 +3,9 @@ package xtdb.indexer
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.*
-import kotlinx.coroutines.awaitCancellation
 import org.apache.arrow.memory.RootAllocator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -16,7 +14,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import xtdb.api.log.Log
-import xtdb.api.log.PartitionLog
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
@@ -45,7 +42,6 @@ class FollowerLogProcessorTest {
     private lateinit var tableCatalog: TableCatalog
     private lateinit var trieCatalog: TrieCatalog
     private lateinit var partitionState: PartitionState
-    private lateinit var replicaLog: Log<ReplicaMessage>
 
     // runTest cancels and joins backgroundScope before tearDown, so the followers are quiescent here
     // and freed before `allocator` closes.
@@ -63,11 +59,6 @@ class FollowerLogProcessorTest {
         partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
 
-        // The processor self-launches its replica tail; park it so it idles while the test drives
-        // processRecords directly — a relaxed mock would return immediately and tear the proc down.
-        replicaLog = mockk(relaxed = true)
-        coEvery { replicaLog.tailAll(any(), any(), any()) } coAnswers { awaitCancellation() }
-
         every { bufferPool.epoch } returns 1
     }
 
@@ -77,14 +68,14 @@ class FollowerLogProcessorTest {
         allocator.close()
     }
 
-    private fun TestScope.makeProcessor(
+    private fun makeProcessor(
         maxBufferedRecords: Int = 1024,
         hasExternalSource: Boolean = false,
         meterRegistry: MeterRegistry? = null,
     ) =
         FollowerLogProcessor(
-            allocator, PartitionLog(replicaLog, 0), bufferPool, partitionState, "test", compactor,
-            watchers, null, null, backgroundScope,
+            allocator, bufferPool, partitionState, "test", compactor,
+            watchers, null, null,
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,
             maxBufferedRecords = maxBufferedRecords,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -110,21 +110,27 @@ class LeaderDriverSimTest : SimulationTestBase() {
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
 
-        val proc = LeaderLogProcessor(
-            allocator, nodeBase, partitionStorage, CrashLogger(allocator, bufferPool, "sim-$name"),
-            partitionState, "test-db",
-            wrapDriver(
-                RecordingDriver(
-                    RealLeaderDriver(
-                        partitionStorage, partitionState,
-                        BlockUploader(
-                            partitionStorage, partitionState, "xtdb", mockk<Compactor.ForDatabase>(relaxed = true),
-                            null, null, scope, uploadDispatcher = dispatcher
-                        )
+        private val driver = wrapDriver(
+            RecordingDriver(
+                RealLeaderDriver(
+                    partitionStorage, partitionState,
+                    BlockUploader(
+                        partitionStorage, partitionState, "xtdb", mockk<Compactor.ForDatabase>(relaxed = true),
+                        null, null, scope, uploadDispatcher = dispatcher
                     )
                 )
-            ),
-            watchers, extSource = null, skipTxs = emptySet(), dbCatalog = null,
+            )
+        )
+
+        private val replicaAppender = ReplicaLogAppender(driver)
+
+        val proc = LeaderLogProcessor(
+            allocator, nodeBase, partitionStorage, CrashLogger(allocator, bufferPool, "sim-$name"),
+            partitionState, "test-db", driver, watchers, replicaAppender,
+            // The sim submits through the processor rather than driving an adapter, so the source only has
+            // to exist for the processor to.
+            extSource = mockk(relaxed = true),
+            skipTxs = emptySet(), dbCatalog = null,
             // Never left at the default: two leaders sharing term 0 would each read the other's records
             // back as its own, and the term is exactly what tells them apart.
             leaderTerm = termId,
@@ -142,13 +148,16 @@ class LeaderDriverSimTest : SimulationTestBase() {
                     }
                 }
                 launch { proc.drive() }
+                launch { proc.gc.runGc() }
+                proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
+                launch { replicaAppender.run(proc::workFailed) }
                 proc.runTerm()
             }
         }
 
         /** Fire-and-forget: the returned handle completes only once the tx is durably replicated. */
         suspend fun submitRows(rows: List<UUID>): Deferred<TransactionResult> =
-            proc.submitTx(null) { openTx ->
+            proc.extSrcProc!!.submitTx(null) { openTx ->
                 val table = openTx.table(docsTable)
                 for (id in rows) table.writePut(mapOf("_id" to id, "tx_id" to openTx.txKey.txId))
                 TxResult.Committed()

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -4,6 +4,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.apache.arrow.memory.BufferAllocator
@@ -24,7 +25,6 @@ import xtdb.api.IndexerConfig
 import xtdb.api.TableRef
 import xtdb.api.TransactionResult
 import xtdb.api.log.InMemoryLog
-import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.ReplicaMessage.BlockBoundary
 import xtdb.api.log.SourceMessage
@@ -125,13 +125,26 @@ class LeaderDriverSimTest : SimulationTestBase() {
                 )
             ),
             watchers, extSource = null, skipTxs = emptySet(), dbCatalog = null,
-            afterReplicaMsgId = afterReplicaMsgId,
             // Never left at the default: two leaders sharing term 0 would each read the other's records
             // back as its own, and the term is exactly what tells them apart.
             leaderTerm = termId,
             flushTimeout = indexerConfig.flushDuration,
-            scope = scope, gcDispatcher = dispatcher,
+            gcDispatcher = dispatcher,
         )
+
+        init {
+            scope.launch {
+                // From the claim record rather than the start of the log: a sim leader begins with empty
+                // catalogs and never replays, so anything before its claim is not its to apply.
+                launch {
+                    partitionStorage.replicaLog.tailAll(afterReplicaMsgId) { records ->
+                        records.forEach { proc.queueReplicaMessage(it) }
+                    }
+                }
+                launch { proc.drive() }
+                proc.runTerm()
+            }
+        }
 
         /** Fire-and-forget: the returned handle completes only once the tx is durably replicated. */
         suspend fun submitRows(rows: List<UUID>): Deferred<TransactionResult> =

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -147,11 +147,9 @@ class LeaderDriverSimTest : SimulationTestBase() {
                         records.forEach { proc.queueReplicaMessage(it) }
                     }
                 }
-                launch { proc.drive() }
                 launch { proc.gc.runGc() }
                 proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
-                launch { replicaAppender.run(proc::workFailed) }
-                proc.runTerm()
+                runLeaderTerm("test-db", watchers, proc, replicaAppender)
             }
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -186,7 +186,7 @@ class LeaderLogProcessorTest {
         )
 
         val now = Instant.now()
-        lp.processRecords(listOf(
+        lp.srcLogProc.processRecords(listOf(
             Log.Record(0, 0, now, SourceMessage.TriesAdded(Storage.VERSION, 0, tries))
         ))
         watchers.awaitSource(0)
@@ -234,7 +234,7 @@ class LeaderLogProcessorTest {
         )
 
         val now = Instant.now()
-        lp.processRecords(listOf(
+        lp.srcLogProc.processRecords(listOf(
             Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
         ))
         watchers.awaitSource(0)
@@ -252,7 +252,7 @@ class LeaderLogProcessorTest {
         val lp = leaderProc(StandardTestDispatcher(testScheduler), liveIndex = liveIndex, watchers = watchers)
 
         val now = Instant.now()
-        lp.processRecords(listOf(
+        lp.srcLogProc.processRecords(listOf(
             Log.Record(0, 0, now, SourceMessage.FlushBlock(5))
         ))
         watchers.awaitSource(0)
@@ -313,7 +313,7 @@ class LeaderLogProcessorTest {
         )
 
         val now = Instant.now()
-        lp.processRecords(listOf(
+        lp.srcLogProc.processRecords(listOf(
             Log.Record(0, 0, now, SourceMessage.FlushBlock(-1))
         ))
         watchers.awaitSource(0)
@@ -360,7 +360,7 @@ class LeaderLogProcessorTest {
 
         // Resolution is decoupled from the append pump: the whole batch resolves and processRecords returns
         // even though the append is still stalled on the gate — reaching the assertions below is the proof.
-        lp.processRecords(records)
+        lp.srcLogProc.processRecords(records)
         appendStarted.await()
         assertFalse(gate.isCompleted, "sanity: nothing opened the append gate")
 
@@ -487,7 +487,7 @@ class LeaderLogProcessorTest {
         val thrown = CompletableDeferred<Throwable>()
         backgroundScope.launch {
             try {
-                lp.processRecords(listOf(
+                lp.srcLogProc.processRecords(listOf(
                     Log.Record(0, 0, Instant.now(), SourceMessage.Tx(ByteArray(0), null, ZoneId.of("UTC"), null, null))
                 ))
                 thrown.complete(AssertionError("processRecords returned normally"))
@@ -622,7 +622,7 @@ class LeaderLogProcessorTest {
         fun pollThread(msgId: Long) = CompletableDeferred<Throwable>().also { outcome ->
             backgroundScope.launch {
                 try {
-                    lp.processRecords(listOf(Log.Record(0, msgId, Instant.now(), SourceMessage.FlushBlock(-1))))
+                    lp.srcLogProc.processRecords(listOf(Log.Record(0, msgId, Instant.now(), SourceMessage.FlushBlock(-1))))
                     outcome.complete(AssertionError("processRecords returned normally"))
                 } catch (e: Throwable) {
                     outcome.complete(e)
@@ -701,13 +701,13 @@ class LeaderLogProcessorTest {
 
         // A token-less source-log tx (msgId 10; skipTxs covers it, so no Arrow payload needed, and its
         // txId must exceed the ext tx's for watchers' monotonicity). It resolves behind the ext tx.
-        lp.processRecords(listOf(
+        lp.srcLogProc.processRecords(listOf(
             Log.Record(0, 10, Instant.now(), SourceMessage.Tx(ByteArray(0), null, ZoneId.of("UTC"), null, null))
         ))
 
         // Force the cut with a FlushBlock: the block's last tx is the token-less source-log tx, so the
         // boundary must carry the earlier ext tx's token (the last non-null token seen), not a null one.
-        lp.processRecords(listOf(
+        lp.srcLogProc.processRecords(listOf(
             Log.Record(0, 11, Instant.now(), SourceMessage.FlushBlock(-1))
         ))
         watchers.awaitSource(11)

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -52,6 +52,7 @@ import java.time.Instant
 import java.time.InstantSource
 import java.time.ZoneId
 import kotlin.time.Duration.Companion.seconds
+import xtdb.api.tx.ExternalSource
 import xtdb.api.tx.TxIndexer
 
 class LeaderLogProcessorTest {
@@ -91,7 +92,11 @@ class LeaderLogProcessorTest {
      * Start a term the way [LogProcessor] does: the term and the partition's replica-log reader launched
      * into the term's own job, so cancelling that job is what stops it, and freed once the test has joined it.
      */
-    private fun CoroutineScope.startTerm(partitionStorage: PartitionStorage, proc: LeaderLogProcessor) =
+    private fun CoroutineScope.startTerm(
+        partitionStorage: PartitionStorage,
+        replicaAppender: ReplicaLogAppender,
+        proc: LeaderLogProcessor,
+    ) =
         proc.also {
             leadersToClose += it
             launch {
@@ -101,6 +106,9 @@ class LeaderLogProcessorTest {
                     }
                 }
                 launch { proc.drive() }
+                launch { proc.gc.runGc() }
+                proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
+                launch { replicaAppender.run(proc::workFailed) }
                 proc.runTerm()
             }
         }
@@ -115,6 +123,9 @@ class LeaderLogProcessorTest {
         trieCatalog: TrieCatalog = mockk(relaxed = true),
         compactor: Compactor.ForDatabase = mockk(relaxed = true),
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1),
+        // These tests submit through the processor rather than driving an adapter, so the source only has
+        // to exist for the processor to.
+        extSource: ExternalSource = mockk(relaxed = true),
         skipTxs: Set<MessageId> = emptySet(),
         leaderTerm: Long = 1,
         wrapDriver: (LeaderDriver) -> LeaderDriver = { it },
@@ -131,13 +142,13 @@ class LeaderLogProcessorTest {
         )
 
         val termScope = backgroundScope + termJob
+        val replicaAppender = ReplicaLogAppender(driver)
 
         return termScope.startTerm(
-            partitionStorage,
+            partitionStorage, replicaAppender,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-                partitionState, "test", driver, watchers,
-                extSource = null,
+                partitionState, "test", driver, watchers, replicaAppender, extSource,
                 skipTxs = skipTxs, dbCatalog = null,
                 leaderTerm = leaderTerm,
                 flushTimeout = IndexerConfig().flushDuration,
@@ -211,11 +222,12 @@ class LeaderLogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
 
         val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
+        val replicaAppender = ReplicaLogAppender(driver)
         val lp = termScope.startTerm(
-            partitionStorage,
+            partitionStorage, replicaAppender,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-                partitionState, "test", driver, watchers,
+                partitionState, "test", driver, watchers, replicaAppender,
                 extSource = null,
                 skipTxs = emptySet(), dbCatalog = null,
                 flushTimeout = IndexerConfig().flushDuration,
@@ -289,11 +301,12 @@ class LeaderLogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
 
         val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
+        val replicaAppender = ReplicaLogAppender(driver)
         val lp = termScope.startTerm(
-            partitionStorage,
+            partitionStorage, replicaAppender,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-                partitionState, "test", driver, watchers,
+                partitionState, "test", driver, watchers, replicaAppender,
                 extSource = null,
                 skipTxs = emptySet(), dbCatalog = null,
                 flushTimeout = IndexerConfig().flushDuration,
@@ -375,7 +388,7 @@ class LeaderLogProcessorTest {
         )
 
         // launch the executeTx so we can observe its completion state without blocking the test
-        val txJob = backgroundScope.async { lp.executeTx(null) { TxIndexer.TxResult.Committed() } }
+        val txJob = backgroundScope.async { lp.extSrcProc!!.executeTx(null) { TxIndexer.TxResult.Committed() } }
 
         appendStarted.await()
 
@@ -407,7 +420,7 @@ class LeaderLogProcessorTest {
         val thrown = CompletableDeferred<Throwable>()
         backgroundScope.launch {
             try {
-                lp.executeTx(null) { TxIndexer.TxResult.Committed() }
+                lp.extSrcProc!!.executeTx(null) { TxIndexer.TxResult.Committed() }
             } catch (e: CancellationException) {
                 thrown.complete(e)
                 throw e
@@ -437,10 +450,10 @@ class LeaderLogProcessorTest {
         // t1 parks the persister inside its writer, so t2's task sits buffered in the channel —
         // never received, so never staged: only the exit drain can unblock its caller.
         val t1 = backgroundScope.async {
-            lp.executeTx(null) { writerEntered.complete(Unit); writerGate.await(); TxIndexer.TxResult.Committed() }
+            lp.extSrcProc!!.executeTx(null) { writerEntered.complete(Unit); writerGate.await(); TxIndexer.TxResult.Committed() }
         }
         writerEntered.await()
-        val t2 = backgroundScope.async { lp.executeTx(null) { TxIndexer.TxResult.Committed() } }
+        val t2 = backgroundScope.async { lp.extSrcProc!!.executeTx(null) { TxIndexer.TxResult.Committed() } }
         testScheduler.advanceUntilIdle()
 
         termJob.cancelAndJoin()
@@ -464,7 +477,7 @@ class LeaderLogProcessorTest {
         // buffer and is never received.
         backgroundScope.launch {
             runCatching {
-                lp.executeTx(null) { writerEntered.complete(Unit); writerGate.await(); TxIndexer.TxResult.Committed() }
+                lp.extSrcProc!!.executeTx(null) { writerEntered.complete(Unit); writerGate.await(); TxIndexer.TxResult.Committed() }
             }
         }
         writerEntered.await()
@@ -520,13 +533,13 @@ class LeaderLogProcessorTest {
         )
 
         // tx 0: stages an ext-source tx and kicks the gated append
-        lp.submitTx(null) { TxIndexer.TxResult.Committed() }
+        lp.extSrcProc!!.submitTx(null) { TxIndexer.TxResult.Committed() }
         appendStarted.await()
 
         // txs 1-4: submitted while the append is in-flight; they pipeline behind it — resolution and the
         // append pump are decoupled, so a stalled append doesn't block subsequent submitTx from resolving
         // and staging. Launched so the test body doesn't block on the cap-1 channel send.
-        repeat(4) { backgroundScope.launch { lp.submitTx(null) { TxIndexer.TxResult.Committed() } } }
+        repeat(4) { backgroundScope.launch { lp.extSrcProc!!.submitTx(null) { TxIndexer.TxResult.Committed() } } }
 
         testScheduler.advanceUntilIdle()
 
@@ -565,7 +578,7 @@ class LeaderLogProcessorTest {
         val thrown = CompletableDeferred<Throwable>()
         backgroundScope.launch {
             try {
-                lp.executeTx(null) { TxIndexer.TxResult.Committed() }
+                lp.extSrcProc!!.executeTx(null) { TxIndexer.TxResult.Committed() }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
@@ -668,12 +681,13 @@ class LeaderLogProcessorTest {
         )
 
         val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
+        val replicaAppender = ReplicaLogAppender(driver)
         val lp = termScope.startTerm(
-            partitionStorage,
+            partitionStorage, replicaAppender,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-                partitionState, "test", driver, watchers,
-                extSource = null,
+                partitionState, "test", driver, watchers, replicaAppender,
+                extSource = mockk(relaxed = true),
                 skipTxs = setOf(10), dbCatalog = null,
                 flushTimeout = IndexerConfig().flushDuration,
             )
@@ -683,7 +697,7 @@ class LeaderLogProcessorTest {
 
         // The ext-source tx carries the CDC resume token; awaiting its durability (txId 0) pins the
         // ordering — it resolves and applies before the token-less source-log tx that follows.
-        lp.submitTx(token) { TxIndexer.TxResult.Committed() }
+        lp.extSrcProc!!.submitTx(token) { TxIndexer.TxResult.Committed() }
         watchers.awaitTx(0)
 
         // A token-less source-log tx (msgId 10; skipTxs covers it, so no Arrow payload needed, and its

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -95,6 +95,7 @@ class LeaderLogProcessorTest {
     private fun CoroutineScope.startTerm(
         partitionStorage: PartitionStorage,
         replicaAppender: ReplicaLogAppender,
+        watchers: Watchers,
         proc: LeaderLogProcessor,
     ) =
         proc.also {
@@ -105,11 +106,9 @@ class LeaderLogProcessorTest {
                         records.forEach { proc.queueReplicaMessage(it) }
                     }
                 }
-                launch { proc.drive() }
                 launch { proc.gc.runGc() }
                 proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
-                launch { replicaAppender.run(proc::workFailed) }
-                proc.runTerm()
+                runLeaderTerm("test", watchers, proc, replicaAppender)
             }
         }
 
@@ -145,7 +144,7 @@ class LeaderLogProcessorTest {
         val replicaAppender = ReplicaLogAppender(driver)
 
         return termScope.startTerm(
-            partitionStorage, replicaAppender,
+            partitionStorage, replicaAppender, watchers,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
                 partitionState, "test", driver, watchers, replicaAppender, extSource,
@@ -224,7 +223,7 @@ class LeaderLogProcessorTest {
         val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
         val replicaAppender = ReplicaLogAppender(driver)
         val lp = termScope.startTerm(
-            partitionStorage, replicaAppender,
+            partitionStorage, replicaAppender, watchers,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
                 partitionState, "test", driver, watchers, replicaAppender,
@@ -303,7 +302,7 @@ class LeaderLogProcessorTest {
         val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
         val replicaAppender = ReplicaLogAppender(driver)
         val lp = termScope.startTerm(
-            partitionStorage, replicaAppender,
+            partitionStorage, replicaAppender, watchers,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
                 partitionState, "test", driver, watchers, replicaAppender,
@@ -539,7 +538,7 @@ class LeaderLogProcessorTest {
         // txs 1-4: submitted while the append is in-flight; they pipeline behind it — resolution and the
         // append pump are decoupled, so a stalled append doesn't block subsequent submitTx from resolving
         // and staging. Launched so the test body doesn't block on the cap-1 channel send.
-        repeat(4) { backgroundScope.launch { lp.extSrcProc!!.submitTx(null) { TxIndexer.TxResult.Committed() } } }
+        repeat(4) { backgroundScope.launch { lp.extSrcProc.submitTx(null) { TxIndexer.TxResult.Committed() } } }
 
         testScheduler.advanceUntilIdle()
 
@@ -683,7 +682,7 @@ class LeaderLogProcessorTest {
         val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
         val replicaAppender = ReplicaLogAppender(driver)
         val lp = termScope.startTerm(
-            partitionStorage, replicaAppender,
+            partitionStorage, replicaAppender, watchers,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
                 partitionState, "test", driver, watchers, replicaAppender,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -8,9 +8,15 @@ import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -81,6 +87,24 @@ class LeaderLogProcessorTest {
             configure()
         }
 
+    /**
+     * Start a term the way [LogProcessor] does: the term and the partition's replica-log reader launched
+     * into the term's own job, so cancelling that job is what stops it, and freed once the test has joined it.
+     */
+    private fun CoroutineScope.startTerm(partitionStorage: PartitionStorage, proc: LeaderLogProcessor) =
+        proc.also {
+            leadersToClose += it
+            launch {
+                launch {
+                    partitionStorage.replicaLog.tailAll(-1) { records ->
+                        records.forEach { proc.queueReplicaMessage(it) }
+                    }
+                }
+                launch { proc.drive() }
+                proc.runTerm()
+            }
+        }
+
     private fun TestScope.leaderProc(
         uploadDispatcher: CoroutineDispatcher,
         sourceLog: InMemoryLog<SourceMessage> = InMemoryLog(InstantSource.system(), 0),
@@ -94,6 +118,7 @@ class LeaderLogProcessorTest {
         skipTxs: Set<MessageId> = emptySet(),
         leaderTerm: Long = 1,
         wrapDriver: (LeaderDriver) -> LeaderDriver = { it },
+        termJob: Job = SupervisorJob(backgroundScope.coroutineContext.job),
     ): LeaderLogProcessor {
         val tableCatalog = mockk<TableCatalog>(relaxed = true)
         val partitionState = PartitionState(blockCatalog, tableCatalog, trieCatalog, liveIndex)
@@ -105,16 +130,19 @@ class LeaderLogProcessorTest {
             )
         )
 
-        return LeaderLogProcessor(
-            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", driver, watchers,
-            extSource = null,
-            skipTxs = skipTxs, dbCatalog = null,
-            afterReplicaMsgId = -1,
-            leaderTerm = leaderTerm,
-            flushTimeout = IndexerConfig().flushDuration,
-            scope = backgroundScope,
-        ).also(leadersToClose::add)
+        val termScope = backgroundScope + termJob
+
+        return termScope.startTerm(
+            partitionStorage,
+            LeaderLogProcessor(
+                allocator, nodeBase, partitionStorage, mockk(relaxed = true),
+                partitionState, "test", driver, watchers,
+                extSource = null,
+                skipTxs = skipTxs, dbCatalog = null,
+                leaderTerm = leaderTerm,
+                flushTimeout = IndexerConfig().flushDuration,
+            )
+        )
     }
 
     // Decorate a driver so its replica-log append blocks on [gate] before the message lands, completing
@@ -182,15 +210,17 @@ class LeaderLogProcessorTest {
         )
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
 
-        val lp = LeaderLogProcessor(
-            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", driver, watchers,
-            extSource = null,
-            skipTxs = emptySet(), dbCatalog = null,
-            afterReplicaMsgId = -1,
-            flushTimeout = IndexerConfig().flushDuration,
-            scope = backgroundScope,
-        ).also(leadersToClose::add)
+        val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
+        val lp = termScope.startTerm(
+            partitionStorage,
+            LeaderLogProcessor(
+                allocator, nodeBase, partitionStorage, mockk(relaxed = true),
+                partitionState, "test", driver, watchers,
+                extSource = null,
+                skipTxs = emptySet(), dbCatalog = null,
+                flushTimeout = IndexerConfig().flushDuration,
+            )
+        )
 
         val now = Instant.now()
         lp.processRecords(listOf(
@@ -258,15 +288,17 @@ class LeaderLogProcessorTest {
         )
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
 
-        val lp = LeaderLogProcessor(
-            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", driver, watchers,
-            extSource = null,
-            skipTxs = emptySet(), dbCatalog = null,
-            afterReplicaMsgId = -1,
-            flushTimeout = IndexerConfig().flushDuration,
-            scope = backgroundScope,
-        ).also(leadersToClose::add)
+        val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
+        val lp = termScope.startTerm(
+            partitionStorage,
+            LeaderLogProcessor(
+                allocator, nodeBase, partitionStorage, mockk(relaxed = true),
+                partitionState, "test", driver, watchers,
+                extSource = null,
+                skipTxs = emptySet(), dbCatalog = null,
+                flushTimeout = IndexerConfig().flushDuration,
+            )
+        )
 
         val now = Instant.now()
         lp.processRecords(listOf(
@@ -364,9 +396,11 @@ class LeaderLogProcessorTest {
         val gate = CompletableDeferred<Unit>()
         val appendStarted = CompletableDeferred<Unit>()
 
+        val termJob = SupervisorJob(backgroundScope.coroutineContext.job)
         val lp = leaderProc(
             StandardTestDispatcher(testScheduler), replicaLog = replicaLog, watchers = watchers,
             wrapDriver = { gatedDriver(it, gate, appendStarted) },
+            termJob = termJob,
         )
 
         // Capture the executeTx failure; the runTest timeout guards against a hang if it never completes.
@@ -386,7 +420,7 @@ class LeaderLogProcessorTest {
 
         // Cancel the leader term — the gate will never open, so without term-close propagation
         // executeTx would hang until the runTest timeout.
-        lp.cancelAndJoin()
+        termJob.cancelAndJoin()
 
         // If executeTx hangs, thrown never completes and runTest's timeout fires — that's the hang guard.
         thrown.await()
@@ -397,7 +431,8 @@ class LeaderLogProcessorTest {
         val writerEntered = CompletableDeferred<Unit>()
         val writerGate = CompletableDeferred<Unit>()
 
-        val lp = leaderProc(StandardTestDispatcher(testScheduler))
+        val termJob = SupervisorJob(backgroundScope.coroutineContext.job)
+        val lp = leaderProc(StandardTestDispatcher(testScheduler), termJob = termJob)
 
         // t1 parks the persister inside its writer, so t2's task sits buffered in the channel —
         // never received, so never staged: only the exit drain can unblock its caller.
@@ -408,7 +443,7 @@ class LeaderLogProcessorTest {
         val t2 = backgroundScope.async { lp.executeTx(null) { TxIndexer.TxResult.Committed() } }
         testScheduler.advanceUntilIdle()
 
-        lp.cancelAndJoin()
+        termJob.cancelAndJoin()
 
         // t1 fails via the pre-stage catch (cancelled mid-writer); t2 via the buffered-task drain.
         // A hang on either fires runTest's timeout.
@@ -422,7 +457,8 @@ class LeaderLogProcessorTest {
         val writerGate = CompletableDeferred<Unit>()
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
 
-        val lp = leaderProc(StandardTestDispatcher(testScheduler), watchers = watchers)
+        val termJob = SupervisorJob(backgroundScope.coroutineContext.job)
+        val lp = leaderProc(StandardTestDispatcher(testScheduler), watchers = watchers, termJob = termJob)
 
         // Park the persister inside an ext-source writer, so the source batch below lands in sourceLogCh's
         // buffer and is never received.
@@ -451,7 +487,7 @@ class LeaderLogProcessorTest {
         }
         testScheduler.advanceUntilIdle()
 
-        lp.cancelAndJoin()
+        termJob.cancelAndJoin()
 
         // A hang here fires runTest's timeout — that's the regression guard.
         val e = thrown.await()
@@ -631,15 +667,17 @@ class LeaderLogProcessorTest {
             partitionStorage, partitionState, blockUploader
         )
 
-        val lp = LeaderLogProcessor(
-            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", driver, watchers,
-            extSource = null,
-            skipTxs = setOf(10), dbCatalog = null,
-            afterReplicaMsgId = -1,
-            flushTimeout = IndexerConfig().flushDuration,
-            scope = backgroundScope,
-        ).also(leadersToClose::add)
+        val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
+        val lp = termScope.startTerm(
+            partitionStorage,
+            LeaderLogProcessor(
+                allocator, nodeBase, partitionStorage, mockk(relaxed = true),
+                partitionState, "test", driver, watchers,
+                extSource = null,
+                skipTxs = setOf(10), dbCatalog = null,
+                flushTimeout = IndexerConfig().flushDuration,
+            )
+        )
 
         val token = byteArrayOf(1, 2, 3)
 

--- a/dev/doc/coroutines.adoc
+++ b/dev/doc/coroutines.adoc
@@ -73,7 +73,7 @@ Two arguments look like reasons to split and aren't:
   Reach for a start method because the owner needs a handle, never to make readiness provable.
 * *Keeping `this` out of the constructor.*
   An initialiser only publishes a half-built object when the launched body needs `this` — a unit that is its own record processor, say.
-  Where the body touches only an already-constructed collaborator, a field initialiser is safe, and moving that collaborator's own loop to a `runTerm` is what made it so.
+  Where the body touches only an already-constructed collaborator, a field initialiser is safe.
 
 A fresh `SupervisorJob` marks a boundary a failure must not cross, which is a separate question from who launched the unit and from how many coroutines it runs.
 That boundary is the database scope: its Job is a supervisor and its handler is `watchers.notifyError`, so a role's fault is reported without cancelling the source-log subscription beside it.

--- a/dev/doc/coroutines.adoc
+++ b/dev/doc/coroutines.adoc
@@ -18,7 +18,7 @@ We tear these down in two explicit phases:
 
 Phase 1 (stop)::
 Cancel-and-join the unit's Job.
-At the database level this is a single `job.cancelAndJoin()` over the whole tree (every term, the compactor and the source-log subscription run under that one `job`); at the term level it is a scoped cancel of just that term's `SupervisorJob` (used on Kafka rebalance).
+At the database level this is a single `job.cancelAndJoin()` over the whole tree (every term, the compactor and the source-log subscription run under that one `job`); at the role level it is a scoped cancel of just that role's Job (used on Kafka rebalance).
 
 Phase 2 (free)::
 Call a synchronous `AutoCloseable.close()` on each unit, freeing its standing resources in allocator-parentage order — children before parents, which Arrow requires.
@@ -46,7 +46,38 @@ Implementation rules that keep this safe:
 * `close()` MUST stay non-suspend, so a rebalance callback that closes a term mid-flight completes within the joined coroutine frame rather than suspending.
 * Standing resources are acquired before the loop and freed by `close()`.
   Resources a coroutine acquires *itself* mid-flight still belong in `.use`/`try-finally` inside the body — they are not standing resources and are not Phase 2's concern.
-* A term is modelled as `(job, closeable)` (`LogProcessor.SubSystem`) so that a job-less or unfreeable term is unrepresentable.
+* A role is modelled as `(job, closeable)` (`LogProcessor.State`) so that a job-less or unfreeable role is unrepresentable.
+
+=== Who launches a unit's coroutines
+
+Two-phase teardown says a unit's `close()` runs after its Job is joined.
+It doesn't say who launched that Job, and the answer follows from whose lifetime the unit has.
+
+A unit whose lifetime is strictly *inside* its owner's exposes a `run`/`runTerm` suspend function that the owner launches, and the owner holds the Job::
+An indexer term is the case.
+Several come and go over one partition's life, and it is the transport, through the owner, that decides when one ends — at a moment the term itself doesn't choose.
+So the owner needs a handle in order to stop it, and that handle is what `LogProcessor.State` pairs with the processor to free.
+
+A unit whose lifetime *is* its owner's launches from its own initialiser, and takes the scope as a constructor parameter::
+`LogProcessor` is the case.
+One per partition, created and closed with the database, and stopped only by the database's job tree being cancelled.
+There is no moment at which the owner stops this one thing and keeps the rest, so a handle buys nothing — and the scope it would be launched on is the same scope its constructor is handed.
+
+Splitting construction from starting where the two lifetimes coincide invents a state, "constructed but not started", that nothing else needs.
+The tells are a `lateinit` scope, a "not yet running" variant bolted onto an otherwise-total state machine, and a `check` to keep callers out of it.
+
+Two arguments look like reasons to split and aren't:
+
+* *Proving the unit is ready.*
+  A constructor returning is exactly as strong a proof as a `launch` returning — in both cases nothing can hold the object before its work exists.
+  Reach for a start method because the owner needs a handle, never to make readiness provable.
+* *Keeping `this` out of the constructor.*
+  An initialiser only publishes a half-built object when the launched body needs `this` — a unit that is its own record processor, say.
+  Where the body touches only an already-constructed collaborator, a field initialiser is safe, and moving that collaborator's own loop to a `runTerm` is what made it so.
+
+A fresh `SupervisorJob` marks a boundary a failure must not cross, which is a separate question from who launched the unit and from how many coroutines it runs.
+That boundary is the database scope: its Job is a supervisor and its handler is `watchers.notifyError`, so a role's fault is reported without cancelling the source-log subscription beside it.
+Within a role, a plain `scope.launch` is what you want, because a role's coroutines are meant to fail together — the leader's replica-log reader is a child of the term's Job precisely so that a read that fails ends the term.
 
 === Accepted behaviour: resources of a self-crashed unit are freed lazily
 

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -66,7 +66,6 @@ class BlockGarbageCollectorTest {
                 val blockCat = BlockCatalog(bufferPool.latestBlock)
 
                 val gc = BlockGarbageCollector(
-                    backgroundScope,
                     bufferPool, blockCat,
                     blocksToKeep = 3,
                     enabled = false,
@@ -111,7 +110,6 @@ class BlockGarbageCollectorTest {
                     }
 
                     val gc = BlockGarbageCollector(
-                        backgroundScope,
                         p0, BlockCatalog(p0.latestBlock),
                         blocksToKeep = 3,
                         enabled = false,


### PR DESCRIPTION
Part of #5917 — groundwork only. None of that issue's `G1`–`G10` (replica-log self-election) is here.

## tl;dr

- **Every commit is behaviour-preserving.**
  No new functionality and no changed semantics. The whole diff is about which object owns what.

- **One object owns every loop in this system now.**
  `LogProcessor` runs both work loops, and nothing else under `xtdb/indexer` owns a `selectUnbiased`. It also holds the replica-log reader, the term's coroutines and the policy for what a failure means; `LeaderLogProcessor` has no `launch`, no `coroutineScope` and no select of its own.

- **Four components came out of the leader term**, each owning one queue and a handler, none owning a loop: `GarbageCollector`, `ExternalSourceProcessor`, `SourceLogProcessor`, `ReplicaLogAppender`.

- **`LeaderLogProcessor` is 537 → 303 lines**, and is now state plus suspend transitions.

## Context

#5917 needs leadership arbitrated by the replica log rather than by Kafka's consumer group. That can't be written against a leader term that starts its own coroutines, owns its own loop and decides what its own failures mean — the election logic would be entangled with all three.

An earlier attempt inlined the term into the log processor directly and produced one large tangle. This branch takes the other order: separate out the pieces that have no concurrency of their own first, so the remaining inline is a move rather than an untangling.

## What the branch establishes

- **A component is a service iff it owns the loop that decides what happens next**
  Owning a channel and exposing it as a select clause is not that — it's a component declaring available work. Four components do exactly that, and `LogProcessor`'s select arms them.

- **The term is state and transitions**
  `runTerm` became `shutdown(cause)`, `termFailure` was deleted rather than moved, and `selectWork` became `selectLeaderWork` in the owner. What's left on the term is `applyRecord`, `cutBlock`, `appendTx`, `blockState` and `pendingBlock`.

- **Three fields that could disagree became one sealed state**
  `blockInProgress`, `rowsSinceBlock` and `pendingBlock` tracked nested phases of a single thing. `Filling(rows)` → `Cut` → `Uploading(pendingBlock)` makes a pending block while filling, and a row gauge climbing during a cut, both unrepresentable.

- **The resolve-side watermarks joined the resolved head**
  `Watchers` advances `latestSourceMsgId`, `latestTxId` and `externalSourceToken` together on apply. `TxResolver` held one of that triple as `latestCompletedTx` while the term held the other two, so a boundary cut reached across for two of three. All three advance together in `stage` now.

- **Two abstractions over roles were retired once what they abstracted stopped varying**
  `Role`/`drive()` went when the leader's select moved up and left one implementor; `LogProcessor.Processor` went because only the leader was ever handed to a transport as a `RecordProcessor`, and only to forward — so `commitLeader` hands over `srcLogProc` itself.

## Decisions

- **`D1` The append queue is per-term, not per-partition**
  Queued items are term-stamped and term-fenced, and a queued `TxItem` borrows a `ResolvedTx` that the term's resolver frees — so a queue outliving its term would render over freed Arrow buffers on the next term's first drain.

- **`D2` The term is stamped where an item is made, not where it is drained**
  `ControlItem`s already carried it from their construction sites; `TxItem` was the outlier, deferring to the pump. A record can no longer be stamped with the term of whoever happened to be draining the queue.

- **`D3` `SourceBatches` stays on the driver**
  Unlike the external source's queue, it is the simulable edge — `LeaderDriverSimTest` wraps the driver to inject batches and stall appends — so moving it onto the processor would put it out of the mock's reach.

## Out of scope

- **`G1`–`G10` on #5917** — self-election, the conferring test, `termEpoch` removal. This branch changes no election behaviour.
- **The `.allium` vocabulary.** `AbandonPreparedLeader`'s "its pumps + persister cancelled" was the one claim this branch made false, and it is fixed. The other 41 "persister"/"pumps" mentions across `live-index`, `db` and `gc` name mechanisms that moved without changing behaviour, so they are a terminology refresh rather than a correctness fix, and they read better as one pass than as churn spread through this diff.

- **`mid_block` in `log-processor-lifecycle.allium`.** Found while weeding: the spec reads it at transition step 4 but no rule ever sets it true, so `DanglingBlockFinished` is unreachable on paper while the code preserves the dangling block correctly. Pre-existing, untouched by this branch, and fixing it properly means deciding how the spec expresses "an upload was in flight" — its own change.
- **Deduplicating the three apply paths.** Follower and Transition are verbatim-identical across four of six message types, but that is its own change.

- **`R1` Shutdown signals still reach `Watchers.notifyError`.** Real, reachable, and older than this branch — see Review below.

## Review

Three lenses over the whole diff: correctness and concurrency, the house style in `dev/CODING.adoc`, and the diff's comments against the comment rules. Two findings applied, one raised.

- **Applied: the collector was the only one of three reaching into a channel**
  `GarbageCollector` handed out its raw task channel while `ExternalSourceProcessor` and `SourceLogProcessor`, armed either side of it in the same function, keep theirs private. It answers `onTask` now.

- **Applied: four comments deleted, one corrected**
  The four restated a one-line body from its own name or named their only caller. The correction matters on its own: the collectors' `run()` claimed `signal` and `awaitNoGarbage` "do nothing until this is running", when a signal queues and `awaitNoGarbage` suspends.

- **`R1` Raised, not fixed: a benign interrupt can still wedge a database**
  `isShutdownSignal` exists because `Watchers`' `Failed` state is absorbing, so `InterruptedException` and `Interrupted` must not reach `notifyError`. Three outer catch ladders exclude only `CancellationException` — `runLeaderTerm`, `tailReplica`, and `ExternalSourceProcessor.run` — so an interrupt that the inner guards deliberately declined to report is reported by the outer one. It is reachable: `LocalStorage.putObject` turns `ClosedByInterruptException` into a raw `InterruptedException`, and that is on the leader's block-upload path, so interrupting a thread mid-upload during a routine handover can take a healthy database down until the process restarts.

  All three ladders are byte-identical to `main` (`LeaderLogProcessor.kt:520-534`, `FollowerLogProcessor.kt:300-308`, `LeaderLogProcessor.kt:558-568` there), so this branch moved them unchanged, which is what it is supposed to do. Fixing it is a behavioural change on a failure path and wants its own commit, its own test and its own review — putting it here would cost this PR the one property it claims. Adjacent to #5910, which addresses recovering a database that has already failed rather than not failing it.

## Verification

Every commit was built and tested before landing, and the branch was re-verified after rebasing onto current `main`. The block-state commit additionally ran at `-PsimulationIterations=500` — 13,514/0, with per-class counts scaling linearly to confirm the flag actually reached the Kotlin simulations rather than silently no-opping.

The failure mode throughout is a hang rather than an assertion, since teardown and coroutine ownership moved repeatedly, so runs were checked for hang-watchdog trips and allocator leaks as well as for failures. None seen.

Two flakes appeared across the branch's runs, and neither was taken on the label alone:

- **`can-ingest-ts-devices-mini-with-stop-start-and-reach-same-state`** (#5876). This branch touches the teardown path, so it fails the label's "subsystem your change doesn't touch" condition. Eight isolated runs measured 7 pass / 1 fail with an identical one-block shortfall; a broken teardown fails consistently rather than one in eight.

- **`test-l2+-compaction`** (#5885). Measured **3 pass / 3 fail over six isolated runs** on an idle 16-core machine, durations spanning 6.4–16.6 s. #5885 matches the signature exactly — same two test names, same exception at the same frame, same 1000/2000/5000 ms budgets — and predates this branch's first commit by ten days.

  Four reasons it isn't this diff: `Compactor.kt` and `BlockUploader.kt` are not in the diff and have not been touched since 30 July; `signalBlock`'s call sites are byte-identical to `main`; the test binds `*ignore-signal-block?* true`, so the block-boundary path it might have perturbed is not live; and the budget is a fixed wall-clock the test hands to `compact-all!` over CPU-bound merge work, so the failure is a timeout rather than a wrong result — when it passes, the row-set assertion and the arrow-edn golden check both pass.

  Flagged rather than filed away: the **rate** is higher than #5885's own evidence table, which records two idle re-runs both fully green. Whether that is this machine, or the nine commits `main` gained since the branch forked, is not something this branch's tree can distinguish.
