### PR TITLE
fix(expression): read a zero-leg type as null where legs are dispatched on

### DIFF
--- a/api/src/main/clojure/xtdb/serde/types.clj
+++ b/api/src/main/clojure/xtdb/serde/types.clj
@@ -434,6 +434,7 @@
     (keyword? type-spec) (case type-spec
                            :tstz-range VectorType/TSTZ_RANGE
                            :null VectorType$Null/INSTANCE
+                           :nothing VectorType$Nothing/INSTANCE
                            (VectorType/scalar (->arrow-type type-spec)))
 
     (set? type-spec) (VectorType/fromLegs (into #{} (map ->type) type-spec))

--- a/api/src/main/kotlin/xtdb/arrow/VectorType.kt
+++ b/api/src/main/kotlin/xtdb/arrow/VectorType.kt
@@ -50,6 +50,25 @@ sealed class VectorType {
 
     abstract val legs: Iterable<Mono>
 
+    /**
+     * The legs a *read* of this type can yield, as against [legs], which is the lattice's answer. The two
+     * differ only at [Nothing], which has no legs and reads as null - it is backed by a valueless
+     * `NullVector`, whose `isNull` is unconditionally true.
+     *
+     * MUST NOT be substituted for [legs] when *constructing* a type: `fromLegs([Nothing, I64])` over this
+     * gives `Maybe(I64)` where the lattice law demands `I64`.
+     */
+    val readsAs: Iterable<Mono>
+        get() =
+            // not `else -> legs`: a new direct subclass of VectorType has no known reading, and should stop
+            // this compiling until someone picks one
+            when (this) {
+                is Mono -> legs
+                is Maybe -> legs
+                is Poly -> legs
+                Nothing -> listOf(Null)
+            }
+
     @get:JvmName("asMono")
     val asMono get() = this as Mono
 

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -555,7 +555,7 @@
 
 (defmethod codegen-expr :let [{:keys [local expr body]} opts]
   (let [{^VectorType local-return-type :return-type, continue-expr :continue, :as emitted-expr} (codegen-expr expr opts)
-        emitted-bodies (->> (for [local-type (.getLegs local-return-type)]
+        emitted-bodies (->> (for [local-type (.getReadsAs local-return-type)]
                               (MapEntry/create local-type
                                                (codegen-expr body (assoc-in opts [:local-types local] local-type))))
                             (into {}))
@@ -572,7 +572,7 @@
   (let [{continue-expr :continue, ^VectorType expr-return-type :return-type, :as emitted-expr}
         (codegen-expr expr opts)
 
-        expr-rets (set (.getLegs expr-return-type))
+        expr-rets (set (.getReadsAs expr-return-type))
 
         emitted-thens (->> (for [local-type (disj expr-rets #xt/type :null)]
                              (MapEntry/create local-type
@@ -721,7 +721,7 @@
 
         all-arg-types (reduce (fn [acc {:keys [^VectorType return-type]}]
                                 (for [el acc
-                                      arg-type (.getLegs return-type)]
+                                      arg-type (.getReadsAs return-type)]
                                   (conj el arg-type)))
                               [[]]
                               emitted-args)
@@ -1969,8 +1969,8 @@
 
         (let [inner-calls (->> (for [field fields]
                                  (MapEntry/create field
-                                                  (->> (for [l-val-type (VectorType/.getLegs (get l-field-types field))
-                                                             r-val-type (VectorType/.getLegs (get r-field-types field))]
+                                                  (->> (for [l-val-type (VectorType/.getReadsAs (get l-field-types field))
+                                                             r-val-type (VectorType/.getReadsAs (get r-field-types field))]
                                                          (MapEntry/create [l-val-type r-val-type]
                                                                           (if (or (= #xt/type :null l-val-type) (= #xt/type :null r-val-type))
                                                                             {:return-type #xt/type :null, :->call-code (constantly nil)}
@@ -2017,8 +2017,8 @@
       {:return-type #xt/type :bool, :->call-code (constantly false)}
       (let [inner-calls (->> (for [field fields]
                                (MapEntry/create field
-                                                (->> (for [l-val-type (VectorType/.getLegs (get l-field-types field))
-                                                           r-val-type (VectorType/.getLegs (get r-field-types field))]
+                                                (->> (for [l-val-type (VectorType/.getReadsAs (get l-field-types field))
+                                                           r-val-type (VectorType/.getReadsAs (get r-field-types field))]
                                                        (MapEntry/create [l-val-type r-val-type]
                                                                         (codegen-call {:f :===, :arg-types [l-val-type r-val-type]})))
                                                      (into {}))))
@@ -2061,11 +2061,11 @@
 (defmethod codegen-call [:_patch :struct :struct] [{[^VectorType$Struct l-type, ^VectorType$Struct r-type] :arg-types}]
   (let [l-ks (into {} (.getChildren l-type))
         r-ks (into {} (.getChildren r-type))
-        flattened-r-types (update-vals r-ks (fn [^VectorType r-field-type]
-                                               (set (.getLegs r-field-type))))
+        r-read-legs (update-vals r-ks (fn [^VectorType r-field-type]
+                                       (set (.getReadsAs r-field-type))))
         ret-type (VectorType/structOf (into l-ks
                                             (map (fn [[k ^VectorType r-field-type]]
-                                                   (let [r-types (get flattened-r-types k)]
+                                                   (let [r-types (get r-read-legs k)]
                                                      (MapEntry/create k
                                                                       (if-not (contains? r-types #xt/type :null)
                                                                         r-field-type
@@ -2087,7 +2087,7 @@
                                            (let [k-str (str k)]
                                              [k-str
                                               (if (and (contains? l-ks k)
-                                                       (get-in flattened-r-types [k #xt/type :null]))
+                                                       (get-in r-read-legs [k #xt/type :null]))
                                                 `(-patch (get ~l-sym ~k-str) (get ~r-sym ~k-str))
                                                 `(get ~r-sym ~k-str))])))
                                     (keys r-ks))))))}))
@@ -2259,8 +2259,8 @@
           n-sym (gensym 'n)
           len-sym (gensym 'len)
           res-sym (gensym 'res)
-          inner-calls (->> (for [l-el-type (.getLegs l-el-type)
-                                 r-el-type (.getLegs r-el-type)]
+          inner-calls (->> (for [l-el-type (.getReadsAs l-el-type)
+                                 r-el-type (.getReadsAs r-el-type)]
                              (MapEntry/create [l-el-type r-el-type]
                                               (if (or (= #xt/type :null l-el-type) (= #xt/type :null r-el-type))
                                                 {:return-type #xt/type :null, :->call-code (constantly nil)}
@@ -2306,8 +2306,8 @@
         n-sym (gensym 'n)
         len-sym (gensym 'len)
         res-sym (gensym 'res)
-        inner-calls (->> (for [l-el-type (.getLegs l-el-type)
-                               r-el-type (.getLegs r-el-type)]
+        inner-calls (->> (for [l-el-type (.getReadsAs l-el-type)
+                               r-el-type (.getReadsAs r-el-type)]
                            (MapEntry/create [l-el-type r-el-type]
                                             (codegen-call {:f :===, :arg-types [l-el-type r-el-type]})))
                          (into {}))]

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -432,7 +432,7 @@
 (defn- continue-read [f ^VectorType vec-type reader-sym & args]
   (if (instance? VectorType$Mono vec-type)
     (f vec-type (apply read-value-code vec-type reader-sym args))
-    (continue-read-union f (set (.getLegs vec-type)) reader-sym args)))
+    (continue-read-union f (set (.getReadsAs vec-type)) reader-sym args)))
 
 (def ^:dynamic ^String *snapshot-token* nil)
 (def ^:dynamic ^String *await-token* nil)

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -515,9 +515,9 @@
                                     :or {extract-vecs-from-rel? true}}]
   (let [return-type (or (get var-types variable)
                         (throw (AssertionError. (str "unknown variable: " variable))))
-        ;; `Nothing` is the catalog's lattice bottom for a declared-but-valueless column; when such a
-        ;; column is read in a query its rows are simply null, so the EE treats it as `:null` and never
-        ;; needs `:nothing` call definitions (Nothing's empty legs would otherwise collapse codegen).
+        ;; `readsAs` handles the read wherever legs are dispatched on, so this looks redundant - it is not.
+        ;; `:return-type` flows outward into writer allocation and the merges above, where the bottom would
+        ;; declare a column that has no values while the emitted code writes nulls into it.
         return-type (if (= return-type VectorType$Nothing/INSTANCE) #xt/type :null return-type)
         var-rdr-sym (gensym (util/symbol->normal-form-symbol variable))]
 

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -15,7 +15,7 @@
            (java.time Duration Instant InstantSource LocalDate LocalDateTime LocalTime Period ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
            org.apache.arrow.vector.types.TimeUnit
-           (xtdb.arrow RelationReader Vector VectorReader VectorType VectorType$Nothing)
+           (xtdb.arrow RelationReader Vector VectorReader)
            (xtdb.time Interval)
            (xtdb.util StringUtil)))
 
@@ -1745,7 +1745,7 @@
 
 (t/deftest a-column-of-empty-lists-compares-as-a-literal-does-5948
   (with-open [rel (tu/open-rel {:xs [[] []]})]
-    (t/is (= (types/->type [:list VectorType$Nothing/INSTANCE])
+    (t/is (= #xt/type [:list :nothing]
              (.getType (.vectorForOrNull rel "xs")))
           "the column's element type is the lattice bottom, which is what makes this test cover anything")
 
@@ -1758,12 +1758,12 @@
 
   (t/testing "an element written as null heals to `Null`, an empty list does not"
     (with-open [rel (tu/open-rel {:xs [[nil]]})]
-      (t/is (= (types/->type [:list :null]) (.getType (.vectorForOrNull rel "xs"))))
+      (t/is (= #xt/type [:list :null] (.getType (.vectorForOrNull rel "xs"))))
       (t/is (= [nil] (:res (run-projection rel '(== xs [nil])))))))
 
   (t/testing "a null list leaves the element type at the bottom"
     (with-open [rel (tu/open-rel {:xs [nil []]})]
-      (t/is (= (VectorType/maybe (types/->type [:list VectorType$Nothing/INSTANCE]))
+      (t/is (= #xt/type [:? :list :nothing]
                (.getType (.vectorForOrNull rel "xs"))))
       (t/is (= [nil true] (:res (run-projection rel '(== xs []))))))))
 

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -15,7 +15,7 @@
            (java.time Duration Instant InstantSource LocalDate LocalDateTime LocalTime Period ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
            org.apache.arrow.vector.types.TimeUnit
-           (xtdb.arrow RelationReader Vector VectorReader)
+           (xtdb.arrow RelationReader Vector VectorReader VectorType VectorType$Nothing)
            (xtdb.time Interval)
            (xtdb.util StringUtil)))
 
@@ -1742,6 +1742,35 @@
 
   (t/testing "Nested expr"
     (t/is (= [42] (project1 '[(+ 1 a)] {:a 41})))))
+
+(t/deftest a-column-of-empty-lists-compares-as-a-literal-does-5948
+  (with-open [rel (tu/open-rel {:xs [[] []]})]
+    (t/is (= (types/->type [:list VectorType$Nothing/INSTANCE])
+             (.getType (.vectorForOrNull rel "xs")))
+          "the column's element type is the lattice bottom, which is what makes this test cover anything")
+
+    (t/are [form expected] (= expected (:res (run-projection rel form)))
+      '(== xs [])     [true true]
+      '(== xs [1])    [false false]
+      '(<> xs [])     [false false]
+      '(=== xs [])    [true true]
+      '(== xs xs)     [true true]))
+
+  (t/testing "an element written as null heals to `Null`, an empty list does not"
+    (with-open [rel (tu/open-rel {:xs [[nil]]})]
+      (t/is (= (types/->type [:list :null]) (.getType (.vectorForOrNull rel "xs"))))
+      (t/is (= [nil] (:res (run-projection rel '(== xs [nil])))))))
+
+  (t/testing "a null list leaves the element type at the bottom"
+    (with-open [rel (tu/open-rel {:xs [nil []]})]
+      (t/is (= (VectorType/maybe (types/->type [:list VectorType$Nothing/INSTANCE]))
+               (.getType (.vectorForOrNull rel "xs"))))
+      (t/is (= [nil true] (:res (run-projection rel '(== xs []))))))))
+
+(t/deftest a-struct-field-holding-an-empty-list-compares-5948
+  (with-open [rel (tu/open-rel {:s [{:xs []}]})]
+    (t/is (= [true] (:res (run-projection rel '(== s s))))
+          "struct comparison recurses into the field, so the bottom is reached one level down")))
 
 (t/deftest test-list-equal
   (t/is (= true (project1 '(== [] []) {})))

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -582,6 +582,15 @@
   (t/is (= [{:eq true}]
            (xt/q tu/*node* "SELECT (INTERVAL '3 1' DAY TO HOUR = INTERVAL '3 1' DAY TO HOUR) as eq"))))
 
+(t/deftest empty-array-column-compares-5948
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO docs (_id, xs) VALUES (1, ARRAY[])"]])
+
+  (t/is (= [] (xt/q tu/*node* "SELECT _id FROM docs WHERE xs = ARRAY[1]")))
+  (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT _id FROM docs WHERE xs = ARRAY[]")))
+
+  (t/is (nil? (:error (xt/execute-tx tu/*node* [[:sql "UPDATE docs SET seen = true WHERE xs = ARRAY[1]"]])))
+        "a fault here stops the database's ingestion rather than aborting the transaction"))
+
 (t/deftest test-array-construction
   (t/are [sql expected]
       (= expected (plan-expr-with-foo sql))

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -92,7 +92,13 @@
   (t/is (thrown? xtdb.api.error.Fault (types/merge-types nil)))
   (t/is (thrown? xtdb.api.error.Fault (types/merge-types #xt/type :i64 nil)))
 
-  ;; `#xt/type :nothing` doesn't read - `render-type` emits `:nothing` but the reader has no clause for it
   (t/testing "the lattice bottom is how a source says it has nothing to contribute"
     (t/is (= #xt/type :i64
-             (types/merge-types #xt/type :i64 xtdb.arrow.VectorType$Nothing/INSTANCE)))))
+             (types/merge-types #xt/type :i64 #xt/type :nothing)))))
+
+(t/deftest the-lattice-bottom-round-trips-through-the-reader
+  (t/are [type-spec] (= type-spec (st/render-type (st/->type type-spec)))
+    :nothing
+    [:list :nothing]
+    [:? :list :nothing]
+    [:struct {"a" :nothing}]))


### PR DESCRIPTION
Resolves #5948.

## tl;dr

- **A list column holding only empty lists could not be compared, and reached from DML it stopped the database's ingestion**
  `INSERT INTO docs (_id, xs) VALUES (1, ARRAY[])` followed by any `=` against `xs` threw `NullPointerException: … "__GT_call_code" is null` — at code-generation time, so no data was needed beyond the one row.

- **The engine worked out "which legs will a read hand me" in two places, and they disagreed at one type**
  `continue-read` treats a zero-leg type as reading null; the per-leg dispatch tables built their keys from `legs` and so had no key for it. This names the reader's answer as `VectorType.readsAs` and has the tables ask for it.

- **The fix routes `Nothing` into `Null`'s existing handling rather than teaching the engine a new type**
  That is what makes a nine-site substitution small: no site gained a case, because each already handled `:null` — the `:null` guard the list methods already carried was simply never being evaluated.

- **Present since `519b33937` (2026-06-09), bisected against a passing parent**
  In both 2.2.0 release candidates and every nightly since; in no GA release. Unrelated to #5916, confirmed by running the repro on the commit before it.

## Reading order

1. `tidy(types)` — the accessor, used in `continue-read` and nowhere else. **Behaviour-preserving, and provably so**: for an empty leg set and for `{Null}`, `continue-read-union` takes the same `(empty? without-null)` branch and emits identical code. No tests change; the suite is the check.
2. `fix(expression)` — the nine dispatch derivations. This is where behaviour changes.
3. `tidy(expression)` — the comment on the `Nothing` guard at `:521`, which justified the guard on grounds the accessor now covers.
4. `fix(types)` — `#xt/type` reads `:nothing`, so the tests can spell the type they assert.

## What is worth a reviewer's attention

- **Only four of the nine sites are reachable today, and reachability is not why the other five changed**
  All nine ask the same question, so deriving it from two sources that disagree is the defect whether or not a site is currently exposed. The four reachable ones are the list and struct comparison methods; the other five are latent behind two separate mechanisms, set out in the issue. The practical consequence is test coverage, not correctness: the four are tested, the five cannot be.

- **`_patch` looked like the worst of them and is not reachable at all**
  Its `(contains? r-types :null)` decides whether to emit the runtime null check, so with no legs it takes the patch value and would overwrite an existing value with null. But `StructVector.endStruct` pads short children with `writeNull()`, which takes a child off the bottom — so a struct with a bottom-typed child has no non-null rows, and the wrong branch needs one to execute. The condition producing the type forbids the code running.

- **`flattened-r-types` becomes `r-read-legs`, and that is the whole of the `_patch` change beyond the substitution**
  Both its uses want the read answer — `contains? :null` obviously, and `(disj r-types :null)` fed to `merge-types`, which asks what non-null values the right side could produce. One derivation, correctly sourced, named for the question it answers, since not being able to tell is how the wrong answer got in.

- **Three `.getLegs` sites are deliberately left alone**
  `:491` asks whether a type is a union needing a box, `:2387` allocates writers per leg and is gated on `Poly`, and `:1518` shortcuts a `:null` argument before the leg set is consulted. None asks what a read yields.

## Tests

- **The column path must answer what the literal path already answers.** A literal `[]` types as `Listy(LIST, Null)` via `mergeTypes(∅)`; a column of `[]` types as `Listy(LIST, Nothing)`. The test asserts the column's element type really is the bottom first, so it cannot rot into a tautology if the producer changes. A same-data differential is not constructible — an empty list's element type is necessarily the bottom.
- **The boundary is not the one a reader would guess**: `ARRAY[]` and a null list leave the element vector untouched, so the bottom survives; `ARRAY[NULL]` writes one cell and heals to `Null`.
- **Both new tests were run against the pre-fix tree and fail there**, so they bite rather than passing vacuously. A third test covering `:let`, `:if-some` and `codegen-call*` passed both before and after and was dropped — which is how those three were established as unreachable.

## Out of scope

- **#5954** — two sites asking a *different* question, where the bottom may legitimately differ from `Null`: `nullable-vec-type?` ("is this nullable", and `information_schema` wants the opposite answer for a declared column), and the metadata filter ("can I prune this page", where prune-everything is right for equality and unsound in general). Both also block #5871.
- **#5871** — makes the merge preserve the bottom, which is what takes the protection off four of the five latent sites. Blocked by this and by #5954.
- **The fail-stop on a `Fault` is correct and unchanged.** `indexTx` converting only `Anomaly.Caller` into an abort is the intended split; an unhandled codegen exception is genuinely "we do not know what state we are in". The fix belongs in codegen.

## Verification

`./gradlew test` green — 2,227 tests. Not `property-test`: no indexing, compaction or GC. No spec updates; none of the `.allium` files covers the expression engine.
