### PR TITLE
fix(types): the lattice bottom survives a merge

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -523,10 +523,6 @@
                                     :or {extract-vecs-from-rel? true}}]
   (let [return-type (or (get var-types variable)
                         (throw (AssertionError. (str "unknown variable: " variable))))
-        ;; `Nothing` is the catalog's lattice bottom for a declared-but-valueless column; when such a
-        ;; column is read in a query its rows are simply null, so the EE treats it as `:null` and never
-        ;; needs `:nothing` call definitions (Nothing's empty legs would otherwise collapse codegen).
-        return-type (if (= return-type VectorType$Nothing/INSTANCE) #xt/type :null return-type)
         var-rdr-sym (gensym (util/symbol->normal-form-symbol variable))]
 
     ;; NOTE: when used from metadata exprs, incoming vectors might not exist

--- a/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
+++ b/core/src/main/kotlin/xtdb/arrow/MergeTypes.kt
@@ -56,7 +56,8 @@ data class MergeTypes(
             val listyTypes = listyTypes .map { (arrowType, el) -> Listy(arrowType, el.asType) }
             val structType = structKeys?.let { structOf(it.mapValues { e -> e.value.asType }) }
 
-            return fromLegs(scalars + listyTypes + listOfNotNull(structType, nullType))
+            val legs = scalars + listyTypes + listOfNotNull(structType, nullType)
+            return if (legs.isEmpty()) Nothing else fromLegs(legs)
         }
 
     companion object {
@@ -66,19 +67,6 @@ data class MergeTypes(
         private val cache = Caffeine.newBuilder()
             .maximumSize(4096)
             .build<Set<VectorType>, VectorType> { mergeTypes0(it) }
-
-        /**
-         * [mergeTypes] with `Nothing` restored as the identity.
-         *
-         * `⊔` is not idempotent at the bottom today - `mergeTypes(Nothing, Nothing)` returns `Null` (#5871) -
-         * so a join over sources that all have nothing to say reports a dataless column as nullable. Both the
-         * read path and the block merge need the law to hold, hence one repair rather than a copy at each.
-         *
-         * Delete this and call [mergeTypes] directly once `fromLegs(∅)` returns the bottom.
-         */
-        @JvmStatic
-        fun joinContributions(types: Collection<VectorType>): VectorType =
-            if (types.all { it == Nothing }) Nothing else mergeTypes(types)
 
         /**
          * A source with nothing to say contributes [VectorType.Nothing], the lattice bottom - never a Kotlin

--- a/core/src/main/kotlin/xtdb/arrow/NullVector.kt
+++ b/core/src/main/kotlin/xtdb/arrow/NullVector.kt
@@ -26,6 +26,10 @@ class NullVector(
     // from polluting to Maybe on its first insert: Nothing ⊔ I64 = I64, whereas Null ⊔ I64 = Maybe(I64).
     override val type get() = if (nullable) Null else Nothing
 
+    /**
+     * Answers for the `Null` reading. A `Nothing`-typed vector (see [type]) has no defined cells, so this
+     * is vacuous there rather than a claim that reading the bottom yields null - the bottom is not read.
+     */
     override fun isNull(idx: Int) = true
 
     override fun writeUndefined() {

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -15,7 +15,7 @@ import xtdb.api.log.LeaderTerm
 import xtdb.api.storage.ObjectStore
 import xtdb.api.tx.BlockDetails
 import xtdb.api.tx.ExternalSourceToken
-import xtdb.arrow.MergeTypes.Companion.joinContributions
+import xtdb.arrow.MergeTypes.Companion.mergeTypes
 import xtdb.arrow.VectorType
 import xtdb.arrow.VectorType.Companion.asType
 import xtdb.arrow.VectorType.Companion.field
@@ -396,7 +396,7 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
                     val newAbsent = VectorType.absentContribution(new)
 
                     (old.keys + new.keys).associateWith { col ->
-                        joinContributions(listOf(old[col] ?: oldAbsent, new[col] ?: newAbsent))
+                        mergeTypes(listOf(old[col] ?: oldAbsent, new[col] ?: newAbsent))
                     }
                 }
             }

--- a/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
+++ b/core/src/main/kotlin/xtdb/indexer/Snapshot.kt
@@ -2,7 +2,7 @@ package xtdb.indexer
 
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.api.TransactionKey
-import xtdb.arrow.MergeTypes.Companion.joinContributions
+import xtdb.arrow.MergeTypes.Companion.mergeTypes
 import xtdb.arrow.VectorType
 import xtdb.catalog.TableCatalog
 import xtdb.indexer.LiveTable.Companion.logRelTypes
@@ -80,7 +80,7 @@ class Snapshot(
         val supersededAbsent = superseded?.let { VectorType.absentContribution(it) } ?: VectorType.Nothing
 
         return cols.associateWith { col ->
-            joinContributions(
+            mergeTypes(
                 liveSnaps.map { it.contributedType(col) }
                         + (superseded?.get(col) ?: supersededAbsent)
                         + tableCatSnap.contributedType(table, col)

--- a/core/src/test/kotlin/xtdb/arrow/RelationTest.kt
+++ b/core/src/test/kotlin/xtdb/arrow/RelationTest.kt
@@ -264,4 +264,16 @@ class RelationTest {
             assertEquals(rows, rel.toMaps(SNAKE_CASE_STRING))
         }
     }
+
+    // xtdb.expression emits a read that faults on a bottom-typed column, relying on this to keep it
+    // unreachable - so a change to this padding is not a local change (#5948).
+    @Test
+    fun `endRows takes a short column off the lattice bottom`() {
+        Relation(allocator, listOf(NullVector("a", false)), 0).use { rel ->
+            assertEquals(VectorType.Nothing, rel["a"].type)
+
+            rel.endRows(1)
+            assertEquals(VectorType.Null, rel["a"].type, "padding writes a real null")
+        }
+    }
 }

--- a/core/src/test/kotlin/xtdb/types/MergeTypesTest.kt
+++ b/core/src/test/kotlin/xtdb/types/MergeTypesTest.kt
@@ -24,7 +24,7 @@ class MergeTypesTest {
 
     @Test
     fun `test basic mergeTypes`() {
-        assertEquals(Null, mergeTypes())
+        assertEquals(Nothing, mergeTypes())
 
         assertEquals(UTF8, mergeTypes(UTF8, UTF8), "Same types merge ofType themselves")
 
@@ -185,7 +185,7 @@ class MergeTypesTest {
     fun `test Nothing is the lattice bottom`() {
         assertEquals(I64, mergeTypes(Nothing, I64), "Nothing widens to the first type it meets - I64, not Maybe(I64)")
         assertEquals(Null, mergeTypes(Nothing, Null), "Nothing merged with Null is Null")
-        assertEquals(Null, mergeTypes(Nothing), "Nothing alone collapses like an empty merge")
+        assertEquals(Nothing, mergeTypes(Nothing), "Nothing alone is the identity")
         assertEquals(I64, mergeTypes(Nothing, I64, Nothing), "Nothing is absorbed regardless of position")
 
         assertEquals(Null, maybe(Nothing), "making the bottom nullable yields Null")

--- a/src/test/kotlin/xtdb/InProcessAdbcTest.kt
+++ b/src/test/kotlin/xtdb/InProcessAdbcTest.kt
@@ -1040,9 +1040,8 @@ class InProcessAdbcTest {
     }
 
     /**
-     * `[:list :null]` rather than the more accurate `[:list :nothing]` is #5871 — `mergeTypes` rewrites a
-     * nested lattice bottom. What this pins is that all three surfaces say the *same* thing; the value they
-     * agree on gets more accurate when that lands.
+     * All three surfaces say the same thing, and it is the accurate one: an empty list constrains its
+     * element type not at all, so `[:list :nothing]` rather than `[:list :null]`.
      */
     @Test
     fun `an empty list column reports the same type on every surface`() {
@@ -1059,7 +1058,7 @@ class InProcessAdbcTest {
             }
         }
 
-        assertEquals("[:list :null]", infoSchema, "information_schema must agree with both")
+        assertEquals("[:list :nothing]", infoSchema, "information_schema must agree with both")
     }
 
     @Test


### PR DESCRIPTION
Resolves #5871. Unblocked by #5969, which shipped the prerequisite this card was waiting on.

## tl;dr

- **`Nothing ⊔ Nothing` answered `Null`, so `mergeTypes` silently rewrote every nested lattice bottom**
  An empty list literal was enough: `Listy(Nothing)` came back as `Listy(Null)`, which asserts a list whose elements *are* null rather than a list that says nothing about its elements. It also broke the law one level down — `[] ++ [1]` wants `[i64]`, which needs `Nothing ⊔ I64 = I64`, not `Null ⊔ I64 = Maybe(I64)`.

- **Three surfaces disagreed about the same column on `main`, and now agree on the accurate answer**
  `getTableSchema` said `Nothing`, the query result schema said `Null`, `information_schema` said `:nothing`. All three now say the bottom.

- **Three sites laundered the bottom out of a type; all three go**
  `fromLegs(∅)` via `asType`, `joinContributions`, and `codegen-expr :variable`'s `Nothing → :null` rewrite. Each was a workaround for a rule that did not exist until #5969 supplied it.

## Context

Attempted under #5855 and backed out: making the merge honest turns an empty list literal into `Listy(Nothing)`, and list-comparison codegen could not read one — `test-list-equal` and `test-list-diff` died on a nil `->call-code`. #5948 owned that defect and #5969 fixed it, by making a read of a zero-leg type a **defined error** rather than a value. Those two tests are the canaries and they stay green.

## Implementation

- **`MergeTypes.asType` returns the bottom for an empty accumulator; `fromLegs` is untouched**
  Three unrelated questions reach `fromLegs`' `0 -> Null` branch, one of them the deliberate unknown-parameter marker (`Xtdb.kt:384`, `TxWriter.kt:30`, named as such at `pgwire.clj:776`). Changing it there would silently retype every unknown prepared-statement parameter to something that is not a `Mono` and cannot be a union leg.

- **`joinContributions` deleted, both call sites redirected**
  Its own kdoc: *"Delete this and call `mergeTypes` directly once `fromLegs(∅)` returns the bottom."* It restored the identity at the bottom for the two callers that could not tolerate the damage, so `TableCatalog` and `Snapshot` get the same answer from `mergeTypes` — the whole of the observable change is nested.

- **`codegen-expr :variable`'s rewrite deleted, with the invariant it relied on pinned**
  Measured before removing it, by replacing its result with a throw: it **is** reached — five tests, on `_id` and `email`, all predicates against tables with no put rows — and it has no behavioural effect, because `Relation.endRows` pads every column with `writeNull()`, which is the one call that flips a vector off the bottom. A bottom-typed column and a populated relation are mutually exclusive. `RelationTest` now pins that, alongside the equivalents `StructVector.endStruct` and list element promotion already had.

- **`NullVector.isNull`'s kdoc says who it answers for**
  It returns `true` unconditionally for both types the class backs, and that has already been mined once for the wrong rule — that `Null` and `Nothing` agree on what a read yields. They do not; the bottom has no cells to ask about.

## Two consequences, neither a regression

- **Expressions over never-written columns advertise the bottom rather than `Null`**
  `codegen-call*`'s leg product collapses to empty, and `nullable-vec-type?` answers false for zero legs, so `AND`/`OR` declare `:bool` rather than `[:? :bool]`. Over empty result sets, and ADBC-visible only — `Null` and `Nothing` share `PgType.Null` and OID 25, so pgwire is unaffected. It is the same direction as the rest of this PR: report the bottom honestly.

- **It makes #5954's `AND`/`OR` case reachable, which that card records as latent**
  The consequence there is the type narrowing above, not a wrong value: since #5969 the operand read emits a fault rather than reading as `false`. Recorded on #5954.

## Out of scope

- **`information_schema.is_nullable` for a declared column** — descriptive (*have nulls been observed*) versus prescriptive (*can this hold NULL*). Deliberate since `519b33937` and pinned in `create_table_test.clj` and `metabase_test.clj`; untouched here, and those pins hold.
- **The `fromLegs()` unknown-parameter marker** — changeable now in principle, a separate question, and probably better left as `Null`.
- **#5954's two sites** — the half of this family that answers rather than failing.

## Test plan

Full `./gradlew test --rerun-tasks --continue` green: 2,258 tests across 215 result files, every task executed, and `zero-leg-read` appears nowhere.

- **Reading the commits in order gives a green run at each rung** — the merge fix alone was run before the laundering deletion was added, so neither is carried by the other.
- **`test-list-equal` and `test-list-diff`** — the canaries #5855 tripped over.
- **`declared-column-widens-cleanly` and `declared-columns-survive-block-flush`** — the `is_nullable` and `data_type` pins.
- **`an empty list column reports the same type on every surface`** — its expectation moves to `[:list :nothing]`, the change its own kdoc anticipated.
- **`endRows takes a short column off the lattice bottom`** — new, and what the laundering deletion rests on.
