### PR TITLE
fix(metrics): a node's meters outlive the roles it has held

### DIFF
--- a/core/src/main/kotlin/xtdb/Metrics.kt
+++ b/core/src/main/kotlin/xtdb/Metrics.kt
@@ -1,6 +1,7 @@
 package xtdb
 
 import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.binder.jvm.*
@@ -131,5 +132,44 @@ object Metrics {
             scope?.close()
             span?.end()
         }
+    }
+}
+
+/**
+ * The meters one object owns — registered through [register], and removed from the registry by [close].
+ *
+ * Micrometer keeps the first registration for a meter ID and discards every later one, so a meter left
+ * behind by a dead owner shadows its replacement. For a gauge bound to an object that means reading the
+ * dead owner's state for the rest of the node's life, rather than the live owner's.
+ */
+class Meters(private val registry: MeterRegistry?) : AutoCloseable {
+
+    private val owned = mutableListOf<Meter>()
+
+    fun <M : Meter> register(build: (MeterRegistry) -> M): M? =
+        registry?.let { reg ->
+            val incumbents = reg.meters.toSet()
+
+            // `build` hands back an incumbent rather than registering ours where the ID is taken — a meter
+            // some owner didn't get to remove. Evicting it and building again is what stops one leak
+            // shadowing every later owner: what we return has to be the meter the registry now holds.
+            build(reg)
+                .let { if (it in incumbents) { reg.removeWithDerived(it); build(reg) } else it }
+                .also(owned::add)
+        }
+
+    override fun close() {
+        registry?.let { reg -> owned.forEach { reg.removeWithDerived(it) } }
+        owned.clear()
+    }
+
+    // A percentile-publishing timer or summary also registers a `<name>.percentile` gauge per phi, as
+    // meters in their own right that `remove` doesn't reach — and they read the parent being removed. The
+    // tag check keeps the sweep off another database's meters.
+    private fun MeterRegistry.removeWithDerived(meter: Meter) {
+        remove(meter)
+
+        meters.filter { it.id.name.startsWith("${meter.id.name}.") && it.id.tags.containsAll(meter.id.tags) }
+            .forEach { remove(it) }
     }
 }

--- a/core/src/main/kotlin/xtdb/NodeBase.kt
+++ b/core/src/main/kotlin/xtdb/NodeBase.kt
@@ -1,6 +1,7 @@
 package xtdb
 
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import io.micrometer.tracing.otel.bridge.OtelTracer
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
@@ -27,6 +28,9 @@ class NodeBase(
     val remotes: Map<RemoteAlias, Remote>,
     val compactor: Compactor,
     val querySource: IQuerySource,
+
+    /** Untagged, so node-scoped: a per-database owner would collide on the single meter ID. */
+    val txOpTimer: Timer?,
 ) : AutoCloseable {
 
     override fun close() {
@@ -100,6 +104,12 @@ class NodeBase(
                     remotes = remotes,
                     compactor = compactor,
                     querySource = querySource,
+                    txOpTimer = meterReg?.let { reg ->
+                        Timer.builder("tx.op.timer")
+                            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
+                            .description("indicates the timing and number of transactions")
+                            .register(reg)
+                    },
                 )
             }
     }

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -1,6 +1,5 @@
 package xtdb.garbage_collector
 
-import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -11,7 +10,6 @@ import xtdb.catalog.BlockCatalog
 import xtdb.catalog.BlockCatalog.Companion.allBlockFiles
 import xtdb.catalog.BlockCatalog.Companion.tableBlocks
 import xtdb.storage.BufferPool
-import xtdb.api.DatabaseName
 import xtdb.util.StringUtil.fromLexHex
 import xtdb.util.debug
 import xtdb.util.logger
@@ -41,12 +39,11 @@ class BlockGarbageCollector(
     private val blocksToKeep: Int,
     /** Gates the auto-signal from the leader's block-boundary path; direct `awaitNoGarbage()` is unaffected. */
     val enabled: Boolean,
-    private val meterRegistry: MeterRegistry? = null,
+    private val metrics: GcMetrics,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
     /** Base for the parallel delete fan-out pools; the loop itself runs on its caller's thread. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    dbName: DatabaseName,
 ) {
 
     // [signal] is fire-and-forget; bursts coalesce into one upcoming cycle.
@@ -58,20 +55,6 @@ class BlockGarbageCollector(
 
     private val tableDispatcher = dispatcher.limitedParallelism(tableParallelism)
     private val deleteDispatcher = dispatcher.limitedParallelism(deleteParallelism)
-
-    private val blockDeleteTimer: Timer? = meterRegistry?.let {
-        Timer.builder("xtdb.gc.block_files.delete.timer")
-            .publishPercentiles(0.75, 0.95, 0.99)
-            .tag("db", dbName)
-            .register(it)
-    }
-
-    private val tableBlockDeleteTimer: Timer? = meterRegistry?.let {
-        Timer.builder("xtdb.gc.table_block_files.delete.timer")
-            .publishPercentiles(0.75, 0.95, 0.99)
-            .tag("db", dbName)
-            .register(it)
-    }
 
     init {
         require(blocksToKeep >= 1) { "blocksToKeep must be >= 1, got $blocksToKeep" }
@@ -138,9 +121,9 @@ class BlockGarbageCollector(
             coroutineScope {
                 paths.filter { it.isGarbage() }.forEach { path ->
                     launch(deleteDispatcher) {
-                        val timer = meterRegistry?.let { Timer.start(it) }
+                        val sample = gcTimer?.let { Timer.start() }
                         bufferPool.deleteIfExists(path)
-                        gcTimer?.let { timer?.stop(it) }
+                        gcTimer?.let { sample?.stop(it) }
                     }
                 }
             }
@@ -148,14 +131,14 @@ class BlockGarbageCollector(
 
         supervisorScope {
             launch(tableDispatcher) {
-                deleteGarbage(bufferPool.allBlockFiles.asSequence().map { it.key }, blockDeleteTimer)
+                deleteGarbage(bufferPool.allBlockFiles.asSequence().map { it.key }, metrics.blockDelete)
             }
         }
 
         supervisorScope {
             for (table in blockCatalog.allTables) {
                 launch(tableDispatcher) {
-                    deleteGarbage(bufferPool.tableBlocks(table).asSequence().map { it.key }, tableBlockDeleteTimer)
+                    deleteGarbage(bufferPool.tableBlocks(table).asSequence().map { it.key }, metrics.tableBlockDelete)
                 }
             }
         }

--- a/core/src/main/kotlin/xtdb/garbage_collector/GcMetrics.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/GcMetrics.kt
@@ -1,0 +1,28 @@
+package xtdb.garbage_collector
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import xtdb.Meters
+import xtdb.api.DatabaseName
+
+/**
+ * A database's garbage-collection meters. The collectors that record into them are built per leader term,
+ * and these outlive any one term — so a node that has never led still reports them.
+ */
+class GcMetrics(registry: MeterRegistry?, private val dbName: DatabaseName) : AutoCloseable {
+
+    private val meters = Meters(registry)
+
+    private fun deleteTimer(name: String) = meters.register { reg ->
+        Timer.builder(name)
+            .publishPercentiles(0.75, 0.95, 0.99)
+            .tag("db", dbName)
+            .register(reg)
+    }
+
+    val trieDelete = deleteTimer("xtdb.gc.tries.delete.timer")
+    val blockDelete = deleteTimer("xtdb.gc.block_files.delete.timer")
+    val tableBlockDelete = deleteTimer("xtdb.gc.table_block_files.delete.timer")
+
+    override fun close() = meters.close()
+}

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -1,6 +1,5 @@
 package xtdb.garbage_collector
 
-import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -8,7 +7,6 @@ import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.selects.select
 import xtdb.catalog.BlockCatalog.Companion.blockFromLatest
-import xtdb.api.DatabaseName
 import xtdb.database.PartitionState
 import xtdb.storage.BufferPool
 import xtdb.api.TableRef
@@ -53,7 +51,6 @@ private const val TRIES_DELETED_CHUNK_SIZE = 1024
 class TrieGarbageCollector(
     private val bufferPool: BufferPool,
     partitionState: PartitionState,
-    dbName: DatabaseName,
     /**
      * Publishes a `TriesDeleted` to the replica log AND removes the keys from the local trie catalog — atomically, in a single Persister task on the leader.
      * The Persister channel is the sole ordering point, so no other replica-log write interleaves between the two.
@@ -63,7 +60,7 @@ class TrieGarbageCollector(
     private val blocksToKeep: Int,
     private val garbageLifetime: Duration,
     val enabled: Boolean,
-    private val meterRegistry: MeterRegistry? = null,
+    private val metrics: GcMetrics,
     tableParallelism: Int = DEFAULT_TABLE_PARALLELISM,
     deleteParallelism: Int = DEFAULT_DELETE_PARALLELISM,
     /** Base for the parallel delete fan-out pools; the loop itself runs on its caller's thread. Sims inject the seeded dispatcher so deletes stay on the simulation's thread. */
@@ -80,13 +77,6 @@ class TrieGarbageCollector(
     private val tableDispatcher = dispatcher.limitedParallelism(tableParallelism)
     private val deleteDispatcher = dispatcher.limitedParallelism(deleteParallelism)
 
-    private val deleteTimer: Timer? = meterRegistry?.let {
-        Timer.builder("xtdb.gc.tries.delete.timer")
-            .publishPercentiles(0.75, 0.95, 0.99)
-            .tag("db", dbName)
-            .register(it)
-    }
-    
     /** Collect on every trigger until cancelled. Nothing is serviced until this is running: [signal] queues, and [awaitNoGarbage] suspends. */
     suspend fun run(): Unit = coroutineScope {
         LOGGER.debug("Starting TrieGarbageCollector (enabled=$enabled, blocksToKeep=$blocksToKeep, garbageLifetime=$garbageLifetime)")
@@ -174,10 +164,10 @@ class TrieGarbageCollector(
                         "L0 trie keys must never reach GC deletion: $trieKey"
                     }
                     launch(deleteDispatcher) {
-                        val timer = meterRegistry?.let { Timer.start(it) }
+                        val sample = metrics.trieDelete?.let { Timer.start() }
                         bufferPool.deleteIfExists(tableName.dataFilePath(trieKey))
                         bufferPool.deleteIfExists(tableName.metaFilePath(trieKey))
-                        deleteTimer?.let { timer?.stop(it) }
+                        metrics.trieDelete?.let { sample?.stop(it) }
                     }
                 }
             }

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -1,7 +1,5 @@
 package xtdb.indexer
 
-import io.micrometer.core.instrument.DistributionSummary
-import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.selects.SelectBuilder
@@ -42,45 +40,15 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val dbCatalog: Database.Catalog?,
     pendingBlock: PendingBlock?,
     private val hasExternalSource: Boolean,
-    private val meterRegistry: MeterRegistry? = null,
+    private val metrics: ReplicaMetrics,
     private val maxBufferedRecords: Int = 1024,
 ) : AutoCloseable {
-
-    private fun processTimer(msgType: String): Timer? = meterRegistry?.let {
-        Timer.builder("xtdb.replica.process.timer")
-            .description("Time spent processing replica log records, by message type")
-            .tag("db", dbName)
-            .tag("msg.type", msgType)
-            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
-            .register(it)
-    }
-
-    private val resolvedTxTimer = processTimer("ResolvedTx")
-    private val triesAddedTimer = processTimer("TriesAdded")
-    private val blockBoundaryTimer = processTimer("BlockBoundary")
-    private val blockUploadedTimer = processTimer("BlockUploaded")
-    private val triesDeletedTimer = processTimer("TriesDeleted")
-
-    private val blockBufferTimer: Timer? = meterRegistry?.let {
-        Timer.builder("xtdb.replica.block.buffer.timer")
-            .description("Time the follower spends buffering records between BlockBoundary and BlockUploaded")
-            .tag("db", dbName)
-            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
-            .register(it)
-    }
-
-    private val bufferedRecordsSummary: DistributionSummary? = meterRegistry?.let {
-        DistributionSummary.builder("xtdb.replica.block.buffered.records")
-            .description("Number of records buffered while a follower waits for BlockUploaded")
-            .tag("db", dbName)
-            .register(it)
-    }
 
     private var blockBufferStartSample: Timer.Sample? = null
 
     private inline fun <R> Timer?.timed(block: () -> R): R {
         if (this == null) return block()
-        val sample = Timer.start(meterRegistry!!)
+        val sample = Timer.start()
         try {
             return block()
         } finally {
@@ -149,7 +117,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
     private suspend fun processRecord(record: Log.Record<ReplicaMessage>, replicaMsgId: MessageId?) {
         when (val msg = record.message) {
-            is ReplicaMessage.ResolvedTx -> resolvedTxTimer.timed {
+            is ReplicaMessage.ResolvedTx -> metrics.resolvedTx.timed {
                 val systemTime = msg.systemTime
                 val txKey = TransactionKey(msg.txId, systemTime)
 
@@ -192,18 +160,18 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 watchers.notifyApplied(replicaMsgId, effectiveSrcMsgId, result, msg.externalSourceToken)
             }
 
-            is ReplicaMessage.TriesAdded -> triesAddedTimer.timed {
+            is ReplicaMessage.TriesAdded -> metrics.triesAdded.timed {
                 if (msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch)
                     addTries(msg.tries, record.logTimestamp)
 
                 watchers.notifyApplied(replicaMsgId, msg.sourceMsgId)
             }
 
-            is ReplicaMessage.BlockBoundary -> blockBoundaryTimer.timed {
+            is ReplicaMessage.BlockBoundary -> metrics.blockBoundary.timed {
                 pendingBlock = PendingBlock(record.msgId, msg, maxBufferedRecords)
                 LOG.debug("[$dbName] block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} — waiting for BlockUploaded...")
                 watchers.notifyApplied(replicaMsgId, msg.latestProcessedMsgId)
-                blockBufferStartSample = meterRegistry?.let { Timer.start(it) }
+                blockBufferStartSample = metrics.blockBuffer?.let { Timer.start() }
             }
 
             is ReplicaMessage.BlockUploaded -> error(
@@ -212,7 +180,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
             is ReplicaMessage.NoOp -> watchers.notifyApplied(replicaMsgId, msg.srcMsgId)
 
-            is ReplicaMessage.TriesDeleted -> triesDeletedTimer.timed {
+            is ReplicaMessage.TriesDeleted -> metrics.triesDeleted.timed {
                 trieCatalog.deleteTries(fromSchemaAndTable(msg.tableName), msg.trieKeys)
                 watchers.notifyApplied(replicaMsgId)
             }
@@ -232,7 +200,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
                 && msg.storageEpoch == bufferPool.epoch
             ) {
                 LOG.debug("[$dbName] block uploaded b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} (${pendingBlock.bufferedRecords.size} buffered)")
-                val bufferedRecords = blockUploadedTimer.timed {
+                val bufferedRecords = metrics.blockUploaded.timed {
                     val block = parseFrom(bufferPool.getByteArray(blockFilePath(pendingBlockIdx)))
 
                     addTries(msg.tries, record.logTimestamp)
@@ -242,8 +210,8 @@ class FollowerLogProcessor @JvmOverloads constructor(
                     compactor.signalBlock()
 
                     val bufferedRecords = pendingBlock.bufferedRecords
-                    bufferedRecordsSummary?.record(bufferedRecords.size.toDouble())
-                    blockBufferTimer?.let { blockBufferStartSample?.stop(it) }
+                    metrics.bufferedRecords?.record(bufferedRecords.size.toDouble())
+                    metrics.blockBuffer?.let { blockBufferStartSample?.stop(it) }
                     blockBufferStartSample = null
                     this.pendingBlock = null
                     bufferedRecords

--- a/core/src/main/kotlin/xtdb/indexer/GarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/indexer/GarbageCollector.kt
@@ -8,12 +8,12 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import xtdb.NodeBase
-import xtdb.api.DatabaseName
 import xtdb.api.TableRef
 import xtdb.api.log.ReplicaMessage.TriesDeleted
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.garbage_collector.BlockGarbageCollector
+import xtdb.garbage_collector.GcMetrics
 import xtdb.garbage_collector.TrieGarbageCollector
 import xtdb.trie.TrieKey
 
@@ -21,9 +21,9 @@ internal class GarbageCollector(
     private val nodeBase: NodeBase,
     partitionStorage: PartitionStorage,
     private val partitionState: PartitionState,
-    private val dbName: DatabaseName,
     private val leaderTerm: Long,
     private val replicaAppender: ReplicaLogAppender,
+    private val metrics: GcMetrics,
 
     // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
     gcDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -38,9 +38,8 @@ internal class GarbageCollector(
             bufferPool, blockCatalog,
             blocksToKeep = cfg.blocksToKeep,
             enabled = cfg.enabled,
-            meterRegistry = nodeBase.meterRegistry,
+            metrics = metrics,
             dispatcher = gcDispatcher,
-            dbName = dbName
         )
     }
 
@@ -62,10 +61,10 @@ internal class GarbageCollector(
         }
 
         TrieGarbageCollector(
-            bufferPool, partitionState, dbName,
+            bufferPool, partitionState,
             commitTriesDeleted, cfg.blocksToKeep, cfg.garbageLifetime,
             cfg.enabled,
-            nodeBase.meterRegistry,
+            metrics,
             dispatcher = gcDispatcher,
         )
     }

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -12,6 +12,7 @@ import xtdb.api.DatabaseName
 import xtdb.api.log.*
 import xtdb.api.log.ReplicaMessage.BlockBoundary
 import xtdb.database.*
+import xtdb.garbage_collector.GcMetrics
 import xtdb.api.log.ReplicaMessage
 import xtdb.util.*
 import java.time.*
@@ -43,6 +44,7 @@ internal class LeaderLogProcessor(
     skipTxs: Set<MessageId>,
     private val dbCatalog: Database.Catalog?,
     private val leaderTerm: Long = 0,
+    gcMetrics: GcMetrics,
     instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration,
     // Base for the GCs' delete fan-out; defaults to IO in prod, sims inject the seeded dispatcher.
@@ -115,7 +117,7 @@ internal class LeaderLogProcessor(
     private val rowsPerBlock = liveIndex.rowsPerBlock
 
     val gc = GarbageCollector(
-        nodeBase, partitionStorage, partitionState, dbName, leaderTerm, replicaAppender, gcDispatcher
+        nodeBase, partitionStorage, partitionState, leaderTerm, replicaAppender, gcMetrics, gcDispatcher
     )
 
     val srcLogProc = SourceLogProcessor(

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.selects.SelectBuilder
 import kotlinx.coroutines.selects.selectUnbiased
 import kotlinx.coroutines.withContext
 import org.apache.arrow.memory.BufferAllocator
+import xtdb.Meters
 import xtdb.NodeBase
 import xtdb.api.TransactionResult
 import xtdb.api.log.*
@@ -31,6 +32,8 @@ import xtdb.api.tx.ExternalSource
 import xtdb.api.error.Fault
 import xtdb.api.error.Interrupted
 import xtdb.types.MessageId
+import xtdb.garbage_collector.GcMetrics
+import xtdb.util.closeAll
 import xtdb.util.debug
 import xtdb.util.error
 import xtdb.util.info
@@ -180,6 +183,11 @@ class LogProcessor(
     private val replicaLog = partitionStorage.replicaLog
     private val hasExternalSource = externalSourceFactory != null
 
+    // Declared ahead of `state`, whose initialiser opens the first follower and reads them.
+    private val replicaMetrics = ReplicaMetrics(base.meterRegistry, dbName)
+    private val gcMetrics = GcMetrics(base.meterRegistry, dbName)
+    private val meters = Meters(base.meterRegistry)
+
     // The committed-role state machine — see allium/log-processor-lifecycle.allium.
     // `state` is written from two places: the transport's serialization point (commitLeader /
     // demoteLeader) and the off-thread transition coroutine (cutoverToLeader → Prepared, or its catch
@@ -219,6 +227,7 @@ class LogProcessor(
             externalSourceFactory?.open(dbName, base.remotes, base.meterRegistry),
             skipTxs, dbCatalog,
             leaderTerm = termId,
+            gcMetrics = gcMetrics,
             flushTimeout = flushTimeout,
             gcDispatcher = gcDispatcher,
         )
@@ -272,7 +281,7 @@ class LogProcessor(
             allocator, partitionStorage.bufferPool, partitionState, dbName, compactor, watchers,
             dbCatalog, pendingBlock,
             hasExternalSource = hasExternalSource,
-            meterRegistry = base.meterRegistry,
+            metrics = replicaMetrics,
         )
 
         return Following(proc, scope.launch {
@@ -285,7 +294,7 @@ class LogProcessor(
     private var state: State = openFollower()
 
     init {
-        base.meterRegistry?.let { reg ->
+        meters.register { reg ->
             Gauge.builder("xtdb.log.leader", this) { if (it.state is Leading) 1.0 else 0.0 }
                 .description("1 if this node is the log leader, 0 if follower")
                 .tag("db", dbName)
@@ -403,7 +412,15 @@ class LogProcessor(
         state = openFollower(leader.proc.pendingBlock)
     }
 
-    override fun close() = state.proc.close()
+    // Removal ahead of the processor, and in a `finally`: its allocator throws on a leaked buffer, which
+    // would otherwise leave the leader gauge holding this dead LogProcessor for the life of the node.
+    override fun close() {
+        try {
+            listOf(meters, replicaMetrics, gcMetrics).closeAll()
+        } finally {
+            state.proc.close()
+        }
+    }
 
     /**
      * Run one cycle of every garbage collector owned by the leader (block + trie) and wait for

--- a/core/src/main/kotlin/xtdb/indexer/ReplicaMetrics.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ReplicaMetrics.kt
@@ -1,0 +1,48 @@
+package xtdb.indexer
+
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import xtdb.Meters
+import xtdb.api.DatabaseName
+
+/**
+ * A database's follower-side meters. The node opens a fresh [FollowerLogProcessor] every time it returns
+ * to following, and these outlive any one of them.
+ */
+class ReplicaMetrics(registry: MeterRegistry?, private val dbName: DatabaseName) : AutoCloseable {
+
+    private val meters = Meters(registry)
+
+    private fun processTimer(msgType: String) = meters.register { reg ->
+        Timer.builder("xtdb.replica.process.timer")
+            .description("Time spent processing replica log records, by message type")
+            .tag("db", dbName)
+            .tag("msg.type", msgType)
+            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
+            .register(reg)
+    }
+
+    val resolvedTx = processTimer("ResolvedTx")
+    val triesAdded = processTimer("TriesAdded")
+    val blockBoundary = processTimer("BlockBoundary")
+    val blockUploaded = processTimer("BlockUploaded")
+    val triesDeleted = processTimer("TriesDeleted")
+
+    val blockBuffer = meters.register { reg ->
+        Timer.builder("xtdb.replica.block.buffer.timer")
+            .description("Time the follower spends buffering records between BlockBoundary and BlockUploaded")
+            .tag("db", dbName)
+            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
+            .register(reg)
+    }
+
+    val bufferedRecords = meters.register { reg ->
+        DistributionSummary.builder("xtdb.replica.block.buffered.records")
+            .description("Number of records buffered while a follower waits for BlockUploaded")
+            .tag("db", dbName)
+            .register(reg)
+    }
+
+    override fun close() = meters.close()
+}

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogTxIndexer.kt
@@ -1,6 +1,5 @@
 package xtdb.indexer
 
-import io.micrometer.core.instrument.Timer
 import io.micrometer.tracing.Tracer
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.Metrics.withSpan
@@ -59,12 +58,7 @@ internal class SourceLogTxIndexer(
     private val tracer: Tracer? =
         if (base.config.tracer.transactionTracing) base.tracer else null
 
-    private val txTimer: Timer? = base.meterRegistry?.let { reg ->
-        Timer.builder("tx.op.timer")
-            .publishPercentiles(0.75, 0.85, 0.95, 0.98, 0.99, 0.999)
-            .description("indicates the timing and number of transactions")
-            .register(reg)
-    }
+    private val txTimer = base.txOpTimer
 
     internal data class TxOpts(
         val txKey: TransactionKey,

--- a/core/src/test/kotlin/xtdb/MetersTest.kt
+++ b/core/src/test/kotlin/xtdb/MetersTest.kt
@@ -1,0 +1,60 @@
+package xtdb
+
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicLong
+
+class MetersTest {
+
+    private fun Meters.gauge(name: String, source: AtomicLong) =
+        register { reg -> Gauge.builder(name, source) { it.get().toDouble() }.register(reg) }
+
+    private fun SimpleMeterRegistry.names() = meters.map { it.id.name }
+
+    @Test
+    fun `a gauge reads its own registrant, not one an earlier owner left behind`() {
+        val reg = SimpleMeterRegistry()
+        val abandoned = AtomicLong(1)
+        val live = AtomicLong(2)
+
+        Meters(reg).gauge("test.gauge", abandoned)
+
+        Meters(reg).use { meters ->
+            meters.gauge("test.gauge", live)
+            assertEquals(2.0, reg.get("test.gauge").gauge().value(), "the live owner's source")
+        }
+
+        assertEquals(emptyList<String>(), reg.names(), "and the evicting owner still cleans up after itself")
+    }
+
+    @Test
+    fun `closing takes the percentiles a summary publishes alongside it`() {
+        val reg = SimpleMeterRegistry()
+
+        Meters(reg).use { meters ->
+            meters.register { r ->
+                DistributionSummary.builder("test.summary").publishPercentiles(0.5, 0.99).register(r)
+            }
+
+            assertTrue(reg.names().size > 1, "the summary publishes gauges of its own, was: ${reg.names()}")
+        }
+
+        assertEquals(emptyList<String>(), reg.names())
+    }
+
+    @Test
+    fun `a node without metrics builds nothing`() {
+        var built = false
+
+        Meters(null).use { meters ->
+            assertNull(meters.register { reg -> built = true; Gauge.builder("test.gauge") { 1.0 }.register(reg) })
+        }
+
+        assertEquals(false, built)
+    }
+}

--- a/core/src/test/kotlin/xtdb/NodeBaseTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeBaseTest.kt
@@ -1,13 +1,25 @@
 package xtdb
 
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import xtdb.NodeBase.Companion.openBase
 import xtdb.api.Xtdb
 import xtdb.api.log.KafkaCluster
 import xtdb.api.error.Incorrect
 
 class NodeBaseTest {
+
+    @Test
+    fun `the tx-op timer is reported before any database has led`() {
+        openBase(openMeterRegistry = true).use { base ->
+            assertNotNull(
+                base.meterRegistry!!.find("tx.op.timer").timer(),
+                "an untagged, node-scoped meter, so it outlives every leader term",
+            )
+        }
+    }
 
     @Test
     fun `same alias under logClusters and remotes fails node startup`() {

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -29,6 +29,7 @@ import xtdb.database.DatabaseLogs
 import xtdb.database.DatabaseName
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
+import xtdb.garbage_collector.GcMetrics
 import xtdb.garbage_collector.TrieGarbageCollector
 import xtdb.log.proto.TrieDetails
 import xtdb.storage.BufferPool
@@ -125,7 +126,7 @@ class NodeSimulationTest : SimulationTestBase() {
             val compactorForDb = compactor.openForDatabase(compactorScope, allocator, partitionStorage, partitionState, Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1))
             val gcScope = CoroutineScope(dispatcher)
             val garbageCollector = TrieGarbageCollector(
-                sharedBufferPool, partitionState, "xtdb",
+                sharedBufferPool, partitionState,
                 commitTriesDeleted = { tableName, trieKeys ->
                     // No replica log in the mock — apply the catalog mutation directly so the
                     // simulation's view of the catalog still converges as the test asserts.
@@ -134,6 +135,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 blocksToKeep = 2,
                 garbageLifetime = garbageLifetime,
                 enabled = false,
+                metrics = GcMetrics(null, "xtdb"),
                 dispatcher = dispatcher,
             ).also { gcScope.launch { it.run() } }
             MockDatabase("xtdb", allocator, sharedBufferPool, trieCatalog, blockCatalog, compactor, compactorForDb, garbageCollector, gcScope, compactorScope)

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import xtdb.NodeBase
+import xtdb.garbage_collector.GcMetrics
 import xtdb.NodeBase.Companion.openBase
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.api.log.*
@@ -134,6 +135,7 @@ class ExternalSourceTest {
             allocator, nodeBase, partitionStorage, crashLogger,
             partitionState, "test", driver, watchers, replicaAppender, extSource,
             skipTxs = emptySet(), dbCatalog = null,
+            gcMetrics = GcMetrics(null, "test"),
             flushTimeout = IndexerConfig().flushDuration,
         ).also { proc ->
             leadersToClose += proc

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -77,7 +77,7 @@ class FollowerLogProcessorTest {
             allocator, bufferPool, partitionState, "test", compactor,
             watchers, null, null,
             hasExternalSource = hasExternalSource,
-            meterRegistry = meterRegistry,
+            metrics = ReplicaMetrics(meterRegistry, "test"),
             maxBufferedRecords = maxBufferedRecords,
         ).also(followersToClose::add)
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import xtdb.NodeBase
+import xtdb.garbage_collector.GcMetrics
 import xtdb.NodeBase.Companion.openBase
 import xtdb.RepeatableSimulationTest
 import xtdb.SimulationTestBase
@@ -134,6 +135,7 @@ class LeaderDriverSimTest : SimulationTestBase() {
             // Never left at the default: two leaders sharing term 0 would each read the other's records
             // back as its own, and the term is exactly what tells them apart.
             leaderTerm = termId,
+            gcMetrics = GcMetrics(null, "test-db"),
             flushTimeout = indexerConfig.flushDuration,
             gcDispatcher = dispatcher,
         )

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -42,6 +42,7 @@ import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
+import xtdb.garbage_collector.GcMetrics
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.trieMetadata
 import xtdb.storage.BufferPool
@@ -150,6 +151,7 @@ class LeaderLogProcessorTest {
                 partitionState, "test", driver, watchers, replicaAppender, extSource,
                 skipTxs = skipTxs, dbCatalog = null,
                 leaderTerm = leaderTerm,
+                gcMetrics = GcMetrics(null, "test"),
                 flushTimeout = IndexerConfig().flushDuration,
             )
         )
@@ -223,6 +225,7 @@ class LeaderLogProcessorTest {
             partitionState, "test", leaderDriver, watchers, appender, extSource,
             skipTxs = emptySet(), dbCatalog = null,
             leaderTerm = 1,
+            gcMetrics = GcMetrics(null, "test"),
             flushTimeout = IndexerConfig().flushDuration,
         )
         leadersToClose += proc
@@ -302,6 +305,7 @@ class LeaderLogProcessorTest {
                 partitionState, "test", driver, watchers, replicaAppender,
                 extSource = null,
                 skipTxs = emptySet(), dbCatalog = null,
+                gcMetrics = GcMetrics(null, "test"),
                 flushTimeout = IndexerConfig().flushDuration,
             )
         )
@@ -381,6 +385,7 @@ class LeaderLogProcessorTest {
                 partitionState, "test", driver, watchers, replicaAppender,
                 extSource = null,
                 skipTxs = emptySet(), dbCatalog = null,
+                gcMetrics = GcMetrics(null, "test"),
                 flushTimeout = IndexerConfig().flushDuration,
             )
         )
@@ -761,6 +766,7 @@ class LeaderLogProcessorTest {
                 partitionState, "test", driver, watchers, replicaAppender,
                 extSource = mockk(relaxed = true),
                 skipTxs = setOf(10), dbCatalog = null,
+                gcMetrics = GcMetrics(null, "test"),
                 flushTimeout = IndexerConfig().flushDuration,
             )
         )

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -1,5 +1,6 @@
 package xtdb.indexer
 
+import io.micrometer.core.instrument.MeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -64,6 +65,8 @@ class LogProcessorTest {
         watchers: Watchers,
         blockUploader: BlockUploader,
         scope: CoroutineScope,
+        nodeBase: NodeBase = this.nodeBase,
+        allocator: BufferAllocator = this.allocator,
     ) = LogProcessor(
         allocator, nodeBase, mockk(relaxed = true),
         partitionStorage, partitionState, "test-db", watchers, blockUploader,
@@ -278,5 +281,60 @@ class LogProcessorTest {
         logProc.close()
         sourceLog.close()
         replicaLog.close()
+    }
+
+    // Names rather than meters: `xtdb.replica.process.timer` appears once per message type.
+    private val roleIndependentMeters = setOf(
+        "xtdb.log.leader",
+        "xtdb.replica.process.timer",
+        "xtdb.replica.block.buffer.timer",
+        "xtdb.replica.block.buffered.records",
+        "xtdb.gc.tries.delete.timer",
+        "xtdb.gc.block_files.delete.timer",
+        "xtdb.gc.table_block_files.delete.timer",
+    )
+
+    private fun MeterRegistry.roleIndependentNames() =
+        meters.map { it.id.name }.filter { it in roleIndependentMeters }.toSet()
+
+    // Wider than the above: a percentile-publishing timer registers `<name>.percentile` gauges as meters
+    // in their own right, and those have to go when their parent does or they read a removed meter.
+    private fun MeterRegistry.namesUnderRoleIndependent() =
+        meters.map { it.id.name }
+            .filter { name -> roleIndependentMeters.any { name == it || name.startsWith("$it.") } }
+            .toSet()
+
+    @Test
+    fun `a database reports its meters before it has led, and none once it closes`() = runTest {
+        openBase(openMeterRegistry = true).use { meteredBase ->
+            val registry = meteredBase.meterRegistry!!
+
+            meteredBase.allocator.newChildAllocator("metrics", 0, Long.MAX_VALUE).use { allocator ->
+                val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+                val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+                val partitionState = newPartitionState()
+                val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), mockBufferPool(), null)
+                val blockUploader =
+                    BlockUploader(partitionStorage, partitionState, "test-db", mockk(relaxed = true), null, null, backgroundScope)
+                val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+
+                val scope = CoroutineScope(SupervisorJob())
+
+                // No group subscription, so this database never elects — the meters are the database's
+                // rather than a term's or a follower's, or there would be nothing here to find.
+                val logProc =
+                    logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope, meteredBase, allocator)
+
+                assertEquals(roleIndependentMeters, registry.roleIndependentNames())
+
+                scope.coroutineContext.job.cancelAndJoin()
+                logProc.close()
+
+                assertEquals(emptySet<String>(), registry.namesUnderRoleIndependent())
+
+                sourceLog.close()
+                replicaLog.close()
+            }
+        }
     }
 }

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PostgresSource.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.subclass
 import org.postgresql.replication.LogSequenceNumber
 import org.postgresql.util.PSQLException
+import xtdb.Meters
 import xtdb.api.tx.TxIndexer
 import xtdb.api.Remote
 import xtdb.api.RemoteAlias
@@ -50,27 +51,29 @@ class PostgresSource(
         Tag.of("source_type", "postgres"),
     )
 
-    private val eventsCounter: Counter? = meterRegistry?.let {
+    private val meters = Meters(meterRegistry)
+
+    private val eventsCounter: Counter? = meters.register { reg ->
         Counter.builder("xtdb.postgres_source.events.total")
             .description("pgoutput insert/update/delete events ingested")
             .tags(tags)
-            .register(it)
+            .register(reg)
     }
 
-    private val commitsCounter: Counter? = meterRegistry?.let {
+    private val commitsCounter: Counter? = meters.register { reg ->
         Counter.builder("xtdb.postgres_source.commits.total")
             .description("source transactions committed")
             .tags(tags)
-            .register(it)
+            .register(reg)
     }
 
-    private val commitLag: DistributionSummary? = meterRegistry?.let {
+    private val commitLag: DistributionSummary? = meters.register { reg ->
         DistributionSummary.builder("xtdb.postgres_source.commit_lag_seconds")
             .description("wall-clock seconds between source commit and apply")
             .baseUnit("seconds")
             .publishPercentiles(0.5, 0.95, 0.99)
             .tags(tags)
-            .register(it)
+            .register(reg)
     }
 
     // epoch seconds of the latest applied commit; 0 until the first event
@@ -88,18 +91,22 @@ class PostgresSource(
         }
 
     init {
-        meterRegistry?.let { reg ->
+        meters.register { reg ->
             Gauge.builder("xtdb.postgres_source.last_event_time", lastEventEpochSeconds) { it.get().toDouble() }
                 .description("epoch seconds of the most recently applied source commit")
                 .baseUnit("seconds")
                 .tags(tags)
                 .register(reg)
+        }
 
+        meters.register { reg ->
             Gauge.builder("xtdb.postgres_source.connection_state", connectionState) { it.get().toDouble() }
                 .description("1 if a replication stream is currently open, 0 otherwise")
                 .tags(tags)
                 .register(reg)
+        }
 
+        meters.register { reg ->
             Gauge.builder("xtdb.postgres_source.wal_lag_bytes", this) { it.walLagBytes() }
                 .description("WAL bytes between pg_current_wal_lsn and our slot's confirmed_flush_lsn; NaN if we can't read it")
                 .baseUnit("bytes")
@@ -374,6 +381,7 @@ class PostgresSource(
 
     override fun close() {
         LOG.info("[$dbName] Closing external source")
+        meters.close()
         runCatching { indexer.close() }
         driver.close()
     }

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceMetricsTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceMetricsTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
-class WalLagGaugeTest {
+class PostgresSourceMetricsTest {
 
     private class StubDriver(private val lagBytes: () -> Long?) : PostgresDriver {
         override fun openSnapshot(): PostgresDriver.SnapshotReader = error("unused")
@@ -17,6 +17,9 @@ class WalLagGaugeTest {
 
     private fun SimpleMeterRegistry.walLag() =
         get("xtdb.postgres_source.wal_lag_bytes").gauge().value()
+
+    private fun SimpleMeterRegistry.sourceMeterNames() =
+        meters.map { it.id.name }.filter { it.startsWith("xtdb.postgres_source.") }.sorted()
 
     private fun openSource(reg: SimpleMeterRegistry, lagBytes: () -> Long?) =
         PostgresSource("xtdb", StubDriver(lagBytes), "test_slot", DirectMirror(), reg)
@@ -51,5 +54,41 @@ class WalLagGaugeTest {
             refuseConnection = true
             assertTrue(reg.walLag().isNaN(), "failed read — unknown, not caught up")
         }
+    }
+
+    @Test
+    fun `the gauge reads the source that is running, not the one that has been replaced`() {
+        val reg = SimpleMeterRegistry()
+
+        openSource(reg) { 1024 }.use { assertEquals(1024.0, reg.walLag()) }
+
+        openSource(reg) { 4096 }.use {
+            assertEquals(4096.0, reg.walLag(), "the live source's slot, not the closed source's")
+        }
+    }
+
+    @Test
+    fun `a closed source leaves no meters behind`() {
+        val reg = SimpleMeterRegistry()
+
+        openSource(reg) { 1024 }.use {
+            assertTrue(
+                reg.sourceMeterNames().containsAll(
+                    listOf(
+                        "xtdb.postgres_source.commit_lag_seconds",
+                        "xtdb.postgres_source.commits.total",
+                        "xtdb.postgres_source.connection_state",
+                        "xtdb.postgres_source.events.total",
+                        "xtdb.postgres_source.last_event_time",
+                        "xtdb.postgres_source.wal_lag_bytes",
+                    )
+                ),
+                "a running source reports all six, was: ${reg.sourceMeterNames()}",
+            )
+        }
+
+        // The `.percentile` gauges the commit-lag summary publishes are meters in their own right, so an
+        // empty list here is the assertion that removal reaches those too.
+        assertEquals(emptyList<String>(), reg.sourceMeterNames())
     }
 }

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -12,6 +12,7 @@ import xtdb.block.proto.txKey
 import xtdb.cache.MemoryCache
 import xtdb.catalog.BlockCatalog.Companion.latestBlock
 import xtdb.garbage_collector.BlockGarbageCollector
+import xtdb.garbage_collector.GcMetrics
 import xtdb.storage.BufferPool
 import xtdb.test.AllocatorResolver
 import xtdb.time.InstantUtil.asMicros
@@ -69,7 +70,7 @@ class BlockGarbageCollectorTest {
                     bufferPool, blockCat,
                     blocksToKeep = 3,
                     enabled = false,
-                    dbName = "xtdb",
+                    metrics = GcMetrics(null, "xtdb"),
                 )
 
                 // Validate that the latest block is correct
@@ -113,7 +114,7 @@ class BlockGarbageCollectorTest {
                         p0, BlockCatalog(p0.latestBlock),
                         blocksToKeep = 3,
                         enabled = false,
-                        dbName = "xtdb",
+                        metrics = GcMetrics(null, "xtdb"),
                     )
 
                     gc.garbageCollectBlocks()


### PR DESCRIPTION
Resolves #5943.

## tl;dr

- **What a node reports no longer depends on which roles it has happened to hold**
  Every meter that was registered by a leader term or by a follower instance now belongs to the node or to the database, and is removed when that owner goes. A CDC database's WAL-lag, connection-state and last-event gauges keep moving across a failover instead of freezing at the first term's values, and the GC delete timers and `tx.op.timer` are reported by a node that has never led.

- **Three things change on an operator's dashboards**
  `xtdb.postgres_source.*` now appears only on the node actually holding the source, rather than on every node that has ever held it — so a follower shows a gap where it used to show a flat line. Those series' three counters restart at zero when leadership returns to a node it has left. And a detached database's `db`-tagged meters disappear instead of reporting their last value for the life of the node.

- **`xtdb.Meters` is where meter ownership now lives**
  A nullable registry plus the meters registered through it, removed on `close()`. Four owners take one: the Postgres source, `ReplicaMetrics`, `GcMetrics`, and `LogProcessor` for its leader gauge.

## Implementation notes

**One owner per meter, chosen as the longest-lived thing that can still see the state.**

- **`xtdb.postgres_source.*` (six) → the `PostgresSource`, registered in `init` and removed in `close()`**
  Three of the six are gauges bound to instance state — `last_event_time` and `connection_state` to `AtomicLong`s, `wal_lag_bytes` to the source and so to its driver — and a new term's source was being dropped on the floor. Scoping the whole set to the source means the series exists exactly while this node is replicating, which is what the gauges measure. The leader term already closes its source, via `ExternalSourceProcessor.close` → `LeaderLogProcessor.close`.

- **`tx.op.timer` → `NodeBase`**
  It carries no `db` tag, so every database's indexer was already recording into one timer while each leader term re-registered it. Its owner now sits where the registry itself is opened.

- **`xtdb.replica.*` (seven) and `xtdb.gc.*` (three) → `LogProcessor`, via `ReplicaMetrics` and `GcMetrics`**
  Both are `db`-tagged and `LogProcessor` is the per-database object that builds both roles, so it constructs both sets at database open and removes them in `close()`. `GcMetrics` is threaded down to the two collectors, replacing the `MeterRegistry` each took; `ReplicaMetrics` is handed to each `FollowerLogProcessor`. With the meters injected there is no registry left at the recording sites, so `FollowerLogProcessor`'s `Timer.start(meterRegistry!!)` — one field's nullity standing in for another's — goes with them.

- **`xtdb.log.leader` → same owner, but now with an ending**
  It was already registered per database, and never removed.

**Two Micrometer behaviours `Meters` absorbs so that call sites needn't.**

- **A percentile-publishing timer or summary registers `<name>.percentile` gauges as meters in their own right**, which `registry.remove(parent)` does not reach. Left behind they read the parent that was just removed, and shadow the replacement's — the same freeze one level down. Removal sweeps them by name prefix and tag containment, which is also what keeps the sweep off another database's meters.

- **Where an ID is already taken, `register` evicts the incumbent and builds again.** See D2.

**Three corrections to the card's analysis, from sweeping every registration in `main`.**

- **`KafkaConnectSource` is already correct** — it registers inside `onPartitionAssigned` and removes everything in the `finally`, so it's the precedent for the fix rather than a second instance of the bug. Unchanged here.
- **The three GC delete timers are per-leader-term too**, which the card didn't list. They were the clearest case of a meter absent on a node that had never led.
- **The `xtdb.replica.*` meters were not actually absent.** `LogProcessor` opens its first follower in a property initialiser, so they existed from database open all along; what was wrong with them was re-registration on every switchover and no removal on detach.

## Decision rationale

- **D1: the source's three counters share the gauges' lifetime rather than keeping the node's**
  `events.total`, `commits.total` and `commit_lag_seconds` were unharmed by the bug — a counter's second registration is a harmless no-op — so leaving them registered for the node's life was available. That buys a monotonic counter at the price of six meters under two owners with two different removal rules. Prometheus handles a counter reset natively and `node-id` is a common tag, so the series is per-node either way. One lifetime won.

- **D2: `register` evicts an incumbent rather than adopting it or refusing to own it**
  Micrometer hands back the incumbent instead of registering ours when an ID is taken. Adopting it — the naive reading — means `close()` deregisters a live meter this owner never created. Refusing to own it is safe but leaves an orphan shadowing every later owner for the life of the node, which is the bug being fixed. Evicting is the only one of the three where what the registry holds afterwards is the live owner's meter. It costs a second `build` call and a Micrometer WARN in that state, and it is about five lines to revert if the conservative reading is preferred.

- **D3: `tx.op.timer` stays untagged**
  Giving it a `db` tag would have made per-database ownership sound, and would also have changed the meter's identity and broken existing dashboards. Naming is #5408's.

- **D4: `LogProcessor.close()` removes meters ahead of closing the processor, in a `try`/`finally`**
  `closeAll` is a bare `forEach` with no `finally`, and a follower's `allocator.close()` throws on a leaked buffer — so with the processor first, a leak would have left the leader gauge holding a dead `LogProcessor`. Raised in review.

## Out of scope

- **`tx.error`, the one meter in the sweep left where it is**
  `TxResolver` registers it per term, but `->conn-metrics` in `node/impl.clj` already registers the same untagged ID at node startup, so it never goes missing. Routing its three registration sites through one owner is a tidy.

- **Meter naming and new meters** — #5408 and #5404 respectively.

- **#5333's WARN**
  Same family, but its meter is `xtdb.allocator.memory.allocated` from the root allocator's `AllocationListener`, which already removes on `onChildRemoved`. Left open pending a repro rather than assumed fixed.

- **An `ExternalSource` orphaned by a throwing `LeaderLogProcessor` constructor**
  Found in the review pass. It leaks a Postgres replication connection, not just meters, and it predates this change — so it is a bug in its own right rather than meter lifetime. Not carded yet.

- **`Database.open` and `KafkaConnectSource` both have the `Meters` pattern inline** and are left alone; converting them is equivalence work and would want its own commit.

## Test plan

- **`PostgresSourceMetricsTest`** (renamed from `WalLagGaugeTest`, which is now one of its four cases) — a replacement source's gauge reads the replacement's driver, and a closed source leaves no meters behind. The first fails on `main` by reading the closed source's value.
- **`MetersTest`** — eviction, derived-percentile removal, and the no-metrics path.
- **`LogProcessorTest`** — a `LogProcessor` built without a group subscription cannot elect, so it pins the meters as the database's rather than a role's; and reports none once closed.
- **`NodeBaseTest`** — `tx.op.timer` on a node that has opened no databases at all.

`xtdb.information-schema-test/test-metrics` is the symptom the card reports, and it is **not** the regression test: it passes on `main`, because a self-electing node usually wins its first term before the query runs. The four above assert the absence deterministically instead.

Full suite green — 2228 unit tests across the root project and every module, plus `property-test` at 100 iterations covering `NodeSimulationTest`, `LogProcessorSimTest`, `LeaderDriverSimTest`, `CompactorSimulationTest` and `CacheSimulationTest` (2714 simulation invocations), all passing.
