### PR TITLE
fix(indexer): an interrupt ends a leader term without failing the database

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ExternalSourceProcessor.kt
@@ -92,7 +92,7 @@ internal class ExternalSourceProcessor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            watchers.notifyError(e)
+            if (!e.isShutdownSignal) watchers.notifyError(e)
         }
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -133,9 +133,11 @@ internal suspend fun runLeaderTerm(
     } catch (t: Throwable) {
         // A genuine term fault (e.g. an append fault) surfaces to queries as a failed term. Idempotent —
         // the apply arm may already have notified for its own faults.
-        LOG.error(t) { "[$dbName] leader term failed" }
+        if (!t.isShutdownSignal) {
+            LOG.error(t) { "[$dbName] leader term failed" }
+            watchers.notifyError(t)
+        }
         cause = t
-        watchers.notifyError(t)
     } finally {
         term.shutdown(cause ?: CancellationException("leader term closed"))
     }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -195,6 +195,79 @@ class LeaderLogProcessorTest {
         assertTrue(replicaLog.latestSubmittedOffset() >= 0, "replica log should have received a message")
     }
 
+    /**
+     * A term wired up but not started, so a test can drive [runLeaderTerm] or one of its components
+     * directly and have it return. [leaderProc] launches the term into a scope instead, where the only
+     * handle on its completion is scheduler advancement.
+     */
+    private fun TestScope.unstartedTerm(
+        watchers: Watchers,
+        driver: (LeaderDriver) -> LeaderDriver = { it },
+        extSource: ExternalSource? = null,
+    ): Pair<LeaderLogProcessor, ReplicaLogAppender> {
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
+        val partitionState =
+            PartitionState(BlockCatalog(null), mockk(relaxed = true), mockk(relaxed = true), liveIndexMock())
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(
+            partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null,
+            backgroundScope, StandardTestDispatcher(testScheduler)
+        )
+        val leaderDriver = driver(RealLeaderDriver(partitionStorage, partitionState, blockUploader))
+        val appender = ReplicaLogAppender(leaderDriver)
+
+        val proc = LeaderLogProcessor(
+            allocator, nodeBase, partitionStorage, mockk(relaxed = true),
+            partitionState, "test", leaderDriver, watchers, appender, extSource,
+            skipTxs = emptySet(), dbCatalog = null,
+            leaderTerm = 1,
+            flushTimeout = IndexerConfig().flushDuration,
+        )
+        leadersToClose += proc
+        return proc to appender
+    }
+
+    @Test
+    fun `an interrupt on the append path leaves the database queryable`() = runTest {
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+
+        val (proc, appender) = unstartedTerm(watchers, driver = { inner ->
+            object : LeaderDriver by inner {
+                // LocalStorage converts a ClosedByInterruptException into this on both its write paths
+                override suspend fun appendToReplica(msg: ReplicaMessage): Log.MessageMetadata =
+                    throw InterruptedException("interrupted writing to storage")
+            }
+        })
+
+        appender.append(ControlItem(ReplicaMessage.NoOp(termId = 1)))
+
+        // returns once the pump's failure has ended the term
+        runLeaderTerm("test", watchers, proc, appender)
+
+        assertNull(
+            watchers.exception,
+            "an interrupt ends the term without failing the database"
+        )
+    }
+
+    @Test
+    fun `an interrupt in the external source leaves the database queryable`() = runTest {
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+        val extSource = mockk<ExternalSource>(relaxed = true) {
+            coEvery { onPartitionAssigned(any(), any(), any()) } throws InterruptedException("interrupted")
+        }
+
+        val (proc, _) = unstartedTerm(watchers, extSource = extSource)
+        proc.extSrcProc!!.run()
+
+        assertNull(
+            watchers.exception,
+            "an interrupt ends the term without failing the database"
+        )
+    }
+
     @Test
     fun `FlushBlock triggers block finish when CAS matches`() = runTest(timeout = 5.seconds) {
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)


### PR DESCRIPTION
Part of #5917.

## tl;dr

- **Interrupting a node mid-write could leave a database unqueryable until the process restarted.**
  A routine teardown was enough to trigger it; `Watchers`' `Failed` state is absorbing, so nothing recovered it short of a restart.
- **Two guard ladders were reading a shutdown signal as an ingestion fault.** They now ask `Throwable.isShutdownSignal`, the same predicate the inner ladders moved onto in #5940.
- **Two lines of production change, one per site**, plus two regression tests.

## Context

`LocalStorage` converts a `ClosedByInterruptException` into a raw `InterruptedException` on both of its write paths, and the leader reaches it through its block upload and its replica-log append alike.

That exception is neither a `CancellationException` nor an `xtdb.api.error.Interrupted`, so it fell past both outer ladders into their `catch (Throwable)` arm, which reports to `Watchers` as an ingestion fault:

- `runLeaderTerm` (`LogProcessor.kt`) — reachable via `applyRecord` → `driver.uploadBlock` → `BlockUploader` → `bufferPool.putObject`, and via the append pump.
- `ExternalSourceProcessor.run` — reachable through whatever the source adapter does on the calling thread.

#5940 fixed the *inner* ladders — `runTaskGuarded`, the leader's apply arm, the transition's `processRecords` — and deliberately left these two, because a refactor was in flight across both files at the time. This is the same one-line-per-site change, applied to the two that were skipped.

## Implementation

- **Only the log and the notify become conditional.**
  `cause` is still assigned outside the guard, exactly as before, so the term still ends and still ends with the interrupt as its cause. `asCancellation` wraps a non-cancellation cause, so everything the teardown fails — staged txs, a paused batch, the replica reader — sees precisely what it saw before, and the interrupt survives into the logs rather than being swapped for a synthetic cancellation.

- **No comment at either site.**
  `isShutdownSignal`'s own definition already carries the reason (`Failed` is absorbing); re-narrating a pattern at each application site is what the comment guidance says to cut, and #5940 added none at its three sites either.

- **`runFollower` needs nothing** — its `Throwable` arm swallows without notifying, because `FollowerLogProcessor` reports before it throws.

## The tests were green before they were red

Worth recording, because it nearly cost the fix its evidence.

The first version of both tests drove the term through the existing `leaderProc` helper, which launches it into a scope, then asserted after `advanceUntilIdle()`. Both passed — while the captured log showed `leader term failed` and `ingestion stopping` arriving five milliseconds after the assertion had already run.

A test that passes because the code under test has not run *yet* would have certified this fix without ever exercising it.

The new `unstartedTerm` helper builds a term without starting it, so `runLeaderTerm` and `ExternalSourceProcessor.run` are called directly from the test body and return only once their handler has run. Both then failed with `expected: <null> but was: <IngestionStoppedException>`, and pass with the fix.

## Test plan

- `./gradlew test` — 2140 tests, 0 failures.
- `./gradlew property-test` — 2747 tests; the one failure is #5851, the known `dropSlot` teardown flake in postgres-source, matching all three of that issue's stated identification criteria. All indexer simulations green: `NodeSimulationTest` 800, `CompactorSimulationTest` 813, `CacheSimulationTest` 700, `LogProcessorSimTest` 300, `LeaderDriverSimTest` 101.
- Red/green confirmed in both directions on the two new tests.
