### PR TITLE
fix(expression): a read of a zero-leg type yields null

### DIFF
--- a/api/src/main/clojure/xtdb/serde/types.clj
+++ b/api/src/main/clojure/xtdb/serde/types.clj
@@ -434,6 +434,7 @@
     (keyword? type-spec) (case type-spec
                            :tstz-range VectorType/TSTZ_RANGE
                            :null VectorType$Null/INSTANCE
+                           :nothing VectorType$Nothing/INSTANCE
                            (VectorType/scalar (->arrow-type type-spec)))
 
     (set? type-spec) (VectorType/fromLegs (into #{} (map ->type) type-spec))

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1935,7 +1935,7 @@
                                                  emitted-vals)]) map-sym)))}))
 
 (defmethod codegen-call [:get_field :struct] [{[^VectorType$Struct struct-type] :arg-types, :keys [field]}]
-  (if-let [val-type (.get (.getChildren struct-type) (str field))]
+  (if-let [val-type (some-> (.get (.getChildren struct-type) (str field)) read-type)]
     {:return-type val-type
      :continue-call (fn [f [struct-code]]
                       (continue-read f val-type
@@ -1966,10 +1966,14 @@
                          ~(f #xt/type :transit val-sym)
                          ~(f #xt/type :null nil))))})
 
+(defn- read-field-types [^VectorType$Struct struct-type]
+  (-> (into {} (.getChildren struct-type))
+      (update-vals read-type)))
+
 (doseq [[op return-code] [[:== 1] [:<> -1]]]
   (defmethod codegen-call [op :struct :struct] [{[^VectorType$Struct l-type, ^VectorType$Struct r-type] :arg-types}]
-    (let [l-field-types (.getChildren l-type)
-          r-field-types (.getChildren r-type)
+    (let [l-field-types (read-field-types l-type)
+          r-field-types (read-field-types r-type)
           fields (set (keys l-field-types))]
       (if-not (= fields (set (keys r-field-types)))
         {:return-type #xt/type :bool, :->call-code (constantly (if (= :== op) false true))}
@@ -2017,8 +2021,8 @@
                                    ~(f #xt/type :bool `(== ~return-code ~res-sym))))))})))))
 
 (defmethod codegen-call [:=== :struct :struct] [{[^VectorType$Struct l-type, ^VectorType$Struct r-type] :arg-types}]
-  (let [l-field-types (.getChildren l-type)
-        r-field-types (.getChildren r-type)
+  (let [l-field-types (read-field-types l-type)
+        r-field-types (read-field-types r-type)
         fields (set (keys l-field-types))]
     (if-not (= fields (set (keys r-field-types)))
       {:return-type #xt/type :bool, :->call-code (constantly false)}
@@ -2164,18 +2168,24 @@
                                             (f return-type code))))))))
 
 (defmethod codegen-call [:nth :list :int] [{[^VectorType list-type _n-type] :arg-types}]
-  (let [list-el-vec-type (types/unnest-type list-type)
-        return-type (types/merge-types list-el-vec-type #xt/type :null)]
-    {:return-type return-type
-     :continue-call (fn [f [list-code n-code]]
-                      (let [list-sym (gensym 'list)
-                            n-sym (gensym 'n)]
-                        `(let [~list-sym ~list-code
-                               ~n-sym ~n-code]
-                           (if (and (>= ~n-sym 0) (< ~n-sym (.size ~list-sym)))
-                             (do
-                               ~(continue-read f list-el-vec-type `(.nth ~list-sym ~n-sym)))
-                             ~(f #xt/type :null nil)))))}))
+  (let [list-el-vec-type (types/unnest-type list-type)]
+    (if (bottom? list-el-vec-type)
+      ;; a bottom element type means the list is empty on every row, so every index is out of range.
+      ;; the operands are still evaluated - an index expression that throws must still throw
+      {:return-type #xt/type :null
+       :->call-code (fn [[list-code n-code]] `(do ~list-code ~n-code nil))}
+
+      (let [return-type (types/merge-types list-el-vec-type #xt/type :null)]
+        {:return-type return-type
+         :continue-call (fn [f [list-code n-code]]
+                          (let [list-sym (gensym 'list)
+                                n-sym (gensym 'n)]
+                            `(let [~list-sym ~list-code
+                                   ~n-sym ~n-code]
+                               (if (and (>= ~n-sym 0) (< ~n-sym (.size ~list-sym)))
+                                 (do
+                                   ~(continue-read f list-el-vec-type `(.nth ~list-sym ~n-sym)))
+                                 ~(f #xt/type :null nil)))))}))))
 
 (defmethod codegen-call [:nth :any :int] [_]
   {:return-type #xt/type :null, :->call-code (constantly nil)})
@@ -2261,6 +2271,72 @@
 
 (doseq [[op return-code] [[:== 1] [:<> -1]]]
   (defmethod codegen-call [op :list :list] [{[^VectorType$Listy l-type ^VectorType$Listy r-type] :arg-types}]
+    (if (or (bottom? (.getElType l-type)) (bottom? (.getElType r-type)))
+      ;; a bottom element type means that side is empty on every row, so length alone decides and no
+      ;; element is read - hence :bool, where the general case is [:? :bool] for an unknown comparison
+      {:return-type #xt/type :bool
+       :->call-code (fn [[l r]]
+                      (let [l-sym (gensym 'l), r-sym (gensym 'r)
+                            both-empty `(let [~(with-tag l-sym ListValueReader) ~l
+                                              ~(with-tag r-sym ListValueReader) ~r]
+                                          (and (zero? (.size ~l-sym)) (zero? (.size ~r-sym))))]
+                        (if (= :== op) both-empty `(not ~both-empty))))}
+
+      (let [l-el-type (.getElType l-type)
+            r-el-type (.getElType r-type)
+            n-sym (gensym 'n)
+            len-sym (gensym 'len)
+            res-sym (gensym 'res)
+            inner-calls (->> (for [l-el-type (.getLegs l-el-type)
+                                   r-el-type (.getLegs r-el-type)]
+                               (MapEntry/create [l-el-type r-el-type]
+                                                (if (or (= #xt/type :null l-el-type) (= #xt/type :null r-el-type))
+                                                  {:return-type #xt/type :null, :->call-code (constantly nil)}
+                                                  (codegen-call {:f :==, :arg-types [l-el-type r-el-type]}))))
+                             (into {}))]
+
+        {:return-type #xt/type [:? :bool]
+         :children (vals inner-calls)
+         :continue-call (fn continue-list= [f [l-code r-code]]
+                          (let [l-sym (gensym 'l), r-sym (gensym 'r)]
+                            ;; this is essentially `(every? = ...)` but with 3VL
+                            `(let [~l-sym ~l-code, ~r-sym ~r-code
+                                   ~(-> res-sym (with-tag 'long))
+                                   (let [~len-sym (.size ~l-sym)]
+                                     (if-not (= ~len-sym (.size ~r-sym))
+                                       -1
+                                       (loop [~n-sym 0, ~res-sym 1]
+                                         (cond
+                                           (>= ~n-sym ~len-sym) ~res-sym
+                                           (== -1 ~res-sym) -1
+                                           :else (recur (inc ~n-sym)
+                                                        (min ~res-sym
+                                                             (do
+                                                               ~(continue-read
+                                                                 (fn cont-l [l-el-type l-el-code]
+                                                                   `(do
+                                                                      ~(continue-read (fn cont-r [r-el-type r-el-code]
+                                                                                        (let [{:keys [return-type continue-call ->call-code]} (get inner-calls [l-el-type r-el-type])]
+                                                                                          (if continue-call
+                                                                                            (continue-call cont-b3-call [l-el-code r-el-code])
+                                                                                            (cont-b3-call return-type (->call-code [l-el-code r-el-code])))))
+                                                                                      r-el-type
+                                                                                      `(.nth ~r-sym ~n-sym))))
+                                                                 l-el-type
+                                                                 `(.nth ~l-sym ~n-sym)))))))))]
+                               (if (zero? ~res-sym)
+                                 ~(f #xt/type :null nil)
+                                 ~(f #xt/type :bool `(== ~return-code ~res-sym))))))}))))
+
+(defmethod codegen-call [:=== :list :list] [{[^VectorType$Listy l-type ^VectorType$Listy r-type] :arg-types}]
+  (if (or (bottom? (.getElType l-type)) (bottom? (.getElType r-type)))
+    {:return-type #xt/type :bool
+     :->call-code (fn [[l r]]
+                    (let [l-sym (gensym 'l), r-sym (gensym 'r)]
+                      `(let [~(with-tag l-sym ListValueReader) ~l
+                             ~(with-tag r-sym ListValueReader) ~r]
+                         (and (zero? (.size ~l-sym)) (zero? (.size ~r-sym))))))}
+
     (let [l-el-type (.getElType l-type)
           r-el-type (.getElType r-type)
           n-sym (gensym 'n)
@@ -2269,83 +2345,36 @@
           inner-calls (->> (for [l-el-type (.getLegs l-el-type)
                                  r-el-type (.getLegs r-el-type)]
                              (MapEntry/create [l-el-type r-el-type]
-                                              (if (or (= #xt/type :null l-el-type) (= #xt/type :null r-el-type))
-                                                {:return-type #xt/type :null, :->call-code (constantly nil)}
-                                                (codegen-call {:f :==, :arg-types [l-el-type r-el-type]}))))
+                                              (codegen-call {:f :===, :arg-types [l-el-type r-el-type]})))
                            (into {}))]
 
-      {:return-type #xt/type [:? :bool]
+      {:return-type #xt/type :bool
        :children (vals inner-calls)
        :continue-call (fn continue-list= [f [l-code r-code]]
                         (let [l-sym (gensym 'l), r-sym (gensym 'r)]
-                          ;; this is essentially `(every? = ...)` but with 3VL
-                          `(let [~l-sym ~l-code, ~r-sym ~r-code
-                                 ~(-> res-sym (with-tag 'long))
-                                 (let [~len-sym (.size ~l-sym)]
-                                   (if-not (= ~len-sym (.size ~r-sym))
-                                     -1
-                                     (loop [~n-sym 0, ~res-sym 1]
-                                       (cond
-                                         (>= ~n-sym ~len-sym) ~res-sym
-                                         (== -1 ~res-sym) -1
-                                         :else (recur (inc ~n-sym)
-                                                      (min ~res-sym
-                                                           (do
-                                                             ~(continue-read
-                                                               (fn cont-l [l-el-type l-el-code]
-                                                                 `(do
-                                                                    ~(continue-read (fn cont-r [r-el-type r-el-code]
-                                                                                      (let [{:keys [return-type continue-call ->call-code]} (get inner-calls [l-el-type r-el-type])]
-                                                                                        (if continue-call
-                                                                                          (continue-call cont-b3-call [l-el-code r-el-code])
-                                                                                          (cont-b3-call return-type (->call-code [l-el-code r-el-code])))))
-                                                                                    r-el-type
-                                                                                    `(.nth ~r-sym ~n-sym))))
-                                                               l-el-type
-                                                               `(.nth ~l-sym ~n-sym)))))))))]
-                             (if (zero? ~res-sym)
-                               ~(f #xt/type :null nil)
-                               ~(f #xt/type :bool `(== ~return-code ~res-sym))))))})))
-
-(defmethod codegen-call [:=== :list :list] [{[^VectorType$Listy l-type ^VectorType$Listy r-type] :arg-types}]
-  (let [l-el-type (.getElType l-type)
-        r-el-type (.getElType r-type)
-        n-sym (gensym 'n)
-        len-sym (gensym 'len)
-        res-sym (gensym 'res)
-        inner-calls (->> (for [l-el-type (.getLegs l-el-type)
-                               r-el-type (.getLegs r-el-type)]
-                           (MapEntry/create [l-el-type r-el-type]
-                                            (codegen-call {:f :===, :arg-types [l-el-type r-el-type]})))
-                         (into {}))]
-
-    {:return-type #xt/type :bool
-     :children (vals inner-calls)
-     :continue-call (fn continue-list= [f [l-code r-code]]
-                      (let [l-sym (gensym 'l), r-sym (gensym 'r)]
-                        (f #xt/type :bool
-                           `(let [~l-sym ~l-code, ~r-sym ~r-code
-                                  ~len-sym (.size ~l-sym)]
-                              (if-not (= ~len-sym (.size ~r-sym))
-                                false
-                                (loop [~n-sym 0]
-                                  (cond
-                                    (>= ~n-sym ~len-sym) true
-                                    :else (let [~res-sym ~(continue-read
-                                                           (fn cont-l [l-el-type l-el-code]
-                                                             `(do
-                                                                ~(continue-read (fn cont-r [r-el-type r-el-code]
-                                                                                  (let [{:keys [return-type continue-call ->call-code]} (get inner-calls [l-el-type r-el-type])]
-                                                                                    (if continue-call
-                                                                                      (continue-call cont-b3-call [l-el-code r-el-code])
-                                                                                      (cont-b3-call return-type (->call-code [l-el-code r-el-code])))))
-                                                                                r-el-type
-                                                                                `(.nth ~r-sym ~n-sym))))
-                                                           l-el-type
-                                                           `(.nth ~l-sym ~n-sym))]
-                                            (if (< ~res-sym 1)
-                                              false
-                                              (recur (inc ~n-sym)))))))))))}))
+                          (f #xt/type :bool
+                             `(let [~l-sym ~l-code, ~r-sym ~r-code
+                                    ~len-sym (.size ~l-sym)]
+                                (if-not (= ~len-sym (.size ~r-sym))
+                                  false
+                                  (loop [~n-sym 0]
+                                    (cond
+                                      (>= ~n-sym ~len-sym) true
+                                      :else (let [~res-sym ~(continue-read
+                                                             (fn cont-l [l-el-type l-el-code]
+                                                               `(do
+                                                                  ~(continue-read (fn cont-r [r-el-type r-el-code]
+                                                                                    (let [{:keys [return-type continue-call ->call-code]} (get inner-calls [l-el-type r-el-type])]
+                                                                                      (if continue-call
+                                                                                        (continue-call cont-b3-call [l-el-code r-el-code])
+                                                                                        (cont-b3-call return-type (->call-code [l-el-code r-el-code])))))
+                                                                                  r-el-type
+                                                                                  `(.nth ~r-sym ~n-sym))))
+                                                             l-el-type
+                                                             `(.nth ~l-sym ~n-sym))]
+                                              (if (< ~res-sym 1)
+                                                false
+                                                (recur (inc ~n-sym)))))))))))})))
 
 (defn series [^long start, ^long end, ^long step, inclusive?]
   (let [box (ValueBox.)

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -416,6 +416,11 @@
   (if (bottom? vec-type) #xt/type :null vec-type))
 
 (defn- continue-read-union [f inner-types reader-sym args]
+  (when (empty? inner-types)
+    (throw (err/fault ::zero-leg-read
+                      "no values to read from a zero-leg type - the calling codegen should normalise it with `read-type`, or fold the read away"
+                      {:reader-sym reader-sym})))
+
   (let [without-null (disj inner-types #xt/type :null)]
     (if (empty? without-null)
       (f #xt/type :null nil)

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -408,6 +408,13 @@
 
   (defmethod write-value-code k [_ & args] `(.writeObject ~@args)))
 
+(defn- bottom? [^VectorType vec-type]
+  (= vec-type VectorType$Nothing/INSTANCE))
+
+(defn- read-type ^VectorType [^VectorType vec-type]
+  ;; a column or field with no cells reads null on every row
+  (if (bottom? vec-type) #xt/type :null vec-type))
+
 (defn- continue-read-union [f inner-types reader-sym args]
   (let [without-null (disj inner-types #xt/type :null)]
     (if (empty? without-null)
@@ -515,10 +522,10 @@
                                     :or {extract-vecs-from-rel? true}}]
   (let [return-type (or (get var-types variable)
                         (throw (AssertionError. (str "unknown variable: " variable))))
-        ;; `Nothing` is the catalog's lattice bottom for a declared-but-valueless column; when such a
-        ;; column is read in a query its rows are simply null, so the EE treats it as `:null` and never
-        ;; needs `:nothing` call definitions (Nothing's empty legs would otherwise collapse codegen).
-        return-type (if (= return-type VectorType$Nothing/INSTANCE) #xt/type :null return-type)
+        ;; this normalises the outward `:return-type` as well as the read - writer allocation in
+        ;; `->expression-projection-spec` and every parent's leg enumeration take it from here, and the
+        ;; bottom there would declare a column with no values while the emitted code writes nulls into it
+        return-type (read-type return-type)
         var-rdr-sym (gensym (util/symbol->normal-form-symbol variable))]
 
     ;; NOTE: when used from metadata exprs, incoming vectors might not exist

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -1743,6 +1743,54 @@
   (t/testing "Nested expr"
     (t/is (= [42] (project1 '[(+ 1 a)] {:a 41})))))
 
+(t/deftest a-column-of-empty-lists-compares-as-a-literal-does-5948
+  (with-open [rel (tu/open-rel {:xs [[] []]})]
+    (t/is (= #xt/type [:list :nothing]
+             (.getType (.vectorForOrNull rel "xs")))
+          "the column's element type is the lattice bottom, which is what makes this test cover anything")
+
+    (t/are [form expected] (= expected (:res (run-projection rel form)))
+      '(== xs [])     [true true]
+      '(== xs [1])    [false false]
+      '(<> xs [])     [false false]
+      '(=== xs [])    [true true]
+      '(== xs xs)     [true true]))
+
+  (t/testing "an element written as null heals to `Null`, an empty list does not"
+    (with-open [rel (tu/open-rel {:xs [[nil]]})]
+      (t/is (= #xt/type [:list :null] (.getType (.vectorForOrNull rel "xs"))))
+      (t/is (= [nil] (:res (run-projection rel '(== xs [nil])))))))
+
+  (t/testing "a null list leaves the element type at the bottom"
+    (with-open [rel (tu/open-rel {:xs [nil []]})]
+      (t/is (= #xt/type [:? :list :nothing]
+               (.getType (.vectorForOrNull rel "xs"))))
+      (t/is (= [nil true] (:res (run-projection rel '(== xs []))))))))
+
+(t/deftest reading-a-valueless-struct-field-yields-null-5948
+  (with-open [rel (vr/rel-reader [(tu/open-vec "s" #xt/type [:struct {"a" :nothing}] [nil])])]
+    (t/is (= #xt/type [:? :struct {"a" :nothing}]
+             (.getType (.vectorForOrNull rel "s")))
+          "the field's type is the lattice bottom, which is what makes this test cover anything")
+
+    (t/are [form expected-type expected-res] (= [expected-type expected-res]
+                                                ((juxt :res-type :res) (run-projection rel form)))
+      '(. s a) #xt/type :null [nil]
+      '(== s s) #xt/type [:? :bool] [nil]
+      '(=== s s) #xt/type :bool [true])))
+
+(t/deftest indexing-a-column-of-empty-lists-yields-null-5948
+  (with-open [rel (tu/open-rel {:xs [[] []]})]
+    (t/are [form] (= [nil nil] (:res (run-projection rel form)))
+      '(nth xs 0)
+      '(nth xs 1)
+      '(nth xs -1))))
+
+(t/deftest a-struct-field-holding-an-empty-list-compares-5948
+  (with-open [rel (tu/open-rel {:s [{:xs []}]})]
+    (t/is (= [true] (:res (run-projection rel '(== s s))))
+          "struct comparison recurses into the field, so the bottom is reached one level down")))
+
 (t/deftest test-list-equal
   (t/is (= true (project1 '(== [] []) {})))
   (t/is (= false (project1 '(== [1 2] [1 2 3]) {})))

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -22,6 +22,43 @@
     (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
       (f page-metadata))))
 
+(t/deftest a-declared-column-holds-the-bottom-until-a-put-writes-a-row-5948
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE foo (a)"]])
+
+  (t/is (= [{:data-type ":nothing"}]
+           (xt/q tu/*node* "SELECT data_type FROM information_schema.columns
+                            WHERE table_name = 'foo' AND column_name = 'a'")))
+
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+
+  (t/is (= [{:data-type ":null"}]
+           (xt/q tu/*node* "SELECT data_type FROM information_schema.columns
+                            WHERE table_name = 'foo' AND column_name = 'a'"))
+        "the put pads the declared column, which is what takes it off the bottom"))
+
+;; the read-side handling is tested in `xtdb.expression-test`, which states the struct type by hand;
+;; this is here to show a user query still reaches that type, so that handling isn't dead code
+(t/deftest pull-reaches-a-struct-of-valueless-fields-5948
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE foo (a, b)"]])
+
+  (t/is (= [{:xt/id 1}]
+           (xt/q tu/*node* '(-> (rel [{:_id 1}] [_id])
+                                (with {:p (pull (from :foo [a b]))})
+                                (with {:m (== p {:a 1, :b 2})}))))
+        "struct comparison reads every field of the pulled struct")
+
+  (t/is (= [{:xt/id 1, :m false}]
+           (xt/q tu/*node* '(-> (rel [{:_id 1}] [_id])
+                                (with {:p (pull (from :foo [a b]))})
+                                (with {:m (=== p {:a 1, :b 2})}))))
+        "identity comparison doesn't short-circuit a null, so it compiles the struct leg too")
+
+  (t/is (= [{:xt/id 1}]
+           (xt/q tu/*node* '(-> (rel [{:_id 1}] [_id])
+                                (with {:p (pull (from :foo [a b]))})
+                                (with {:x (. p a)}))))
+        "get_field reads one"))
+
 (t/deftest test-find-gt-ivan
   (with-open [node (xtn/start-node (assoc tu/*node-opts* :indexer {:rows-per-block 10}))]
     (xt/execute-tx node [[:put-docs :xt_docs {:name "Håkan", :xt/id :hak}]])

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -582,6 +582,18 @@
   (t/is (= [{:eq true}]
            (xt/q tu/*node* "SELECT (INTERVAL '3 1' DAY TO HOUR = INTERVAL '3 1' DAY TO HOUR) as eq"))))
 
+(t/deftest empty-array-column-compares-5948
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO docs (_id, xs) VALUES (1, ARRAY[])"]])
+
+  (t/is (= [] (xt/q tu/*node* "SELECT _id FROM docs WHERE xs = ARRAY[1]")))
+  (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT _id FROM docs WHERE xs = ARRAY[]")))
+
+  (t/is (nil? (:error (xt/execute-tx tu/*node* [[:sql "UPDATE docs SET seen = true WHERE xs = ARRAY[1]"]])))
+        "a fault here stops the database's ingestion rather than aborting the transaction")
+
+  (t/is (thrown? Exception (xt/q tu/*node* "SELECT xs[_id/0] FROM docs"))
+        "the index expression is still evaluated, even though every index is out of range"))
+
 (t/deftest test-array-construction
   (t/are [sql expected]
       (= expected (plan-expr-with-foo sql))

--- a/src/test/clojure/xtdb/types_test.clj
+++ b/src/test/clojure/xtdb/types_test.clj
@@ -92,7 +92,13 @@
   (t/is (thrown? xtdb.api.error.Fault (types/merge-types nil)))
   (t/is (thrown? xtdb.api.error.Fault (types/merge-types #xt/type :i64 nil)))
 
-  ;; `#xt/type :nothing` doesn't read - `render-type` emits `:nothing` but the reader has no clause for it
   (t/testing "the lattice bottom is how a source says it has nothing to contribute"
     (t/is (= #xt/type :i64
-             (types/merge-types #xt/type :i64 xtdb.arrow.VectorType$Nothing/INSTANCE)))))
+             (types/merge-types #xt/type :i64 #xt/type :nothing)))))
+
+(t/deftest the-lattice-bottom-round-trips-through-the-reader
+  (t/are [type-spec] (= type-spec (st/render-type (st/->type type-spec)))
+    :nothing
+    [:list :nothing]
+    [:? :list :nothing]
+    [:struct {"a" :nothing}]))


### PR DESCRIPTION
Resolves #5948.

## tl;dr

- **A query against a column holding only empty arrays crashed code generation**, and reached from DML it stopped the database's ingestion rather than aborting the transaction. `SELECT _id FROM docs WHERE xs = ARRAY[1]`, where every `xs` is `ARRAY[]`, is the whole repro.
- **The rule is now stated once — a read of a zero-leg type yields null.** Three codegen sites take that answer; three others fold the read away entirely, because a list reports its own length at runtime and so never needs to know about the bottom.
- **`continue-read-union` now faults on a zero-leg read** rather than fabricating a null, so the next unhandled site names itself instead of surfacing as `__GT_call_code is null`.
- **This is an alternative to #5967**, which fixes the same bug by teaching `VectorType` a `readsAs` accessor. #5967 stays open for comparison rather than being closed by this.

## Root cause

A column holding only empty arrays has element type `Nothing` — the lattice bottom, whose leg set is empty. `Nothing` is not a `Mono`, so reading one goes through `continue-read-union`, which answered an empty leg set by fabricating `(f #xt/type :null nil)`.

That answer is correct, and that is what made this hard to see. The fault was that callers had independently derived *which legs will the callback hand me?* from `.getLegs`, so their dispatch tables had no `:null` entry to look up:

```clojure
;; [:== :list :list] — keyed off the element types' legs
inner-calls (->> (for [l-el-type (.getLegs l-el-type)
                       r-el-type (.getLegs r-el-type)]
                   ...))

;; a bottom element type ⇒ empty cross product ⇒ {}
;; ⇒ (get inner-calls [#xt/type :null #xt/type :i64]) is nil
;; ⇒ ->call-code is nil
```

Two derivations of the same question, agreeing everywhere except at the bottom — where one said "you will be handed `:null`" and the other said "you will be handed nothing at all".

## Alternatives considered

**#5967 — `readsAs` on `VectorType`.** Give the lattice an accessor for what reading a type yields (`Nothing.readsAs = [Null]`) and switch every `.getLegs`-for-reading site to it. One rule, one place, every dispatch site migrated.

**This PR — confine the bottom at the codegen sites.** `read-type` where a read has to be emitted, and a fold where it doesn't.

| | #5967 | this PR |
| --- | --- | --- |
| `VectorType` | gains a public accessor | untouched |
| sites that learn the rule | all dispatch sites | three |
| sites that stop asking the question | none | three (the folds) |
| `ARRAY[] = ARRAY[1]` | reads an element, then answers | compares lengths, never reads |

The folds are what an accessor cannot buy: a list carries its own length, so those sites need no notion of the bottom at all. Against that, #5967 puts the rule somewhere a future site finds it without knowing to look — which is worth something, given six sites needed the guard here and four of them were found by the assertion rather than by reading the code.

No strong preference; the two are close enough that it is worth a second opinion.

## Implementation notes

**Normalise where a read must be emitted; fold where the container reports its own extent.**

- **`get_field` and both struct comparisons normalise, because the fact they would need is not theirs to see**
  A bottom struct field means the struct has no non-null rows, so the read never executes. But the site is handed a struct `ValueReader` — `readObject()` gives it a map of child readers, no row count and no validity — and it has already been dispatched onto the non-null leg by its caller. "This struct has no non-null rows" is a fact about how the vector was built, not a value it can test, so the site can only state the answer, which is null.

- **The list sites fold, because `(.size l)` is right there**
  A bottom element type means that list is empty on every row, and the emitted code can observe that. `[:== / :<> :list :list]` and `[:=== :list :list]` decide on length alone; `[:nth :list :int]` is always out of range. These are correct *by observation* rather than by invariant — the generated code reads the size whether or not the bottom's meaning holds, which is the property the struct sites can't have.

- **`===` is the reason the struct sites don't fold either**
  A bottom field reads null, so `==` could fold it to "unknown" — which is what normalising produces anyway, through the site's existing null branch. `===` can't: null-vs-null is true and null-vs-value is false, so that field's answer depends on the other side's leg and has to be compared. Folding both on the grounds that the code is unreachable would hold only while the padding invariant does, and buys nothing over normalising.

- **The fault is a deliberate narrowing, and code review pushed back on it**
  The suggestion was `log/warn` plus the null, since a future unhandled site now faults during DML codegen. That comparison holds only for the pass-through caller shape, whose two callers today both normalise; the leg-dispatching shape already took ingestion down, via the NPE, which is the reported incident. And a pass-through caller reading correctly as null would still hand the bottom outward as its `:return-type` — the mis-declared-column hazard `codegen-expr :variable` warns about — so "silently correct" is correct at the read and probably not at the site.

- **The struct type is stated by hand in the test rather than reached through `pull`**
  `pull` is the only surface that currently produces `Struct{a: Nothing}`, via `:star` and `RelationAsStructReader`. A test driving it would silently stop covering anything the day `pull` is replanned to `NEST_ONE`'s shape, where each field passes through `codegen-expr :variable` and arrives as `Null`. So `xtdb.expression-test` states the type directly and `xtdb.query-test` keeps a separate reachability test, so this handling can't become dead code unnoticed.

## Out of scope

Split on "reachable from the same surface, but not caused or worsened by this change" — all four are recorded on #5948.

- **`[:_patch :struct :struct]`** puts a bottom child straight into `:return-type`, and `[:_patch :null :struct]` returns `r-type` verbatim. Reachable via `pull` over an empty table. Behaves exactly as before this change.
- **`codegen-cast [:list :list]`** hands `(.indexOf … :nothing)` → `-1` to `MonoToPolyReader` as a type id. Pre-existing.
- **`pull` should plan like `NEST_ONE`.** `NEST_ONE` builds a struct expression over named columns (`sql.clj:202`), so its fields pass through the `codegen-expr :variable` gateway; `pull` uses `:star` and bypasses it. Lining them up needs the `provided-vars` question answered first.
- **`fromLegs(∅)` returning `Null` rather than the bottom** (`MergeTypes.kt:70-77` carries its own deletion note). Fixing it turns every empty collection literal into a bottom-element list — `ValueTypes.kt:99`/`:101`/`:59`, `expression.clj`'s `:list` and `:set`. The folds here already handle either side being the bottom, so this change is a prerequisite for that cleanup rather than blocked by it.

## Changes

1. **`fix(types)`** — `#xt/type` reads `:nothing`. `render-type` emitted it and `->type` had no clause, so the type was writable and not readable. Needed by the tests, and already load-bearing via `information_schema.columns` → `read-string` → `->field`.
2. **`refactor(expression)`** — name the bottom (`bottom?`) and what reading it yields (`read-type`). Behaviour-preserving: `codegen-expr :variable` already did this rewrite inline.
3. **`fix(expression)`** — the fix. Normalisations, folds and tests.
4. **`fix(expression)`** — the fault, last, because it is only safe once 3 is in.

## Test plan

`./gradlew test` — 2,254 tests, 0 failures, on the exact tree of commit 4.

- **`xtdb.expression-test`** — `reading-a-valueless-struct-field-yields-null-5948` states `#xt/type [:struct {"a" :nothing}]` by hand and asserts the output *types* (`:null`, `[:? :bool]`, `:bool`), which is what distinguishes correct normalisation from merely not faulting. Plus the empty-list column comparisons and `indexing-a-column-of-empty-lists-yields-null-5948`.
- **`xtdb.sql.expr-test`** — the reported statement at the surface it was reported from, including the `UPDATE` (a fault there stops ingestion rather than aborting the transaction), and `xs[_id/0]` to pin that the fold still evaluates its operands.
- **`xtdb.query-test`** — `pull` reachability, and `a-declared-column-holds-the-bottom-until-a-put-writes-a-row-5948`, which pins the invariant the reasoning above rests on: `data_type` is `":nothing"` after `CREATE TABLE foo (a)` and `":null"` after the first put, because `endStruct` pads.
- **`xtdb.types-test`** — the reader round-trip.

Not run: `property-test` (touches neither indexing, compaction nor GC) and `integration-test` (no integration surface). Reflection was not verified — the Gradle build never sets `*warn-on-reflection*` — so the fold binds its operands to `^ListValueReader` gensyms rather than relying on the caller's tags.
