### PR TITLE
refactor(catalog): a table's files live under a slug the block records

### DIFF
--- a/core/src/main/clojure/xtdb/block_catalog.clj
+++ b/core/src/main/clojure/xtdb/block_catalog.clj
@@ -2,7 +2,7 @@
   (:require [xtdb.db-catalog :as db]
             [xtdb.serde :as serde]
             [xtdb.time :as time])
-  (:import (xtdb.block.proto Block TxKey)))
+  (:import (xtdb.block.proto Block TableEntry TxKey)))
 
 (defn <-TxKey [^TxKey tx-key]
   (serde/->TxKey (.getTxId tx-key) (time/micros->instant (.getSystemTime tx-key))))
@@ -12,5 +12,11 @@
    :latest-completed-tx (<-TxKey (.getLatestCompletedTx block))
    :latest-processed-msg-id (.getLatestProcessedMsgId block)
    :table-names (set (.getTableNamesList block))
+   :tables (->> (.getTablesList block)
+                (into [] (map (fn [^TableEntry entry]
+                                {:oid (.getOid entry)
+                                 :schema-name (.getSchemaName entry)
+                                 :table-name (.getTableName entry)
+                                 :slug (.getSlug entry)}))))
    :secondary-dbs (->> (.getSecondaryDatabasesMap block)
                        (into {} (map (juxt key (comp db/<-DatabaseConfig val)))))})

--- a/core/src/main/clojure/xtdb/block_tables.clj
+++ b/core/src/main/clojure/xtdb/block_tables.clj
@@ -171,10 +171,13 @@
    "partition_count" (int (count partitions))})
 
 (defn- resolve-table-block
-  "Resolves a table-block file given table name and block idx. Returns parsed map or nil."
-  [^BufferPool buffer-pool ^String table-name ^long block-idx]
+  "Resolves a table-block file given table name and block idx. Returns parsed map or nil.
+
+  Takes the slug from the current registry rather than from block-idx's own. The two agree for as long as
+  a slug can't change; once renaming lands, this has to read the registry out of the block it's looking at."
+  [^BufferPool buffer-pool ^TableCatalog table-cat ^String table-name ^long block-idx]
   (let [table-ref (table/->ref table-name)
-        table-path (Trie/getTablePath table-ref)
+        table-path (.getTablePath (.slug table-cat table-ref))
         obj-key (table-cat/->table-block-metadata-obj-key table-path block-idx)]
     (try
       (-> (.getByteArray buffer-pool obj-key)
@@ -198,7 +201,7 @@
 
     (let [^BufferPool buffer-pool (.getBufferPool db)
           block-idx (<-lex-hex (str block-idx))
-          table-block (resolve-table-block buffer-pool (str table-name) block-idx)
+          table-block (resolve-table-block buffer-pool (.getTableCatalog db) (str table-name) block-idx)
           rows (if table-block
                  [(table-block->row (str table-name) block-idx table-block)]
                  [])
@@ -253,7 +256,7 @@
     (let [^BufferPool buffer-pool (.getBufferPool db)
           block-idx-hex (str block-idx)
           block-idx (<-lex-hex block-idx-hex)
-          table-block (resolve-table-block buffer-pool (str table-name) block-idx)
+          table-block (resolve-table-block buffer-pool (.getTableCatalog db) (str table-name) block-idx)
           rows (if table-block
                  (trie-details->rows (str table-name) block-idx-hex (:partitions table-block))
                  [])

--- a/core/src/main/clojure/xtdb/compactor/reset.clj
+++ b/core/src/main/clojure/xtdb/compactor/reset.clj
@@ -12,10 +12,11 @@
             [xtdb.trie-catalog :as trie-cat])
   (:import (java.nio.file Path)
            (xtdb.api.storage ObjectStore$StoredObject)
+           (xtdb.catalog TableCatalog)
            (xtdb.database Database)
            (xtdb.storage BufferPool)
-           xtdb.api.TableRef
-           (xtdb.trie Trie)))
+           (xtdb.table TableSlug)
+           xtdb.api.TableRef))
 
 (defn- meta-file->trie-key
   "\"…/meta/l00-rc-b00.arrow\" → \"l00-rc-b00\"."
@@ -26,10 +27,10 @@
 
 (defn- list-data-file-sizes
   "Build a `trie-key → data-file-size` lookup from the table's data dir."
-  [^BufferPool bp ^TableRef table]
+  [^BufferPool bp ^TableSlug slug]
   (into {} (map (fn [^ObjectStore$StoredObject obj]
                   [(meta-file->trie-key (.getKey obj)) (.getSize obj)]))
-        (.listAllObjects bp (Trie/dataFileDir table))))
+        (.listAllObjects bp (.dataFileDir slug))))
 
 (defn- list-l0-entries
   "Enumerate the L0 trie files for a table directly from the object store.
@@ -39,9 +40,9 @@
    half-written tries that the GC's data-then-meta deletion order leaves transiently visible.
    `:trie-metadata` is left absent — the post-reset `CatalogEntry.getTemporalMetadata` fallback
    handles that until the next compaction re-derives it."
-  [^BufferPool bp ^TableRef table]
-  (let [data-sizes (list-data-file-sizes bp table)]
-    (->> (.listAllObjects bp (Trie/metaFileDir table))
+  [^BufferPool bp ^TableSlug slug]
+  (let [data-sizes (list-data-file-sizes bp slug)]
+    (->> (.listAllObjects bp (.metaFileDir slug))
          (keep (fn [^ObjectStore$StoredObject obj]
                  (let [trie-key (meta-file->trie-key (.getKey obj))]
                    (when-some [parsed (trie/parse-trie-key trie-key)]
@@ -49,9 +50,9 @@
                                                 (data-sizes trie-key))]
                        (assoc parsed :data-file-size data-size)))))))))
 
-(defn- enumerate-l0s [^BufferPool bp tables]
+(defn- enumerate-l0s [^BufferPool bp ^TableCatalog table-cat tables]
   (into {} (for [^TableRef table tables]
-             [table (vec (list-l0-entries bp table))])))
+             [table (vec (list-l0-entries bp (.slug table-cat table)))])))
 
 (defn reset-compactor! [node-opts ^String db-name {:keys [dry-run?]}]
   (let [config (doto (xtn/->config node-opts)
@@ -71,19 +72,21 @@
 
         (let [bp (.getBufferPool db)
               trie-cat (.getTrieCatalog db)
+              table-cat (.getTableCatalog db)
               live-idx (.getLiveIndex db)
               tables (.getTables trie-cat)
               compacted-file-keys (vec (for [^TableRef table tables
+                                             :let [slug (.slug table-cat table)]
                                              ^String trie-key (trie-cat/compacted-trie-keys (trie-cat/trie-state trie-cat table))
 
                                              ;; meta file first, as it's the marker
-                                             file-key [(Trie/metaFilePath table trie-key)
-                                                       (Trie/dataFilePath table trie-key)]]
+                                             file-key [(.metaFilePath slug trie-key)
+                                                       (.dataFilePath slug trie-key)]]
                                          file-key))
               ;; Source of truth for L0 is the object store, not the catalog: catalog L0s
               ;; are dropped on supersession, so by the time we get here the catalog will be
               ;; missing every L0 that's already been consumed by an L1C we're about to wipe.
-              table->l0-entries (enumerate-l0s bp tables)]
+              table->l0-entries (enumerate-l0s bp table-cat tables)]
           (cond
             dry-run?
             (do

--- a/core/src/main/clojure/xtdb/export.clj
+++ b/core/src/main/clojure/xtdb/export.clj
@@ -71,14 +71,15 @@
 
              (let [block-files [(TableCatalog/blockFilePath block-idx)]
                    table-block-files (for [^TableRef table tables]
-                                       (-> (Trie/getTablePath table)
+                                       (-> (.getTablePath (.slug table-cat table))
                                            (table-cat/->table-block-metadata-obj-key block-idx)))
                    trie-files (for [^TableRef table tables
                                     :let [trie-keys (all-trie-keys trie-cat table)
-                                          _ (log/infof "Table %s: %d active trie files" (pr-str table) (count trie-keys))]
+                                          _ (log/infof "Table %s: %d active trie files" (pr-str table) (count trie-keys))
+                                          slug (.slug table-cat table)]
                                     ^String trie-key trie-keys
-                                    path [(Trie/metaFilePath table trie-key)
-                                          (Trie/dataFilePath table trie-key)]]
+                                    path [(.metaFilePath slug trie-key)
+                                          (.dataFilePath slug trie-key)]]
                                 path)
                    files-to-copy (vec (concat block-files table-block-files trie-files))]
 

--- a/core/src/main/clojure/xtdb/expression/pg.clj
+++ b/core/src/main/clojure/xtdb/expression/pg.clj
@@ -18,14 +18,23 @@
   ;; table-info / schema keys are `[db-name table-ref]` qualified pairs; tolerate a bare ref/symbol too
   (table/ref->schema+table (if (vector? k) (second k) k)))
 
-(defn tables [schema]
-  (into #{} (map schema-key->table)
-        (concat (keys (info/table-info "xtdb")) (keys schema))))
+(defn table-oids
+  "Every relation the query can see, as `{schema-qualified-symbol oid}`.
+
+   The oid is the one the table's block records, resolved through `info/table-oid` so that a
+   `::regclass` and the `pg_class` row for the same table come out equal — pgjdbc and Metabase resolve
+   a name through the cast and then join on `pg_class.oid`."
+  ;; TODO multi-db - a name present in two databases resolves to whichever the map happened to hold
+  [schema]
+  (-> (into {} (map (fn [k] (let [table (schema-key->table k)]
+                              [table (info/table-oid nil table)])))
+            (keys (info/table-info "xtdb")))
+      (into (map (fn [[k {:keys [oid]}]] (let [table (schema-key->table k)]
+                                           [table (info/table-oid oid table)])))
+            schema)))
 
 (defn find-table [schema table-name]
-  ;; TODO multi-db
-  (or (some-> (some (tables schema) (symbol-names table-name))
-              (info/name->oid))
+  (or (some (table-oids schema) (symbol-names table-name))
       (throw (err/incorrect ::unknown-relation (format "Relation %s does not exist" table-name)))))
 
 (defmethod expr/codegen-cast [:utf8 :regclass] [_]
@@ -34,9 +43,8 @@
                   `(find-table ~expr/schema-sym (expr/buf->str ~utf8-code)))})
 
 (defn oid->table [schema oid]
-  (->> (tables schema)
-       (filter #(= oid (info/name->oid (table/ref->schema+table %))))
-       (first)))
+  (->> (table-oids schema)
+       (some (fn [[table oid']] (when (= oid oid') table)))))
 
 (defn string-name [fq-name]
   (when fq-name

--- a/core/src/main/clojure/xtdb/information_schema.clj
+++ b/core/src/main/clojure/xtdb/information_schema.clj
@@ -24,10 +24,19 @@
            xtdb.operator.SelectionSpec
            (xtdb.query IQuerySource IQuerySource$QueryCatalog IQuerySource$QueryDatabase)
            xtdb.api.TableRef
+           xtdb.table.TableEntry
            xtdb.trie.TrieCatalog))
 
 (defn name->oid [s]
   (Math/abs ^Integer (hash s)))
+
+(defn table-oid
+  "The oid `pg_class` reports for a table, given the one its block records — or nil where no block does.
+
+   The virtual catalog relations never reach a block, so they have no allocated oid and keep a hash of
+   their name. `::regclass` resolves through here too, so both populations agree across the join."
+  [oid table]
+  (int (or oid (name->oid (table/ref->schema+table table)))))
 
 (defn- map->vec-types [m]
   (update-vals m types/->type))
@@ -249,9 +258,9 @@
      :tableowner "xtdb"
      :tablespace nil}))
 
-(defn pg-class [table-refs]
+(defn pg-class [oid-by-table table-refs]
   (for [^TableRef table table-refs]
-    {:oid (name->oid (table/ref->schema+table table))
+    {:oid (table-oid (get oid-by-table table) table)
      :relname (.denormalize ^IKeyFn (identity #xt/key-fn :snake-case-string) (.getTableName table))
      :relnamespace (name->oid (.getSchemaName table))
      :relowner (name->oid "xtdb")
@@ -325,11 +334,11 @@
      :is-identity "NO"
      :is-generated "NEVER"}))
 
-(defn pg-attribute [col-rows]
+(defn pg-attribute [oid-by-table col-rows]
   (for [{:keys [idx table name ^VectorType vec-type]} col-rows
         :let [^PgType pg-type (PgType/fromVectorType vec-type)
               ^PgType pg-type (if (or (nil? pg-type) (identical? pg-type PgType/PG_DEFAULT)) PgType/PG_JSON pg-type)]]
-    {:attrelid (name->oid (table/ref->schema+table table))
+    {:attrelid (table-oid (get oid-by-table table) table)
      :attname (.denormalize ^IKeyFn (identity #xt/key-fn :snake-case-string) (str name))
      :atttypid (.getOid pg-type)
      :attlen (int (or (.getTyplen pg-type) -1))
@@ -376,9 +385,9 @@
      :datallowconn true
      :datistemplate false}))
 
-(defn pg-stat-user-tables [table-refs]
+(defn pg-stat-user-tables [oid-by-table table-refs]
   (for [^TableRef table table-refs]
-    {:relid (name->oid (table/ref->schema+table table))
+    {:relid (table-oid (get oid-by-table table) table)
      :relname (.getTableName table)
      :schemaname (.getSchemaName table)
      :n-live-tup 0}))
@@ -529,6 +538,9 @@
                              (map table/->ref)
                              (keys meta-table-schemas))
 
+            oid-by-table (->> (.getEntries (.getTableCatSnap ^Snapshot snap))
+                              (into {} (map (juxt #(.getTable ^TableEntry %) #(.getOid ^TableEntry %)))))
+
             ;; delayed: only `columns` and `pg_attribute` need types, and this is bound ahead of the
             ;; dispatch — eagerly, the other 32 tables would each derive every column of every table.
             ;; Values stay as the Kotlin maps `allColumnTypes` returns; every consumer reads them as
@@ -549,15 +561,15 @@
                                      information_schema/constraint_column_usage nil
                                      pg_catalog/pg_tables (pg-tables table-refs)
                                      pg_catalog/pg_type (pg-type)
-                                     pg_catalog/pg_class (pg-class table-refs)
+                                     pg_catalog/pg_class (pg-class oid-by-table table-refs)
                                      pg_catalog/pg_description nil
                                      pg_catalog/pg_views nil
                                      pg_catalog/pg_matviews nil
-                                     pg_catalog/pg_attribute (pg-attribute (schema-info->col-rows @schema-info))
+                                     pg_catalog/pg_attribute (pg-attribute oid-by-table (schema-info->col-rows @schema-info))
                                      pg_catalog/pg_namespace (pg-namespace)
                                      pg_catalog/pg_proc (pg-proc)
                                      pg_catalog/pg_database (pg-database (.getDatabaseNames db-cat))
-                                     pg_catalog/pg_stat_user_tables (pg-stat-user-tables table-refs)
+                                     pg_catalog/pg_stat_user_tables (pg-stat-user-tables oid-by-table table-refs)
                                      pg_catalog/pg_settings (pg-settings)
                                      pg_catalog/pg_range (pg-range)
                                      pg_catalog/pg_am (pg-am)

--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -220,8 +220,9 @@
                    (long (- (count current-tries) (count filtered-tries)))
                    (long (count filtered-tries)))
 
-        (doseq [{:keys [^String trie-key]} filtered-tries]
-          (.add !segments (BufferPoolSegment. allocator buffer-pool metadata-mgr table trie-key metadata-pred)))
+        (let [slug (.slug snapshot table)]
+          (doseq [{:keys [^String trie-key]} filtered-tries]
+            (.add !segments (BufferPoolSegment. allocator buffer-pool metadata-mgr slug trie-key metadata-pred))))
 
         (doseq [^TableSnapshot live-table-snap (.table snapshot table)]
           (.add !segments (.getSegment live-table-snap)))

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -361,6 +361,8 @@
                     (.put !snaps db-name (.openSnapshot db (get min-basis db-name))))
                   (into {} !snaps)))
 
+              ;; `{[db-name table-ref] {:cols #{…}, :oid n}}` — the oid read from the same snapshot as
+              ;; the columns, so `::regclass` and the planner can't disagree about which tables exist.
               (->table-info [min-basis]
                 ;; TODO this, too, gets the schema for *every* db in the catalog
                 (->> (.getDatabaseNames db-cat)
@@ -368,11 +370,13 @@
                                         ;; same detach race as open-snaps above
                                         (when-let [db (.databaseOrNull db-cat db-name)]
                                           (util/with-open [^DatabaseSnapshot snap (.openSnapshot db (get min-basis db-name))]
-                                            (->> (.tableInfo snap)
-                                                 (map (fn [[table-ref cols]] [[db-name table-ref] (set cols)]))))))))))
+                                            (let [oids (.tableOids snap)]
+                                              (->> (.tableInfo snap)
+                                                   (map (fn [[table-ref cols]]
+                                                          [[db-name table-ref] {:cols (set cols), :oid (get oids table-ref)}])))))))))))
 
               (plan-query* [table-info]
-                (-plan-query this parsed-query query-opts table-info))]
+                (-plan-query this parsed-query query-opts (update-vals table-info :cols)))]
 
         (let [!table-info (atom (->table-info prepare-min-basis))]
 

--- a/core/src/main/clojure/xtdb/table_catalog.clj
+++ b/core/src/main/clojure/xtdb/table_catalog.clj
@@ -82,7 +82,8 @@
 
 (defn load-tables-to-metadata ^java.util.Map [^BufferPool buffer-pool, ^TableCatalog table-cat]
   (when-let [block-idx (.getCurrentBlockIndex table-cat)]
-    (let [entries (.getEntries (.snap table-cat))]
+    ;; recorded, not all: a table allocated but not yet written has no block file to read
+    (let [entries (.getRecordedEntries (.snap table-cat))]
       (->> (for [^TableEntry entry entries
                  :let [table (.getTable entry)
                        table-block-path (->table-block-metadata-obj-key (.getTablePath (.getSlug entry)) block-idx)

--- a/core/src/main/clojure/xtdb/table_catalog.clj
+++ b/core/src/main/clojure/xtdb/table_catalog.clj
@@ -13,13 +13,13 @@
            (xtdb.catalog TableCatalog)
            xtdb.storage.BufferPool
            xtdb.api.TableRef
-           xtdb.trie.Trie
+           (xtdb.table TableEntry TableSlug)
            (xtdb.util HyperLogLog)))
 
 (def ^java.nio.file.Path block-table-metadata-path (util/->path "blocks"))
 
-(defn ->table-block-dir ^java.nio.file.Path [^TableRef table]
-  (-> (Trie/getTablePath table)
+(defn ->table-block-dir ^java.nio.file.Path [^TableSlug slug]
+  (-> (.getTablePath slug)
       (.resolve block-table-metadata-path)))
 
 (defn ->table-block-metadata-obj-key ^java.nio.file.Path [^Path table-path block-idx]
@@ -82,9 +82,10 @@
 
 (defn load-tables-to-metadata ^java.util.Map [^BufferPool buffer-pool, ^TableCatalog table-cat]
   (when-let [block-idx (.getCurrentBlockIndex table-cat)]
-    (let [tables (.getAllTables table-cat)]
-      (->> (for [^TableRef table tables
-                 :let [table-block-path (->table-block-metadata-obj-key (Trie/getTablePath table) block-idx)
+    (let [entries (.getEntries (.snap table-cat))]
+      (->> (for [^TableEntry entry entries
+                 :let [table (.getTable entry)
+                       table-block-path (->table-block-metadata-obj-key (.getTablePath (.getSlug entry)) block-idx)
                        {:keys [fields] :as tb} (-> (.getByteArray buffer-pool table-block-path)
                                                    (TableBlock/parseFrom)
                                                    (<-table-block))]]

--- a/core/src/main/clojure/xtdb/trie.clj
+++ b/core/src/main/clojure/xtdb/trie.clj
@@ -92,12 +92,6 @@
     (catch IllegalArgumentException _)
     (catch IllegalStateException _)))
 
-(defn table-name->table-path ^java.nio.file.Path [^String table-name]
-  (Trie/getTablePath table-name))
-
-(defn ->table-meta-dir ^java.nio.file.Path [^String table-name]
-  (Trie/metaFileDir table-name))
-
 (defn ->live-trie ^MemoryHashTrie [log-limit page-limit iid-rdr]
   (-> (doto (MemoryHashTrie/builder iid-rdr)
         (.setLogLimit log-limit)

--- a/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
@@ -1,8 +1,8 @@
 package xtdb.api.tx
 
-import xtdb.api.TableRef
 import xtdb.api.TransactionKey
 import xtdb.database.proto.DatabaseConfig
+import xtdb.table.TableEntry
 import xtdb.trie.BlockIndex
 import xtdb.types.MessageId
 
@@ -22,6 +22,6 @@ data class BlockDetails(
     // term-fencing (see #5817)
     val termId: Long,
     val externalSourceToken: ExternalSourceToken?,
-    val tableNames: List<TableRef>,
+    val tables: List<TableEntry>,
     val secondaryDatabases: Map<String, DatabaseConfig>,
 )

--- a/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
@@ -22,6 +22,7 @@ data class BlockDetails(
     // term-fencing (see #5817)
     val termId: Long,
     val externalSourceToken: ExternalSourceToken?,
+    /** The tables this block records — so, the tables with a per-table block file beside it. */
     val tables: List<TableEntry>,
     val secondaryDatabases: Map<String, DatabaseConfig>,
 )

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -27,12 +27,13 @@ import xtdb.block.proto.txKey
 import xtdb.database.proto.DatabaseConfig
 import xtdb.indexer.LiveTable
 import xtdb.storage.BufferPool
+import xtdb.table.TableEntry
+import xtdb.table.TableSlug
 import xtdb.table.fromSchemaAndTable
 import xtdb.time.InstantUtil.asMicros
 import xtdb.time.microsAsInstant
 import xtdb.trie.BlockIndex
 import xtdb.trie.ColumnName
-import xtdb.trie.Trie.tablePath
 import xtdb.types.MessageId
 import xtdb.util.HLL
 import xtdb.util.StringUtil.asLexHex
@@ -45,6 +46,17 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 import kotlin.io.path.extension
 
+/**
+ * A block written before the registry existed carries names alone, and every table in it is on disk under
+ * its escaped name — so that is the slug each takes, and their files stay where they are.
+ *
+ * Oids come from the sorted names rather than from list order: the proto's order comes from a Set, so it
+ * isn't stable, and every node has to derive the same registry from the same bytes.
+ */
+private fun Block.tableEntries(): List<TableEntry> =
+    tablesList.takeIf { it.isNotEmpty() }?.map { TableEntry.fromProto(it) }
+        ?: tableNamesList.sorted().mapIndexed { idx, name -> TableEntry.mint(idx + 1L, fromSchemaAndTable(name)) }
+
 // The proto is the storage format, so this is the only place that reads its presence flags: everything
 // downstream sees ordinary Kotlin nullability.
 private fun Block.asBlockDetails() = BlockDetails(
@@ -55,7 +67,7 @@ private fun Block.asBlockDetails() = BlockDetails(
     boundaryReplicaMsgId = boundaryReplicaMsgId.takeIf { hasBoundaryReplicaMsgId() },
     termId = termId,
     externalSourceToken = takeIf { it.hasExternalSourceToken() }?.externalSourceToken?.toByteArray(),
-    tableNames = tableNamesList.map { fromSchemaAndTable(it) },
+    tables = tableEntries(),
     secondaryDatabases = secondaryDatabasesMap,
 )
 
@@ -105,6 +117,23 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
         /** The historical half's contribution — an unknown table has written nothing. */
         fun contributedType(table: TableRef, col: ColumnName): VectorType =
             tables[table]?.let { it.vecTypes[col] ?: it.absentContribution } ?: VectorType.Nothing
+
+        val entries: List<TableEntry> get() = block?.tables.orEmpty()
+
+        private val entriesByTable by lazy { entries.associateBy { it.table } }
+
+        fun entry(table: TableRef): TableEntry? = entriesByTable[table]
+
+        /**
+         * Where [table]'s files live.
+         *
+         * Resolving through a pinned [State] is what keeps a query's paths consistent with the trie state it
+         * planned against: the block it read is the block whose slugs it uses.
+         *
+         * A table the registry doesn't hold has yet to reach a block, so nothing of it is on disk under any
+         * other name and the derived slug is the one its first write will record.
+         */
+        fun slug(table: TableRef): TableSlug = entry(table)?.slug ?: TableSlug.of(table)
     }
 
     private val _state = MutableStateFlow(State(initialBlock?.asBlockDetails(), emptyMap()))
@@ -136,7 +165,30 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
 
     val externalSourceToken: ExternalSourceToken? get() = snap().block?.externalSourceToken
 
-    val allTables: List<TableRef> get() = snap().block?.tableNames.orEmpty()
+    val allTables: List<TableRef> get() = snap().entries.map { it.table }
+
+    fun slug(table: TableRef): TableSlug = snap().slug(table)
+
+    /**
+     * The registry for a block covering [tables]: the entry this catalog already holds for each, carried
+     * forward verbatim, and a freshly minted one for each table it doesn't.
+     *
+     * Carrying forward rather than recomputing is what freezes a slug for the table's lifetime. A leader
+     * that re-derived them would move every path the moment the minting algorithm changed, orphaning
+     * everything already written.
+     *
+     * Sorted, so that the same table set yields the same block bytes whichever node wrote it.
+     */
+    fun resolveTables(tables: Collection<TableRef>): List<TableEntry> {
+        val existing = snap().entries.associateBy { it.table }
+        val nextOid = (existing.values.maxOfOrNull { it.oid } ?: 0L) + 1
+
+        val minted = tables.filterNot { it in existing }.sortedBy { it.schemaAndTable }
+            .mapIndexed { idx, table -> TableEntry.mint(nextOid + idx, table) }
+            .associateBy { it.table }
+
+        return tables.sortedBy { it.schemaAndTable }.map { existing[it] ?: minted.getValue(it) }
+    }
 
     val secondaryDatabases: Map<String, DatabaseConfig> get() = snap().block?.secondaryDatabases.orEmpty()
 
@@ -163,7 +215,7 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
     fun loadTables() {
         val snap = snap()
         val blockIndex = snap.blockIdx ?: return
-        val tables = loadTablesFromStorage(bufferPool, snap.block?.tableNames.orEmpty(), blockIndex)
+        val tables = loadTablesFromStorage(bufferPool, snap.entries, blockIndex)
 
         _state.update { it.copy(tables = tables) }
     }
@@ -202,7 +254,7 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
         latestCompletedTx: TransactionKey?,
         latestProcessedMsgId: MessageId,
         boundaryReplicaMsgId: MessageId?,
-        tables: Collection<TableRef>,
+        tables: Collection<TableEntry>,
         secondaryDatabases: Map<String, DatabaseConfig>?,
         externalSourceToken: ExternalSourceToken? = null,
         termId: Long = LeaderTerm.NONE,
@@ -222,7 +274,10 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
             }
             this.latestProcessedMsgId = latestProcessedMsgId
             boundaryReplicaMsgId?.let { this.boundaryReplicaMsgId = it }
-            this.tableNames.addAll(tables.map { it.sym.toString() })
+            // table_names is how a reader predating the registry finds the tables, so it keeps being
+            // written. See #4037.
+            this.tableNames.addAll(tables.map { it.table.sym.toString() })
+            this.tables.addAll(tables.map { it.toProto() })
             secondaryDatabases?.let { this.secondaryDatabases.putAll(it) }
             externalSourceToken?.let { this.externalSourceToken = ByteString.copyFrom(it) }
             this.termId = termId
@@ -237,13 +292,13 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
             blocksPath.resolve("b${blockIndex.asLexHex}.binpb")
 
         @JvmStatic
-        fun tableBlockPath(table: TableRef, blockIndex: BlockIndex): Path =
+        fun tableBlockPath(table: TableSlug, blockIndex: BlockIndex): Path =
             table.tablePath.resolve(blocksPath).resolve("b${blockIndex.asLexHex}.binpb")
 
         val BufferPool.allBlockFiles: Iterable<ObjectStore.StoredObject>
             get() = listAllObjects(blocksPath).filter { it.key.fileName.extension == "binpb" }
 
-        fun BufferPool.tableBlocks(table: TableRef): Iterable<ObjectStore.StoredObject> =
+        fun BufferPool.tableBlocks(table: TableSlug): Iterable<ObjectStore.StoredObject> =
             listAllObjects(table.tablePath.resolve(blocksPath))
 
         @JvmStatic
@@ -265,10 +320,13 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
             )
 
         internal fun loadTablesFromStorage(
-            bufferPool: BufferPool, tables: List<TableRef>, blockIndex: BlockIndex
+            bufferPool: BufferPool, entries: List<TableEntry>, blockIndex: BlockIndex
         ): Map<TableRef, TableMeta> =
-            tables.associateWith { table ->
-                parseTableBlock(TableBlock.parseFrom(bufferPool.getByteArray(tableBlockPath(table, blockIndex))))
+            entries.associate { entry ->
+                entry.table to
+                        parseTableBlock(
+                            TableBlock.parseFrom(bufferPool.getByteArray(tableBlockPath(entry.slug, blockIndex)))
+                        )
             }
 
         /** Folds a block's per-table deltas into the accumulated catalog. */

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -47,15 +47,16 @@ import java.nio.file.Path
 import kotlin.io.path.extension
 
 /**
- * A block written before the registry existed carries names alone, and every table in it is on disk under
- * its escaped name — so that is the slug each takes, and their files stay where they are.
+ * A block that records no entries carries names alone, and every table in it is on disk under its escaped
+ * name — so that is the slug each takes, and their files stay where they are.
  *
  * Oids come from the sorted names rather than from list order: the proto's order comes from a Set, so it
- * isn't stable, and every node has to derive the same registry from the same bytes.
+ * isn't stable, and every node has to derive the same entries from the same bytes.
  */
 private fun Block.tableEntries(): List<TableEntry> =
     tablesList.takeIf { it.isNotEmpty() }?.map { TableEntry.fromProto(it) }
-        ?: tableNamesList.sorted().mapIndexed { idx, name -> TableEntry.mint(idx + 1L, fromSchemaAndTable(name)) }
+        ?: tableNamesList.sorted()
+            .mapIndexed { idx, name -> TableEntry.mint(TableEntry.FIRST_OID + idx, fromSchemaAndTable(name)) }
 
 // The proto is the storage format, so this is the only place that reads its presence flags: everything
 // downstream sees ordinary Kotlin nullability.
@@ -103,6 +104,14 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
     data class State internal constructor(
         val block: BlockDetails?,
         internal val tables: Map<TableRef, TableMeta>,
+        /**
+         * Every table this catalog can name, whether or not a block has recorded it yet.
+         *
+         * Allocation follows the order tables first appear in the log, which every node replays
+         * identically — so a follower reaches the same oid as the leader without it ever travelling on
+         * the wire.
+         */
+        internal val entriesByTable: Map<TableRef, TableEntry>,
     ) {
         val blockIdx: BlockIndex? get() = block?.blockIndex
 
@@ -118,11 +127,29 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
         fun contributedType(table: TableRef, col: ColumnName): VectorType =
             tables[table]?.let { it.vecTypes[col] ?: it.absentContribution } ?: VectorType.Nothing
 
-        val entries: List<TableEntry> get() = block?.tables.orEmpty()
+        /**
+         * The entries the current block records, and so the only tables with a per-table block file to
+         * read. Distinct from [entries], which also holds tables allocated but not yet written.
+         */
+        val recordedEntries: List<TableEntry> get() = block?.tables.orEmpty()
 
-        private val entriesByTable by lazy { entries.associateBy { it.table } }
+        /** Every table this catalog can name, recorded or not. */
+        val entries: Collection<TableEntry> get() = entriesByTable.values
 
         fun entry(table: TableRef): TableEntry? = entriesByTable[table]
+
+        /** [this], plus an entry for each of [tables] that hasn't one. */
+        internal fun withEntriesFor(tables: Collection<TableRef>): State {
+            val fresh = tables.filterNot { it in entriesByTable }.sortedBy { it.schemaAndTable }
+            if (fresh.isEmpty()) return this
+
+            val firstOid = entries.maxOfOrNull { it.oid + 1 } ?: TableEntry.FIRST_OID
+
+            return copy(
+                entriesByTable = entriesByTable +
+                        fresh.mapIndexed { idx, table -> table to TableEntry.mint(firstOid + idx, table) }
+            )
+        }
 
         /**
          * Where [table]'s files live.
@@ -130,13 +157,15 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
          * Resolving through a pinned [State] is what keeps a query's paths consistent with the trie state it
          * planned against: the block it read is the block whose slugs it uses.
          *
-         * A table the registry doesn't hold has yet to reach a block, so nothing of it is on disk under any
-         * other name and the derived slug is the one its first write will record.
+         * Every table the catalog knows of has an entry, so the derived fallback is for one it has never
+         * been told about — a query naming a table that does not exist.
          */
         fun slug(table: TableRef): TableSlug = entry(table)?.slug ?: TableSlug.of(table)
     }
 
-    private val _state = MutableStateFlow(State(initialBlock?.asBlockDetails(), emptyMap()))
+    private val _state = initialBlock?.asBlockDetails().let { block ->
+        MutableStateFlow(State(block, emptyMap(), block?.tables.orEmpty().associateBy { it.table }))
+    }
 
     fun snap(): State = _state.value
 
@@ -180,15 +209,21 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
      * Sorted, so that the same table set yields the same block bytes whichever node wrote it.
      */
     fun resolveTables(tables: Collection<TableRef>): List<TableEntry> {
-        val existing = snap().entries.associateBy { it.table }
-        val nextOid = (existing.values.maxOfOrNull { it.oid } ?: 0L) + 1
+        registerTables(tables)
+        val known = snap().entriesByTable
 
-        val minted = tables.filterNot { it in existing }.sortedBy { it.schemaAndTable }
-            .mapIndexed { idx, table -> TableEntry.mint(nextOid + idx, table) }
-            .associateBy { it.table }
-
-        return tables.sortedBy { it.schemaAndTable }.map { existing[it] ?: minted.getValue(it) }
+        return tables.sortedBy { it.schemaAndTable }.map { known.getValue(it) }
     }
+
+    /**
+     * Gives an entry to each of [tables] that hasn't one, so that a table has its identity from the moment
+     * the catalog learns of it rather than from its first block.
+     *
+     * Allocating in name order is what lets a follower agree with the leader: a transaction's tables reach
+     * this as an unordered map, so arrival order within one transaction differs between them, while the
+     * order transactions themselves arrive does not.
+     */
+    fun registerTables(tables: Collection<TableRef>) = _state.update { it.withEntriesFor(tables) }
 
     val secondaryDatabases: Map<String, DatabaseConfig> get() = snap().block?.secondaryDatabases.orEmpty()
 
@@ -202,8 +237,9 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
     fun seedTable(table: TableRef, colNames: List<ColumnName>) {
         val meta = TableMeta(colNames.associateWith { VectorType.Nothing }, 0, emptyMap())
 
-        _state.update {
-            if (it.tables.containsKey(table)) it else it.copy(tables = it.tables + (table to meta))
+        _state.update { cur ->
+            cur.copy(tables = if (cur.tables.containsKey(table)) cur.tables else cur.tables + (table to meta))
+                .withEntriesFor(listOf(table))
         }
     }
 
@@ -215,7 +251,7 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
     fun loadTables() {
         val snap = snap()
         val blockIndex = snap.blockIdx ?: return
-        val tables = loadTablesFromStorage(bufferPool, snap.entries, blockIndex)
+        val tables = loadTablesFromStorage(bufferPool, snap.recordedEntries, blockIndex)
 
         _state.update { it.copy(tables = tables) }
     }
@@ -229,9 +265,16 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
         val delta = metadata.mapValues { (_, bm) -> TableMeta(bm.vecTypes, bm.rowCount.toLong(), bm.hllDeltas) }
 
         _state.update { cur ->
+            val newBlock =
+                if (block != null && block.blockIndex == cur.blockIdx) cur.block else block?.asBlockDetails()
+
             State(
-                block = if (block != null && block.blockIndex == cur.blockIdx) cur.block else block?.asBlockDetails(),
-                tables = if (delta.isEmpty()) cur.tables else cur.tables.foldIn(delta)
+                block = newBlock,
+                tables = if (delta.isEmpty()) cur.tables else cur.tables.foldIn(delta),
+                // The block wins over what we allocated: ordinarily the two agree, but a block written
+                // before entries were recorded resolves to derived ones, and those are what every other
+                // node reading it will use.
+                entriesByTable = cur.entriesByTable + newBlock?.tables.orEmpty().associateBy { it.table }
             )
         }
     }

--- a/core/src/main/kotlin/xtdb/compactor/Compactor.kt
+++ b/core/src/main/kotlin/xtdb/compactor/Compactor.kt
@@ -81,6 +81,7 @@ interface Compactor : AutoCloseable {
                         private val log = partitionStorage.sourceLog
                         private val bp = partitionStorage.bufferPool
                         private val mm = partitionStorage.metadataManager
+                        private val tableCat = partitionState.tableCatalog
 
                         private val trieWriter = PageTrieWriter(al, bp, calculateBlooms = true)
                         private val segMerge = SegmentMerge(al)
@@ -99,7 +100,9 @@ interface Compactor : AutoCloseable {
 
                         override suspend fun executeJob(job: Job): TriesAdded =
                             try {
-                                job.trieKeys.map { BufferPoolSegment(al, bp, mm, job.table, it) }.useAll { segs ->
+                                val slug = tableCat.slug(job.table)
+
+                                job.trieKeys.map { BufferPoolSegment(al, bp, mm, slug, it) }.useAll { segs ->
                                     val recencyPartitioning =
                                         if (job.partitionedByRecency) SegmentMerge.RecencyPartitioning.Partition
                                         else SegmentMerge.RecencyPartitioning.Preserve(job.outputTrieKey.recency)
@@ -115,7 +118,7 @@ interface Compactor : AutoCloseable {
 
                                                             val (dataFileSize, trieMetadata) =
                                                                 trieWriter.writePageTree(
-                                                                    job.table, trieKey,
+                                                                    slug, trieKey,
                                                                     loader, it.leaves.asTree,
                                                                     pageSize
                                                                 )

--- a/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
+++ b/core/src/main/kotlin/xtdb/compactor/SegmentMerge.kt
@@ -20,13 +20,12 @@ import xtdb.segment.MergeTask
 import xtdb.segment.Segment
 import xtdb.segment.Segment.PageMeta.Companion.pageMeta
 import xtdb.api.TableRef
+import xtdb.table.TableSlug
 import xtdb.table.fromSchemaAndTable
 import xtdb.trie.ArrowHashTrie
 import xtdb.trie.EventRowPointer
 import xtdb.trie.Trie
-import xtdb.trie.Trie.dataFilePath
 import xtdb.trie.Trie.dataRelSchema
-import xtdb.trie.Trie.metaFilePath
 import xtdb.trie.RecencyMicros
 import xtdb.trie.TrieKey
 import xtdb.arrow.withName
@@ -241,11 +240,11 @@ internal class SegmentMerge(private val al: BufferAllocator) : AutoCloseable {
  */
 
 private class LocalSegment(
-    private val al: BufferAllocator, table: TableRef, dir: Path, trieKey: TrieKey,
+    private val al: BufferAllocator, slug: TableSlug, dir: Path, trieKey: TrieKey,
 ) : Segment<ArrowHashTrie.Leaf>, AutoCloseable {
 
-    private val dataFile = dir.resolve(table.dataFilePath(trieKey))
-    private val metaFile = dir.resolve(table.metaFilePath(trieKey))
+    private val dataFile = dir.resolve(slug.dataFilePath(trieKey))
+    private val metaFile = dir.resolve(slug.metaFilePath(trieKey))
     private val parsedTrieKey = Trie.parseKey(trieKey)
     private val recency: RecencyMicros = parsedTrieKey.recency?.atStartOfDay()?.asMicros ?: Long.MAX_VALUE
 
@@ -280,14 +279,14 @@ private class LocalSegment(
 
 internal fun main() {
     val dir = "/tmp/downloads/compactor-error".asPath
-    val table = fromSchemaAndTable("foo")
+    val slug = TableSlug.of(fromSchemaAndTable("foo"))
     val trieKeys = listOf("l01-rc-b2c74", "l00-rc-b2c75")
 
     try {
         RootAllocator().use { al ->
             SegmentMerge(al).use { segMerge ->
                 trieKeys
-                    .safeMap { trieKey -> LocalSegment(al, table, dir, trieKey) }
+                    .safeMap { trieKey -> LocalSegment(al, slug, dir, trieKey) }
                     .useAll { segments ->
                         segMerge.mergeSegmentsSync(
                             segments, null, SegmentMerge.RecencyPartitioning.Partition

--- a/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/BlockGarbageCollector.kt
@@ -153,9 +153,9 @@ class BlockGarbageCollector(
         }
 
         supervisorScope {
-            for (table in tableCatalog.allTables) {
+            for (entry in tableCatalog.snap().entries) {
                 launch(tableDispatcher) {
-                    deleteGarbage(bufferPool.tableBlocks(table).asSequence().map { it.key }, tableBlockDeleteTimer)
+                    deleteGarbage(bufferPool.tableBlocks(entry.slug).asSequence().map { it.key }, tableBlockDeleteTimer)
                 }
             }
         }

--- a/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
+++ b/core/src/main/kotlin/xtdb/garbage_collector/TrieGarbageCollector.kt
@@ -12,10 +12,9 @@ import xtdb.api.DatabaseName
 import xtdb.database.PartitionState
 import xtdb.storage.BufferPool
 import xtdb.api.TableRef
+import xtdb.table.TableEntry
 import xtdb.time.microsAsInstant
 import xtdb.trie.Trie
-import xtdb.trie.Trie.dataFilePath
-import xtdb.trie.Trie.metaFilePath
 import xtdb.trie.TrieKey
 import xtdb.util.debug
 import xtdb.util.logger
@@ -137,21 +136,22 @@ class TrieGarbageCollector(
         LOGGER.debug("Garbage collecting tries older than $asOf")
 
         supervisorScope {
-            for (tableName in tableCatalog.allTables) {
+            for (entry in tableCatalog.snap().entries) {
                 launch(tableDispatcher) {
                     try {
-                        garbageCollectTable(tableName, asOf)
+                        garbageCollectTable(entry, asOf)
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
-                        LOGGER.warn(e, "Trie GC failed for table $tableName")
+                        LOGGER.warn(e, "Trie GC failed for table ${entry.table}")
                     }
                 }
             }
         }
     }
 
-    private suspend fun garbageCollectTable(tableName: TableRef, asOf: Instant) {
+    private suspend fun garbageCollectTable(entry: TableEntry, asOf: Instant) {
+        val tableName = entry.table
         val garbageTries = trieCatalog.garbageTries(tableName, asOf)
         if (garbageTries.isEmpty()) return
 
@@ -175,8 +175,8 @@ class TrieGarbageCollector(
                     }
                     launch(deleteDispatcher) {
                         val timer = meterRegistry?.let { Timer.start(it) }
-                        bufferPool.deleteIfExists(tableName.dataFilePath(trieKey))
-                        bufferPool.deleteIfExists(tableName.metaFilePath(trieKey))
+                        bufferPool.deleteIfExists(entry.slug.dataFilePath(trieKey))
+                        bufferPool.deleteIfExists(entry.slug.metaFilePath(trieKey))
                         deleteTimer?.let { timer?.stop(it) }
                     }
                 }

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -108,10 +108,14 @@ class BlockUploader(
 
         val tableBlocks = tableCatalog.finishBlock(finishedBlocks, tablePartitions)
 
+        // A table new in this block has already written its L0 trie by now, under the slug its LiveTable was
+        // created with — the same one minted here, because both resolve through `State.slug`.
+        val entries = tableCatalog.resolveTables(tableBlocks.keys).associateBy { it.table }
+
         coroutineScope {
             tableBlocks.forEach { (table, tableBlock) ->
                 launch(uploadDispatcher) {
-                    val path = TableCatalog.tableBlockPath(table, blockIdx)
+                    val path = TableCatalog.tableBlockPath(entries.getValue(table).slug, blockIdx)
                     bufferPool.putObject(path, ByteBuffer.wrap(tableBlock.toByteArray()))
                 }
             }
@@ -123,7 +127,7 @@ class BlockUploader(
 
         val block = tableCatalog.buildBlock(
             blockIdx, liveIndex.latestCompletedTx, latestProcessedMsgId,
-            boundaryReplicaMsgId, tableBlocks.keys, secondaryDatabasesForBlock,
+            boundaryReplicaMsgId, entries.values, secondaryDatabasesForBlock,
             externalSourceToken, termId
         )
 

--- a/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/DatabaseSnapshot.kt
@@ -3,6 +3,8 @@ package xtdb.indexer
 import xtdb.api.TransactionKey
 import xtdb.api.TableRef
 import xtdb.trie.ColumnName
+import xtdb.table.Oid
+import xtdb.database.Database
 import xtdb.util.closeAll
 import java.time.Instant
 
@@ -34,6 +36,17 @@ class DatabaseSnapshot(val partitions: List<Snapshot>) : AutoCloseable {
                 a + (table to (a[table].orEmpty() + cols))
             }
         }
+
+    /**
+     * Each table's oid, union across [partitions].
+     *
+     * Each partition allocates independently, so partitions could in principle disagree about a table's
+     * oid and the lowest-indexed one wins here. #5557 has to settle whether an oid is per-database or
+     * per-partition before `partitions > 1` is enabled — today [Database] rejects it outright.
+     */
+    fun tableOids(): Map<TableRef, Oid> =
+        if (partitions.size == 1) partitions[0].tableOids
+        else partitions.fold(emptyMap()) { acc, snap -> snap.tableOids + acc }
 
     /** One [TransactionKey] per partition, in partition-index order. */
     val txBasis: List<TransactionKey?> get() = partitions.map { it.txBasis }

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -132,7 +132,9 @@ class LiveIndex private constructor(
             for ((ref, rel) in tables) {
                 val liveTable =
                     this@LiveIndex.tables.getOrPut(ref) {
-                        LiveTable(allocator, ref, blockIdx, rowCounter, liveTrieFactory)
+                        // Pinned at creation, so the L0 trie this table writes at the block boundary lands
+                        // under the same slug `BlockUploader` then records for it.
+                        LiveTable(allocator, ref, tableCatalog.slug(ref), blockIdx, rowCounter, liveTrieFactory)
                     }
                 liveTable.importData(rel)
             }

--- a/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveIndex.kt
@@ -129,6 +129,10 @@ class LiveIndex private constructor(
     fun commitTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>) {
         val stamp = snapLock.writeLock()
         try {
+            // Inside the lock, so a table's identity and its rows reach readers together — snapshot
+            // capture brackets itself with the same lock. Whole batch at once, per `registerTables`.
+            tableCatalog.registerTables(tables.keys)
+
             for ((ref, rel) in tables) {
                 val liveTable =
                     this@LiveIndex.tables.getOrPut(ref) {

--- a/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LiveTable.kt
@@ -11,6 +11,7 @@ import xtdb.arrow.*
 import xtdb.arrow.VectorType.Mono
 import xtdb.log.proto.TrieMetadata
 import xtdb.storage.BufferPool
+import xtdb.table.TableSlug
 import xtdb.api.TableRef
 import xtdb.trie.*
 import xtdb.util.HLL
@@ -19,6 +20,7 @@ import xtdb.util.RowCounter
 class LiveTable @JvmOverloads constructor(
     private val al: BufferAllocator,
     val table: TableRef,
+    val slug: TableSlug,
     val blockIdx: Long,
     private val rowCounter: RowCounter,
     liveTrieFactory: LiveTrieFactory = LiveTrieFactory { MemoryHashTrie.emptyTrie(it) }
@@ -104,7 +106,7 @@ class LiveTable @JvmOverloads constructor(
 
         return liveRelation.openDirectSlice(al).use { dataRel ->
             val trieWriter = LiveTrieWriter(al, bp, calculateBlooms = false)
-            val dataFileSize = trieWriter.writeLiveTrie(table, trieKey, liveTrie, dataRel)
+            val dataFileSize = trieWriter.writeLiveTrie(slug, trieKey, liveTrie, dataRel)
             FinishedBlock(
                 vecTypes = vecTypes,
                 rowCount = rowCount,

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -42,6 +42,13 @@ class Snapshot(
     private val supersededLiveTypes: Map<TableRef, Map<ColumnName, VectorType>>,
     val tableInfo: Map<TableRef, Set<ColumnName>>,
 ) : AutoCloseable {
+
+    /**
+     * Where [table]'s files live, as of this snapshot — so the slugs a scan reads by are the ones recorded
+     * in the block whose trie state it planned against.
+     */
+    fun slug(table: TableRef) = tableCatSnap.slug(table)
+
     interface Source {
         fun openSnapshot(minSystemTime: Instant?): Snapshot
     }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -7,6 +7,7 @@ import xtdb.arrow.VectorType
 import xtdb.catalog.TableCatalog
 import xtdb.indexer.LiveTable.Companion.logRelTypes
 import xtdb.api.TableRef
+import xtdb.table.Oid
 import xtdb.trie.ColumnName
 import xtdb.trie.TrieCatalog
 import xtdb.util.closeAll
@@ -48,6 +49,9 @@ class Snapshot(
      * in the block whose trie state it planned against.
      */
     fun slug(table: TableRef) = tableCatSnap.slug(table)
+
+    /** Each table's oid, whether or not a block has recorded it yet. */
+    val tableOids: Map<TableRef, Oid> get() = tableCatSnap.entries.associate { it.table to it.oid }
 
     interface Source {
         fun openSnapshot(minSystemTime: Instant?): Snapshot

--- a/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
+++ b/core/src/main/kotlin/xtdb/segment/BufferPoolSegment.kt
@@ -10,20 +10,18 @@ import xtdb.metadata.PageMetadata
 import xtdb.segment.Segment.PageMeta
 import xtdb.segment.Segment.PageMeta.Companion.pageMeta
 import xtdb.storage.BufferPool
-import xtdb.api.TableRef
+import xtdb.table.TableSlug
 import xtdb.trie.ArrowHashTrie
 import xtdb.trie.Trie
-import xtdb.trie.Trie.dataFilePath
-import xtdb.trie.Trie.metaFilePath
 import xtdb.trie.RecencyMicros
 import xtdb.trie.TrieKey
 import xtdb.time.LocalDateTimeUtil.asMicros
 
 class BufferPoolSegment(
     al: BufferAllocator, private val bp: BufferPool, private val mm: PageMetadata.Factory,
-    val table: TableRef, val trieKey: TrieKey, val metadataPredicate: MetadataPredicate? = null,
+    val slug: TableSlug, val trieKey: TrieKey, val metadataPredicate: MetadataPredicate? = null,
 ) : Segment<ArrowHashTrie.Leaf> {
-    val dataFilePath = table.dataFilePath(trieKey)
+    val dataFilePath = slug.dataFilePath(trieKey)
     private val parsedTrieKey = Trie.parseKey(trieKey)
     private val resolveSameSystemTimeEvents = parsedTrieKey.level == 0L
     private val recency: RecencyMicros = parsedTrieKey.recency?.atStartOfDay()?.asMicros ?: Long.MAX_VALUE
@@ -60,7 +58,7 @@ class BufferPoolSegment(
         override fun close() = pageMetadata.close()
     }
 
-    override suspend fun openMetadata(): Metadata = Metadata(mm.openPageMetadata(table.metaFilePath(trieKey)))
+    override suspend fun openMetadata(): Metadata = Metadata(mm.openPageMetadata(slug.metaFilePath(trieKey)))
 
     override suspend fun loadDataPage(al: BufferAllocator, leaf: ArrowHashTrie.Leaf): RelationReader =
         if (currentDataPageIndex == leaf.dataPageIndex) dataRel

--- a/core/src/main/kotlin/xtdb/table/TableEntry.kt
+++ b/core/src/main/kotlin/xtdb/table/TableEntry.kt
@@ -1,0 +1,33 @@
+package xtdb.table
+
+import xtdb.api.TableRef
+import xtdb.block.proto.TableEntry as TableEntryProto
+
+typealias Oid = Long
+
+/** A table's entry in the block's registry: its identity, and the directory its files live in. */
+data class TableEntry(val oid: Oid, val table: TableRef, val slug: TableSlug) {
+
+    fun toProto(): TableEntryProto =
+        TableEntryProto.newBuilder()
+            .setOid(oid.toInt())
+            .setSchemaName(table.schemaName)
+            .setTableName(table.tableName)
+            .setSlug(slug.slug)
+            .build()
+
+    companion object {
+        /** Mints an entry for a table that has none. Minting one for a table that does orphans its files. */
+        @JvmStatic
+        fun mint(oid: Oid, table: TableRef) = TableEntry(oid, table, TableSlug.of(table))
+
+        @JvmStatic
+        fun fromProto(proto: TableEntryProto) =
+            TableEntry(
+                // the proto field is uint32, which the generated accessor hands back as a signed Int
+                proto.oid.toUInt().toLong(),
+                TableRef(proto.schemaName, proto.tableName),
+                TableSlug(proto.slug)
+            )
+    }
+}

--- a/core/src/main/kotlin/xtdb/table/TableEntry.kt
+++ b/core/src/main/kotlin/xtdb/table/TableEntry.kt
@@ -17,6 +17,13 @@ data class TableEntry(val oid: Oid, val table: TableRef, val slug: TableSlug) {
             .build()
 
     companion object {
+        /**
+         * The lowest oid we hand out. Postgres reserves everything below this for its own catalog objects,
+         * and tooling filters on the boundary to tell a user's tables from the system's — so a table
+         * numbered from 1 reads as a system catalog to the clients we publish the oid to.
+         */
+        const val FIRST_OID: Oid = 16384L
+
         /** Mints an entry for a table that has none. Minting one for a table that does orphans its files. */
         @JvmStatic
         fun mint(oid: Oid, table: TableRef) = TableEntry(oid, table, TableSlug.of(table))

--- a/core/src/main/kotlin/xtdb/table/TableSlug.kt
+++ b/core/src/main/kotlin/xtdb/table/TableSlug.kt
@@ -1,0 +1,44 @@
+package xtdb.table
+
+import xtdb.api.TableRef
+import xtdb.trie.TrieKey
+import xtdb.util.asPath
+import java.nio.file.Path
+
+/**
+ * The directory under `tables/` holding one table's files.
+ *
+ * A table's location, never its identity: it is frozen when the table is first recorded and carried
+ * forward verbatim from block to block, so renaming a table changes its name and leaves this alone.
+ * Deriving one from a name is therefore only correct for a table that has no recorded slug — see [of].
+ */
+data class TableSlug(val slug: String) {
+
+    val tablePath: Path get() = tablesDir.resolve(slug)
+
+    fun dataFileDir(): Path = tablePath.resolve("data")
+
+    fun dataFilePath(trieKey: TrieKey): Path = dataFileDir().resolve("$trieKey.arrow")
+
+    fun metaFileDir(): Path = tablePath.resolve("meta")
+
+    fun metaFilePath(trieKey: TrieKey): Path = metaFileDir().resolve("$trieKey.arrow")
+
+    companion object {
+        @JvmStatic
+        val tablesDir = "tables".asPath
+
+        /**
+         * The slug a table takes when nothing has recorded one for it — whether because it is new, or
+         * because it predates the registry.
+         *
+         * Those two cases must produce the same answer, which is why this stays the escaped name: a table
+         * already on disk has to resolve to the path it has always had. Changing it orphans every file
+         * written by a node that hasn't got the change yet, so it can only move at a release boundary at
+         * which every node reads the recorded slug instead of calling this. See #4037.
+         */
+        @JvmStatic
+        fun of(table: TableRef) =
+            TableSlug("${table.schemaName}$${table.tableName}".replace(Regex("[./]"), "\\$"))
+    }
+}

--- a/core/src/main/kotlin/xtdb/trie/DataFileWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/DataFileWriter.kt
@@ -5,17 +5,16 @@ import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.ArrowWriter
 import xtdb.storage.BufferPool
 import xtdb.arrow.Relation
-import xtdb.api.TableRef
-import xtdb.trie.Trie.dataFilePath
+import xtdb.table.TableSlug
 
 class DataFileWriter(
     al: BufferAllocator, private val bp: BufferPool,
-    private val table: TableRef, private val trieKey: TrieKey, dataSchema: Schema,
+    private val slug: TableSlug, private val trieKey: TrieKey, dataSchema: Schema,
 ) : AutoCloseable {
     val dataRel: Relation = Relation(al, dataSchema)
 
     private val dataFileWriter: ArrowWriter =
-        runCatching { bp.openArrowWriter(table.dataFilePath(trieKey), dataRel) }
+        runCatching { bp.openArrowWriter(slug.dataFilePath(trieKey), dataRel) }
             .onFailure { dataRel.close() }
             .getOrThrow()
 

--- a/core/src/main/kotlin/xtdb/trie/LiveTrieWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/LiveTrieWriter.kt
@@ -3,13 +3,13 @@ package xtdb.trie
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.storage.BufferPool
 import xtdb.arrow.RelationReader
-import xtdb.api.TableRef
+import xtdb.table.TableSlug
 
 class LiveTrieWriter(
     private val al: BufferAllocator, private val bp: BufferPool,
     private val calculateBlooms: Boolean
 ) {
-    suspend fun writeLiveTrie(table: TableRef, trieKey: TrieKey, trie: MemoryHashTrie, dataRel: RelationReader): FileSize =
+    suspend fun writeLiveTrie(table: TableSlug, trieKey: TrieKey, trie: MemoryHashTrie, dataRel: RelationReader): FileSize =
         DataFileWriter(al, bp, table, trieKey, dataRel.schema).use { dataFileWriter ->
             MetadataFileWriter(al, bp, table, trieKey, dataFileWriter.dataRel, calculateBlooms, false)
                 .use { metaFileWriter ->

--- a/core/src/main/kotlin/xtdb/trie/MetadataFileWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/MetadataFileWriter.kt
@@ -19,12 +19,11 @@ import xtdb.indexer.TrieMetadataCalculator
 import xtdb.log.proto.TrieMetadata
 import xtdb.metadata.ColumnMetadata
 import xtdb.storage.BufferPool
-import xtdb.api.TableRef
-import xtdb.trie.Trie.metaFilePath
+import xtdb.table.TableSlug
 
 class MetadataFileWriter(
     al: BufferAllocator, private val bp: BufferPool,
-    private val table: TableRef, private val trieKey: TrieKey,
+    private val slug: TableSlug, private val trieKey: TrieKey,
     private val dataRel: RelationReader,
     calculateBlooms: Boolean, writeTrieMetadata: Boolean
 ) : AutoCloseable {
@@ -114,7 +113,7 @@ class MetadataFileWriter(
     }
 
     suspend fun end(): TrieMetadata {
-        bp.openArrowWriter(table.metaFilePath(trieKey), metaRel)
+        bp.openArrowWriter(slug.metaFilePath(trieKey), metaRel)
             .use { metaFileWriter ->
                 metaFileWriter.writePage()
                 metaFileWriter.end()

--- a/core/src/main/kotlin/xtdb/trie/PageTrieWriter.kt
+++ b/core/src/main/kotlin/xtdb/trie/PageTrieWriter.kt
@@ -7,7 +7,7 @@ import xtdb.arrow.Relation
 import xtdb.arrow.VectorReader
 import xtdb.compactor.PageTree
 import xtdb.log.proto.TrieMetadata
-import xtdb.api.TableRef
+import xtdb.table.TableSlug
 
 private typealias Selection = IntArray
 
@@ -50,7 +50,7 @@ class PageTrieWriter(
     }
 
     suspend fun writePageTree(
-        table: TableRef, trieKey: TrieKey,
+        table: TableSlug, trieKey: TrieKey,
         loader: Relation.Loader, pageTree: PageTree?,
         pageSize: Int
     ): Pair<FileSize, TrieMetadata?> =

--- a/core/src/main/kotlin/xtdb/trie/Trie.kt
+++ b/core/src/main/kotlin/xtdb/trie/Trie.kt
@@ -79,38 +79,6 @@ object Trie {
     }
 
     @JvmStatic
-    val tablesDir = "tables".asPath
-
-    @JvmStatic
-    val TableName.tablePath: Path get() = tablesDir.resolve(replace(Regex("[./]"), "\\$"))
-
-    @JvmStatic
-    fun TableName.metaFileDir(): Path = tablePath.resolve("meta")
-
-    @JvmStatic
-    fun TableName.metaFilePath(trieKey: TrieKey): Path =
-        metaFileDir().resolve("$trieKey.arrow")
-
-    @JvmStatic
-    val TableRef.tablePath: Path
-        get() =
-            tablesDir.resolve("$schemaName$$tableName".replace(Regex("[./]"), "\\$"))
-
-    @JvmStatic
-    fun TableRef.dataFileDir(): Path = tablePath.resolve("data")
-
-    @JvmStatic
-    fun TableRef.dataFilePath(trieKey: TrieKey): Path =
-        dataFileDir().resolve("$trieKey.arrow")
-
-    @JvmStatic
-    fun TableRef.metaFileDir(): Path = tablePath.resolve("meta")
-
-    @JvmStatic
-    fun TableRef.metaFilePath(trieKey: TrieKey): Path =
-        metaFileDir().resolve("$trieKey.arrow")
-
-    @JvmStatic
     fun dataRelSchema(putDocField: Field?): Schema =
         schema(
             "_iid" ofType IID,

--- a/core/src/main/proto/xtdb/meta/block/proto/block.proto
+++ b/core/src/main/proto/xtdb/meta/block/proto/block.proto
@@ -33,10 +33,21 @@ message TxKey {
     int64 system_time = 2;
 }
 
+message TableEntry {
+    uint32 oid = 1;
+    string schema_name = 2;
+    string table_name = 3;
+    // The directory under `tables/` holding this table's files, frozen when the table is first
+    // recorded — renaming the table does not move them. A table already on disk before this field
+    // existed takes its escaped name, which is what keeps its existing files reachable. See #4037.
+    string slug = 4;
+}
+
 message Block {
     int64 block_index = 1;
     TxKey latest_completed_tx = 2;
     int64 latest_processed_msg_id = 4;
+    // Superseded by `tables`, and still written for readers that predate it. See #4037.
     repeated string table_names = 3;
 
     // present iff it's the cluster's primary ('xtdb') database
@@ -51,4 +62,6 @@ message Block {
     // the leader term that produced this block's boundary; followers seed their
     // read-side term fence from it. Default 0 for blocks written before this field. See #5817.
     int64 term_id = 8;
+
+    repeated TableEntry tables = 9;
 }

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -183,7 +183,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
-                tables = listOf(table),
+                tables = tableCatalog.resolveTables(listOf(table)),
                 secondaryDatabases = null
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
@@ -241,7 +241,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
-                tables = listOf(table),
+                tables = tableCatalog.resolveTables(listOf(table)),
                 secondaryDatabases = null
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
@@ -318,7 +318,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
-                tables = listOf(table),
+                tables = tableCatalog.resolveTables(listOf(table)),
                 secondaryDatabases = null
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
@@ -389,7 +389,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
-                    tables = listOf(table),
+                    tables = db.tableCatalog.resolveTables(listOf(table)),
                     secondaryDatabases = null
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
@@ -461,7 +461,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
-                    tables = listOf(table),
+                    tables = db.tableCatalog.resolveTables(listOf(table)),
                     secondaryDatabases = null
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
@@ -556,7 +556,7 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
-                tables = listOf(table),
+                tables = tableCatalog.resolveTables(listOf(table)),
                 secondaryDatabases = null
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
@@ -607,7 +607,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
-                    tables = listOf(table),
+                    tables = db.tableCatalog.resolveTables(listOf(table)),
                     secondaryDatabases = null
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
@@ -697,7 +697,7 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestCompletedTx = TransactionKey(txId = blockIndex, systemTime = Instant.now()),
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
-                    tables = listOf(table),
+                    tables = db.tableCatalog.resolveTables(listOf(table)),
                     secondaryDatabases = null
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))

--- a/core/src/test/kotlin/xtdb/SimulationTestUtils.kt
+++ b/core/src/test/kotlin/xtdb/SimulationTestUtils.kt
@@ -5,8 +5,7 @@ import xtdb.log.proto.TrieDetails
 import xtdb.storage.BufferPool
 import xtdb.trie.TrieCatalog
 import xtdb.api.TableRef
-import xtdb.trie.Trie.dataFilePath
-import xtdb.trie.Trie.metaFilePath
+import xtdb.table.TableSlug
 import xtdb.trie.TrieKey
 import xtdb.util.StringUtil.asLexHex
 import xtdb.util.requiringResolve
@@ -25,8 +24,8 @@ class SimulationTestUtils {
         fun addTriesToBufferPool(bufferPool: BufferPool, tableRef: TableRef, tries: List<TrieDetails>) {
             tries.forEach { trie ->
                 val trieKey = trie.trieKey
-                bufferPool.putObjectSync(tableRef.dataFilePath(trieKey), ByteBuffer.allocate(1))
-                bufferPool.putObjectSync(tableRef.metaFilePath(trieKey), ByteBuffer.allocate(1))
+                bufferPool.putObjectSync(TableSlug.of(tableRef).dataFilePath(trieKey), ByteBuffer.allocate(1))
+                bufferPool.putObjectSync(TableSlug.of(tableRef).metaFilePath(trieKey), ByteBuffer.allocate(1))
             }
         }
 

--- a/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LiveTableTest.kt
@@ -8,6 +8,7 @@ import xtdb.arrow.STRUCT_TYPE
 import xtdb.arrow.VectorType.Companion.I64
 import xtdb.storage.MemoryStorage
 import xtdb.api.TableRef
+import xtdb.table.TableSlug
 import xtdb.trie.MemoryHashTrie
 import xtdb.trie.Trie
 import xtdb.util.RowCounter
@@ -16,13 +17,15 @@ import java.util.UUID
 
 class LiveTableTest {
 
+    private val DOCS = TableRef("public", "docs")
+
     @Test
     fun `importData appends rows to liveRelation and updates trie`() {
         RootAllocator().use { allocator ->
             val table = TableRef("public", "docs")
             val rowCounter = RowCounter()
 
-            LiveTable(allocator, table, 0L, rowCounter).use { liveTable ->
+            LiveTable(allocator, table, TableSlug.of(table), 0L, rowCounter).use { liveTable ->
                 Trie.openLogDataWriter(allocator).use { sourceRel ->
                     sourceRel["_iid"].writeBytes(ByteBuffer.wrap(ByteArray(16)))
                     sourceRel["_system_from"].writeLong(1000L)
@@ -62,7 +65,7 @@ class LiveTableTest {
             val table = TableRef("public", "docs")
             val rowCounter = RowCounter()
 
-            LiveTable(allocator, table, 0L, rowCounter).use { liveTable ->
+            LiveTable(allocator, table, TableSlug.of(table), 0L, rowCounter).use { liveTable ->
                 Trie.openLogDataWriter(allocator).use { rel ->
                     rel["_iid"].writeBytes(ByteBuffer.wrap(ByteArray(16)))
                     rel["_system_from"].writeLong(1000L)
@@ -119,7 +122,7 @@ class LiveTableTest {
         val uuid = UUID.fromString("7fffffff-ffff-ffff-4fff-ffffffffffff")
 
         RootAllocator().use { allocator ->
-            LiveTable(allocator, TableRef("public", "docs"), 0L, RowCounter(), liveTrieFactory).use { liveTable ->
+            LiveTable(allocator, DOCS, TableSlug.of(DOCS), 0L, RowCounter(), liveTrieFactory).use { liveTable ->
                 Trie.openLogDataWriter(allocator).use { sourceRel ->
                     val iid = uuid.toIidBytes()
                     repeat(n) { writePut(sourceRel, iid, 0, 0, 0) }
@@ -166,7 +169,7 @@ class LiveTableTest {
 
         RootAllocator().use { allocator ->
             MemoryStorage(allocator, epoch = 0).use { bp ->
-                LiveTable(allocator, TableRef("public", "docs"), 0L, RowCounter()).use { liveTable ->
+                LiveTable(allocator, DOCS, TableSlug.of(DOCS), 0L, RowCounter()).use { liveTable ->
 
                     Trie.openLogDataWriter(allocator).use { sourceRel ->
                         writePut(sourceRel, uuid.toIidBytes(), 0, 0, 0)

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -31,9 +31,8 @@ import xtdb.indexer.SimLog.Companion.launchSimLog
 import xtdb.api.tx.TxIndexer.TxResult
 import xtdb.storage.MemoryStorage
 import xtdb.api.TableRef
+import xtdb.table.TableSlug
 import xtdb.table.fromSchemaAndTable
-import xtdb.trie.Trie.dataFilePath
-import xtdb.trie.Trie.metaFilePath
 import xtdb.util.debug
 import xtdb.util.logger
 import java.nio.ByteBuffer
@@ -199,20 +198,20 @@ class LogProcessorSimTest : SimulationTestBase() {
             val tables = upload.tries.map { fromSchemaAndTable(it.tableName) }.toSet()
 
             for (trie in upload.tries) {
-                val table = fromSchemaAndTable(trie.tableName)
+                val slug = TableSlug.of(fromSchemaAndTable(trie.tableName))
                 assertTrue(
-                    table.dataFilePath(trie.trieKey) in storedPaths,
+                    slug.dataFilePath(trie.trieKey) in storedPaths,
                     "data file missing for ${trie.tableName}/${trie.trieKey}"
                 )
                 assertTrue(
-                    table.metaFilePath(trie.trieKey) in storedPaths,
+                    slug.metaFilePath(trie.trieKey) in storedPaths,
                     "meta file missing for ${trie.tableName}/${trie.trieKey}"
                 )
             }
 
             for (table in tables) {
                 assertTrue(
-                    TableCatalog.tableBlockPath(table, blockIdx) in storedPaths,
+                    TableCatalog.tableBlockPath(TableSlug.of(table), blockIdx) in storedPaths,
                     "table-block file missing for ${table.schemaAndTable}/b$blockIdx"
                 )
             }

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -1571,23 +1571,35 @@ rule ProcessingErrorHaltsNode {
 ---- Contracts
 
 contract TableEntries {
-    -- Obligations on the entries a Block carries, saying where each table's files live.
-    -- These are about a slug's history across successive blocks, so they cannot be expressed as single-snapshot invariants over entity state.
+    -- Obligations on the entries a Block carries: each table's identity, and where its files live.
+    -- These are about an entry's history across successive blocks, so they cannot be expressed as single-snapshot invariants over entity state.
 
     @invariant SlugFixedWhenFirstRecorded
         -- A table's slug is chosen once, by the first block that records the table, and every later block carries it forward unchanged.
+
+    @invariant OidFixedWhenTheTableIsFirstSeen
+        -- A table's oid is allocated when the catalog first learns of the table, and every later block carries it forward unchanged.
+        -- - The catalog learns of a table when a transaction writes to it, which is earlier than the block that first records it.
+
+    @invariant EveryNodeAllocatesTheSameOid
+        -- Two nodes reach the same oid for a table without it passing between them.
+        -- - Allocation follows the order tables first appear in the log, and the tables of one transaction are allocated in name order, so replaying the same log is enough to agree.
 
     @invariant EveryTableTheBlockNamesHasAnEntry
         -- A block records an entry for each table it names, taking the entry from the preceding block wherever that block held one.
 
     @invariant UnrecordedTableTakesItsEscapedName
-        -- A table with no entry takes the escaped form of its name as its slug.
+        -- A table a block does not record takes the escaped form of its name as its slug.
         -- - This is what a block carrying names alone resolves to, so the files its tables have already written stay where they are.
         -- - Oids for those tables are derived in name order, so every node resolving the same block resolves the same entries.
 
     @invariant SlugPrecedesTheFirstWrite
         -- A table's slug is fixed before anything is written under its path.
-        -- - A live table takes its slug when the live index creates it, so the L0 trie it writes at the block boundary lands under the slug the block then records for it.
+        -- - A live table takes its entry when the live index creates it, so the L0 trie it writes at the block boundary lands under the slug the block then records for it.
+
+    @invariant OnlyARecordedTableHasABlockFile
+        -- A per-table block file exists for exactly the tables the block records.
+        -- - A table allocated but not yet written has an entry and no file.
 }
 
 contract ExternalSourceConfirmation {

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -425,7 +425,17 @@ value Block {
     -- leader claiming a regressed election counter is refused rather than silently ignored
     -- (see log-processor-lifecycle.allium step 2a).
     term_id: Integer
+    -- Every table this block covers, and where each one's files live. See contract TableEntries.
+    tables: List<TableEntry>
     -- See: catalog/TableCatalog.kt, block/proto/block.proto
+}
+
+value TableEntry {
+    -- A table's identity, and the directory under `tables/` holding its files.
+    -- See: table/TableEntry.kt, table/TableSlug.kt, block/proto/block.proto (TableEntry)
+    oid: Integer
+    table: trie_cat/TableRef
+    slug: String
 }
 
 value PendingBlock {
@@ -1559,6 +1569,26 @@ rule ProcessingErrorHaltsNode {
 }
 
 ---- Contracts
+
+contract TableEntries {
+    -- Obligations on the entries a Block carries, saying where each table's files live.
+    -- These are about a slug's history across successive blocks, so they cannot be expressed as single-snapshot invariants over entity state.
+
+    @invariant SlugFixedWhenFirstRecorded
+        -- A table's slug is chosen once, by the first block that records the table, and every later block carries it forward unchanged.
+
+    @invariant EveryTableTheBlockNamesHasAnEntry
+        -- A block records an entry for each table it names, taking the entry from the preceding block wherever that block held one.
+
+    @invariant UnrecordedTableTakesItsEscapedName
+        -- A table with no entry takes the escaped form of its name as its slug.
+        -- - This is what a block carrying names alone resolves to, so the files its tables have already written stay where they are.
+        -- - Oids for those tables are derived in name order, so every node resolving the same block resolves the same entries.
+
+    @invariant SlugPrecedesTheFirstWrite
+        -- A table's slug is fixed before anything is written under its path.
+        -- - A live table takes its slug when the live index creates it, so the L0 trie it writes at the block boundary lands under the slug the block then records for it.
+}
 
 contract ExternalSourceConfirmation {
     -- Obligations on an ExternalSource that confirms progress upstream. These are about the

--- a/src/dev/clojure/dev.clj
+++ b/src/dev/clojure/dev.clj
@@ -7,6 +7,7 @@
             [xtdb.log :as xt-log]
             [xtdb.node :as xtn]
             [xtdb.pgwire :as pgw]
+            [xtdb.table :as table]
             [xtdb.table-catalog :as table-cat]
             [xtdb.test-util :as tu]
             [xtdb.trie :as trie]
@@ -21,6 +22,7 @@
            (xtdb.arrow Relation Vector)
            (xtdb.block.proto TableBlock)
            (xtdb.log.proto TrieDetails)
+           (xtdb.table TableSlug)
            (xtdb.trie ArrowHashTrie ArrowHashTrie$IidBranch ArrowHashTrie$Leaf ArrowHashTrie$Node)
            [xtdb.api.log SourceMessage]))
 
@@ -169,7 +171,7 @@
 
 (defn read-table-block-file [store-path table-name block-idx]
   (with-open [in (io/input-stream (.toFile (-> (util/->path store-path)
-                                               (.resolve (trie/table-name->table-path table-name))
+                                               (.resolve (.getTablePath (TableSlug/of (table/->ref table-name))))
                                                (table-cat/->table-block-metadata-obj-key block-idx))))]
     (-> (TableBlock/parseFrom in)
         (table-cat/<-table-block)

--- a/src/test/clojure/xtdb/compactor_test.clj
+++ b/src/test/clojure/xtdb/compactor_test.clj
@@ -11,6 +11,7 @@
             [xtdb.log :as xt-log]
             [xtdb.node :as xtn]
             [xtdb.object-store :as os]
+            [xtdb.table :as table]
             [xtdb.table-catalog :as table-cat]
             [xtdb.table-catalog-test :as table-test]
             [xtdb.test-util :as tu]
@@ -23,15 +24,16 @@
            [xtdb.block.proto TableBlock]
            (xtdb.compactor RecencyPartition)
            xtdb.segment.BufferPoolSegment
+           (xtdb.table TableSlug)
            xtdb.storage.LocalStorage))
 
 (t/use-fixtures :each tu/with-allocator tu/with-mock-clock tu/with-node)
 
-(defn table-path ^java.nio.file.Path [node table]
-  (-> (db/primary-db node)
-      ^LocalStorage (.getBufferPool)
-      (.getRootPath)
-      (.resolve (str "tables/" table))))
+(defn table-path ^java.nio.file.Path [node table-name]
+  (let [db (db/primary-db node)]
+    (-> ^LocalStorage (.getBufferPool db)
+        (.getRootPath)
+        (.resolve (.getTablePath (.slug (.getTableCatalog db) (table/->ref table-name)))))))
 
 (t/deftest test-l1-compaction
   (let [node-dir (util/->path "target/compactor/test-l1-compaction")]
@@ -72,7 +74,7 @@
           (t/is (= (range 500) (q)))
 
           (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/test-l1-compaction")))
-                                   (table-path node "public$foo")
+                                   (table-path node "public/foo")
                                    #"l01-rc-(.+)\.arrow"))))))
 
 (t/deftest test-l1-compaction-by-recency
@@ -121,10 +123,10 @@
         (t/is (= [{:row-count 200}] (xt/q node "SELECT COUNT(*) row_count FROM prices FOR ALL VALID_TIME")))
 
         (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/test-l1-compaction-by-recency/readings")))
-                                 (table-path node "public$readings") #"l01-(.+)\.arrow")
+                                 (table-path node "public/readings") #"l01-(.+)\.arrow")
 
         (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/test-l1-compaction-by-recency/prices")))
-                                 (table-path node "public$prices") #"l01-(.+)\.arrow")))))
+                                 (table-path node "public/prices") #"l01-(.+)\.arrow")))))
 
 (t/deftest test-l2+-compaction
   (let [node-dir (util/->path "target/compactor/test-l2+-compaction")]
@@ -165,7 +167,7 @@
           (t/is (= (set (range 2000)) (set (q))))
 
           (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/test-l2+-compaction")))
-                                   (table-path node "public$foo")
+                                   (table-path node "public/foo")
                                    #"l(?!00|01)\d\d-(.+)\.arrow"))))))
 
 (t/deftest test-l2+-compaction-by-recency
@@ -196,11 +198,11 @@
         (c/compact-all! node #xt/duration "PT5S")
 
         (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/test-l2+-compaction-by-recency/readings")))
-                                 (table-path node "public$readings")
+                                 (table-path node "public/readings")
                                  #"l(?!00|01)(.+)\.arrow")
 
         (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/test-l2+-compaction-by-recency/prices")))
-                                 (table-path node "public$prices")
+                                 (table-path node "public/prices")
                                  #"l(?!00|01)(.+)\.arrow")))))
 
 (defn bad-uuid-seq
@@ -231,13 +233,13 @@
             (xt-log/sync-node node #xt/duration "PT5S")
             (c/compact-all! node (Duration/ofSeconds 5))
 
-            (let [^String table-name "foo"
-                  meta-files (->> (.listAllObjects bp (trie/->table-meta-dir table-name))
+            (let [slug (TableSlug/of #xt/table foo)
+                  meta-files (->> (.listAllObjects bp (.metaFileDir slug))
                                   (mapv (comp :key os/<-StoredObject)))]
 
-              #_ ; TODO this doseq seems to return nothing, so nothing gets tested?
+              #_ ; TODO discarded — enabling it needs the doseq's assertions checked over
               (doseq [{:keys [^String trie-key]} (map trie/parse-trie-file-path meta-files)]
-                (util/with-open [seg (BufferPoolSegment. tu/*allocator* bp meta-mgr table-name trie-key nil)
+                (util/with-open [seg (BufferPoolSegment. tu/*allocator* bp meta-mgr slug trie-key nil)
                                  seg-meta (.openMetadataSync seg)]
                   (doseq [leaf (.getLeaves (.getTrie seg-meta))
                           :let [page (.page seg-meta leaf)
@@ -305,7 +307,7 @@
                                   GROUP BY _id"))))
 
         (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/lose-data-on-compaction")))
-                                 (table-path node "public$docs")
+                                 (table-path node "public/docs")
                                  #"(.+)\.arrow")))))
 
 (t/deftest test-compaction-promotion-bug-3673
@@ -395,7 +397,7 @@
                    (set (xt/q node "SELECT _id FROM foo FOR ALL VALID_TIME FOR ALL SYSTEM_TIME")))))
 
         (aet/check-arrow-edn-dir (.toPath (io/as-file (io/resource "xtdb/compactor-test/compaction-with-erase")))
-                                 (table-path node "public$foo")
+                                 (table-path node "public/foo")
                                  #"l01-rc-(.+)\.arrow")))))
 
 (t/deftest compactor-trie-metadata

--- a/src/test/clojure/xtdb/expression/pg_test.clj
+++ b/src/test/clojure/xtdb/expression/pg_test.clj
@@ -7,6 +7,13 @@
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 
+(defn- ->table-oid
+  "The oid pg_class reports for a table. Resolved rather than hardcoded: it is allocated when the
+   catalog first sees the table, so a literal would pin the order the tests happened to create them in."
+  [relname]
+  (-> (xt/q tu/*node* (format "SELECT oid FROM pg_catalog.pg_class WHERE relname = '%s'" relname))
+      first :oid))
+
 (t/deftest test-oid
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
 
@@ -18,7 +25,7 @@
            (xt/q tu/*node* "SELECT 12345::oid::int v"))
         "oid -> int")
 
-  (t/is (= [{:v (Oid. 357712798)}]
+  (t/is (= [{:v (Oid. (->table-oid "foo"))}]
            (xt/q tu/*node* "SELECT 'foo'::regclass::oid v"))
         "regclass -> oid")
 
@@ -42,7 +49,7 @@
   (xt/submit-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
 
   (t/testing "regclass uses search path to resolve unqualified names"
-    (t/is (= [{:v (RegClass. 357712798)}]
+    (t/is (= [{:v (RegClass. (->table-oid "foo"))}]
              (xt/q tu/*node* "SELECT 'public.foo'::regclass v")
              (xt/q tu/*node* "SELECT 'foo'::regclass v"))
           "text -> regclass"))
@@ -56,7 +63,7 @@
              (xt/q tu/*node* "SELECT 'information_schema.columns'::regclass::varchar v"))
           "text -> regclass -> text"))
 
-  (t/is (= [{:v 357712798}]
+  (t/is (= [{:v (->table-oid "foo")}]
            (xt/q tu/*node* "SELECT 'public.foo'::regclass::int v"))
         "text -> regclass -> int")
 
@@ -78,13 +85,13 @@
                 (mapv (comp symbol :attname)))))
 
   (t/is (= [{:v true}]
-           (xt/q tu/*node* "SELECT 357712798::regclass = 'foo'::regclass v"))
+           (xt/q tu/*node* (format "SELECT %s::regclass = 'foo'::regclass v" (->table-oid "foo"))))
         "regclass with identical oid are equal")
 
   (t/testing "testing non-literal cast"
     (xt/submit-tx tu/*node* [[:sql "INSERT INTO bar RECORDS {_id: 1, tn: 'foo'}"]])
 
-    (t/is (= [{:v (RegClass. 357712798)}]
+    (t/is (= [{:v (RegClass. (->table-oid "foo"))}]
              (xt/q tu/*node* "SELECT tn::regclass v FROM bar"))
           "text -> regclass")))
 
@@ -93,7 +100,7 @@
                            [:sql "INSERT INTO bar RECORDS {_id: 2}"]])
 
   (t/is (= [{:xt/id 2} {:xt/id 1}]
-           (xt/q tu/*node* "SELECT _id FROM bar WHERE 'bar'::regclass = 904292726"))))
+           (xt/q tu/*node* (format "SELECT _id FROM bar WHERE 'bar'::regclass = %s" (->table-oid "bar"))))))
 
 (t/deftest test-regproc
   (t/is (= [{:v (RegProc. 1989914641)}]

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -124,9 +124,10 @@
           (xt/execute-tx node [[:put-docs :docs {:xt/id 1 :foo 1}]])
           (tu/flush-block! node)
 
-          ;; sizes include the block boundary's term_id (=1 for a fresh leader), added in #5817 level 1
-          (t/is (= [(os/->StoredObject (util/->path "blocks/b00.binpb") 64)
-                    (os/->StoredObject (util/->path "blocks/b01.binpb") 65)]
+          ;; sizes include the block boundary's term_id (=1 for a fresh leader, added in #5817 level 1)
+          ;; and the table registry each block carries (#4037)
+          (t/is (= [(os/->StoredObject (util/->path "blocks/b00.binpb") 161)
+                    (os/->StoredObject (util/->path "blocks/b01.binpb") 162)]
                    (.listAllObjects bp (util/->path "blocks")))))))))
 
 (t/deftest staged-empty-create-table-visible-across-a-batch-5507

--- a/src/test/clojure/xtdb/indexer/live_index_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_index_test.clj
@@ -126,8 +126,8 @@
 
           ;; sizes include the block boundary's term_id (=1 for a fresh leader, added in #5817 level 1)
           ;; and the table registry each block carries (#4037)
-          (t/is (= [(os/->StoredObject (util/->path "blocks/b00.binpb") 161)
-                    (os/->StoredObject (util/->path "blocks/b01.binpb") 162)]
+          (t/is (= [(os/->StoredObject (util/->path "blocks/b00.binpb") 167)
+                    (os/->StoredObject (util/->path "blocks/b01.binpb") 168)]
                    (.listAllObjects bp (util/->path "blocks")))))))))
 
 (t/deftest staged-empty-create-table-visible-across-a-batch-5507

--- a/src/test/clojure/xtdb/indexer/live_table_test.clj
+++ b/src/test/clojure/xtdb/indexer/live_table_test.clj
@@ -9,6 +9,7 @@
   (:import (java.nio ByteBuffer)
            (org.apache.arrow.memory RootAllocator)
            (xtdb.indexer LiveTable)
+           (xtdb.table TableSlug)
            (xtdb.util RowCounter)))
 
 (t/use-fixtures :each tu/with-allocator tu/with-node)
@@ -31,7 +32,8 @@
         (util/with-open [node (tu/->local-node {:node-dir path, :compactor-threads 0})
                          bp (.getBufferPool (db/primary-db node))
                          allocator (RootAllocator.)
-                         live-table (LiveTable. allocator #xt/table foo 0 (RowCounter.) (partial trie/->live-trie 2 4))]
+                         live-table (LiveTable. allocator #xt/table foo (TableSlug/of #xt/table foo) 0 (RowCounter.)
+                                                (partial trie/->live-trie 2 4))]
           (util/with-open [rel (tu/open-put-log-rel allocator 0 (->max-depth-puts uuid n))]
             (.importData live-table rel))
 

--- a/src/test/clojure/xtdb/information_schema_test.clj
+++ b/src/test/clojure/xtdb/information_schema_test.clj
@@ -102,32 +102,40 @@
       (t/is (= seeded (txs-data-cols))
             "a real transaction writes exactly the seeded columns - no drift between seed and writeTxRow"))))
 
+(defn- ->table-oids
+  "`{relname oid}` as pg_class reports it — resolved rather than hardcoded, because an allocated oid
+   depends on the order tables were first seen, and a new seeded system table would shift every literal."
+  []
+  (into {} (map (juxt :relname :oid))
+        (xt/q tu/*node* "SELECT relname, oid FROM pg_catalog.pg_class")))
+
 (deftest test-pg-attribute
   (xt/submit-tx tu/*node* test-data)
 
-  (t/is (= (set (for [[attrelid attname attnum atttypeid attlen] [[127091884 "_id" 1 11111 -1]
-                                                                  [127091884 "_system_from" 2 1184 8]
-                                                                  [127091884 "_system_to" 3 1184 8]
-                                                                  [127091884 "_valid_from" 4 1184 8]
-                                                                  [127091884 "_valid_to" 5 1184 8]
-                                                                  [127091884 "col1" 6 114 -1]
+  (let [{beanie "beanie", baseball "baseball", txs "txs"} (->table-oids)]
+    (t/is (= (set (for [[attrelid attname attnum atttypeid attlen] [[beanie "_id" 1 11111 -1]
+                                                                  [beanie "_system_from" 2 1184 8]
+                                                                  [beanie "_system_to" 3 1184 8]
+                                                                  [beanie "_valid_from" 4 1184 8]
+                                                                  [beanie "_valid_to" 5 1184 8]
+                                                                  [beanie "col1" 6 114 -1]
 
-                                                                  [732573471 "_id" 1 11111 -1]
-                                                                  [732573471 "_system_from" 2 1184 8]
-                                                                  [732573471 "_system_to" 3 1184 8]
-                                                                  [732573471 "_valid_from" 4 1184 8]
-                                                                  [732573471 "_valid_to" 5 1184 8]
-                                                                  [732573471 "col1" 6 20 8]
-                                                                  [732573471 "col2" 7 20 8]
+                                                                  [baseball "_id" 1 11111 -1]
+                                                                  [baseball "_system_from" 2 1184 8]
+                                                                  [baseball "_system_to" 3 1184 8]
+                                                                  [baseball "_valid_from" 4 1184 8]
+                                                                  [baseball "_valid_to" 5 1184 8]
+                                                                  [baseball "col1" 6 20 8]
+                                                                  [baseball "col2" 7 20 8]
 
-                                                                  [598393539 "_id" 1 20 8]
-                                                                  [598393539 "_system_from" 2 1184 8]
-                                                                  [598393539 "_system_to" 3 1184 8]
-                                                                  [598393539 "_valid_from" 4 1184 8]
-                                                                  [598393539 "_valid_to" 5 1184 8]
-                                                                  [598393539 "committed" 6 16 1]
-                                                                  [598393539 "error" 7 16384 -1]
-                                                                  [598393539 "system_time" 8 1184 8]]]
+                                                                  [txs "_id" 1 20 8]
+                                                                  [txs "_system_from" 2 1184 8]
+                                                                  [txs "_system_to" 3 1184 8]
+                                                                  [txs "_valid_from" 4 1184 8]
+                                                                  [txs "_valid_to" 5 1184 8]
+                                                                  [txs "committed" 6 16 1]
+                                                                  [txs "error" 7 16384 -1]
+                                                                  [txs "system_time" 8 1184 8]]]
                   {:atttypmod -1,
                    :attrelid attrelid,
                    :attidentity "",
@@ -144,7 +152,7 @@
                               attnotnull, atttypmod, attidentity, attgenerated
                        FROM pg_catalog.pg_attribute
                        WHERE attname IN ('_id', '_valid_from', '_valid_to', '_system_from', '_system_to',
-                                         'col1', 'col2', 'error', 'system_time', 'committed')")))))
+                                         'col1', 'col2', 'error', 'system_time', 'committed')"))))))
 
 (deftest test-pg-tables
   (xt/submit-tx tu/*node* test-data)
@@ -169,9 +177,10 @@
 (deftest test-pg-class
   (xt/submit-tx tu/*node* test-data)
 
-  (t/is (= #{{:relkind "r",
+  (let [{beanie "beanie", baseball "baseball", txs "txs"} (->table-oids)]
+    (t/is (= #{{:relkind "r",
               :relnamespace 1106696632,
-              :oid 732573471,
+              :oid baseball,
               :relname "baseball",
               :relam 2,
               :relchecks 0,
@@ -188,7 +197,7 @@
               :reltoastrelid 0}
              {:relkind "r",
               :relnamespace 683075021,
-              :oid 598393539,
+              :oid txs,
               :relname "txs",
               :relam 2,
               :relchecks 0,
@@ -205,7 +214,7 @@
               :reltoastrelid 0}
              {:relkind "r",
               :relnamespace 1106696632,
-              :oid 127091884,
+              :oid beanie,
               :relname "beanie",
               :relam 2,
               :relchecks 0,
@@ -223,7 +232,7 @@
            (set (xt/q tu/*node*
                       "SELECT reltablespace, reloftype, relhastriggers, relchecks, relpersistence, relhasrules, relispartition, relname, relforcerowsecurity, oid, relnamespace, relreplident, relhasindex, reltoastrelid, relkind, relam, relrowsecurity
                        FROM pg_catalog.pg_class
-                       WHERE relname IN ('beanie', 'baseball', 'txs')")))))
+                       WHERE relname IN ('beanie', 'baseball', 'txs')"))))))
 
 (deftest test-pg-type
   (xt/submit-tx tu/*node* test-data)
@@ -289,7 +298,7 @@
   (t/is (= [{:column-name "_id"}]
            (xt/q tu/*node* "SELECT column_name FROM information_schema.columns ORDER BY column_name LIMIT 1")))
 
-  (t/is (= [{:attname "_id", :attrelid 127091884}]
+  (t/is (= [{:attname "_id", :attrelid (apply min (vals (->table-oids)))}]
            (xt/q tu/*node* "SELECT attname, attrelid FROM pg_attribute ORDER BY attname, attrelid LIMIT 1")))
 
   (t/is (= [{:table-name "baseball",
@@ -605,3 +614,17 @@
             (t/is (= [{:table-catalog "new-db", :table-schema "public", :table-name "foo", :column-name "_id", :data-type ":keyword"}]
                      (xt/q xt-conn "SELECT table_catalog, table_schema, table_name, column_name, data_type FROM \"new-db\".information_schema.columns WHERE table_schema = 'public' AND column_name = '_id'"))
                   "query other db's information_schema from xtdb connection")))))))
+
+(deftest a-tables-oid-does-not-change-when-its-first-block-is-written
+  (xt/execute-tx tu/*node* [[:put-docs :docs {:xt/id 1}]])
+
+  (let [->oid #(-> (xt/q tu/*node* "SELECT oid FROM pg_catalog.pg_class WHERE relname = 'docs'")
+                   first :oid)
+        before (->oid)]
+    (t/is (not= (i-s/name->oid 'public/docs) before)
+          "pg_class reports the allocated oid, not a hash of the name, before any block records it")
+
+    (tu/flush-block! tu/*node*)
+    (xt/execute-tx tu/*node* [[:put-docs :unrelated {:xt/id 1}]])
+
+    (t/is (= before (->oid)))))

--- a/src/test/clojure/xtdb/metadata_test.clj
+++ b/src/test/clojure/xtdb/metadata_test.clj
@@ -14,7 +14,7 @@
             [xtdb.vector.writer :as vw])
   (:import (clojure.lang MapEntry)
            xtdb.storage.LocalStorage
-           xtdb.trie.Trie))
+           (xtdb.table TableSlug)))
 
 (t/use-fixtures :each tu/with-mock-clock tu/with-node)
 (t/use-fixtures :once tu/with-allocator)
@@ -132,7 +132,7 @@
             literal-selector (expr.meta/->metadata-selector tu/*allocator* '(and (< _id 11) (> _id 9)) '{_id #xt/field {"_id" :i64}} vw/empty-args)]
 
         (t/testing "L0"
-          (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))]
+          (let [meta-file-path (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l0-trie-key 0))]
             (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
               (t/is (= 4 (.rowIndex page-metadata "_id" 0)))
 
@@ -141,7 +141,7 @@
                   (t/is (true? (.test page-idx-pred page-idx))))))))
 
         (t/testing "L1"
-          (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
+          (let [meta-file-path (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 0))]
             (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
               (let [page-idx-pred (.build literal-selector page-metadata)]
                 (doseq [page-idx relevant-pages]
@@ -155,7 +155,7 @@
   (c/compact-all! tu/*node* #xt/duration "PT1S")
 
   (let [metadata-mgr (.getMetadataManager (db/primary-db tu/*node*))
-        meta-file-path (Trie/metaFilePath "public$xt_docs" ^String (trie/->l0-trie-key 0))]
+        meta-file-path (.metaFilePath (TableSlug. "public$xt_docs") ^String (trie/->l0-trie-key 0))]
     (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
       (let [sys-time-micros (time/instant->micros #xt/instant "2020-01-01T00:00:00.000000Z")
             temporal-metadata (tu/->temporal-metadata sys-time-micros Long/MAX_VALUE sys-time-micros sys-time-micros)]
@@ -169,7 +169,7 @@
         true-selector (expr.meta/->metadata-selector tu/*allocator* '(== boolean_or_int true) '{boolean_or_int #xt/field {"boolean_or_int" :bool}} vw/empty-args)]
 
     (t/testing "L0"
-      (let [meta-file-path (Trie/metaFilePath "public$xt_docs" ^String (trie/->l0-trie-key 0))]
+      (let [meta-file-path (.metaFilePath (TableSlug. "public$xt_docs") ^String (trie/->l0-trie-key 0))]
         (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
           (let [page-idx-pred (.build true-selector page-metadata)]
             (t/is (= 5 (.rowIndex page-metadata "boolean_or_int" 0)))
@@ -179,7 +179,7 @@
     (c/compact-all! tu/*node* #xt/duration "PT1S")
 
     (t/testing "L1"
-      (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
+      (let [meta-file-path (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 0))]
         (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
           (let [page-idx-pred (.build true-selector page-metadata)]
             (t/is (= 5 (.rowIndex page-metadata "boolean_or_int" 0)))
@@ -205,12 +205,12 @@
 
         (let [metadata-mgr (.getMetadataManager (db/primary-db node))]
           (t/testing "L0"
-            (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))]
+            (let [meta-file-path (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l0-trie-key 0))]
               (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
                 (t/is (= 6 (.rowIndex page-metadata "colours" 0))))))
 
           (t/testing "L1"
-            (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
+            (let [meta-file-path (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 0))]
               (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
                 (t/is (= 6 (.rowIndex page-metadata "colours" 0)))))))))))
 
@@ -235,7 +235,7 @@
                                  (.resolve (.getRootPath bp) "tables")
                                  #"l01.*")
 
-        (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))]
+        (let [meta-file-path (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 0))]
           (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
             (t/is (= 5 (.rowIndex page-metadata "duration" 0)))))))))
 
@@ -271,7 +271,7 @@
                 not-null-selector (expr.meta/->metadata-selector tu/*allocator* '(not (nil? status)) '{status #xt/field {"status" :utf8}} vw/empty-args)]
 
             (t/testing "L0 metadata pred"
-              (let [meta-file-path (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))]
+              (let [meta-file-path (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l0-trie-key 0))]
                 (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
                   (let [page-idx-pred (.build not-null-selector page-metadata)]
                     ;; Pages with user1 and user2 (nulls) should be filtered out

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -812,29 +812,34 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
 (deftest test-schema-ee-entry-points
   ;;test is using regclass to verify that expected EE entrypoints have access
   ;;to the new schema variable
-  (xt/submit-tx tu/*node* [[:put-docs :bar {:xt/id 1, :col 904292726}]
-                           [:put-docs :bar {:xt/id 2, :col 1111}]])
+  ;; bar's oid is allocated when the catalog first sees the table, so it can only be read back once
+  ;; bar exists - hence the seed tx ahead of the rows that carry the oid as data
+  (xt/execute-tx tu/*node* [[:put-docs :bar {:xt/id 0, :col 0}]])
 
+  (let [oid (-> (xt/q tu/*node* "SELECT oid FROM pg_catalog.pg_class WHERE relname = 'bar'")
+                first :oid)]
+    (xt/execute-tx tu/*node* [[:put-docs :bar {:xt/id 1, :col oid}]
+                              [:put-docs :bar {:xt/id 2, :col 1111}]])
 
-  (t/is (= [{:v (RegClass. 904292726)}]
-           (tu/query-ra
-            '[:project {:projections [{v (cast "bar" #xt/type :regclass)}]}
-              [:table {:rows [{}]}]]
-            {:node tu/*node*}))
-        "project")
+    (t/is (= [{:v (RegClass. oid)}]
+             (tu/query-ra
+              '[:project {:projections [{v (cast "bar" #xt/type :regclass)}]}
+                [:table {:rows [{}]}]]
+              {:node tu/*node*}))
+          "project")
 
-  (t/is (= [{:v 904292726}]
-           (tu/query-ra
-            '[:select {:predicate (== (cast "bar" #xt/type :regclass) v)}
-              [:table {:rows [{v 904292726} {v 111}]}]]
-            {:node tu/*node*}))
-        "select")
+    (t/is (= [{:v oid}]
+             (tu/query-ra
+              [:select {:predicate '(== (cast "bar" #xt/type :regclass) v)}
+               [:table {:rows [{'v oid} {'v 111}]}]]
+              {:node tu/*node*}))
+          "select")
 
-  (t/is (= [{:col 904292726}]
-           (tu/query-ra
-            '[:scan {:db-name "xtdb", :table #xt/table bar, :columns [{col (== col (cast "bar" #xt/type :regclass))}]}]
-            {:node tu/*node*}))
-        "scan pred"))
+    (t/is (= [{:col oid}]
+             (tu/query-ra
+              '[:scan {:db-name "xtdb", :table #xt/table bar, :columns [{col (== col (cast "bar" #xt/type :regclass))}]}]
+              {:node tu/*node*}))
+          "scan pred")))
 
 (t/deftest copes-with-log-time-going-backwards-3864
   (with-open [node (xtn/start-node {:log [:in-memory {:instant-src (tu/->mock-clock [#inst "2020" #inst "2019" #inst "2021"])}]})]

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -12,7 +12,7 @@
             [xtdb.vector.writer :as vw])
   (:import (java.time LocalTime)
            (xtdb.metadata PageMetadata)
-           (xtdb.trie Trie)))
+           (xtdb.table TableSlug)))
 
 (t/use-fixtures :once tu/with-allocator)
 (t/use-fixtures :each tu/with-node)
@@ -55,24 +55,24 @@
             (let [lit-sel (expr.meta/->metadata-selector tu/*allocator* '(> ordinal 1) '{ordinal #xt/field {"ordinal" :i64}} vw/empty-args)
                   param-sel (expr.meta/->metadata-selector tu/*allocator* '(> ordinal ?ordinal) '{ordinal #xt/field {"ordinal" :i64}} args)]
               (t/testing "L0 files have min-max metadata, so we have to match them"
-                (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))
+                (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l0-trie-key 0))
                   (fn [^PageMetadata page-metadata]
                     (t/is (false? (.test (.build lit-sel page-metadata) 0)))
                     (t/is (false? (.test (.build param-sel page-metadata) 0)))))
 
-                (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 1))
+                (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l0-trie-key 1))
                   (fn [^PageMetadata page-metadata]
                     (t/is (true? (.test (.build lit-sel page-metadata) 0)))
                     (t/is (true? (.test (.build param-sel page-metadata) 0))))))
 
               (t/testing "first L1 file has content metadata, doesn't match"
-                (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))
+                (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 0))
                   (fn [^PageMetadata page-metadata]
                     (t/is (false? (.test (.build lit-sel page-metadata) 0)))
                     (t/is (false? (.test (.build param-sel page-metadata) 0))))))
 
               (t/testing "combined L1 file matches"
-                (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 1))
+                (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 1))
                   (fn [^PageMetadata page-metadata]
                     (t/is (true? (.test (.build lit-sel page-metadata) 0)))
                     (t/is (true? (.test (.build param-sel page-metadata) 0)))))))))
@@ -109,24 +109,24 @@
           (let [lit-sel (expr.meta/->metadata-selector tu/*allocator* '(== name "Ivan") '{name #xt/field {"name" :utf8}} vw/empty-args)
                 param-sel (expr.meta/->metadata-selector tu/*allocator* '(== name ?name) '{name #xt/field {"name" :utf8}} args)]
             (t/testing "L0 has no bloom filter metadata -> always match"
-              (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 0))
+              (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l0-trie-key 0))
                 (fn [^PageMetadata page-metadata]
                   (t/is (true? (.test (.build lit-sel page-metadata) 0)))
                   (t/is (true? (.test (.build param-sel page-metadata) 0)))))
 
-              (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l0-trie-key 1))
+              (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l0-trie-key 1))
                 (fn [^PageMetadata page-metadata]
                   (t/is (true? (.test (.build lit-sel page-metadata) 0)))
                   (t/is (true? (.test (.build param-sel page-metadata) 0))))))
 
             (t/testing "first L1 file matches"
-              (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 0))
+              (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 0))
                 (fn [^PageMetadata page-metadata]
                   (t/is (true? (.test (.build lit-sel page-metadata) 0)))
                   (t/is (true? (.test (.build param-sel page-metadata) 0))))))
 
             (t/testing "combined L1 file also matches"
-              (with-page-metadata node (Trie/metaFilePath #xt/table xt_docs ^String (trie/->l1-trie-key nil 1))
+              (with-page-metadata node (.metaFilePath (TableSlug/of #xt/table xt_docs) ^String (trie/->l1-trie-key nil 1))
                 (fn [^PageMetadata page-metadata]
                   (t/is (true? (.test (.build lit-sel page-metadata) 0)))
                   (t/is (true? (.test (.build param-sel page-metadata) 0)))))))))

--- a/src/test/clojure/xtdb/table_catalog_test.clj
+++ b/src/test/clojure/xtdb/table_catalog_test.clj
@@ -219,12 +219,12 @@
                                               :tries (partial map (comp :trie-key trie/<-trie-details))))
                                     partitions))))))))))
 
-(deftest a-block-carrying-names-alone-resolves-the-registry-its-files-are-already-under
+(deftest a-block-carrying-names-alone-resolves-to-the-entries-its-files-are-already-under
   (let [names ["public/docs" "public/foo" "xt/txs"]
-        entries (map-indexed (fn [idx nm] (TableEntry/mint (inc idx) (table/->ref nm)))
+        entries (map-indexed (fn [idx nm] (TableEntry/mint (+ TableEntry/FIRST_OID idx) (table/->ref nm)))
                              (sort names))
 
-        ;; UNUSED throws on every storage call, so this also pins that resolving the registry reads nothing back.
+        ;; UNUSED throws on every storage call, so this also pins that resolving the entries reads nothing back.
         ->entries (fn [^Block block] (vec (.getEntries (.snap (TableCatalog. BufferPool/UNUSED block)))))]
 
     (t/is (= ["public$docs" "public$foo" "xt$txs"]
@@ -240,9 +240,9 @@
                             (.addAllTableNames names)
                             (.addAllTables (map #(.toProto ^TableEntry %) entries))
                             (.build))))
-          "a recorded registry resolves to the same entries")))
+          "recorded entries resolve to themselves")))
 
-(deftest resolving-a-registry-less-block-depends-on-nothing-but-that-block
+(deftest resolving-a-block-with-no-entries-depends-on-nothing-but-that-block
   (let [->block (fn [block-idx names]
                   (-> (Block/newBuilder) (.setBlockIndex block-idx) (.addAllTableNames names) (.build)))
         ->oids (fn [^TableCatalog cat]
@@ -257,7 +257,38 @@
 
         started-at-b11 (TableCatalog. BufferPool/UNUSED b11)]
 
-    (t/is (= {"public/docs" 1, "public/orders" 2, "xt/txs" 3} (->oids started-at-b11)))
+    (t/is (= {"public/docs" 16384, "public/orders" 16385, "xt/txs" 16386} (->oids started-at-b11)))
 
     (t/is (= (->oids started-at-b11) (->oids caught-up))
-          "two nodes reading one registry-less block agree, whatever each of them read before it")))
+          "two nodes reading one entry-less block agree, whatever each of them read before it")))
+
+(defn- ->oids [^TableCatalog cat]
+  (into {} (map (juxt #(str (.getSym (.getTable ^TableEntry %))) #(.getOid ^TableEntry %)))
+        (.getEntries (.snap cat))))
+
+(defn- register-txs ^TableCatalog [txs]
+  (let [cat (TableCatalog. BufferPool/UNUSED nil)]
+    (doseq [tx txs]
+      (.registerTables cat (mapv table/->ref tx)))
+    cat))
+
+(deftest two-nodes-replaying-one-log-allocate-the-same-oids
+  ;; a leader learns of a table as it resolves the tx that writes it, a follower as it applies the same
+  ;; tx — and within one tx the tables arrive as an unordered map, so the two see them in different orders
+  (t/is (= (->oids (register-txs [["public/docs"] ["public/orders" "public/audit"]]))
+           (->oids (register-txs [["public/docs"] ["public/audit" "public/orders"]])))
+        "the oid never travels between them, so both have to derive it")
+
+  (t/is (not= (->oids (register-txs [["public/docs"] ["public/orders"]]))
+              (->oids (register-txs [["public/orders"] ["public/docs"]])))
+        "across txs the log order is the allocation order, and it is the same order on every node"))
+
+(deftest a-block-records-the-oid-the-catalog-has-already-published
+  (let [tables ["public/docs" "public/orders" "xt/txs"]
+        cat (register-txs [tables])
+        published (->oids cat)
+        recorded (into {} (map (juxt #(str (.getSym (.getTable ^TableEntry %))) #(.getOid ^TableEntry %)))
+                       (.resolveTables cat (mapv table/->ref tables)))]
+
+    (t/is (= published recorded)
+          "a table's oid is fixed when the catalog learns of it, so its first block changes nothing")))

--- a/src/test/clojure/xtdb/table_catalog_test.clj
+++ b/src/test/clojure/xtdb/table_catalog_test.clj
@@ -3,6 +3,7 @@
             [xtdb.api :as xt]
             [xtdb.db-catalog :as db]
             [xtdb.object-store :as os]
+            [xtdb.table :as table]
             [xtdb.table-catalog :as table-cat]
             [xtdb.test-util :as tu]
             [xtdb.trie :as trie]
@@ -13,8 +14,11 @@
            [java.time Instant]
            [java.util Map]
            (org.apache.arrow.vector.types.pojo Schema)
-           (xtdb.block.proto TableBlock)
+           (xtdb.block.proto Block TableBlock)
+           (xtdb.catalog TableCatalog)
            (xtdb.log.proto TrieDetails)
+           (xtdb.storage BufferPool)
+           (xtdb.table TableEntry TableSlug)
            (xtdb.util HyperLogLog)))
 
 (defn trie-details->edn [^TrieDetails trie]
@@ -40,7 +44,7 @@
 
         (t/is (= [(os/->StoredObject "tables/public$foo/blocks/b00.binpb" 4353)
                   (os/->StoredObject "tables/public$foo/blocks/b01.binpb" 4435)]
-                 (.listAllObjects bp (table-cat/->table-block-dir #xt/table foo))))
+                 (.listAllObjects bp (table-cat/->table-block-dir (TableSlug/of #xt/table foo)))))
 
         (let [{hlls1 :hlls :as _table-block1} (->> (.getByteArray bp (util/->path "tables/public$foo/blocks/b00.binpb"))
                                                    TableBlock/parseFrom
@@ -214,3 +218,46 @@
                                       (update partition
                                               :tries (partial map (comp :trie-key trie/<-trie-details))))
                                     partitions))))))))))
+
+(deftest a-block-carrying-names-alone-resolves-the-registry-its-files-are-already-under
+  (let [names ["public/docs" "public/foo" "xt/txs"]
+        entries (map-indexed (fn [idx nm] (TableEntry/mint (inc idx) (table/->ref nm)))
+                             (sort names))
+
+        ;; UNUSED throws on every storage call, so this also pins that resolving the registry reads nothing back.
+        ->entries (fn [^Block block] (vec (.getEntries (.snap (TableCatalog. BufferPool/UNUSED block)))))]
+
+    (t/is (= ["public$docs" "public$foo" "xt$txs"]
+             (mapv #(.getSlug (.getSlug ^TableEntry %)) entries))
+          "a minted slug is the escaped table name, so nothing already on disk moves")
+
+    (t/is (= entries
+             (->entries (-> (Block/newBuilder) (.addAllTableNames names) (.build))))
+          "names alone resolve to slugs and to oids ordered by name")
+
+    (t/is (= entries
+             (->entries (-> (Block/newBuilder)
+                            (.addAllTableNames names)
+                            (.addAllTables (map #(.toProto ^TableEntry %) entries))
+                            (.build))))
+          "a recorded registry resolves to the same entries")))
+
+(deftest resolving-a-registry-less-block-depends-on-nothing-but-that-block
+  (let [->block (fn [block-idx names]
+                  (-> (Block/newBuilder) (.setBlockIndex block-idx) (.addAllTableNames names) (.build)))
+        ->oids (fn [^TableCatalog cat]
+                 (into {} (map (juxt #(str (.getSym (.getTable ^TableEntry %))) #(.getOid ^TableEntry %)))
+                       (.getEntries (.snap cat))))
+
+        b11 (->block 11 ["public/docs" "public/orders" "xt/txs"])
+
+        ;; started before `orders` existed, then caught up
+        caught-up (doto (TableCatalog. BufferPool/UNUSED (->block 10 ["public/docs" "xt/txs"]))
+                    (.refresh b11 {}))
+
+        started-at-b11 (TableCatalog. BufferPool/UNUSED b11)]
+
+    (t/is (= {"public/docs" 1, "public/orders" 2, "xt/txs" 3} (->oids started-at-b11)))
+
+    (t/is (= (->oids started-at-b11) (->oids caught-up))
+          "two nodes reading one registry-less block agree, whatever each of them read before it")))

--- a/src/test/clojure/xtdb/trie_catalog_test.clj
+++ b/src/test/clojure/xtdb/trie_catalog_test.clj
@@ -1,7 +1,9 @@
 (ns xtdb.trie-catalog-test
   (:require [clojure.java.io :as io]
+            [clojure.set :as set]
             [clojure.test :as t]
             [xtdb.api :as xt]
+            [xtdb.block-catalog :as block-cat]
             [xtdb.compactor :as c]
             [xtdb.db-catalog :as db]
             [xtdb.node :as xtn]
@@ -10,12 +12,14 @@
             [xtdb.trie :as trie]
             [xtdb.trie-catalog :as cat]
             [xtdb.util :as util])
-  (:import [java.nio.file Path]
+  (:import (java.io File)
+           [java.nio.file Path]
            (java.time Duration Instant)
            (java.util.concurrent ConcurrentHashMap)
            (xtdb.api.storage ObjectStore$StoredObject)
+           (xtdb.block.proto Block)
            (xtdb.log.proto TemporalMetadata TrieMetadata)
-           (xtdb.trie Trie)
+           (xtdb.table TableSlug)
            (xtdb.trie_catalog TrieCatalog)
            (xtdb.api TableRef)))
 
@@ -712,15 +716,38 @@
   ;; GCing - and hence trie states in the TrieDetails message
   ;; Addition of the Partition message - TrieDetails got moved from TableBlock into Partition
   (binding [cat/*file-size-target* 1024]
-    (letfn [(resource->path [p] (util/->path (io/as-file (io/resource p))))]
+    (letfn [(resource->path [p] (util/->path (io/as-file (io/resource p))))
+            (dir-names [^Path dir] (into #{} (map #(.getName ^File %)) (.listFiles (.toFile dir))))
+            (latest-block [^Path blocks-dir]
+              (with-open [in (io/input-stream (->> (.listFiles (.toFile blocks-dir))
+                                                   (sort-by #(.getName ^File %))
+                                                   last))]
+                (block-cat/<-Block (Block/parseFrom in))))]
       (doseq [^Path node-root (map resource->path ["xtdb/trie-catalog-test/node-2.0.0"
                                                    "xtdb/trie-catalog-test/node-fcb7714ea"])]
-        (let [tmp-dir (util/tmp-dir "test-protobuf-addtions")]
-          (util/copy-dir node-root tmp-dir)
+        (let [tmp-dir (util/tmp-dir "test-protobuf-addtions")
+              _ (util/copy-dir node-root tmp-dir)
+              storage-dir (.resolve tmp-dir "objects/v06")
+              slugs-on-disk (dir-names (.resolve storage-dir "tables"))]
           (with-open [node (xtn/start-node {:log [:local {:path (.resolve tmp-dir "log")}]
                                             :storage [:local {:path (.resolve tmp-dir "objects")}]})]
             (t/is (= [{:cnt 8000}]
-                     (xt/q node "SELECT COUNT(*) AS CNT FROM docs FOR VALID_TIME ALL")))))))))
+                     (xt/q node "SELECT COUNT(*) AS CNT FROM docs FOR VALID_TIME ALL")))
+            (tu/flush-block! node))
+
+          ;; a modern node seeds system tables the fixture predates, so the directory set grows —
+          ;; what must not change is where the tables already on disk live.
+          (let [slugs-after (dir-names (.resolve storage-dir "tables"))
+                recorded (into #{} (map :slug) (:tables (latest-block (.resolve storage-dir "blocks"))))]
+
+            (t/is (set/subset? slugs-on-disk slugs-after)
+                  "no table's directory disappears")
+
+            (t/is (set/subset? slugs-on-disk recorded)
+                  "each directory the fixture arrived with is the slug recorded for its table")
+
+            (t/is (set/subset? recorded slugs-after)
+                  "every recorded slug is a directory that exists")))))))
 
 (t/deftest partitions->max-block-idx-test
   (t/is (= {[0 nil []] {:max-block-idx 0}, [1 nil []] {:max-block-idx 0}}
@@ -853,7 +880,7 @@
 
         ;; Simulate what reset.clj does: list L0 meta files from the object store, parse keys,
         ;; build minimal entries, hand them to reset->l0!.
-        (let [meta-dir (Trie/metaFileDir #xt/table foo)
+        (let [meta-dir (.metaFileDir (TableSlug/of #xt/table foo))
               l0-entries (->> (.listAllObjects bp meta-dir)
                               (keep (fn [^ObjectStore$StoredObject obj]
                                       (let [name (str (.getFileName ^Path (.getKey obj)))

--- a/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
+++ b/src/test/kotlin/xtdb/catalog/BlockGarbageCollectorTest.kt
@@ -15,7 +15,8 @@ import xtdb.garbage_collector.BlockGarbageCollector
 import xtdb.storage.BufferPool
 import xtdb.test.AllocatorResolver
 import xtdb.time.InstantUtil.asMicros
-import xtdb.trie.Trie.tablePath
+import xtdb.api.TableRef
+import xtdb.table.TableSlug
 import xtdb.util.StringUtil.asLexHex
 import xtdb.util.asPath
 import java.nio.ByteBuffer
@@ -49,8 +50,8 @@ class BlockGarbageCollectorTest {
             Storage.local(tempDir).open(al, memoryCache, null, "xtdb").use { bufferPool ->
                 // Write dummy blocks and table blocks
                 val blocksPath = "blocks".asPath
-                val table1BlockPath = "public/foo".tablePath.resolve(blocksPath)
-                val table2BlockPath = "public/bar".tablePath.resolve(blocksPath)
+                val table1BlockPath = TableSlug.of(TableRef("public", "foo")).tablePath.resolve(blocksPath)
+                val table2BlockPath = TableSlug.of(TableRef("public", "bar")).tablePath.resolve(blocksPath)
 
                 (1L..10L).forEach { index ->
                     writeBlock(
@@ -101,7 +102,7 @@ class BlockGarbageCollectorTest {
             Storage.local(tempDir).open(al, memoryCache, null, "xtdb", 0, 2).use { p0 ->
                 Storage.local(tempDir).open(al, memoryCache, null, "xtdb", 1, 2).use { p1 ->
                     val blocksPath = "blocks".asPath
-                    val tableBlockPath = "public/foo".tablePath.resolve(blocksPath)
+                    val tableBlockPath = TableSlug.of(TableRef("public", "foo")).tablePath.resolve(blocksPath)
 
                     for (pool in listOf(p0, p1)) {
                         (1L..10L).forEach { index ->

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 1423,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "foo",
+   :slug "public$foo"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b00.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 1423,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "foo",
    :slug "public$foo"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 1934, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 3357,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "foo",
+   :slug "public$foo"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b01.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 3357,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "foo",
    :slug "public$foo"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 3859,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "foo",
    :slug "public$foo"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
+++ b/src/test/resources/xtdb/compactor-test/compactor-metadata-test/v06/blocks/b02.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 1934, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 3859,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "foo",
+   :slug "public$foo"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
@@ -7,4 +7,18 @@
    "public/device_info"
    "xt/role_membership"
    "public/device_readings"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "device_info",
+   :slug "public$device_info"}
+  {:oid 2,
+   :schema-name "public",
+   :table-name "device_readings",
+   :slug "public$device_readings"}
+  {:oid 3,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 4, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-block-as-arrow-ipc-file-format/pbuf/v06/blocks/b00.binpb.edn
@@ -8,17 +8,17 @@
    "xt/role_membership"
    "public/device_readings"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "device_info",
    :slug "public$device_info"}
-  {:oid 2,
+  {:oid 16387,
    :schema-name "public",
    :table-name "device_readings",
    :slug "public$device_readings"}
-  {:oid 3,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 4, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -8,4 +8,22 @@
    "public/world"
    "xt/role_membership"
    "public/hello"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "foo",
+   :slug "public$foo"}
+  {:oid 2,
+   :schema-name "public",
+   :table-name "hello",
+   :slug "public$hello"}
+  {:oid 3,
+   :schema-name "public",
+   :table-name "world",
+   :slug "public$world"}
+  {:oid 4,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 5, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-build-live-index/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -9,21 +9,21 @@
    "xt/role_membership"
    "public/hello"},
  :tables
- [{:oid 1,
+ [{:oid 16388,
    :schema-name "public",
    :table-name "foo",
    :slug "public$foo"}
-  {:oid 2,
+  {:oid 16386,
    :schema-name "public",
    :table-name "hello",
    :slug "public$hello"}
-  {:oid 3,
+  {:oid 16387,
    :schema-name "public",
    :table-name "world",
    :slug "public$world"}
-  {:oid 4,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 5, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 3767,
  :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "xt_docs",
    :slug "public$xt_docs"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-handle-dynamic-cols-in-same-block/pbuf/v06_e01/blocks/b00.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 3767,
  :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "xt_docs",
+   :slug "public$xt_docs"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 2047,
  :table-names #{"xt/txs" "xt/role_membership" "public/table"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "table",
    :slug "public$table"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/can-index-sql-insert/pbuf/v06/blocks/b00.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 2047,
  :table-names #{"xt/txs" "xt/role_membership" "public/table"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "table",
+   :slug "public$table"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 1591,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "foo",
    :slug "public$foo"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 0, :system-time #xt/instant "2020-01-01T00:00:00Z"},
  :latest-processed-msg-id 1591,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "foo",
+   :slug "public$foo"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 1833, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 3416,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "foo",
+   :slug "public$foo"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/compacted-trie-details/pbuf/objects/v06/blocks/b01.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 3416,
  :table-names #{"xt/txs" "public/foo" "xt/role_membership"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "foo",
    :slug "public$foo"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 5630,
  :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "xt_docs",
    :slug "public$xt_docs"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/multi-block-metadata/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 3215, :system-time #xt/instant "2020-01-02T00:00:00Z"},
  :latest-processed-msg-id 5630,
  :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "xt_docs",
+   :slug "public$xt_docs"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -4,13 +4,13 @@
  :latest-processed-msg-id 5413,
  :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
  :tables
- [{:oid 1,
+ [{:oid 16386,
    :schema-name "public",
    :table-name "xt_docs",
    :slug "public$xt_docs"}
-  {:oid 2,
+  {:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
+++ b/src/test/resources/xtdb/indexer-test/writes-log-file/pbuf/objects/v06/blocks/b00.binpb.edn
@@ -3,4 +3,14 @@
  {:tx-id 2910, :system-time #xt/instant "2020-01-03T00:00:00Z"},
  :latest-processed-msg-id 5413,
  :table-names #{"xt/txs" "xt/role_membership" "public/xt_docs"},
+ :tables
+ [{:oid 1,
+   :schema-name "public",
+   :table-name "xt_docs",
+   :slug "public$xt_docs"}
+  {:oid 2,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 3, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs {}}

--- a/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
+++ b/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
@@ -1,6 +1,12 @@
 {:block-idx 0,
  :latest-processed-msg-id 124,
  :table-names #{"xt/txs" "xt/role_membership"},
+ :tables
+ [{:oid 1,
+   :schema-name "xt",
+   :table-name "role_membership",
+   :slug "xt$role_membership"}
+  {:oid 2, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs
  {"new_db"
   {:log [:local {:path true}],

--- a/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
+++ b/src/test/resources/xtdb/multi-db/attach-db/b00.binpb.edn
@@ -2,11 +2,11 @@
  :latest-processed-msg-id 124,
  :table-names #{"xt/txs" "xt/role_membership"},
  :tables
- [{:oid 1,
+ [{:oid 16385,
    :schema-name "xt",
    :table-name "role_membership",
    :slug "xt$role_membership"}
-  {:oid 2, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
+  {:oid 16384, :schema-name "xt", :table-name "txs", :slug "xt$txs"}],
  :secondary-dbs
  {"new_db"
   {:log [:local {:path true}],

--- a/src/testFixtures/clojure/xtdb/test_util.clj
+++ b/src/testFixtures/clojure/xtdb/test_util.clj
@@ -39,6 +39,7 @@
            xtdb.database.Database$Catalog
            (xtdb.api.tx OpenTx)
            (xtdb.indexer LiveTable)
+           (xtdb.table TableSlug)
            (xtdb.trie Trie)
            (xtdb.log.proto TemporalMetadata TemporalMetadata$Builder)
            (xtdb.api.query PrepareOpts QueryOpts)
@@ -364,7 +365,7 @@
      (.build builder))))
 
 (defn open-live-table ^xtdb.indexer.LiveTable [table]
-  (LiveTable. *allocator* table 0 (RowCounter.)))
+  (LiveTable. *allocator* table (TableSlug/of table) 0 (RowCounter.)))
 
 (defn serialize-tx-ops ^bytes [^BufferAllocator allocator tx-ops
                                {:keys [^Instant system-time, default-tz user-metadata], {:keys [user]} :authn, :as opts}]


### PR DESCRIPTION
Resolves #4037.

## tl;dr

- **A table's files now live at a path the block records, not one derived from its name.**
  Each block carries an entry per table, holding an oid, the name, and a *slug*: the directory under `tables/` that table's files live in. Every path resolves through the slug.

- **A table also now has an oid that outlives its name, and `pg_class` reports it.**
  It is allocated the moment the catalog first sees the table and never moves — where before, `pg_class.oid` was `Math.abs(hash(schemaAndTable))`, which is the table's name by another spelling.

- **Nothing on disk moves.**
  A slug is minted as the escaped name, byte-for-byte what the old path derivation produced, so every existing table resolves to the directory it has always had. No storage-version bump, no migration.

- **One thing is visible to users: `pg_class.oid` returns a different value than it used to.**
  Nothing could legitimately depend on the old one — it was a hash of the name, so it never survived a rename anyway — but it is a change, and it is the only one.

- **The other half of #4037 — keying tables by oid *below the planner* — is not here.**
  That is #5951, and it is a release-ordering matter rather than anything to build. Detail under *Remaining work*.

## Context

A table's object-store path was computed from its name (`Trie.tablePath`), so renaming a table would have orphaned every file it had ever written. #4037 wants an identity that survives a rename, and #3812 (SQL views) is blocked on it, because a stored plan has to keep resolving after one.

The hard constraint is that **nothing already on disk may move**. Existing deployments have to keep working untouched, indefinitely.

Why now: the change splits across two releases and the second half can't start until the first has shipped everywhere, so each release this misses pushes renaming out by another one.

## Implementation

- **`TableSlug` owns path derivation, and `Trie.tablePath` is deleted.**
  Deleting it is what makes the change hold: with no name-to-path function in the codebase, no site can quietly re-derive a path and diverge from the recorded slug.

- **`TableCatalog.State` holds one entry per table it can name**, and those entries reach the wire as `Block.tables`.
  `resolveTables` is now "register, then read" — registration *is* the minting, and carrying forward is just the map already holding the entry.

- **An oid is allocated when the catalog first learns of a table, not when a block records it.**
  `commitTx` registers a transaction's tables before writing them, so a table has its identity for as long as it is queryable. Allocating only at block write would have made `pg_class.oid` change at the next flush, under a client that had already read it.

- **Two nodes reach the same oid without it going on the wire.**
  Allocation follows the order tables first appear in the log, which every node replays identically. Within a single transaction that isn't enough — its tables arrive as an unordered proto map — so those are allocated in name order.

- **Identity and durability are separate questions on `State`.**
  `entries` answers "what oid does this table have?" and includes tables no block has recorded. `recordedEntries` answers "which tables have a block file?" and does not. See *Decision rationale* D9 for why conflating them is not merely untidy.

- **`::regclass` moves with `pg_class`.**
  pgjdbc and Metabase resolve a name through the cast and then join on `pg_class.oid`, so the two have to agree. The runtime schema the expression engine already receives now carries the oid alongside the columns, read from the same snapshot.

- **A live table pins its entry when it is created, not when its block is uploaded.**
  `liveIndex.finishBlock` writes a new table's L0 trie *before* block upload resolves the entries, so resolving only at upload would write the file under one slug and record another.

- **`table_names` keeps being written**, so a reader that predates the `tables` field is unaffected.

## Why the slug format needs two releases

Two nodes must never disagree about where a table's files are. If the minting rule changed while some nodes still derived paths from names, one would write `tables/public$foo/` and another `tables/foo-1234/` — the same table in two directories, each node seeing half the data.

So the fence is the release boundary:

- **This release** writes `Block.tables` and reads every path from it, while keeping the minting rule identical to the old derivation. A node running this and a node running the previous version compute the same paths, so paths are inert.
- **A later release** can then change the rule and enable renaming, because by then every node reads the recorded slug instead of deriving one.

This is sound because of the standing release-notes caveat that users upgrade one minor at a time. *That expectation is on the operator, not on us* — it is the one leaf of this argument we don't enforce in code.

## Remaining work

**Goal: a table can be renamed without orphaning its files, and renaming can be switched on safely.**

- [x] **Every node agrees where a table's files live, whatever wrote the block** — this PR.
- [x] **A table has an oid that survives a rename, and clients can see it** — this PR.
- [ ] **Tables are keyed by oid rather than by name below the planner** — #5951, a later release.
- [ ] **The minting rule changes and renaming is enabled** — a later release, once this one is everywhere. Renaming itself is #5950.

#5951 carries a release-ordering precondition rather than a design problem: **it must not ship in a release that can still meet a writer predating the `tables` field**, because `TrieCatalog` holds per-table state across block boundaries and is never cleared at one. Its own description has the detail.

## Decision rationale

- **D1 — `TableSlug` at the leaves, rather than passing a catalog or a bare `Path`.**
  The query path builds a `BufferPoolSegment`, so a leaf holding a *live* catalog would let a concurrent rename move a path mid-query; handing it a pinned snapshot instead is this design with extra indirection. A bare `Path` works but leaves no type-level barrier against a future site re-deriving from a name.
- **D2 — identity and location travel separately, not as one object.**
  Orchestrators need the name anyway (the compactor logs `job.table`), so passing an entry everywhere would have coupled the two at sites that only want one.
- **D3 — the slug minting rule does not change in this release.** This is the whole fence.
- **D4 — the oid is allocated at table birth, and published.**
  An oid that appears only at the next block flush changes under a client that has already read it, and `pg_class` is exactly where a client caches one.
- **D5 — allocation order is log order, rather than putting the oid on `ResolvedTx`.**
  Leader-allocates-and-broadcasts is what #4037's G1 proposed and it is correct, but it costs a replica-log format change to buy nothing that replaying the same log in the same order doesn't already give.
- **D6 — oids start at 16384, Postgres's `FirstNormalObjectId`.**
  Below it, tooling reads a relation as a system catalog, and our own `pg_am` rows already sit at 2/403/405. The base is free to choose only until a release publishes one.
- **D7 — no per-column entries yet.** Tables first, per #4038.
- **D8 — `uint32` in the proto, `Long` at the Kotlin boundary.** `uint32` is exactly Postgres's oid domain and the field is permanent; Kotlin and Clojure want a `Long`.
- **D9 — `entries` and `recordedEntries` are separate, and that is load-bearing.**
  Collapsing them was tried. `load-tables-to-metadata` reads one block file per entry, and seeded system tables (`xt.txs`, `xt.role_membership`) are entries before any block records them — so against a 2.0.0 fixture it asked for a file that has never existed. `LocalStorage.getByteArray` wraps a missing object in `runBlocking`, so the node hung rather than failed.

## Out of scope

- **Renaming itself** — #5950. No SQL surface here; this makes it possible.
- **Keying tables by oid below the planner** — #5951.
- **Columns**, per D7.
- **Anything on disk moving.** If a test needs an expected *path* changed, that's a bug in this change rather than a test to update.

## Testing

- `./gradlew test` — 1716/1717. The one failure is `xtdb.compactor-test/test-l2+-compaction` timing out, which matches open flake #5885 (`flaky`, `compactor`, "l2 tests time out under concurrent build load"); it passes in isolation.
- `./gradlew property-test` — 27/27, and `./gradlew :xtdb-core:property-test --rerun-tasks` — 2714/2714 across all five simulation classes, because this touches indexing, compaction and GC.
- **`test-protobuf-additions`** starts a real node against checked-in block files written by XTDB 2.0.0 and by commit `fcb7714ea`. Those blocks carry no `tables` field, so it exercises the fallback end to end against bytes a released XTDB actually wrote.
- **`two-nodes-replaying-one-log-allocate-the-same-oids`** feeds the same transactions with a multi-table transaction in different internal orders and requires identical oids — and separately requires that reordering the *transactions* does change them, so it cannot pass if the name-sort is deleted.
- **`a-block-records-the-oid-the-catalog-has-already-published`** pins that a table's first block changes nothing about its oid.
- **`a-tables-oid-does-not-change-when-its-first-block-is-written`** asserts through `pg_class` that the published oid is the allocated one and is stable across a flush.
- **Golden `.binpb.edn` fixtures** were regenerated; the diff is 38 `:oid` lines and nothing else — every slug unchanged.
- Hardcoded oid literals in `information_schema_test`, `pg_test` and `node_test` were replaced with lookups through `pg_class` rather than new literals: an allocated oid depends on the order tables were first seen, so a literal would pin that order and break when a system table is added.

