### PR TITLE
fix(indexer): the leader attaches a database when it reads the record back

### DIFF
--- a/core/src/main/kotlin/xtdb/api/IngestNode.kt
+++ b/core/src/main/kotlin/xtdb/api/IngestNode.kt
@@ -73,6 +73,12 @@ class IngestNode internal constructor(
         override val txScoped = false
         override fun databaseOrNull(dbName: DatabaseName) = dbs[dbName]
 
+        override fun checkCanAttach(dbName: DatabaseName, config: Database.Config): Unit =
+            error("can't attach a database to an ingest node")
+
+        override fun checkCanDetach(dbName: DatabaseName): Unit =
+            error("can't detach a database from an ingest node")
+
         override fun attach(dbName: DatabaseName, config: Database.Config?): Unit =
             error("can't attach a database to an ingest node")
 

--- a/core/src/main/kotlin/xtdb/api/log/DbOp.kt
+++ b/core/src/main/kotlin/xtdb/api/log/DbOp.kt
@@ -4,6 +4,8 @@ import xtdb.database.Database
 import xtdb.database.DatabaseName
 
 sealed interface DbOp {
-    data class Attach(val dbName: DatabaseName, val config: Database.Config) : DbOp
-    data class Detach(val dbName: DatabaseName) : DbOp
+    val dbName: DatabaseName
+
+    data class Attach(override val dbName: DatabaseName, val config: Database.Config) : DbOp
+    data class Detach(override val dbName: DatabaseName) : DbOp
 }

--- a/core/src/main/kotlin/xtdb/database/Database.kt
+++ b/core/src/main/kotlin/xtdb/database/Database.kt
@@ -262,16 +262,7 @@ class Database(
             val indexerConfig = base.config.indexer
             val readOnly = dbConfig.isReadOnly
 
-            // Attach-time gate: the type signatures admit N throughout, but TableCatalog wrappers +
-            // UNION-at-scan (#5835) and xt.txs_$partition naming (#5836) haven't landed. Lifting
-            // this gate is #5837.
-            if (dbConfig.partitions > 1)
-                throw Incorrect(
-                    "multi-partition external-source databases are not yet enabled " +
-                            "(config declared partitions=${dbConfig.partitions})",
-                    "xtdb/multi-partition-not-yet-enabled",
-                    mapOf("db-name" to dbName, "partitions" to dbConfig.partitions)
-                )
+            dbConfig.checkValid(dbName)
 
             val allocator = open { base.allocator.newChildAllocator("database/$dbName", 0, Long.MAX_VALUE) }
 
@@ -480,6 +471,25 @@ class Database(
 
         val isReadOnly: Boolean get() = mode == Mode.READ_ONLY
 
+        /**
+         * Throw if this config can be rejected without opening anything.
+         *
+         * Attach decides a transaction's outcome from this, so it must reach the same verdict on every
+         * node: whether a database's storage or log can actually be reached is local to the node that
+         * tries, and a database the cluster agrees exists is one this node may still fail to open.
+         */
+        fun checkValid(dbName: DatabaseName) {
+            // The type signatures admit N throughout, but TableCatalog wrappers + UNION-at-scan (#5835)
+            // and xt.txs_$partition naming (#5836) haven't landed. Lifting this gate is #5837.
+            if (partitions > 1)
+                throw Incorrect(
+                    "multi-partition external-source databases are not yet enabled " +
+                            "(config declared partitions=$partitions)",
+                    "xtdb/multi-partition-not-yet-enabled",
+                    mapOf("db-name" to dbName, "partitions" to partitions)
+                )
+        }
+
         val serializedConfig: DatabaseConfig
             get() = DatabaseConfig.newBuilder()
                 .also { dbConfig ->
@@ -545,6 +555,12 @@ class Database(
 
                 override fun databaseOrNull(dbName: DatabaseName) = null
 
+                override fun checkCanAttach(dbName: DatabaseName, config: Config): Unit =
+                    error("can't attach database to empty db-cat")
+
+                override fun checkCanDetach(dbName: DatabaseName): Unit =
+                    error("can't detach database from empty db-cat")
+
                 override fun attach(dbName: DatabaseName, config: Config?): Unit =
                     error("can't attach database to empty db-cat")
 
@@ -589,6 +605,17 @@ class Database(
                     dbName to db.partitions.indices.map { db.sourceLog.latestSubmittedMsgId(it) }
                 }
             }.toMap()
+
+        /**
+         * Throw whatever [attach] would throw before it opens anything, leaving the catalog untouched.
+         *
+         * The leader resolves an attach into a committed or aborted tx and only mutates its own catalog
+         * when it reads that tx back, so the verdict has to be reachable without the mutation.
+         */
+        fun checkCanAttach(dbName: DatabaseName, config: Config)
+
+        /** [checkCanAttach]'s mirror. */
+        fun checkCanDetach(dbName: DatabaseName)
 
         fun attach(dbName: DatabaseName, config: Config?)
         fun detach(dbName: DatabaseName)

--- a/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
+++ b/core/src/main/kotlin/xtdb/database/DatabaseCatalog.kt
@@ -76,7 +76,7 @@ class DatabaseCatalog @JvmOverloads constructor(
 
     private val skipDbs: Set<String> get() = base.config.skipDbs
 
-    override fun attach(dbName: DatabaseName, config: Database.Config?) {
+    override fun checkCanAttach(dbName: DatabaseName, config: Database.Config) {
         when (entries[dbName]) {
             is Entry.Detaching -> throw Conflict(
                 "Database is still being detached — retry once the previous detach has completed",
@@ -90,7 +90,24 @@ class DatabaseCatalog @JvmOverloads constructor(
             null -> {}
         }
 
+        config.checkValid(dbName)
+    }
+
+    override fun checkCanDetach(dbName: DatabaseName) {
+        if (dbName == "xtdb")
+            throw Incorrect("Cannot detach the primary 'xtdb' database", "xtdb/cannot-detach-primary", mapOf("db-name" to dbName))
+
+        when (entries[dbName]) {
+            is Entry.Open, is Entry.Skipped -> {}
+
+            is Entry.Detaching, null ->
+                throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))
+        }
+    }
+
+    override fun attach(dbName: DatabaseName, config: Database.Config?) {
         val dbConfig = config ?: Database.Config()
+        checkCanAttach(dbName, dbConfig)
 
         if (dbName in skipDbs) {
             LOG.warn { "Skipping database '$dbName' (XTDB_SKIP_DBS) — database is dormant. Remove from XTDB_SKIP_DBS and restart to re-enable, or DETACH DATABASE to remove permanently." }
@@ -115,8 +132,7 @@ class DatabaseCatalog @JvmOverloads constructor(
     }
 
     override fun detach(dbName: DatabaseName) {
-        if (dbName == "xtdb")
-            throw Incorrect("Cannot detach the primary 'xtdb' database", "xtdb/cannot-detach-primary", mapOf("db-name" to dbName))
+        checkCanDetach(dbName)
 
         fun noSuchDb(): Nothing =
             throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to dbName))

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.channels.Channel
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
 import xtdb.api.DatabaseName
+import xtdb.api.error.Anomaly
+import xtdb.api.error.Fault
+import xtdb.api.log.DbOp
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.ReplicaMessage.BlockBoundary
@@ -16,6 +19,7 @@ import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.types.MessageId
 import xtdb.util.debug
+import xtdb.util.error
 import xtdb.util.logger
 import java.time.Duration
 import java.time.InstantSource
@@ -43,7 +47,7 @@ internal class LeaderLogProcessor(
 
     extSource: ExternalSource?,
     skipTxs: Set<MessageId>,
-    dbCatalog: Database.Catalog?,
+    private val dbCatalog: Database.Catalog?,
     private val leaderTerm: Long = 0,
     instantSource: InstantSource = InstantSource.system(),
     flushTimeout: Duration,
@@ -179,8 +183,11 @@ internal class LeaderLogProcessor(
                         "[$dbName] queue head ${head.txKey.txId} != consumed tx ${msg.txId}"
                     }
                     driver.applyTx(head.txKey, head.allTables.associate { it.ref to it.relation })
-                    // dbOp (attach/detach) was already applied on the resolve side (it had to run to
-                    // produce the tx result); the follower/transition apply it on consume-back, we don't.
+
+                    // Before the handle completes, so a caller that submitted an attach can use the
+                    // database as soon as its transaction returns.
+                    if (msg.committed) applyDbOp(msg.dbOp)
+
                     watchers.notifyApplied(record.msgId, head.srcMsgId, head.txResult, head.externalSourceToken)
                     head.pending?.complete(head.txResult)
                 } catch (e: Throwable) {
@@ -218,6 +225,37 @@ internal class LeaderLogProcessor(
 
             // Catalog already updated on the resolve side (see GarbageCollector.handleTask); nothing to do.
             is ReplicaMessage.TriesDeleted -> watchers.notifyApplied(record.msgId)
+        }
+    }
+
+    private fun applyDbOp(dbOp: DbOp?) {
+        // Only the primary carries a catalog, and a secondary's log can hold dbOps all the same: it was
+        // some other cluster's primary before it was attached here, and those are that cluster's to apply.
+        val dbCatalog = dbCatalog ?: return
+
+        try {
+            when (dbOp) {
+                is DbOp.Attach -> dbCatalog.attach(dbOp.dbName, dbOp.config)
+                is DbOp.Detach -> dbCatalog.detach(dbOp.dbName)
+                null -> {}
+            }
+        } catch (e: Anomaly.Caller) {
+            // A caller fault at resolution belongs to whoever submitted the attach, and aborts their
+            // transaction. The same failure here belongs to nobody: the transaction has committed, no
+            // caller is left to act on it, and nothing re-reads the instruction. So it is this node's
+            // fault, and it stops the database rather than being reported.
+            //
+            // Every refusal reaching here says this node disagrees with the log — including one that
+            // names a database it already holds, because holding the name says nothing about holding
+            // it under the config the log just carried.
+            //
+            // Carrying on is the worse option, not the safer one: a block records the whole secondary
+            // list and replaces the previous one, so the next boundary would erase a database this node
+            // merely failed to open, for the entire cluster.
+            throw Fault(
+                "[$dbName] could not apply $dbOp", "xtdb/db-op-not-applied",
+                mapOf("db-name" to dbName, "db-op" to dbOp.toString()), e
+            )
         }
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
+++ b/core/src/main/kotlin/xtdb/indexer/ResolvedTx.kt
@@ -46,7 +46,7 @@ class ResolvedTx private constructor(
     val txResult: TransactionResult,
     val externalSourceToken: ExternalSourceToken?,
     val pending: CompletableDeferred<TransactionResult>?,
-    private val dbOp: DbOp?,
+    val dbOp: DbOp?,
     private val tables: Map<TableRef, Table>,
 ) : AutoCloseable {
 

--- a/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/SourceLogProcessor.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.selects.SelectBuilder
 import xtdb.api.DatabaseName
 import xtdb.api.TransactionResult
 import xtdb.api.error.Anomaly
+import xtdb.api.error.Conflict
+import xtdb.api.error.NotFound
 import xtdb.api.log.DbOp
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
@@ -92,6 +94,28 @@ internal class SourceLogProcessor(
         resumeCh.trySend(Unit)
     }
 
+    /**
+     * Ask whether a dbOp will be accepted, without performing it — null if it will.
+     *
+     * A caller fault resolves as an aborted tx carrying that error, so the log records the refusal and
+     * every node reaches the same verdict from it. Anything else is ours, and fails the term.
+     */
+    // The catalog is mutated when a record is read back, so it shows the state before every dbOp this
+    // term has queued. The last one queued for a name says what will be there when this op applies; with
+    // none, the catalog's own state stands. Same layering as `resolvedTxs`, read for the catalog.
+    private inline fun checkDbOp(
+        msgId: MessageId, op: String, opDbName: DatabaseName, check: (Database.Catalog) -> Unit,
+    ): Anomaly.Caller? =
+        dbCatalog?.let { dbCatalog ->
+            try {
+                check(dbCatalog)
+                null
+            } catch (e: Anomaly.Caller) {
+                LOG.debug(e) { "[$dbName] leader: $op database '$opDbName' refused at $msgId" }
+                e
+            }
+        }
+
     // Resolve one source-log record, answering whether it cut a block.
     private suspend fun handleRecord(record: Log.Record<SourceMessage>): Boolean {
         val msgId = record.msgId
@@ -116,15 +140,19 @@ internal class SourceLogProcessor(
             }
 
             is SourceMessage.AttachDatabase -> {
-                val error = if (dbCatalog != null) {
-                    try {
-                        dbCatalog.attach(msg.dbName, msg.config)
-                        null
-                    } catch (e: Anomaly.Caller) {
-                        LOG.debug(e) { "[$dbName] leader: attach database '${msg.dbName}' failed at $msgId" }
-                        e
+                val error = checkDbOp(msgId, "attach", msg.dbName) {
+                    when (txResolver.stagedDbOp(msg.dbName)) {
+                        is DbOp.Attach ->
+                            throw Conflict("Database already exists", "xtdb/db-exists", mapOf("db-name" to msg.dbName))
+
+                        is DbOp.Detach -> throw Conflict(
+                            "Database is still being detached — retry once the previous detach has completed",
+                            "xtdb/db-being-detached", mapOf("db-name" to msg.dbName)
+                        )
+
+                        null -> it.checkCanAttach(msg.dbName, msg.config)
                     }
-                } else null
+                }
 
                 appendTx(
                     if (error == null)
@@ -135,15 +163,18 @@ internal class SourceLogProcessor(
             }
 
             is SourceMessage.DetachDatabase -> {
-                val error = if (dbCatalog != null) {
-                    try {
-                        dbCatalog.detach(msg.dbName)
-                        null
-                    } catch (e: Anomaly.Caller) {
-                        LOG.debug(e) { "[$dbName] leader: detach database '${msg.dbName}' failed at $msgId" }
-                        e
+                val error = checkDbOp(msgId, "detach", msg.dbName) {
+                    when (txResolver.stagedDbOp(msg.dbName)) {
+                        // The primary is always held, so it never has one of these; anything that does
+                        // will be there to detach by the time this op is applied.
+                        is DbOp.Attach -> {}
+
+                        is DbOp.Detach ->
+                            throw NotFound("Database does not exist", "xtdb/no-such-db", mapOf("db-name" to msg.dbName))
+
+                        null -> it.checkCanDetach(msg.dbName)
                     }
-                } else null
+                }
 
                 appendTx(
                     if (error == null)

--- a/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TxResolver.kt
@@ -132,6 +132,15 @@ internal class TxResolver(
     /** Queued predecessors for resolution layering (read-your-writes), oldest→newest. */
     private val resolvedTxs: List<ResolvedTx> get() = queue.toList()
 
+    /**
+     * The last dbOp queued against [dbName], if any — the same layering as [resolvedTxs], read for the
+     * database catalog rather than for tables.
+     *
+     * The catalog is mutated when a record is read back, so it still shows the state before everything
+     * queued here, and a resolving dbOp that consulted it alone would not see the term's own.
+     */
+    fun stagedDbOp(dbName: DatabaseName): DbOp? = queue.lastOrNull { it.dbOp?.dbName == dbName }?.dbOp
+
     /** Remove and return the head (oldest) tx; ownership passes to the caller, which imports then closes it. */
     fun removeHead(): ResolvedTx = queue.removeFirst()
 

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -39,6 +39,8 @@ import xtdb.block.proto.TableBlock
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
+import xtdb.api.DatabaseName
+import xtdb.database.Database
 import xtdb.database.DatabaseLogs
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
@@ -127,6 +129,8 @@ class LeaderLogProcessorTest {
         extSource: ExternalSource = mockk(relaxed = true),
         skipTxs: Set<MessageId> = emptySet(),
         leaderTerm: Long = 1,
+        // A leader may only hold one if it is the primary's, so supplying one names this database 'xtdb'.
+        dbCatalog: Database.Catalog? = null,
         wrapDriver: (LeaderDriver) -> LeaderDriver = { it },
         termJob: Job = SupervisorJob(backgroundScope.coroutineContext.job),
     ): LeaderLogProcessor {
@@ -147,12 +151,175 @@ class LeaderLogProcessorTest {
             partitionStorage, replicaAppender, watchers,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-                partitionState, "test", driver, watchers, replicaAppender, extSource,
-                skipTxs = skipTxs, dbCatalog = null,
+                partitionState, if (dbCatalog != null) "xtdb" else "test",
+                driver, watchers, replicaAppender, extSource,
+                skipTxs = skipTxs, dbCatalog = dbCatalog,
                 leaderTerm = leaderTerm,
                 flushTimeout = IndexerConfig().flushDuration,
             )
         )
+    }
+
+    // Records what was asked of it, so a test can ask what this node's set holds rather than what was
+    // called. Nothing here opens a database, so a name is attached the moment it is asked for.
+    private class RecordingDbCatalog : Database.Catalog {
+        val attached = mutableListOf<DatabaseName>()
+
+        override val databaseNames get() = attached.toSet()
+        override val txScoped = false
+        override fun databaseOrNull(dbName: DatabaseName): Database? = null
+
+        override fun checkCanAttach(dbName: DatabaseName, config: Database.Config) {}
+        override fun checkCanDetach(dbName: DatabaseName) {}
+
+        override fun attach(dbName: DatabaseName, config: Database.Config?) {
+            attached += dbName
+        }
+
+        override fun detach(dbName: DatabaseName) {
+            attached -= dbName
+        }
+    }
+
+    @Test
+    fun `an attach is applied when its record is read back, not when it resolves`() = runTest(timeout = 5.seconds) {
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+        val dbCatalog = RecordingDbCatalog()
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler),
+            watchers = watchers,
+            dbCatalog = dbCatalog,
+            wrapDriver = { gatedDriver(it, gate, appendStarted) },
+        )
+
+        backgroundScope.launch {
+            lp.srcLogProc.processRecords(
+                listOf(
+                    Log.Record(
+                        0, 0, Instant.now(),
+                        SourceMessage.AttachDatabase("new_db", Database.Config())
+                    )
+                )
+            )
+        }
+
+        appendStarted.await()
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(
+            emptyList<DatabaseName>(), dbCatalog.attached,
+            "resolved but not yet durable — a term that is superseded here must not have attached anything"
+        )
+
+        gate.complete(Unit)
+        watchers.awaitTx(0)
+
+        assertEquals(listOf("new_db"), dbCatalog.attached, "consume-back is what attaches it")
+    }
+
+    @Test
+    fun `a second attach resolved before the first is read back is refused`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+        // Refuses nothing, so a refusal here can only have come from the resolver's own queued dbOps.
+        val dbCatalog = RecordingDbCatalog()
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler),
+            replicaLog = replicaLog, watchers = watchers, dbCatalog = dbCatalog,
+            wrapDriver = { gatedDriver(it, gate, appendStarted) },
+        )
+
+        backgroundScope.launch {
+            lp.srcLogProc.processRecords(
+                (0L..1L).map {
+                    Log.Record(0, it, Instant.now(), SourceMessage.AttachDatabase("new_db", Database.Config()))
+                }
+            )
+        }
+
+        appendStarted.await()
+        testScheduler.advanceUntilIdle()
+
+        gate.complete(Unit)
+        watchers.awaitTx(1)
+
+        val resolvedTxs = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
+            .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
+
+        assertEquals(listOf(true, false), resolvedTxs.map { it.committed })
+        assertEquals(listOf("new_db"), dbCatalog.attached, "only the first attach reaches the catalog")
+    }
+
+    @Test
+    fun `a detach of a name attached but not yet read back is allowed`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+        val dbCatalog = RecordingDbCatalog()
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler),
+            replicaLog = replicaLog, watchers = watchers, dbCatalog = dbCatalog,
+            wrapDriver = { gatedDriver(it, gate, appendStarted) },
+        )
+
+        backgroundScope.launch {
+            lp.srcLogProc.processRecords(
+                listOf(
+                    Log.Record(0, 0, Instant.now(), SourceMessage.AttachDatabase("new_db", Database.Config())),
+                    Log.Record(0, 1, Instant.now(), SourceMessage.DetachDatabase("new_db")),
+                )
+            )
+        }
+
+        appendStarted.await()
+        gate.complete(Unit)
+        watchers.awaitTx(1)
+
+        val resolvedTxs = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
+            .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
+
+        assertEquals(listOf(true, true), resolvedTxs.map { it.committed })
+        assertEquals(emptyList<DatabaseName>(), dbCatalog.attached, "attached, then detached")
+    }
+
+    @Test
+    fun `a second detach resolved before the first is read back is refused`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val gate = CompletableDeferred<Unit>()
+        val appendStarted = CompletableDeferred<Unit>()
+        val dbCatalog = RecordingDbCatalog()
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler),
+            replicaLog = replicaLog, watchers = watchers, dbCatalog = dbCatalog,
+            wrapDriver = { gatedDriver(it, gate, appendStarted) },
+        )
+
+        backgroundScope.launch {
+            lp.srcLogProc.processRecords(
+                (0L..1L).map {
+                    Log.Record(0, it, Instant.now(), SourceMessage.DetachDatabase("new_db"))
+                }
+            )
+        }
+
+        appendStarted.await()
+        gate.complete(Unit)
+        watchers.awaitTx(1)
+
+        val resolvedTxs = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
+            .mapNotNull { it.message as? ReplicaMessage.ResolvedTx }.toList()
+
+        assertEquals(listOf(true, false), resolvedTxs.map { it.committed })
     }
 
     // Decorate a driver so its replica-log append blocks on [gate] before the message lands, completing

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -925,16 +925,24 @@ rule LeaderProcessesTx {
 }
 
 rule LeaderProcessesAttachDb {
-    -- The catalog mutation happens EAGERLY, here on the resolve side, because it has to
-    -- run to produce the tx result at all. A caller-fault failure is resolved as a FAILED
-    -- dbOp tx rather than propagating: the transaction aborts with that error, and the log
-    -- carries the abort. The leader then SKIPS the dbOp on its own consume-back (the
-    -- catalog is already mutated); followers and the transition processor apply it there.
+    -- The leader asks whether the attach would be refused, and brings its own set into line
+    -- when it reads the record back, as every other node does. A term superseded between
+    -- resolving an attach and consuming it back has therefore attached nothing.
+    --
+    -- The verdict accounts for what this term has already resolved as well as for the
+    -- catalog, which shows the state before every dbOp still queued on the resolver. The
+    -- last one queued for a name says what will be there when this attach applies; with
+    -- none, the catalog's own state stands. This is the layering a resolving transaction
+    -- reads its own queued predecessors through, turned on the catalog rather than on
+    -- tables.
+    --
+    -- A caller fault is resolved as a FAILED dbOp tx rather than propagating: the
+    -- transaction aborts with that error, and the log carries the abort.
     when: SourceAttachDbMessageReceived(msg)
     requires: log_processor.mode = Leader
 
     ensures:
-        let error = ApplyAttachToCatalog(msg.db_name, msg.config)
+        let error = CheckCanAttach(msg.db_name, msg.config)
         let resolved =
             if error = null:
                 ResolveDbOp(tx_resolver, msg, Attach{db_name: msg.db_name, config: msg.config})
@@ -949,7 +957,7 @@ rule LeaderProcessesDetachDb {
     requires: log_processor.mode = Leader
 
     ensures:
-        let error = ApplyDetachToCatalog(msg.db_name)
+        let error = CheckCanDetach(msg.db_name)
         let resolved =
             if error = null:
                 ResolveDbOp(tx_resolver, msg, Detach{db_name: msg.db_name})
@@ -1157,9 +1165,9 @@ rule LeaderAppliesOwnTx {
     -- watchers are notified here, and an external-source caller's durability handle
     -- completes here — after, not before, the tx is durable.
     --
-    -- The dbOp (attach/detach) is NOT applied here: it was applied eagerly on the resolve
-    -- side, because it had to run to produce the tx result. Followers and the transition
-    -- processor do apply it on their consume-back.
+    -- The dbOp (attach/detach) it carries is applied here, as a follower applies it on its
+    -- own consume-back — before the durability handle completes, so a caller that submitted
+    -- an attach can use the database the moment its transaction returns.
     when: ApplyOwnRecord(record)
     requires: record.kind = ResolvedTxMessage
 
@@ -1176,6 +1184,8 @@ rule LeaderAppliesOwnTx {
         -- needs no re-materialisation. The two agree by construction — the head is what was
         -- stamped onto the record at append time.
         ApplyResolvedTx(tx_resolver, head)
+        if record.committed and record.db_op != null:
+            ApplyDbOpToCatalog(database.catalog, record.db_op)
         watchers.notifyTx(head.tx_result, head.src_msg_id, head.external_source_token)
 }
 
@@ -1683,16 +1693,25 @@ deferred ResolveExternalSourceTx     -- tx_resolver.indexTx(msg, srcMsgId): assi
                                      -- greater than the previous tx's, run the caller's writer against a
                                      -- fresh OpenTx, and stage the result with the caller's durability
                                      -- handle. See: live-index.allium CommitTransaction
-deferred ResolveDbOp                 -- tx_resolver.indexDbOp: resolve an attach/detach whose catalog
-                                     -- mutation has already succeeded, as a ResolvedTx carrying the dbOp
-deferred ResolveFailedDbOp           -- tx_resolver.indexFailedDbOp: resolve an attach/detach whose catalog
-                                     -- mutation failed with a caller fault, as an ABORTED ResolvedTx
-                                     -- carrying that error
-deferred ApplyAttachToCatalog        -- dbCatalog.attach(dbName, config), returning the caller fault if it
-                                     -- failed. Runs on the resolve side, before the tx is resolved.
-                                     -- See: database-lifecycle.allium AdmitInstructionCreatesEntry
-deferred ApplyDetachToCatalog        -- dbCatalog.detach(dbName), as above.
-                                     -- See: database-lifecycle.allium RemoveBeginsTeardown
+deferred ResolveDbOp
+  -- Resolve an attach or detach as a ResolvedTx carrying the dbOp, for the catalog to be brought into
+  -- line with when the record is read back.
+deferred ResolveFailedDbOp
+  -- Resolve an attach or detach that would be refused, as an ABORTED ResolvedTx carrying the caller
+  -- fault that refused it.
+deferred CheckCanAttach
+  -- Whether an attach would be refused, and with which caller fault.
+  -- Answered from the catalog's own records folded together with the dbOps the resolver still holds:
+  -- the last one queued for a name says what will be there when this attach applies, and with none the
+  -- catalog's own records stand.
+  -- Reaches its verdict without changing anything.
+deferred CheckCanDetach
+  -- Whether a detach would be refused, answered the same way.
+deferred ApplyDbOpToCatalog
+  -- Bring the catalog into line with a committed dbOp, swallowing a caller fault: the transaction has
+  -- already committed, so a node that cannot carry the instruction out holds none of a database the
+  -- cluster agrees exists.
+  -- See: database-lifecycle.allium AdmitInstructionCreatesEntry, RemoveBeginsTeardown
 deferred TakeResolvedHead            -- tx_resolver.removeHead(): remove and return the OLDEST staged tx,
                                      -- passing ownership to the caller — which must then import it and
                                      -- close it, or fail its durability handle and free it, on every path.


### PR DESCRIPTION
Part of #5917.

## tl;dr

- **A leader that resolved an `ATTACH DATABASE` and was superseded before reading its own record back had already attached the database.** The catalog mutation now happens on consume-back, where a follower has always done it, so a term that never became durable leaves nothing behind.

- **Attach and detach error semantics are unchanged.** `xtdb/db-exists`, `xtdb/no-such-db`, `xtdb/db-being-detached` and `xtdb/cannot-detach-primary` are raised in the same circumstances as before, and the existing SQL tests pass untouched.

- **A refusal arriving at the apply side is now a `Fault` and stops the database.** It has nowhere else to go: the transaction has already committed. Previously it was swallowed and logged.

- **One thing changes for a user**: a config that only fails once something is opened — unreachable storage, a bad log config — no longer aborts the transaction. It stops the node that hit it instead.

## Context

The leader mutated its own `DatabaseCatalog` on the resolve side, because whether `attach` threw was what decided the transaction's outcome: succeed and resolve a committed tx carrying the dbOp, throw a caller fault and resolve an aborted one carrying that error.

That made the mutation outlive the transaction it belonged to. A leader resolves, appends, and learns the record is durable by reading it back — and between those two points it can be fenced by a newer leader. Under the old arrangement it has already attached the database, keeps holding it after it stops being the leader, and the transaction it did that for never committed anywhere.

This matters more under #5917 than it did before. With leadership elected from the replica log rather than held by a consumer group, being superseded mid-term is an ordinary event rather than a rare one, so resolve-side effects that outlive a term stop being a theoretical concern.

## What landed

- **The catalog is brought into line on consume-back.**
  Before the durability handle completes, so a caller that submitted an attach can use the database as soon as its transaction returns.

- **The resolve side asks rather than acts — and has to account for what it has already resolved.**
  Because the catalog no longer moves at resolve time, it shows the state before every dbOp the term has queued but not yet read back. `TxResolver.stagedDbOp` reads the last one queued against a name, and the check folds that together with the catalog's own verdict. Without it, two attaches of one name resolved in that window would both find the name free and the second would report success having done nothing.

- **That fold is the layering the resolver already provides, pointed somewhere new.**
  `TxResolver.resolvedTxs` hands a resolving transaction its own queued predecessors so it can read its own writes. `stagedDbOp` is the same read of the same queue, for the database catalog rather than for tables — which is why it needs no state of its own, no seeding at term start and no clearing at term end. The queue drains exactly as the ops apply.

- **The refusals themselves did not move.**
  `checkCanAttach` and `checkCanDetach` are `attach` and `detach`'s own preconditions, lifted so they can be asked without the mutation and then called by the mutating paths, so there is still one definition of each. `Config.checkValid` is the part of config validation that is decidable without opening anything, extracted from `Database.open` and called by both.

- **A refusal at the apply side is a `Fault`.**
  The same failure means different things at the two ends. At resolution it belongs to whoever submitted the attach, and aborts their transaction. By consume-back the transaction has committed, no caller is left to act on it, and nothing re-reads the instruction — so every refusal arriving there says this node disagrees with the log, and it stops the database rather than being logged. There is deliberately no quiet path, including for a refusal naming a database the node already holds: holding the name says nothing about holding it under the config the log just carried.

  Carrying on is the worse option rather than the safer one. A block records the whole secondary database list and replaces the previous one, so a name the leader does not hold is erased rather than skipped — meaning a leader that merely failed to open a database would delete it for the entire cluster at the next boundary.

## Alternatives considered

- **Make attach and detach idempotent — attach-if-not-exists, detach-if-exists.**
  Built, then backed out. It looked right because it removes the resolve-side/apply-side disagreement by removing the thing being disagreed about, and it matches the framing in `database-lifecycle.allium` where attach and detach are cluster-wide instructions each node applies independently. It costs `xtdb/db-exists` and `xtdb/no-such-db` as errors a submitter can see, and it needs the three refusal rules in `database-lifecycle.allium` rewritten — a file with a substantial rework in flight. Rejected once it was clear the verdict is decidable after all: the catalog's state plus every op queued since, last one winning, determines it exactly.

- **Reserve the name at resolve time and open the database at apply time.**
  Splits the work along the HOLD / MEMBER / RUN axes the lifecycle spec already names, and would close the membership hazard below as a side effect. Rejected for now because it needs a fourth held-only entry state — the mirror of `detaching` — plus reservation cleanup on term teardown, in the same file that is being reworked.

- **Hold a separate resolve-side catalog or config map.**
  A second account of the same facts, needing seeding at term start and clearing at term end. `dev/CODING.adoc` names the shape: a side-map alongside the objects it describes is a second source of truth, and it drifts. The resolver queue already carries the dbOps.

- **Share the apply path with the follower as one function.**
  Written, then withdrawn. It bought about a dozen lines of deduplication and cost a file whose only inhabitant had no class to take a logger from, a log message generic enough to serve two roles that want to name themselves, and a change to a role this PR otherwise does not touch. `FollowerLogProcessor` is byte-identical to `main`.

## Out of scope

- **Membership is still derived from what a node managed to open.**
  A block records the whole secondary database list and replaces the previous one, so an entry a node does not hold is erased rather than skipped. Faulting stops a leader reaching the next boundary in that state, which is why this PR does it — but it is containment, not a fix. The underlying conflation is `MEMBER` versus `RUN`, which the lifecycle spec separates in prose and the catalog does not separate in code.

- **The follower still swallows an apply-side refusal and logs it at debug.**
  Unchanged upstream behaviour. The asymmetry is defensible — a follower's omission degrades that node, a leader's erases the database — but it deserves its own look, in a file that a separate in-flight change also touches.

## Test plan

- Four new tests in `LeaderLogProcessorTest`, all driving a gated replica-log append so the record cannot be read back on demand:
  - `an attach is applied when its record is read back, not when it resolves` — the catalog stays empty while the append is held, and gains the database once it lands.
  - `a second attach resolved before the first is read back is refused` — the catalog stand-in refuses nothing, so the refusal can only have come from the resolver queue. Asserts one committed and one aborted tx on the replica log, and one attach reaching the catalog.
  - `a detach of a name attached but not yet read back is allowed` — covers the branch where the fold deliberately skips the catalog check.
  - `a second detach resolved before the first is read back is refused`.

- The existing SQL coverage is unchanged and passing, which is the check that the error semantics really did stay put — `disallow-duplicate-db-names` and `double-detach-does-not-halt-node` in particular.

- Run locally on an earlier revision of this branch: `xtdb.indexer.*` and `xtdb.database.*` (71), `xtdb.sql.multi_db_test` and `xtdb.database_test` (20), `LogProcessorSimTest` and `LeaderDriverSimTest` (401) — 492 tests, no failures. The final two commits' worth of changes (the fault, and inlining the shared apply) are compile-verified locally and left to CI.
