### PR TITLE
fix(expression): a column holding only empty lists is comparable

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -410,9 +410,14 @@
 
 (defn- continue-read-union [f inner-types reader-sym args]
   (let [without-null (disj inner-types #xt/type :null)]
-    (if (empty? without-null)
+    (cond
+      (empty? inner-types)
+      `(throw (err/fault ::zero-leg-read "internal error: read of a zero-leg type"))
+
+      (empty? without-null)
       (f #xt/type :null nil)
 
+      :else
       (let [nn-code (if (= 1 (count without-null))
                       (let [nn-type (first (seq without-null))]
                         (f nn-type (read-value-code nn-type reader-sym)))

--- a/core/src/test/kotlin/xtdb/arrow/ListVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/ListVectorTest.kt
@@ -47,4 +47,17 @@ class ListVectorTest {
             assertEquals(listOf(listOf(null), listOf(1, 2, 3)), listVec.asList)
         }
     }
+
+    // xtdb.expression's list comparisons emit a read that faults on a bottom element type, relying on
+    // this to keep their `.size` gate exact - so promotion here is not a local change (#5948).
+    @Test
+    fun `a bottom el-type and a non-empty list cannot coexist`() {
+        ListVector(allocator, "list", false, NullVector($$"$data$", false)).use { listVec ->
+            listVec.writeObject(emptyList<Any>())
+            assertEquals(listTypeOf(VectorType.Nothing), listVec.type)
+
+            listVec.writeObject(listOf(1))
+            assertEquals(listTypeOf(VectorType.I32), listVec.type, "the first element promotes it")
+        }
+    }
 }

--- a/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/StructVectorTest.kt
@@ -371,4 +371,19 @@ class StructVectorTest {
             }
         }
     }
+
+    // xtdb.expression's struct comparisons emit a read that faults on a bottom-typed field, relying
+    // on this to keep it unreachable - so relaxing the padding here is not a local change (#5948).
+    @Test
+    fun `a bottom-typed child and a non-null struct row cannot coexist`() {
+        StructVector(allocator, "struct", true, linkedMapOf("a" to NullVector("a", false))).use { structVec ->
+            assertEquals(VectorType.Nothing, structVec.vectorFor("a").type)
+
+            structVec.writeNull()
+            assertEquals(VectorType.Nothing, structVec.vectorFor("a").type, "a null row writes undefineds")
+
+            structVec.endStruct()
+            assertEquals(VectorType.Null, structVec.vectorFor("a").type, "a non-null row pads with writeNull()")
+        }
+    }
 }

--- a/src/test/clojure/xtdb/expression_test.clj
+++ b/src/test/clojure/xtdb/expression_test.clj
@@ -15,7 +15,8 @@
            (java.time Duration Instant InstantSource LocalDate LocalDateTime LocalTime Period ZoneId ZonedDateTime)
            (java.time.temporal ChronoUnit)
            org.apache.arrow.vector.types.TimeUnit
-           (xtdb.arrow RelationReader Vector VectorReader)
+           (xtdb.arrow NullVector RelationReader Vector VectorReader)
+           (xtdb.operator ProjectionSpec$Star)
            (xtdb.time Interval)
            (xtdb.util StringUtil)))
 
@@ -1742,6 +1743,82 @@
 
   (t/testing "Nested expr"
     (t/is (= [42] (project1 '[(+ 1 a)] {:a 41})))))
+
+(t/deftest a-column-of-empty-lists-compares-as-a-literal-does-5948
+  (with-open [rel (tu/open-rel {:xs [[] []]})]
+    (t/is (= #xt/type [:list :nothing]
+             (.getType (.vectorForOrNull rel "xs")))
+          "the column's element type is the lattice bottom, which is what makes this test cover anything")
+
+    (t/are [form expected] (= expected (:res (run-projection rel form)))
+      '(== xs [])     [true true]
+      '(== xs [1])    [false false]
+      '(<> xs [])     [false false]
+      '(=== xs [])    [true true]
+      '(=== xs [1])   [false false]
+      '(== xs xs)     [true true]))
+
+  (t/testing "an element written as null heals to `Null`, an empty list does not"
+    (with-open [rel (tu/open-rel {:xs [[nil]]})]
+      (t/is (= #xt/type [:list :null] (.getType (.vectorForOrNull rel "xs"))))
+      (t/is (= [nil] (:res (run-projection rel '(== xs [nil])))))))
+
+  (t/testing "a null list leaves the element type at the bottom"
+    (with-open [rel (tu/open-rel {:xs [nil []]})]
+      (t/is (= #xt/type [:? :list :nothing]
+               (.getType (.vectorForOrNull rel "xs"))))
+      (t/is (= [nil true] (:res (run-projection rel '(== xs []))))))))
+
+(t/deftest a-null-struct-row-never-reaches-its-valueless-field-5948
+  (with-open [rel (vr/rel-reader [(tu/open-vec "s" #xt/type [:struct {"a" :nothing}] [nil])])]
+    (t/is (= #xt/type [:? :struct {"a" :nothing}]
+             (.getType (.vectorForOrNull rel "s")))
+          "the field's type is the lattice bottom, which is what makes this test cover anything")
+
+    (t/are [form expected-type expected-res] (= [expected-type expected-res]
+                                                ((juxt :res-type :res) (run-projection rel form)))
+      '(. s a) #xt/type :null [nil]
+      '(== s s) #xt/type [:? :bool] [nil]
+      '(=== s s) #xt/type :bool [true])))
+
+(t/deftest indexing-a-column-of-empty-lists-yields-null-5948
+  (with-open [rel (tu/open-rel {:xs [[] []]})]
+    (t/are [form] (= [nil nil] (:res (run-projection rel form)))
+      '(nth xs 0)
+      '(nth xs 1)
+      '(nth xs -1))))
+
+(t/deftest a-struct-field-holding-an-empty-list-compares-5948
+  (with-open [rel (tu/open-rel {:s [{:xs []}]})]
+    (t/is (= [true] (:res (run-projection rel '(== s s))))
+          "struct comparison recurses into the field, so the bottom is reached one level down")))
+
+;; `RelationAsStructReader.valueReader()` has no `pos`, so an expression can only ever see a copy -
+;; which is why the read below goes through `rowCopier` rather than reading the view directly.
+(t/deftest a-star-struct-cannot-carry-the-bottom-to-a-read-5948
+  (with-open [inner (vr/rel-reader [(doto (NullVector. "a" false 0)
+                                      (.writeUndefined)
+                                      (.writeUndefined))]
+                                   2)
+              s (.project (ProjectionSpec$Star. "s" #xt/type [:struct {"a" :nothing}])
+                          tu/*allocator* inner {} vw/empty-args)
+              out (Vector/open tu/*allocator* "s" #xt/type [:struct {"a" :nothing}])]
+
+    (t/is (= #xt/type [:struct {"a" :nothing}] (.getType s))
+          "the premise: rows present, child still at the bottom")
+    (t/is (= 2 (.getValueCount s)))
+    (t/is (false? (.isNull s 0)))
+
+    (let [copier (.rowCopier s out)]
+      (dotimes [idx 2] (.copyRow copier idx)))
+
+    (t/is (= #xt/type [:struct {"a" :null}] (.getType out))
+          "copying is what heals it - the child's rowCopier writes a real null")
+
+    (let [rel (vr/rel-reader [out] 2)]
+      (t/is (= [nil nil] (:res (run-projection rel '(== s s))))
+            "3VL: the only field is null on both sides, so the comparison is unknown")
+      (t/is (= [nil nil] (:res (run-projection rel '(. s a))))))))
 
 (t/deftest test-list-equal
   (t/is (= true (project1 '(== [] []) {})))

--- a/src/test/clojure/xtdb/query_test.clj
+++ b/src/test/clojure/xtdb/query_test.clj
@@ -22,6 +22,44 @@
     (util/with-open [page-metadata (.openPageMetadataSync metadata-mgr meta-file-path)]
       (f page-metadata))))
 
+(t/deftest a-declared-column-holds-the-bottom-until-a-put-writes-a-row-5948
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE foo (a)"]])
+
+  (t/is (= [{:data-type ":nothing"}]
+           (xt/q tu/*node* "SELECT data_type FROM information_schema.columns
+                            WHERE table_name = 'foo' AND column_name = 'a'")))
+
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO foo (_id) VALUES (1)"]])
+
+  (t/is (= [{:data-type ":null"}]
+           (xt/q tu/*node* "SELECT data_type FROM information_schema.columns
+                            WHERE table_name = 'foo' AND column_name = 'a'"))
+        "the put pads the declared column, which is what takes it off the bottom"))
+
+;; `p` is null over the empty table, so every assertion here is about codegen succeeding rather than
+;; about the struct leg running. `NEST_ONE` won't do instead: its fields go through `codegen-expr
+;; :variable` and arrive as `Null`, so `pull` is the only surface that reaches a bottom-typed child.
+(t/deftest pull-reaches-a-struct-of-valueless-fields-5948
+  (xt/execute-tx tu/*node* [[:sql "CREATE TABLE foo (a, b)"]])
+
+  (t/is (= [{:xt/id 1}]
+           (xt/q tu/*node* '(-> (rel [{:_id 1}] [_id])
+                                (with {:p (pull (from :foo [a b]))})
+                                (with {:m (== p {:a 1, :b 2})}))))
+        "struct comparison reads every field of the pulled struct")
+
+  (t/is (= [{:xt/id 1, :m false}]
+           (xt/q tu/*node* '(-> (rel [{:_id 1}] [_id])
+                                (with {:p (pull (from :foo [a b]))})
+                                (with {:m (=== p {:a 1, :b 2})}))))
+        "identity comparison doesn't short-circuit a null, so it compiles the struct leg too")
+
+  (t/is (= [{:xt/id 1}]
+           (xt/q tu/*node* '(-> (rel [{:_id 1}] [_id])
+                                (with {:p (pull (from :foo [a b]))})
+                                (with {:x (. p a)}))))
+        "get_field reads one"))
+
 (t/deftest test-find-gt-ivan
   (with-open [node (xtn/start-node (assoc tu/*node-opts* :indexer {:rows-per-block 10}))]
     (xt/execute-tx node [[:put-docs :xt_docs {:name "Håkan", :xt/id :hak}]])

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -582,6 +582,21 @@
   (t/is (= [{:eq true}]
            (xt/q tu/*node* "SELECT (INTERVAL '3 1' DAY TO HOUR = INTERVAL '3 1' DAY TO HOUR) as eq"))))
 
+(t/deftest empty-array-column-compares-5948
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO docs (_id, xs) VALUES (1, ARRAY[])"]])
+
+  (t/is (= [] (xt/q tu/*node* "SELECT _id FROM docs WHERE xs = ARRAY[1]")))
+  (t/is (= [{:xt/id 1}] (xt/q tu/*node* "SELECT _id FROM docs WHERE xs = ARRAY[]")))
+
+  (xt/execute-tx tu/*node* [[:sql "UPDATE docs SET seen = true WHERE xs = ARRAY[1]"]])
+
+  (t/is (= [{:xt/id 1, :xs []}] (xt/q tu/*node* "SELECT * FROM docs"))
+        "the predicate evaluates false, so `seen` is never written at all - and an answer means a fault didn't stop the database's ingestion")
+
+  (t/is (anomalous? [:incorrect ::expr/division-by-zero]
+                    (xt/q tu/*node* "SELECT xs[_id/0] FROM docs"))
+        "the index expression is still evaluated, even though every index is out of range"))
+
 (t/deftest test-array-construction
   (t/are [sql expected]
       (= expected (plan-expr-with-foo sql))


### PR DESCRIPTION
Resolves #5948. A third approach alongside #5967 and #5968, intended to replace both — the issue's Progress section asks for one to be picked, and this is a smaller answer than either.

## tl;dr

- **A column whose every list is `[]` now compares instead of collapsing codegen**
  `SELECT _id FROM docs WHERE xs = ARRAY[1]` against such a column raised `NullPointerException: Cannot invoke "clojure.lang.IFn.invoke(Object)" because "__GT_call_code" is null`. Reached from a `WHERE` clause in DML it surfaced as a `Fault`, which stops the database's ingestion rather than aborting the transaction, so the transaction replayed on restart and failed identically.

- **The lattice bottom becomes compilable rather than being substituted away**
  `continue-read-union` emits a fault for a zero-leg read, so codegen completes and the per-leg dispatch table is never consulted. Seven lines, one function.

- **The emitted fault is never executed, and four unrelated mechanisms are why**
  None of them is the type system, and none of them was written down before this PR. Each now has a test.

## Alternatives considered

- **A1 — `readsAs` on `VectorType` (#5967)**
  Give the lattice an accessor for what reading a type yields (`Nothing.readsAs = [Null]`) and migrate every `.getLegs`-for-reading site to it. Nine sites, plus a new public accessor on `VectorType`.

- **A2 — confine the bottom at the codegen sites (#5968)**
  Normalise where a read has to be emitted, fold where the container reports its own extent. Six sites, three different treatments, plus a fault in `continue-read-union` used as scaffolding to enumerate the reachable sites.

- **A3 — make the bottom compilable (this PR)**
  Keep A2's fault and drop the site work: if `continue-read` never hands the callback a leg the table lacks, the table is never consulted and there is nothing to migrate.

## Decision rationale

| | A1 (#5967) | A2 (#5968) | A3 (this) |
| --- | --- | --- | --- |
| production diff | accessor + ~9 sites | 6 sites restructured | 7 lines, 1 function |
| where the rule lives | an accessor each site must know to call | per-site, three shapes | `continue-read-union`, which already decides what a read yields |
| outward type over the bottom | `Null` | unchanged | unchanged |
| a site that forgets | silently wrong | silently wrong | named fault |

- **The widening is the substantive objection to A1**
  `Null ⊔ I64 = Maybe(I64)` against `Nothing ⊔ I64 = I64`. Laundering the bottom to `Null` at the read means a column that has only ever held empty values widens permanently on its first insert — the widening `Nothing` exists to prevent, reintroduced one level down. The issue's Out of scope section rules out the same trade at `Vector.kt:137`.

- **A2's folds are correct, and each rests on a different mechanism**
  A list carries its own length, so `(.size l)` answers "is this empty?" at runtime; a struct field has no equivalent, so those sites normalise instead. Two treatments presented as one rule is the shape that let nine sites drift apart in the first place.

- **A3 gives up the ability to answer a bottom read at all**
  That is the cost, and it is only acceptable because the read is unreachable — which is what the four gates below establish, and what the tests now pin.

## Implementation notes

- **The four gates, one per site that emits a bottom read**
  A list comparison is gated by `.size`, and that gate is exact because writing any element promotes the element vector off the bottom. `[:nth :list :int]` is gated by the index bound. A struct comparison is gated by `StructVector.endStruct`, which pads short children with `writeNull()`, so a bottom-typed child and a non-null struct row cannot coexist. A star projection escapes that last one — `RelationAsStructReader` lifts child types verbatim and reports `isNull` as a constant `false` — but its `valueReader()` has no `pos`, so an expression only ever sees a copy, and copying writes real nulls.

- **`fault` rather than `incorrect` is deliberate**
  A zero-leg read reaching execution means codegen emitted something the type system said could not run. `SourceLogTxIndexer.indexTx` converts only `Anomaly.Caller` into an abort, so this keeps the fail-stop the issue's Constraints section defends rather than converting an internal error into a silently aborted transaction.

## Dead ends

- **"A `throw` won't compile in the list folds"**
  Recorded on the issue as a reason to reject the whole approach: the emission sits inside `(min ~res-sym …)` with `res-sym` hinted primitive and flowing through `loop`/`recur`, which reads as a position `ThrowExpr` rejects. Clojure 1.12 compiles it.

- **"`pull` over an empty table executes the struct read"**
  It looks like the one ungated site — `[:get_field :struct]` has no `.size` or index guard, and the driving row is real. But `pull` yields a null `p`, so `codegen-call*`'s null leg dispatches the read away. `(== p {:a 1, :b 2})` answering null on *matching* field sets is what proves it, since the mismatch short-circuit would have answered `false`.

- **"`:star` is a live counter-example"**
  Half right, and the interesting half. `ProjectionSpec$Star` really does produce `Struct{a: Nothing}` over non-null rows, so the `endStruct` invariant genuinely does not hold there. What closes it is unrelated to padding: the view has no positional `ValueReader`, so it cannot be read in place at all.

## Out of scope

One per remaining site that derives leg dispatch for itself.

- **`[:_patch :struct :struct]`** reads `(contains? r-types :null)` off `.getLegs`, so a zero-leg type takes the "cannot be null" branch. Wrong answer rather than a crash; unreachable today.
- **`codegen-and` / `codegen-or`** read nullability through `types/nullable-vec-type?`, same shape.
- **`[:get_field :struct]`** returns the bottom as its `:return-type` where `codegen-expr :variable` launders it to `:null`. Raised in review; left out because laundering is the *less* precise of the two answers, so "make them consistent" runs the wrong way.

All three ask what an expression's outward type should be over the bottom, which is #5871's question rather than this one's.

- **`RelationAsStructReader.valueReader()` returning a reader with no `pos`** is its own defect, filed separately. No plan is known to reach it, since a star column is materialised before an expression reads it.

## Test plan

Full `./gradlew test` green — every task executed, no failures, and the fault's error code appears nowhere in the output. Property tests aren't needed: this touches neither indexing, compaction nor GC.

- **Both struct comparison sites and `[:nth :list :int]` were reached by no test before this branch**
  So the tests construct the types by hand as well as reaching them through SQL and XTQL, and assert the premise — that the constructed type really is the bottom — so they cannot quietly stop covering anything if a producer changes.

- **The gates are tested as invariants, not only through the behaviour they enable**
  `StructVectorTest` walks both transitions on one vector: `writeNull()` leaves a child at `Nothing`, `endStruct()` moves it to `Null`. `ListVectorTest` pins that the first element written promotes off the bottom, which is what makes the `.size` gate exact.

- **Five cases come from #5968** and are kept so the two branches are comparable, with three corrections: an assertion on `execute-tx`'s non-existent `:error` key that could not fail, a `thrown? Exception` that would have passed on the regression it sits next to, and a test name stating #5968's semantics rather than what it verifies.
