### PR TITLE
fix(aws): stop the S3 signer buffering whole uploads onto heap

### DIFF
--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -16,6 +16,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.core.FileTransformerConfiguration
 import software.amazon.awssdk.core.async.AsyncRequestBody
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation.WHEN_REQUIRED
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.S3Configuration
@@ -72,13 +73,9 @@ class S3(
         client.close()
     }
 
-    private fun efficientAsyncRequestBody(buf: ByteBuffer): AsyncRequestBody =
-        buf
-            // prevents copying the buffer into a new heap ByteBuffer, as `fromByteBuffer` would do
-            .let(AsyncRequestBody::fromByteBufferUnsafe)
-            // makes the buffer non-replayable, again preventing heap copies for payload-signing or checksum calculations
-            // (couldn't achive this effect by S3 client configuration)
-            .let(AsyncRequestBody::fromPublisher)
+    // `fromByteBuffer` would copy into a new heap ByteBuffer; the Unsafe variant wraps ours as-is.
+    private fun asyncRequestBody(buf: ByteBuffer): AsyncRequestBody =
+        AsyncRequestBody.fromByteBufferUnsafe(buf)
 
     override suspend fun startMultipart(k: Path): IMultipartUpload<CompletedPart> {
         val s3Key = prefix.resolve(k).toString()
@@ -101,7 +98,7 @@ class S3(
                 val contentLength = buf.remaining().toLong()
                 val partNum = idx + 1
 
-                val partResp = client.uploadPart(efficientAsyncRequestBody(buf)) {
+                val partResp = client.uploadPart(asyncRequestBody(buf)) {
                     it.bucket(bucket)
                     it.key(s3Key)
                     it.uploadId(uploadId)
@@ -178,7 +175,7 @@ class S3(
 
         val contentLength = buf.remaining().toLong()
 
-        client.putObject(efficientAsyncRequestBody(buf)) {
+        client.putObject(asyncRequestBody(buf)) {
             it.bucket(bucket)
             it.key(s3Key)
             it.contentLength(contentLength)
@@ -355,10 +352,21 @@ class S3(
                                 .let { StaticCredentialsProvider.create(it) }
                                 .also { credentialsProvider(it) }
                         }
-                        endpoint?.let { endpointOverride(URI(it)) }
+                        val endpointUri = endpoint?.let(::URI)
+                        endpointUri?.let { endpointOverride(it) }
 
-                        if (pathStyleAccessEnabled)
-                            serviceConfiguration { it.pathStyleAccessEnabled(true) }
+                        // one decision, not two: with chunk encoding off the signer still calculates a checksum,
+                        // and does that by buffering the whole payload. Only worth it over HTTPS - over plain
+                        // HTTP the signer hashes the payload whatever we ask for, and buffers all of it to do
+                        // so, where chunk framing would have bounded the copy to a frame at a time (#5373).
+                        val httpsEndpoint = !"http".equals(endpointUri?.scheme, ignoreCase = true)
+
+                        if (httpsEndpoint) requestChecksumCalculation(WHEN_REQUIRED)
+
+                        serviceConfiguration {
+                            if (httpsEndpoint) it.chunkedEncodingEnabled(false)
+                            if (pathStyleAccessEnabled) it.pathStyleAccessEnabled(true)
+                        }
 
                         s3Configurator.configureClient(this)
                     }.build()

--- a/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
+++ b/modules/aws/src/main/kotlin/xtdb/aws/S3.kt
@@ -38,7 +38,6 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.util.function.Consumer
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Used to set configuration options for an S3 Object Store, which can be used as implementation of objectStore within a [xtdb.api.storage.Storage.RemoteStorageFactory].
@@ -66,8 +65,7 @@ class S3(
     private val bucket: String,
     private val prefix: Path,
     private val configurator: S3Configurator,
-    private val factory: Factory,
-    coroutineContext: CoroutineContext = Dispatchers.IO
+    private val factory: Factory
 ) : ObjectStore, SupportsMultipart<CompletedPart> {
 
     override fun close() {
@@ -293,8 +291,7 @@ class S3(
         var endpoint: String? = null,
         var pathStyleAccessEnabled: Boolean = false,
         var remote: RemoteAlias? = null,
-        @Transient var s3Configurator: S3Configurator = S3Configurator.Default,
-        @Transient var coroutineContext: CoroutineContext = Dispatchers.IO
+        @Transient var s3Configurator: S3Configurator = S3Configurator.Default
     ) : ObjectStore.Factory {
 
         fun prefix(prefix: Path) = apply { this.prefix = prefix }
@@ -319,8 +316,6 @@ class S3(
         fun pathStyleAccessEnabled(enabled: Boolean) = apply { this.pathStyleAccessEnabled = enabled }
 
         fun s3Configurator(s3Configurator: S3Configurator) = apply { this.s3Configurator = s3Configurator }
-
-        fun coroutineContext(coroutineContext: CoroutineContext) = apply { this.coroutineContext = coroutineContext }
 
         private fun resolveCredentials(remotes: Map<RemoteAlias, Remote>): BasicCredentials? {
             val alias = remote ?: return credentials
@@ -368,7 +363,7 @@ class S3(
                         s3Configurator.configureClient(this)
                     }.build()
 
-            return S3(client, bucket, prefix?.resolve(storageRoot) ?: storageRoot, s3Configurator, this, coroutineContext)
+            return S3(client, bucket, prefix?.resolve(storageRoot) ?: storageRoot, s3Configurator, this)
         }
 
         override val configProto by lazy {

--- a/src/test/kotlin/xtdb/aws/S3UploadSigningTest.kt
+++ b/src/test/kotlin/xtdb/aws/S3UploadSigningTest.kt
@@ -1,0 +1,118 @@
+package xtdb.aws
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import software.amazon.awssdk.http.SdkHttpFullResponse
+import software.amazon.awssdk.http.SdkHttpMethod.HEAD
+import software.amazon.awssdk.http.SdkHttpRequest
+import software.amazon.awssdk.http.async.AsyncExecuteRequest
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder
+import xtdb.aws.S3.Companion.s3
+import xtdb.aws.s3.S3Configurator
+import xtdb.util.asPath
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.fail
+
+/**
+ * The signer only skips payload signing over HTTPS - over plain HTTP it hashes the payload regardless of
+ * configuration - so this stands in a fake transport rather than pointing at the HTTP MinIO the other S3
+ * tests use, which would exercise a different branch from production.
+ */
+class S3UploadSigningTest {
+
+    private class StubTransport : S3Configurator, SdkAsyncHttpClient {
+        val requests = ConcurrentHashMap<String, SdkHttpRequest>()
+
+        override fun configureClient(builder: S3AsyncClientBuilder) {
+            builder.httpClient(this)
+        }
+
+        override fun execute(request: AsyncExecuteRequest): CompletableFuture<Void> {
+            val httpRequest = request.request()
+            requests.putIfAbsent(httpRequest.method().name, httpRequest)
+
+            // a real 404 rather than a synthesised NoSuchKeyException: the SDK translates one into the other
+            // for HeadObject, and that translation reads headers off the response the exception came from.
+            val status = if (httpRequest.method() == HEAD) 404 else 200
+
+            request.responseHandler().apply {
+                onHeaders(SdkHttpFullResponse.builder().statusCode(status).build())
+                onStream(EmptyBody)
+            }
+
+            return CompletableFuture.completedFuture(null)
+        }
+
+        override fun clientName() = "stub"
+        override fun close() = Unit
+    }
+
+    private object EmptyBody : Publisher<ByteBuffer> {
+        override fun subscribe(subscriber: Subscriber<in ByteBuffer>) {
+            subscriber.onSubscribe(object : Subscription {
+                private var done = false
+                override fun request(n: Long) {
+                    if (!done) { done = true; subscriber.onComplete() }
+                }
+
+                override fun cancel() = Unit
+            })
+        }
+    }
+
+    private fun uploadTo(endpoint: String): SdkHttpRequest {
+        val transport = StubTransport()
+
+        @Suppress("DEPRECATION")
+        val factory = s3("test-bucket") {
+            region("us-east-1")
+            credentials("test-access", "test-secret")
+            endpoint(endpoint)
+            s3Configurator(transport)
+        }
+
+        factory.openObjectStore("upload-signing-test".asPath).use { store ->
+            runBlocking { store.putObject("foo".asPath, ByteBuffer.allocate(4096)) }
+        }
+
+        return transport.requests["PUT"] ?: fail("no PUT was issued - saw ${transport.requests.keys}")
+    }
+
+    @Test
+    fun `an upload carries neither chunked encoding nor a checksum, so the SDK copies nothing`() {
+        val put = uploadTo("https://s3.example.com")
+
+        assertNull(
+            put.firstMatchingHeader("Content-Encoding").orElse(null),
+            "aws-chunked framing allocates a heap buffer per chunk"
+        )
+
+        assertNull(
+            put.headers().keys.firstOrNull { it.startsWith("x-amz-checksum-", ignoreCase = true) },
+            "a request checksum makes the signer buffer the whole payload in memory"
+        )
+
+        assertEquals(
+            "UNSIGNED-PAYLOAD", put.firstMatchingHeader("x-amz-content-sha256").orElse(null),
+            "payload signing hashes the whole payload before transmitting it"
+        )
+    }
+
+    @Test
+    fun `an upload to a plain-HTTP endpoint keeps chunked encoding`() {
+        val put = uploadTo("http://localhost:9000")
+
+        assertEquals(
+            "aws-chunked", put.firstMatchingHeader("Content-Encoding").orElse(null),
+            "HTTP forces payload signing, and only chunk framing keeps that off the whole payload at once"
+        )
+    }
+}


### PR DESCRIPTION
Resolves #5373

## tl;dr

- **S3 uploads no longer hand the AWS SDK a reason to copy the payload onto heap.** Two client settings — `chunkedEncodingEnabled(false)` and `requestChecksumCalculation(WHEN_REQUIRED)` — move PutObject and UploadPart onto a signing path that passes our buffer straight through.

- **They are one decision, not two: either alone makes the heap worse.** Disabling chunk encoding without the checksum setting swaps bounded per-frame copies for one buffered copy of the entire upload.

- **Only applied to HTTPS endpoints.** Over plain HTTP the SDK forces payload signing on regardless of configuration, so MinIO/LocalStack/on-prem deployments deliberately keep chunk framing.

- **The other half of the OOM was already fixed by `ca7086a4d`'s SDK bump** — nothing more to do there, but it changes what's worth building.

## Context

A production node OOMed during block flush, heap exhausted under `RemoteBufferPool.putObject`. #5373's analysis found two layers of the SDK/Netty stack allocating on the upload path:

1. `ChunkedEncodedPublisher` allocating heap buffers per chunk for `aws-chunked` framing.
2. Netty's `SslHandler` coalescing writes into a heap buffer for `SSLEngine.wrap()`.

Vector 2 is closed already, by accident: `ca7086a4d` bumped the AWS SDK to 2.51.3, and **SDK 2.44.8 removed the workaround that forced `UnpooledByteBufAllocator` onto every JDK-SSL channel** (it existed for netty/netty#9768, since fixed upstream). That unpooled allocator is the one named in the original OOM trace. Channels now take `ByteBufAllocator.DEFAULT` — `AdaptiveByteBufAllocator`, pooled — at our Netty 4.2.9.

This PR is vector 1.

## Root cause

`ChecksumUtil.checksummer()` picks a checksummer from `isPayloadSigning`, `isChunkEncoding` and `isFlexible` **together**, which is why the two settings can't be split:

| chunk encoding | checksum calculation | resolves to | copies |
| --- | --- | --- | --- |
| on | `WHEN_SUPPORTED` (default) | `forPrecomputed256Checksum(STREAMING_UNSIGNED_PAYLOAD_TRAILER)` | per frame, incremental via `UnbufferedChecksumSubscriber` |
| **off** | `WHEN_SUPPORTED` | `forFlexibleChecksum` → `FlexibleChecksummer` → `ChecksumSubscriber` | **whole payload** |
| off | `WHEN_REQUIRED` | `forPrecomputed256Checksum(UNSIGNED_PAYLOAD)` | none |

PutObject carries the flexible-checksum trait without requiring a checksum, so under the default `isHttpChecksumCalculationNeeded` returns true on its last line and the middle row is what you get. `ChecksumSubscriber`'s own javadoc says it "buffers the entire data in memory. This should only be used by non-streaming operations."

`WHEN_REQUIRED` is what makes `isFlexible` false, reaching `PrecomputedSha256Checksummer` — which sets a header and returns `completedFuture(payload)` untouched.

## Invariants

- **Plain-HTTP endpoints must keep chunk framing.** `ChecksumUtil.isPayloadSigning` forces signing on for any request with a payload over an unencrypted connection, whatever `PAYLOAD_SIGNING_ENABLED` says:

  ```java
  if (!isEncrypted && request.payload().isPresent()) { ... return true; }
  ```

  Applying both settings there would give a buffered whole-payload copy where chunk framing had bounded it to a frame at a time. MinIO, LocalStack and on-prem S3-compatible stores are supported configurations, so the gate is on `endpointUri.scheme`, and a test pins the HTTP behaviour so it isn't tidied away later.

## Alternatives considered

Split one per layer the previous approach (#5422) touched.

- **`A1` BoringSSL via `netty-tcnative`, to move TLS coalescing off heap — rejected.** `SslHandlerCoalescingBufferQueue.composeFirst` only runs when a queued entry is *smaller* than the requested wrap size; a large emission is consumed by `readRetainedSlice` with **no copy at all**. `wrapDataSize` defaults to 16KB, so the buffer in question is ≤32KB and, since 2.44.8, pooled. Not worth four native classifier artifacts, a Netty BOM in a module whose Netty versions already span 4.1.130/4.1.136/4.2.9, and a `libgcc` package in the Alpine image.

- **`A2` Slicing uploads into 256KB emissions, to bound the coalescing queue — rejected, and it inverts.** Netty already bounds the queue at 16KB. Smaller emissions make `composeFirst` *more* likely, not less, by turning one oversized entry into many undersized ones — the branch that allocates.

- **`A3` The AWS CRT HTTP client — rejected.** After the two settings above there is no copy left for it to eliminate; the argument reduces to s2n-tls vs JDK `SSLEngine` for a ≤32KB pooled buffer. Against it: #2567's open checkpoint-restore hang, rewriting `SupportsMultipart` against a different client, and re-validating everything #5857's suspend/cancel work touches.

## Implementation notes

- **The request body becomes replayable again.** `fromPublisher` was wrapping the buffer to defeat payload-signing and checksum copies — the previous comment admits it "couldn't achieve this effect by S3 client configuration", which is exactly what this PR does instead. Its only remaining effect was to stop the SDK retrying a transient failure, which matters more since `30b64f29c`: a failed upload now surfaces as `Unavailable` and takes the leader term with it.

- **The `tidy(aws)` commit is behaviour-preserving.** `S3.Factory.coroutineContext` has configured nothing since `5a6316787` deleted the `CoroutineScope` that read it. Azure and GCP keep theirs because they wrap synchronous SDKs and need a dispatcher for `runInterruptible`; the S3 client is async and has no blocking call to place. Nothing in the repo, the tests or the docs set it.

## Out of scope

- **No production heap measurement.** The test proves the wire format carries no chunk framing and no checksum; it does not prove a heap number. If you want that confirmed before this counts as closing #5373, say so and I'll reopen it as `(#5373)`.
- **Plain-HTTP uploads still copy per frame**, by design — see Invariants.

## Changes

1. `tidy(aws): drop the S3 factory's dead coroutine context` — behaviour-preserving; cherry-pickable on its own.
2. `fix(aws): stop the S3 signer buffering whole uploads onto heap` — the two client settings, the `fromPublisher` removal, and the test.

## Test plan

`S3UploadSigningTest` stands in a fake `SdkAsyncHttpClient` and captures the signed request at transmission. No container, no credentials, no network — and it can drive both schemes from one helper.

The MinIO container the other S3 tests use speaks HTTP, so pointing this at it would have asserted against a different signing branch from production. That is the trap the test exists to avoid, and the reason the HTTP case is pinned separately rather than assumed.

- `xtdb.aws.S3UploadSigningTest` — 2/2. HTTPS: no `Content-Encoding`, no `x-amz-checksum-*`, `x-amz-content-sha256: UNSIGNED-PAYLOAD`. HTTP: `Content-Encoding: aws-chunked` retained.
- `xtdb.aws.S3FactoryTest` — 6/6.
- `xtdb.aws.MinioTest` (`integration-test`) — 10/10 against a real MinIO container, which exercises the plain-HTTP branch end to end.

`xtdb.aws.S3Test` targets real AWS and was not run.
