### PR TITLE
fix(group-by): an ordered-set aggregate drops trailing groups that have no values

### DIFF
--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -397,11 +397,14 @@
       (.append acc-col in-vec)
 
       (dotimes [idx row-count]
-        ;; nulls excluded from ordered-set aggregates per SQL standard
-        (when-not (.isNull in-vec idx)
-          (let [group-idx (.getInt group-mapping idx)]
-            (while (<= (.size group-idxmaps) group-idx)
-              (.add group-idxmaps (IntStream/builder)))
+        (let [group-idx (.getInt group-mapping idx)]
+          ;; every group needs its slot even if nothing lands in it - `group-idxmaps` is what
+          ;; `openFinishedVector` iterates, so a short one leaves the last groups off the column
+          (while (<= (.size group-idxmaps) group-idx)
+            (.add group-idxmaps (IntStream/builder)))
+
+          ;; nulls excluded from ordered-set aggregates per SQL standard
+          (when-not (.isNull in-vec idx)
             (.add ^IntStream$Builder (.get group-idxmaps group-idx)
                   (+ base-idx idx)))))
 

--- a/src/test/clojure/xtdb/operator/group_by_test.clj
+++ b/src/test/clojure/xtdb/operator/group_by_test.clj
@@ -647,3 +647,14 @@
              (tu/query-ra '[:group-by {:columns [{avg-dur (avg dur)}]}
                             [:table {:rows []}]]))
           "avg of empty duration set")))
+
+(t/deftest test-ordered-set-agg-emits-a-row-for-a-group-with-no-values
+  ;; the validity buffer doubles from 128 bytes, so an unwritten trailing slot only falls outside
+  ;; it when the groups that did get written exactly fill a power of two
+  (let [group-count 1024
+        rows (conj (vec (for [g (range group-count), _ [1 2]] {:a g, :b 20}))
+                   {:a group-count, :b nil})
+        res (tu/query-ra [:group-by {:columns ['a {'med (list 'percentile_cont 0.5 ['b {:direction :asc}])}]}
+                          [:table {:rows rows}]])]
+    (t/is (= (inc group-count) (count res)))
+    (t/is (nil? (:med (first (filter #(= group-count (:a %)) res)))))))


### PR DESCRIPTION
## tl;dr

- **`PERCENTILE_CONT` / `PERCENTILE_DISC` over a `GROUP BY` can throw `IndexOutOfBoundsException`** when the last group's sort column is entirely NULL.

- **The trigger is narrow enough to look like nothing**: it needs the groups that *did* get values to exactly fill a power of two — 1024, 2048, … — because below that the missing slot happens to read as NULL, which is the right answer.

- **One line**: pad the group slot for every row, and gate only the insertion on the null check. That's what `ArrayAggAggregateSpec` two definitions above already does.

- Pre-existing, so this isn't holding a release up. Found while implementing #5800.

## Symptoms

```sql
SELECT g, PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY b) FROM t GROUP BY g
```

with 1024 groups whose `b` has values and one further group whose `b` is all NULL:

```
java.lang.IndexOutOfBoundsException: index: 128, length: 1 (expected: range(0, 128))
```

No `FILTER`, no unusual configuration — an ordinary grouped percentile over a column with nulls in it.

## Root cause

`PercentileAggregateSpec.aggregate` grew `group-idxmaps` *inside* its null guard:

```clojure
(dotimes [idx row-count]
  ;; nulls excluded from ordered-set aggregates per SQL standard
  (when-not (.isNull in-vec idx)
    (let [group-idx (.getInt group-mapping idx)]
      (while (<= (.size group-idxmaps) group-idx)
        (.add group-idxmaps (IntStream/builder)))
      (.add ^IntStream$Builder (.get group-idxmaps group-idx) (+ base-idx idx)))))
```

`group-idxmaps` is exactly what `openFinishedVector` iterates to write the output column, so a trailing group that contributes no values never gets a slot and the column comes out shorter than the group count. `GroupByCursor` then assembles the relation with the group mapper's row count, so that missing slot is read regardless.

## Why it usually looks fine

That read lands in the output vector's validity buffer, and `BitBuffer` allocates a minimum of 128 bytes and doubles from there. So the unwritten bit is nearly always still inside the allocation, reads as zero, and yields NULL — which is the correct answer, arrived at by accident.

It only leaves the buffer when the groups that *were* written exactly fill it. Measured against the unfixed code, varying the number of value-bearing groups:

| groups with values | result |
| --- | --- |
| 1023 | correct |
| **1024** | `IndexOutOfBoundsException: index: 128, length: 1 (expected: range(0, 128))` |
| 1025–2047 | correct |
| **2048** | `IndexOutOfBoundsException: index: 256, length: 1 (expected: range(0, 256))` |

## Implementation

Move the `group-idx` binding and the padding `while` out of the guard, leaving only the `.add` gated. `ArrayAggAggregateSpec` already has this shape; percentile was the one aggregate in the operator that conflated "note that this group exists" with "accumulate a value into it".

## Test plan

- Full `./gradlew test` green (1713, 0 failures, no leaked memory).
- New `test-ordered-set-agg-emits-a-row-for-a-group-with-no-values` in `xtdb.operator.group-by-test` builds 1024 value-bearing groups plus one all-NULL group, and asserts a row per group with NULL for the empty one. It throws without the fix. The group count is load-bearing rather than arbitrary, so there's a comment saying why.
- `xtdb.operator.group-by.percentile-test` (15 tests) unaffected.

## Related

Found while implementing `FILTER (WHERE ...)` on aggregate functions (#5800), where a group with no contributing values stops being incidental and becomes something a user asks for directly. That branch touches the same lines, so whichever of the two lands second will conflict there — the resolution keeps both the unconditional padding from here and the filter mask's condition in the inner guard.
