### PR TITLE
fix(error): don't classify an interrupt as an anomaly

### DIFF
--- a/api/src/main/clojure/xtdb/error.clj
+++ b/api/src/main/clojure/xtdb/error.clj
@@ -187,9 +187,13 @@
   Throwable
   (->anomaly [ex data] (fault ::unknown (ex-message ex) (into {::cause ex} data))))
 
+;; the interrupt arms mirror `Anomaly/wrapAnomaly`, whose kdoc has the why
 (defmacro wrap-anomaly ^{:style/indent 1} [ctx & body]
   `(try
      ~@body
+     (catch InterruptedException e# (throw e#))
+     (catch ClosedByInterruptException e#
+       (throw (doto (InterruptedException. (ex-message e#)) (.initCause e#))))
      (catch Throwable e#
        (throw (->anomaly e# ~ctx)))))
 

--- a/api/src/main/kotlin/xtdb/api/error/Anomaly.kt
+++ b/api/src/main/kotlin/xtdb/api/error/Anomaly.kt
@@ -71,6 +71,7 @@ sealed class Anomaly(
                 ctx + ("date-time" to parsedString),
                 this,
             )
+            // `XtdbProducer.asFlightException` turns this category into `CallStatus.CANCELLED`
             is ClosedByInterruptException ->
                 Interrupted(message ?: "Interrupted", "xtdb.error/interrupted", ctx, this)
             is InterruptedException -> Interrupted(message, "xtdb.error/interrupted", ctx, this)
@@ -84,9 +85,18 @@ sealed class Anomaly(
         /**
          * Run [block], catching any [Throwable] and rethrowing as the appropriate [Anomaly]
          * with [ctx] merged into its data. Mirrors `xtdb.error/wrap-anomaly`.
+         *
+         * An interrupt propagates as an [InterruptedException] instead: it's a request to stop,
+         * not an error report, and [Interrupted] isn't a [Caller] — so classifying one here
+         * tells the ingestion path to fail the database over a clean shutdown.
          */
         inline fun <R> wrapAnomaly(ctx: Map<String, *> = emptyMap<String, Any?>(), block: () -> R): R = try {
             block()
+        } catch (e: InterruptedException) {
+            throw e
+        } catch (e: ClosedByInterruptException) {
+            // the blocking boundaries convert this themselves; this is in case one is missed
+            throw InterruptedException(e.message).apply { initCause(e) }
         } catch (e: Throwable) {
             throw e.toAnomaly(ctx)
         }

--- a/api/src/test/clojure/xtdb/error_test.clj
+++ b/api/src/test/clojure/xtdb/error_test.clj
@@ -1,7 +1,9 @@
 (ns xtdb.error-test
   (:require [clojure.test :as t]
-            [clojure.pprint :as pprint])
-  (:import [xtdb.api.error Busy]))
+            [clojure.pprint :as pprint]
+            [xtdb.error :as err])
+  (:import [java.nio.channels ClosedByInterruptException]
+           [xtdb.api.error Busy Interrupted]))
 
 (t/deftest test-anomaly-pretty-printing
   (t/testing "Busy anomaly pretty-prints correctly"
@@ -11,3 +13,18 @@
       (t/is (nil? (pprint/pprint ex)))
       (t/is (nil? (pprint/pprint ex-2)))
       (t/is (nil? (pprint/pprint ex-3))))))
+
+(t/deftest interrupts-escape-wrap-anomaly-unclassified
+  (let [interrupt (InterruptedException. "stopping")]
+    (t/is (identical? interrupt (try (err/wrap-anomaly {} (throw interrupt))
+                                     (catch InterruptedException e e)))))
+
+  (let [closed (ClosedByInterruptException.)]
+    (t/is (identical? closed (ex-cause (try (err/wrap-anomaly {} (throw closed))
+                                            (catch InterruptedException e e))))))
+
+  (t/is (anomalous? [:incorrect] (err/wrap-anomaly {} (throw (IllegalArgumentException. "nope"))))))
+
+(t/deftest ->anomaly-gives-an-interrupt-a-category-for-the-wire-boundaries
+  (t/is (instance? Interrupted (err/->anomaly (InterruptedException. "stopping") {})))
+  (t/is (instance? Interrupted (err/->anomaly (ClosedByInterruptException.) {}))))

--- a/api/src/test/kotlin/xtdb/api/error/AnomalyTest.kt
+++ b/api/src/test/kotlin/xtdb/api/error/AnomalyTest.kt
@@ -1,0 +1,38 @@
+package xtdb.api.error
+
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xtdb.api.error.Anomaly.Companion.toAnomaly
+import xtdb.api.error.Anomaly.Companion.wrapAnomaly
+import java.nio.channels.ClosedByInterruptException
+
+class AnomalyTest {
+
+    @Test
+    fun `an interrupt escapes wrapAnomaly unclassified`() {
+        val interrupt = InterruptedException("stopping")
+
+        assertSame(interrupt, assertThrows<InterruptedException> { wrapAnomaly<Unit> { throw interrupt } })
+    }
+
+    @Test
+    fun `a closed-by-interrupt channel escapes wrapAnomaly as an interrupt`() {
+        val closed = ClosedByInterruptException()
+
+        assertSame(closed, assertThrows<InterruptedException> { wrapAnomaly<Unit> { throw closed } }.cause)
+    }
+
+    @Test
+    fun `wrapAnomaly classifies everything else`() {
+        assertThrows<Incorrect> { wrapAnomaly<Unit> { throw IllegalArgumentException("nope") } }
+        assertThrows<Fault> { wrapAnomaly<Unit> { throw RuntimeException("boom") } }
+    }
+
+    @Test
+    fun `toAnomaly gives an interrupt a category for the wire boundaries`() {
+        assertInstanceOf(Interrupted::class.java, InterruptedException("stopping").toAnomaly())
+        assertInstanceOf(Interrupted::class.java, ClosedByInterruptException().toAnomaly())
+    }
+}

--- a/core/src/main/clojure/xtdb/pgwire.clj
+++ b/core/src/main/clojure/xtdb/pgwire.clj
@@ -38,7 +38,7 @@
            (xtdb.arrow Relation Relation$ILoader VectorType)
            xtdb.arrow.RelationReader
            xtdb.database.Database$Config
-           (xtdb.api.error Incorrect Interrupted)
+           (xtdb.api.error Incorrect)
            xtdb.api.ResultCursor
            (xtdb.pgwire PgType PgTypes)
            xtdb.JsonSerde
@@ -822,6 +822,7 @@
                  (visitSetTimeZone [_ _] (create-parsed))
                  (visitOther [_ _] stmt)))
 
+      (catch InterruptedException e (throw e))
       (catch IllegalArgumentException e
         (log/debug e "Error preparing statement")
         (throw e))
@@ -849,7 +850,7 @@
 
       (pgio/cmd-write-msg conn pgio/msg-parse-complete))
 
-    (catch Interrupted e (throw e))
+    (catch InterruptedException e (throw e))
     (catch Exception e
       (when (.isTxReadWrite ^Xtdb$Connection (:node-conn @conn-state))
         (metrics/inc-counter! tx-error-counter))
@@ -1378,7 +1379,6 @@
               (finally
                 (util/close (:cursor portal))))))
 
-        (catch Interrupted e (throw e))
         (catch InterruptedException e (throw e))
         (catch Exception e
           (let [^Xtdb$Connection node-conn (:node-conn @conn-state)]
@@ -1396,7 +1396,6 @@
           (cmd-commit conn))))
 
     ;; here we catch explicitly because we need to send the error, then a ready message
-    (catch Interrupted e (throw e))
     (catch InterruptedException e (throw e))
     (catch Throwable e
       (send-ex conn e)))
@@ -1533,7 +1532,6 @@
       (log/trace "Skipping msg until next sync due to error in extended protocol" {:cid cid, :msg msg})
       (handle-msg* conn msg))
 
-    (catch Interrupted e (throw e))
     (catch InterruptedException e (throw e))
 
     (catch Throwable e
@@ -1654,7 +1652,6 @@
       (catch IOException e
         (log/warn e "IOException in connection" {:port port, :cid cid}))
 
-      (catch Interrupted _)
       (catch InterruptedException _)
 
       (finally
@@ -1708,7 +1705,6 @@
               (log/warn e "Accept IO exception")))
           (recur))))
 
-    (catch Interrupted _)
     (catch InterruptedException _)
 
     (finally

--- a/core/src/main/kotlin/xtdb/indexer/CrashLogger.kt
+++ b/core/src/main/kotlin/xtdb/indexer/CrashLogger.kt
@@ -11,7 +11,6 @@ import xtdb.arrow.VectorReader
 import xtdb.api.error.Anomaly
 import xtdb.api.error.Anomaly.Companion.wrapAnomaly
 import xtdb.storage.BufferPool
-import xtdb.api.error.Interrupted
 import xtdb.api.TableRef
 import xtdb.util.asPath
 import java.nio.file.Path
@@ -125,8 +124,6 @@ class CrashLogger @JvmOverloads constructor(
     ): R {
         try {
             return wrapAnomaly(data, block)
-        } catch (e: Interrupted) {
-            throw e
         } catch (e: Anomaly.Caller) {
             throw e
         } catch (e: Anomaly) {

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -15,7 +15,6 @@ import xtdb.api.log.ReplicaMessage.TriesAdded
 import xtdb.api.storage.Storage
 import xtdb.database.*
 import xtdb.api.error.Anomaly
-import xtdb.api.error.Interrupted
 import xtdb.garbage_collector.BlockGarbageCollector
 import xtdb.garbage_collector.TrieGarbageCollector
 import xtdb.api.tx.TxIndexer.TxResult
@@ -583,20 +582,12 @@ internal class LeaderLogProcessor(
             }
 
             when (work) {
-                // The apply loop is where a supersession fails the term; let it propagate (interrupts too).
+                // supersession fails the term, not the database — rationale on the outer ladder
                 is Apply ->
                     try {
                         applyRecord(work.record)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: LeaderSupersededException) {
-                        throw e
-                    } catch (e: InterruptedException) {
-                        throw e
-                    } catch (e: Interrupted) {
-                        throw e
                     } catch (e: Throwable) {
-                        watchers.notifyError(e)
+                        if (!e.isShutdownSignal && e !is LeaderSupersededException) watchers.notifyError(e)
                         throw e
                     }
 
@@ -640,16 +631,12 @@ internal class LeaderLogProcessor(
         } catch (e: CancellationException) {
             if (!onComplete.isCompleted) onComplete.cancel(e)
             throw e
-        } catch (e: InterruptedException) {
-            if (!onComplete.isCompleted) onComplete.completeExceptionally(e)
-            throw e
-        } catch (e: Interrupted) {
-            if (!onComplete.isCompleted) onComplete.completeExceptionally(e)
-            throw e
         } catch (e: Throwable) {
-            watchers.notifyError(e)
+            if (!e.isShutdownSignal) {
+                watchers.notifyError(e)
+                extResult?.let { if (!it.isCompleted) it.completeExceptionally(e) }
+            }
             if (!onComplete.isCompleted) onComplete.completeExceptionally(e)
-            extResult?.let { if (!it.isCompleted) it.completeExceptionally(e) }
             throw e
         }
     }

--- a/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TransitionLogProcessor.kt
@@ -10,7 +10,6 @@ import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
 import xtdb.api.error.Anomaly
-import xtdb.api.error.Interrupted
 import xtdb.database.Database
 import xtdb.database.PartitionState
 import xtdb.storage.BufferPool
@@ -137,16 +136,14 @@ class TransitionLogProcessor(
 
             try {
                 if (!record.message.stale) processRecord(record)
-            } catch (e: InterruptedException) {
-                throw e
-            } catch (e: Interrupted) {
-                throw e
             } catch (e: Throwable) {
-                LOG.error(
-                    e,
-                    "[$dbName] transition: failed to process log record with msgId $msgId (${record.message::class.simpleName})"
-                )
-                watchers.notifyError(e)
+                if (!e.isShutdownSignal) {
+                    LOG.error(
+                        e,
+                        "[$dbName] transition: failed to process log record with msgId $msgId (${record.message::class.simpleName})"
+                    )
+                    watchers.notifyError(e)
+                }
                 throw e
             }
         }

--- a/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/kafka/connectsrc/DocsIndexer.kt
@@ -80,6 +80,8 @@ class DocsIndexer(internal val table: TableRef) : RecordIndexer {
                     TxResult.Committed()
                 } catch (e: CancellationException) {
                     throw e
+                } catch (e: InterruptedException) {
+                    throw e
                 } catch (e: Throwable) {
                     throw e.toAnomaly(coordsFor(rec))
                 }

--- a/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/DocsIndexerTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/kafka/connectsrc/DocsIndexerTest.kt
@@ -1,18 +1,26 @@
 package xtdb.kafka.connectsrc
 
 import clojure.lang.Keyword
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.data.Timestamp as ConnectTimestamp
 import org.apache.kafka.connect.sink.SinkRecord
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import xtdb.api.error.Anomaly
 import xtdb.api.error.Incorrect
 import xtdb.api.TableRef
+import xtdb.api.tx.OpenTx
+import xtdb.api.tx.TxIndexer
+import xtdb.api.tx.TxIndexer.TxResult
 import java.time.Instant
 import java.util.Date
 
@@ -91,5 +99,27 @@ class DocsIndexerTest {
 
         assertEquals(Keyword.intern("xtdb.kafka-connect-source", "docs-no-key"), e.errorCode)
         assertTrue(e.message!!.contains("no usable key"), "message shouldn't claim the key is absent, got: ${e.message}")
+    }
+
+    // an Interrupted would reach the leader's `runTaskGuarded` as an ingestion fault and fail the database
+    @Test
+    fun `an interrupt while writing propagates instead of becoming an anomaly`() {
+        val interrupt = InterruptedException("stopping")
+
+        val openTx = mockk<OpenTx>()
+        every { openTx.table(any(), any()) } throws interrupt
+
+        val txIndexer = mockk<TxIndexer>()
+        coEvery { txIndexer.submitTx(any(), any(), any()) } coAnswers {
+            @Suppress("UNCHECKED_CAST")
+            (arg<Any>(2) as suspend (OpenTx) -> TxResult)(openTx)
+            error("writer should have thrown")
+        }
+
+        val indexer = DocsIndexer.Factory(table = "events").open() as DocsIndexer
+
+        assertSame(interrupt, assertThrows<InterruptedException> {
+            runBlocking { indexer.indexRecords(listOf(recWithKey("k1")), txIndexer) }
+        })
     }
 }


### PR DESCRIPTION
## tl;dr

- **Interrupting an XTDB node mid-write could leave one of its databases unqueryable until the process restarted.**
  A thread interrupt was being classified as an `xtdb.error` anomaly, and the ingestion path reads that particular anomaly as "this database has faulted". `Watchers`' `Failed` state is absorbing, so a routine teardown or leadership handover could wedge a database with no operator route out.

- **An interrupt is now a control signal end to end, never an error report.**
  `wrapAnomaly` / `wrap-anomaly` rethrow `InterruptedException` untouched instead of converting it. `toAnomaly` still classifies, because the flight-sql boundary needs a category to map onto a wire status — the split is between the in-stack wrapper and the boundary.

- **The leader and transition guard ladders now ask `Throwable.isShutdownSignal` instead of naming exception types.**
  Hand-listing the types is what let the bug in, and the predicate already existed. Behaviour is unchanged for `CancellationException`, `InterruptedException` and ordinary faults.

- **Nothing user-facing changes shape.** No SQL, pgwire, config or public-API surface moves; the anomaly categories on the wire are untouched.

## Context

`Anomaly` exists to classify exceptions so the indexer can decide whether to abort a transaction or fail the node. `Anomaly.Caller` means "the caller's fault, abort this transaction and carry on"; anything else means "our fault, fail the term".

`Interrupted` is not an `Anomaly.Caller`. So a thread interrupt, once classified, told the ingestion path to fail the database — which is the opposite of what a shutdown signal means.

This came out of a broader question about whether `Anomaly` still earns its keep now that single-writer has removed the determinism requirement the design was built for. That question is still open; this PR is the part of it that is unambiguously a bug, separated out so the rest can be decided on its own merits.

## Root cause

`wrapAnomaly` caught every `Throwable` and ran it through `toAnomaly`, whose `when` has arms for `InterruptedException` and `ClosedByInterruptException`. Total by construction — which is what made it wrong for interrupts specifically.

```
thread interrupted → InterruptedException
  → wrapAnomaly → Interrupted   (an Anomaly, but not an Anomaly.Caller)
  → the guard ladders name only InterruptedException, so this isn't a shutdown signal to them
  → watchers.notifyError → database Failed (absorbing) → unqueryable until restart
```

Two things made this survive review for as long as it did.

- **Every consumer already treated the two as the same thing**, so the symptom never showed up as a distinction anyone had to reason about.
  Ten `catch Interrupted` arms sat next to identical `InterruptedException` arms — five in `pgwire.clj`, two in `LeaderLogProcessor`, one each in `TransitionLogProcessor` and `CrashLogger`. `CrashLogger`'s existed solely to undo the conversion three lines above it.

- **`toAnomaly` is called mid-stack as well as at the boundaries.**
  `DocsIndexer` classifies every non-`CancellationException` throwable from its writer lambda, and that lambda runs inside `runTaskGuarded` via `TxResolver.msg.writer`. So the Kafka-connect ingestion path produced an `Interrupted` even after `wrapAnomaly` stopped doing so, and a ladder naming only `InterruptedException` reported it as an ingestion fault.

## Implementation notes

- **The classify/propagate split is between the wrapper and the boundary**
  `wrapAnomaly` and `wrap-anomaly` rethrow `InterruptedException`, and convert `ClosedByInterruptException` into one. `toAnomaly` and `->anomaly` are unchanged, so `XtdbProducer.asFlightException` keeps mapping the category onto `CallStatus.CANCELLED` and `flight_sql.clj` keeps mapping CANCELLED back the other way. A boundary classifies a throwable without unwinding through it, which is why it can want the opposite thing from the wrapper.

- **The `ClosedByInterruptException` arm is a backstop, not the canonical site**
  Twelve blocking boundaries already convert it at the channel — `LocalStorage`, `MemoryCache`, `Relation`, `ArrowUnloader`, `MemoryUtil`, `Compactor` and `util.clj` among them. The arm in `wrapAnomaly` is there in case one is missed.

- **`isShutdownSignal` replaces the hand-listed types in three ladders**
  `LeaderLogProcessor`'s apply arm and `runTaskGuarded`, and `TransitionLogProcessor.processRecords`. `runTaskGuarded` keeps a separate `CancellationException` arm because it cancels `onComplete` where the others complete it exceptionally. The predicate itself is unchanged.

- **`prep-stmt` needed its own arm because a checked exception falls through a ladder differently**
  Its ladder logs at debug via `RuntimeException` and at error via `Throwable`. `Interrupted` took the former; `InterruptedException` takes the latter, so without this a clean teardown mid-prepare would have started emitting ERROR-level stack traces. The same reasoning gives `cmd-parse` an `InterruptedException` arm in place of its `Interrupted` one, keeping `tx-error-counter` off shutdown.

- **One deliberate behaviour change beyond the fix**
  An interrupt no longer increments `txErrorCounter` at `Xtdb.doSubmit`, which catches `Anomaly`. A shutdown isn't a transaction error, so this is the right side of the line — but it is a metric that will read differently.

## Out of scope

Both of these are pre-existing, reachable, and left exactly as they were rather than quietly changed.

- **`runTaskGuarded` leaves `extResult` uncompleted on a shutdown signal**, so an external-source caller awaiting a `TransactionResult` can hang until the term closes. The deleted `Interrupted` arm had the identical gap, and `isShutdownSignal` preserves it.

- **The outer ladders in `LeaderLogProcessor` still test `CancellationException` alone** — `runLeaderTerm` and the ext-source arm. Reachable through `LocalStorage`'s raw `InterruptedException` on the leader's block-upload path, so interrupting a thread mid-upload during a handover can still fail a healthy database. Raised as `R1` on #5926 and independent of everything here; the fix is the same one-line-per-site change as this PR's inner ladders.

Also unchanged: whether the nine-member `Anomaly` hierarchy and its wire taxonomy are worth their weight. Worth noting for that discussion that `pgwire`'s `ex->pgw-err` maps three of the nine categories and falls the other six through to `XX000` plus an "Uncaught exception" error log, and that no client in `lang/` reads the category keyword.

## Test plan

- **New**: `AnomalyTest` and two deftests in `xtdb.error-test` cover both wrappers — an interrupt escapes unclassified, a closed-by-interrupt channel escapes as an interrupt, everything else still classifies, and `toAnomaly` still gives an interrupt a category for the boundaries.
- **New**: a regression test in `DocsIndexerTest` for the mid-stack path. Red-greened — with the `DocsIndexer` fix reverted it fails with `expected: <java.lang.InterruptedException> but was: <xtdb.api.error.Interrupted>`, which is the reported failure mode exactly.
- `./gradlew test` — 1712 tests, 0 failures, and the kafka module's 51 alongside them.
- `./gradlew property-test` — 2714 tests, 0 failures at 100 iterations, including `LeaderDriverSimTest` and `LogProcessorSimTest`, which are the simulations covering the restructured ladders.
- `cancel_big_query` flaked once mid-session on the known `BoundQuery/openCursor` allocator leak (#5426) and passed on the verification run.
