### PR TITLE
refactor(indexer): one replica tail per partition

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -229,31 +229,29 @@ class FollowerLogProcessor @JvmOverloads constructor(
         if (msg.stale) watchers.notifyApplied(replicaMsgId) else processRecord(record, replicaMsgId)
     }
 
-    suspend fun processRecords(records: List<Log.Record<ReplicaMessage>>) {
-        for (record in records) {
-            try {
-                val term = record.message.termId
-                if (termFence.admit(term)) handleRecord(record, record.msgId)
-                else {
-                    // Fenced: a higher-term leader has superseded this message's writer. Discard it, but
-                    // still advance the consume position (discard suppresses application, not consumption)
-                    // so a transition catch-up can't hang on a fenced no-op.
-                    LOG.debug {
-                        "[$dbName] follower: discarding fenced record ${record.msgId} " +
-                                "(term ${LeaderTerm.format(term)} < ${LeaderTerm.format(termFence.highestSeen)})"
-                    }
-                    watchers.notifyApplied(record.msgId)
+    suspend fun processRecord(record: Log.Record<ReplicaMessage>) {
+        try {
+            val term = record.message.termId
+            if (termFence.admit(term)) handleRecord(record, record.msgId)
+            else {
+                // Fenced: a higher-term leader has superseded this message's writer. Discard it, but
+                // still advance the consume position (discard suppresses application, not consumption)
+                // so a transition catch-up can't hang on a fenced no-op.
+                LOG.debug {
+                    "[$dbName] follower: discarding fenced record ${record.msgId} " +
+                            "(term ${LeaderTerm.format(term)} < ${LeaderTerm.format(termFence.highestSeen)})"
                 }
-            } catch (e: Throwable) {
-                if (e.isShutdownSignal) throw e
-
-                LOG.error(
-                    e,
-                    "[$dbName] follower: failed to process log record with msgId ${record.msgId} (${record.message::class.simpleName})"
-                )
-                watchers.notifyError(e)
-                throw e
+                watchers.notifyApplied(record.msgId)
             }
+        } catch (e: Throwable) {
+            if (e.isShutdownSignal) throw e
+
+            LOG.error(
+                e,
+                "[$dbName] follower: failed to process log record with msgId ${record.msgId} (${record.message::class.simpleName})"
+            )
+            watchers.notifyError(e)
+            throw e
         }
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -4,6 +4,9 @@ import io.micrometer.core.instrument.Gauge
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.selects.selectUnbiased
 import org.apache.arrow.memory.BufferAllocator
 import xtdb.NodeBase
@@ -44,12 +47,28 @@ internal fun Throwable?.asCancellation(): CancellationException =
         ?: CancellationException("leader term closed").also { c -> this?.let { c.initCause(it) } }
 
 /**
+ * A replica record handed to a leader term, carrying the handle its sender waits on.
+ *
+ * Application runs on the term's coroutine rather than the tail's because it shares the term's block
+ * state, live index and tx resolver with the clauses [runLeaderTerm] arms — concurrently, a tx could
+ * resolve during a block cut, which the term treats as unreachable.
+ */
+internal class ReplicaApply(val record: Log.Record<ReplicaMessage>) {
+    val applied = CompletableDeferred<Unit>()
+}
+
+/**
+ * Failure arrives as a cancellation whatever its cause, because the term reports its own: a caller that
+ * sees this throw learns only that the term is over and its record still needs a home.
+ */
+internal suspend fun SendChannel<ReplicaApply>.applyAndAwait(record: Log.Record<ReplicaMessage>) =
+    ReplicaApply(record).also { send(it) }.applied.await()
+
+/**
  * Run a leader term until it ends, then fail everything staged on it.
  *
- * The term's work, its append pump and its replica reader are structured together, so whichever fails
- * first cancels the others and arrives here as the cause. Cancelling the caller is what ends a term that
- * hasn't failed. The reader belongs in here for the same reason the pump does: consume-back is the only
- * thing that acks a write, so a term outliving its reader hangs whatever is staged on it.
+ * The term's work and its append pump are structured together, so whichever fails first cancels the other
+ * and arrives here as the cause. Cancelling the caller is what ends a term that hasn't failed.
  *
  * Which failures reach the watchers is decided here rather than in the term, because the term is not the
  * thing that knows a resignation from a fault: a supersession means this node is merely no longer the
@@ -59,31 +78,36 @@ internal suspend fun runLeaderTerm(
     dbName: DatabaseName,
     watchers: Watchers,
     term: LeaderLogProcessor,
-    replicaMsgs: ReceiveChannel<Log.Record<ReplicaMessage>>,
+    replicaMsgs: ReceiveChannel<ReplicaApply>,
     appender: ReplicaLogAppender,
-    readReplica: suspend () -> Unit,
 ) {
     try {
         coroutineScope {
             launch(CoroutineName("$dbName-replica-appender")) { appender.run() }
-            launch(CoroutineName("$dbName-replica-reader")) { readReplica() }
 
             while (true)
                 selectUnbiased {
-                    replicaMsgs.onReceive {
-                        val msg = it.message
-                        val termId = msg.termId
+                    replicaMsgs.onReceive { pending ->
+                        try {
+                            val record = pending.record
+                            val termId = record.message.termId
 
-                        if (termId > term.leaderTerm)
-                            throw LeaderSupersededException("[$dbName] superseded: read term $termId > our term ${term.leaderTerm} at ${it.msgId}")
+                            if (termId > term.leaderTerm)
+                                throw LeaderSupersededException("[$dbName] superseded: read term $termId > our term ${term.leaderTerm} at ${record.msgId}")
 
-                        // Below our term should not appear past our replay target; discard defensively, still advancing.
+                            // Below our term should not appear past our replay target; discard defensively, still advancing.
 
-                        if (termId != 0L && termId < term.leaderTerm) {
-                            LOG.debug { "[$dbName] leader: discarding stale-term record ${it.msgId} (term $termId < ${term.leaderTerm})" }
-                            watchers.notifyApplied(replicaMsgId = it.msgId)
-                        } else {
-                            term.applyReplicaMessage(it)
+                            if (termId != 0L && termId < term.leaderTerm) {
+                                LOG.debug { "[$dbName] leader: discarding stale-term record ${record.msgId} (term $termId < ${term.leaderTerm})" }
+                                watchers.notifyApplied(replicaMsgId = record.msgId)
+                            } else {
+                                term.applyReplicaMessage(record)
+                            }
+
+                            pending.applied.complete(Unit)
+                        } catch (t: Throwable) {
+                            pending.applied.completeExceptionally(t.asCancellation())
+                            throw t
                         }
                     }
 
@@ -131,38 +155,62 @@ class LogProcessor(
     private val replicaLog = partitionStorage.replicaLog
     private val hasExternalSource = externalSource != null
 
-    /**
-     * The highest leader term this partition has seen on its replica log.
-     *
-     * Seeded from the persisted block boundary and only ever raised, so it spans every role change —
-     * held per role it would be reseeded from the boundary at each one, forgetting every term written
-     * since the last block flush, and the same term could be admitted twice either side of a demote.
-     */
     val termFence = TermFence(dbName, partitionState.tableCatalogOrNull?.boundaryTermId ?: LeaderTerm.NONE)
 
     // The role state machine — see allium/log-processor-lifecycle.allium.
-    // `state` is written by the off-thread transition coroutine (cutoverToLeader → Leading, or its catch
-    // → Following) and by demoteLeader on the transport's thread. They don't race: a revoke
-    // cancel-and-joins the transition before demoteLeader reads `state`.
-    //
-    // The leader and the follower process different message types, so the only thing a state can offer
-    // without narrowing to its variant is the teardown: a role is stopped by cancelling its job and freed
-    // by closing its processor, in that order (dev/doc/coroutines.adoc).
+    // Written by the transition coroutine and by demoteLeader; they don't race, because a revoke
+    // cancel-and-joins the transition before demoteLeader reads it.
     private sealed interface State {
         val proc: AutoCloseable
-        val job: Job
+
+        val scope: CoroutineScope
+
+        val job get() = scope.coroutineContext.job
+
+        suspend fun handleReplicaMessage(record: Log.Record<ReplicaMessage>)
     }
 
-    private class Following(override val proc: FollowerLogProcessor, override val job: Job) : State
+    private class Following(override val proc: FollowerLogProcessor, override val scope: CoroutineScope) : State {
+        override suspend fun handleReplicaMessage(record: Log.Record<ReplicaMessage>) {
+            scope.async { proc.processRecord(record) }.await()
+        }
+    }
 
-    private class Leading(override val proc: LeaderLogProcessor, override val job: Job) : State
+    private class Leading(
+        override val proc: LeaderLogProcessor,
+        override val scope: CoroutineScope,
+        private val replicaMsgs: SendChannel<ReplicaApply>,
+    ) : State {
+        override suspend fun handleReplicaMessage(record: Log.Record<ReplicaMessage>) {
+            scope.async { replicaMsgs.applyAndAwait(record) }.await()
+        }
+    }
 
-    // Read the partition's replica log into [apply] until cancelled. The reader belongs to the partition
-    // rather than to a role: a follower and a leader consume the same log from the same position, and what
-    // differs between them is only what a record does when it arrives.
-    private suspend fun tailReplica(apply: suspend (List<Log.Record<ReplicaMessage>>) -> Unit) {
+    // A role's scope is the database's, with a job of its own so that stopping the role leaves the
+    // partition's tail running. Derived from `scope` rather than built from the job alone: a bare
+    // `CoroutineScope(job)` carries no dispatcher, so every apply would land on Dispatchers.Default —
+    // which under a simulation's virtual clock is a deadlock, the scheduler having nothing left to advance.
+    private fun roleScope(job: Job) = scope + job
+
+    private suspend fun tailReplica() = coroutineScope {
         try {
-            replicaLog.tailAll(watchers.latestReplicaMsgId, apply)
+            replicaLog.tailAll(watchers.latestReplicaMsgId) { recs ->
+                recs.forEach { record ->
+                    // A role ending cancels the handle mid-record, leaving the record unapplied and its
+                    // position unadvanced — so it is offered again to whatever replaces that role.
+                    while (true) {
+                        this@coroutineScope.ensureActive()
+                        val role = state
+
+                        try {
+                            role.handleReplicaMessage(record)
+                            break
+                        } catch (_: CancellationException) {
+                            stateFlow.first { it !== role }
+                        }
+                    }
+                }
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
@@ -187,22 +235,16 @@ class LogProcessor(
             meterRegistry = base.meterRegistry,
         )
 
-        val inbound = Channel<List<Log.Record<ReplicaMessage>>>()
-
-        return Following(
-            proc,
-
-            scope.launch {
-                launch { tailReplica(inbound::send) }
-
-                for (batch in inbound) {
-                    proc.processRecords(batch)
-                }
-            })
+        return Following(proc, roleScope(Job(scope.coroutineContext.job)))
     }
 
-    @Volatile
-    private var state: State = openFollower()
+    private val stateFlow = MutableStateFlow<State>(openFollower())
+
+    private var state
+        get() = stateFlow.value
+        set(value) {
+            stateFlow.value = value
+        }
 
     init {
         base.meterRegistry?.let { reg ->
@@ -211,6 +253,22 @@ class LogProcessor(
                 .tag("db", dbName)
                 .register(reg)
         }
+
+        scope.launch(CoroutineName("$dbName-replica-tail")) { tailReplica() }
+    }
+
+    private suspend fun claimLeadership(termId: Long) {
+        // Append a NoOp stamped with the new term as the replay target: the follower catches up to it
+        // before we cut over, which is what proves our own claim has been read back. A plain append
+        // now — the term on read-back is the fence, replacing the transactional producer (#5817).
+        val replayTarget = replicaLog.appendMessage(NoOp(termId = termId)).msgId
+        LOG.debug("[${dbName}] transition: awaiting replica catch-up to $replayTarget")
+        watchers.awaitReplicaMsg(replayTarget)
+        LOG.debug("[${dbName}] transition: replica caught up to $replayTarget")
+
+        // Our own claim is now read back, so the follower's max term is the log's — anything above
+        // it fences us, and leading would index nothing. Refuse loudly instead (#5817).
+        termFence.checkUnfenced(termId)
     }
 
     override fun transitionToLeader(partition: Int, termId: Long): Deferred<TailSpec<SourceMessage>> {
@@ -227,17 +285,7 @@ class LogProcessor(
         // before close(). See dev/doc/coroutines.adoc and allium/log-processor-lifecycle.allium.
         return scope.async {
             try {
-                // Append a NoOp stamped with the new term as the replay target: the follower catches up to it
-                // before we cut over, which is what proves our own claim has been read back. A plain append
-                // now — the term on read-back is the fence, replacing the transactional producer (#5817).
-                val replayTarget = replicaLog.appendMessage(NoOp(termId = termId)).msgId
-                LOG.debug("[${dbName}] transition: awaiting replica catch-up to $replayTarget")
-                watchers.awaitReplicaMsg(replayTarget)
-                LOG.debug("[${dbName}] transition: replica caught up to $replayTarget")
-
-                // Our own claim is now read back, so the follower's max term is the log's — anything above
-                // it fences us, and leading would index nothing. Refuse loudly instead (#5817).
-                termFence.checkUnfenced(termId)
+                claimLeadership(termId)
 
                 val pendingBlock = following.proc.pendingBlock
 
@@ -272,23 +320,19 @@ class LogProcessor(
                     LOG.debug("[${dbName}] transition: building leader processor")
                     val resumeAfterMsgId = watchers.latestSourceMsgId
 
-                    // Records read back off the replica log, awaiting application. Its capacity is what bounds
-                    // how far the term's reader may run ahead of the apply loop.
-                    val replicaMsgs = Channel<Log.Record<ReplicaMessage>>(capacity = 128)
+                    // The handover from the partition's tail. Unbuffered: the tail waits on each record's
+                    // own handle, so a buffer would only let it read ahead of a term about to end.
+                    val replicaMsgs = Channel<ReplicaApply>()
 
-                    // Reading is the partition's for a leader too — the term's own writes are confirmed by
-                    // arriving back here. The GCs and the external source are the term's to stop, so
-                    // `shutdown` reaches them; the reader is structured into the term instead.
+                    // The GCs and the external source are the term's to stop, so `shutdown` reaches them.
                     val termJob = scope.launch {
                         launch { proc.gc.runGc() }
                         proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
 
-                        runLeaderTerm(dbName, watchers, proc, replicaMsgs, replicaAppender) {
-                            tailReplica { records -> records.forEach { replicaMsgs.send(it) } }
-                        }
+                        runLeaderTerm(dbName, watchers, proc, replicaMsgs, replicaAppender)
                     }
 
-                    val leading = Leading(proc, termJob).also { state = it }
+                    val leading = Leading(proc, roleScope(termJob), replicaMsgs).also { state = it }
 
                     LOG.info("[${dbName}] leader startup complete, resuming after $resumeAfterMsgId")
                     TailSpec(resumeAfterMsgId, leading.proc.srcLogProc)

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -34,8 +34,10 @@ import xtdb.indexer.LeaderDriver
 import xtdb.indexer.LeaderLogProcessor
 import xtdb.indexer.LiveIndex
 import xtdb.indexer.RealLeaderDriver
+import xtdb.indexer.ReplicaApply
 import xtdb.indexer.ReplicaLogAppender
 import xtdb.indexer.TermFence
+import xtdb.indexer.applyAndAwait
 import xtdb.indexer.runLeaderTerm
 import xtdb.storage.MemoryStorage
 import xtdb.tx.TxOpts
@@ -136,15 +138,21 @@ class ExternalSourceTest {
             flushTimeout = IndexerConfig().flushDuration,
         ).also { proc ->
             leadersToClose += proc
-            val replicaMsgs = Channel<Log.Record<ReplicaMessage>>(capacity = 128)
+            val replicaMsgs = Channel<ReplicaApply>()
             backgroundScope.launch {
                 launch { proc.gc.runGc() }
                 proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
 
-                runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender) {
+                val reader = launch {
                     partitionStorage.replicaLog.tailAll(-1) { records ->
-                        records.forEach { replicaMsgs.send(it) }
+                        records.forEach { replicaMsgs.applyAndAwait(it) }
                     }
+                }
+
+                try {
+                    runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender)
+                } finally {
+                    reader.cancel()
                 }
             }
         }

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -29,6 +29,9 @@ import xtdb.util.closeAll
 import java.time.Instant
 import xtdb.api.log.LeaderTerm
 
+private suspend fun FollowerLogProcessor.processRecords(records: List<Log.Record<ReplicaMessage>>) =
+    records.forEach { processRecord(it) }
+
 class FollowerLogProcessorTest {
 
     private val dbName = "test"

--- a/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderDriverSimTest.kt
@@ -144,19 +144,25 @@ class LeaderDriverSimTest : SimulationTestBase() {
             gcDispatcher = dispatcher,
         )
 
-        private val replicaMsgs = Channel<Log.Record<ReplicaMessage>>(capacity = 128)
+        private val replicaMsgs = Channel<ReplicaApply>()
 
         init {
             scope.launch {
                 launch { proc.gc.runGc() }
                 proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
 
-                runLeaderTerm("test-db", watchers, proc, replicaMsgs, replicaAppender) {
+                val reader = launch {
                     // From the claim record rather than the start of the log: a sim leader begins with empty
                     // catalogs and never replays, so anything before its claim is not its to apply.
                     partitionStorage.replicaLog.tailAll(afterReplicaMsgId) { records ->
-                        records.forEach { replicaMsgs.send(it) }
+                        records.forEach { replicaMsgs.applyAndAwait(it) }
                     }
+                }
+
+                try {
+                    runLeaderTerm("test-db", watchers, proc, replicaMsgs, replicaAppender)
+                } finally {
+                    reader.cancel()
                 }
             }
         }

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -88,7 +88,7 @@ internal class LeaderLogProcessorTest : LeaderTermTest() {
         appender.append(ControlItem(ReplicaMessage.NoOp(termId = 1)))
 
         // returns once the pump's failure has ended the term
-        runLeaderTerm("test", watchers, proc, Channel(), appender) { awaitCancellation() }
+        runLeaderTerm("test", watchers, proc, Channel(), appender)
 
         assertNull(
             watchers.exception,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
@@ -116,8 +116,11 @@ internal abstract class LeaderTermTest {
     }
 
     /**
-     * Start a term the way [LogProcessor] does: the term and the partition's replica-log reader launched
-     * into the term's own job, so cancelling that job is what stops it, and freed once the test has joined it.
+     * Start a term the way [LogProcessor] does: the term and a replica-log reader feeding it launched into
+     * the term's own job, so cancelling that job is what stops it, and freed once the test has joined it.
+     *
+     * The reader stands in for the partition's tail, which in production outlives the term — so it is the
+     * term ending that has to stop it here.
      */
     protected fun CoroutineScope.startTerm(
         partitionStorage: PartitionStorage,
@@ -127,15 +130,21 @@ internal abstract class LeaderTermTest {
     ) =
         proc.also {
             leadersToClose += it
-            val replicaMsgs = Channel<Log.Record<ReplicaMessage>>(capacity = 128)
+            val replicaMsgs = Channel<ReplicaApply>()
             launch {
                 launch { proc.gc.runGc() }
                 proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
 
-                runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender) {
+                val reader = launch {
                     partitionStorage.replicaLog.tailAll(-1) { records ->
-                        records.forEach { replicaMsgs.send(it) }
+                        records.forEach { replicaMsgs.applyAndAwait(it) }
                     }
+                }
+
+                try {
+                    runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender)
+                } finally {
+                    reader.cancel()
                 }
             }
         }


### PR DESCRIPTION
Part of #5917.

## tl;dr

- **A partition now has one replica-log tail, spanning every role change, instead of one per role**
  A follower and a leader consume the same log from the same position; the only thing that differs is what a record does when it arrives. That is now the only thing a role decides.

- **Behaviour-preserving.** A record in flight when a role ends is offered to whatever replaces that role, which is precisely what re-tailing from `latestReplicaMsgId` did before.

- **The interesting bugs were both about *where* work runs**, not about what it does — see `D1` and `D2`. Each presented as a hang under the simulations' virtual clock rather than as anything a stack trace would name.

## Problem

`LogProcessor` opened a fresh subscription to the partition's replica log for each role: a follower's tail, and a leader term's reader structured into `runLeaderTerm`. Every role change therefore tore one subscription down and started another from `watchers.latestReplicaMsgId`.

That put reading in the wrong place. Reading is the partition's business — the position is the partition's, the log is the partition's, and both roles consume it identically. Only *application* is the role's. Splitting it per role also means the database stops consuming entirely between a term ending and its successor opening.

## Approach

The tail moves to `LogProcessor` and outlives every role, dispatching each record to `state.handleReplicaMessage(record)`. `State` gains that alongside its teardown members, and `FollowerLogProcessor.processRecords` narrows to `processRecord` in consequence — batching belonged to the subscription it no longer owns.

**A leader still applies on the term's own coroutine.** `LeaderLogProcessor.applyReplicaMessage` shares block state, the live index and the tx resolver with the clauses `runLeaderTerm` arms, and the term treats a tx resolving during a block cut as unreachable — it calls `error(...)` on it. Applying on the tail instead would make two things concurrent that never have been. So `Leading` hands the record to the term over an unbuffered channel and waits for it:

```kotlin
internal class ReplicaApply(val record: Log.Record<ReplicaMessage>) {
    val applied = CompletableDeferred<Unit>()
}
```

The per-record handle is what stops a record being lost. Without it, a record sent into a term that then ends is neither applied nor re-offered — nothing re-reads the log any more.

## Decisions

- **`D1` — the tail parks on a role change rather than retrying, so `state` is a `MutableStateFlow`**
  Re-reading `state` and trying again costs a dispatch per attempt, and a permanently-runnable coroutine is one a deterministic scheduler's ready queue never drains: the simulations' virtual clock stops, and the cutover being waited on never completes. `first { it !== role }` parks instead, and reads the current value before suspending, so a successor published between the throw and the subscribe is seen rather than waited for.

- **`D2` — a role's scope is the database's with a job substituted in, not `CoroutineScope(job)`**
  A `Job` carries no `ContinuationInterceptor`, so a scope built from one alone silently relocates every apply to `Dispatchers.Default`. Under `runTest` that is not a wrong-pool bug but a deadlock — the work leaves the test scheduler, which then has nothing left to advance. This cost a `LogProcessorSimTest` hang to find, and presented as an idle process rather than as a spin.

- **`D3` — no new mechanism for a term that ends without a demote behind it**
  `runLeaderTerm`'s catch already classifies the three ways a term ends. A supersession means another node holds a higher term, which the transport could only have granted after revoking ours — so a demote is already caused, if not yet delivered. A non-shutdown fault has poisoned the watchers and the database is stopped. A cancellation *is* the demote, or it is teardown. In each case the tail's wait is correct, and matches what happens today: between a term ending and its successor, nothing consumed the replica log before this change either.

## Why it is behaviour-preserving

A role ending cancels its in-flight apply, leaving the record unapplied and its position unadvanced, so the tail offers it to the successor. The consume position only ever advances on a successful apply, so this is the same delivery the old re-tail produced.

`BlockBoundary` is the case that shows it holds. The leader sets `Uploading` before `uploadBlock` and `Filling` after, specifically so that a demote mid-upload hands the pending block on; the follower that inherits it then sees the same boundary record again. That was true before and is true now — the record simply arrives without a re-read.

## Out of scope

- **Three log implementations demote on shutdown, against `NoDemoteOnShutdown`**
  `InMemoryLog`, `LocalLog` and `ReadOnlyLocalLog` each end their group subscription with `finally { withContext(NonCancellable) { listener.demoteLeader(p) } }`, driving a full leader→follower transition during teardown and opening a `FollowerLogProcessor` — and its child allocator — on a database whose teardown join is already under way. `allium/log-processor-lifecycle.allium` forbids this and `KafkaCluster` deliberately avoids it. Pre-existing, and left alone here.

  Worth recording as evidence for whoever picks it up: a pre-rebase CI property-test job stalled after all 2,722 of its tests had passed, sitting 13 minutes in `JUnitPlatformTestClassProcessor.stop` before being killed and leaving four orphan JVMs. The last line before the silence was `LogProcessor - [cdc] starting follower` on a dispatcher thread, at the same millisecond as the test worker closing the external source — this violation, swapping roles mid-teardown. It did not recur after the rebase and was never reproduced locally across 12,001 simulation iterations, so the link is unproven.

- **`InterruptedException` ends a term without a demote behind it**
  `isShutdownSignal` counts it, so a storage interrupt on the append path ends a term without poisoning the watchers and without a successor being scheduled. Pre-existing; unchanged by this PR.

## Testing

- `:xtdb-core:test` — 442 tests, all passing.
- `:xtdb-core:property-test` — 2,716 tests at the default 100 iterations, all passing.
- The simulations again at **1,000** iterations — `LogProcessorSimTest`, `LeaderDriverSimTest` and `NodeSimulationTest`, 12,001 iterations, all passing.
- `:modules:xtdb-postgres-source:property-test` — all passing.
- CI green on the rebased branch: property-test in 8m10s, plus Gradle Test, both SLT jobs, Integration Test and the non-JVM tests.
