### PR TITLE
fix(postgres-source): stop pgjdbc confirming the slot, and rebound the confirmation test

### DIFF
--- a/dev/doc/pgsrc.allium
+++ b/dev/doc/pgsrc.allium
@@ -113,6 +113,7 @@ contract ConfirmablePosition {
         -- At most one party confirms a given slot.
         -- - Two would race to a position neither could justify, each knowing
         --   only its own durable extent.
+        -- - A driver that advances the flush position on a schedule of its own is such a party, and knows no durable extent at all.
 }
 
 ---- Entities and Variants

--- a/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
+++ b/modules/postgres-source/src/main/kotlin/xtdb/postgres/PgWireDriver.kt
@@ -360,6 +360,13 @@ class PgWireDriver(
                     .withStartPosition(LogSequenceNumber.valueOf(startLsn))
                     .withSlotOption("proto_version", "1")
                     .withSlotOption("publication_names", publicationName)
+                    // on by default, and pgjdbc's flush is not ours: a keepalive otherwise raises its flush
+                    // LSN to the server's, which the next status update sends, confirming the slot without
+                    // ever reaching [acknowledge]. The two LSNs its guard compares both start invalid, so
+                    // the window is open from stream open — where the resume position leads the durable
+                    // extent and is exactly what must not be confirmed over. SoleConfirmer in
+                    // dev/doc/pgsrc.allium; #5975.
+                    .withAutomaticFlush(false)
                     .start()
 
                 if (attempt > 1)

--- a/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
+++ b/modules/postgres-source/src/test/kotlin/xtdb/postgres/PostgresSourceIntegrationTest.kt
@@ -317,7 +317,7 @@ class PostgresSourceIntegrationTest {
     }
 
     @Test
-    fun `slot is confirmed only as far as the last durable block`() = runTest(timeout = 180.seconds) {
+    fun `slot is not confirmed past a streamed transaction no block covers`() = runTest(timeout = 180.seconds) {
         val pubName = "test_pub_${UUID.randomUUID().toString().replace("-", "_")}"
         val slotName = "test_slot_${UUID.randomUUID().toString().replace("-", "_")}"
         val sourceTopic = "test-topic-${UUID.randomUUID()}"
@@ -338,35 +338,38 @@ class PostgresSourceIntegrationTest {
             eventually(30.seconds) { assertTrue(cdc.tableCatalog.currentBlockIndex != null, "first block persisted") }
             val blockLsn = PostgresSourceToken.parseFrom(cdc.tableCatalog.externalSourceToken!!).latestCommittedLsn
 
-            pgExecute(
-                "INSERT INTO pg_confirm (_id, name) VALUES (2, 'streamed-two')",
-                "INSERT INTO pg_confirm (_id, name) VALUES (3, 'streamed-three')",
-            )
+            pgExecute("INSERT INTO pg_confirm (_id, name) VALUES (2, 'streamed-two')")
+
+            // Sampled between the two rows, so it sits above every WAL record of the first: reaching it
+            // means confirming over a transaction the replica log and the live index are the only copies
+            // of. A sample taken before the inserts would not mean that — heldLsn moves at the Commit
+            // message, so the source legitimately confirms positions inside a transaction it is part-way
+            // through reading, and Postgres pins restart_lsn at the start of one and re-sends it whole.
+            val pastFirstStreamed = pgCurrentWalLsn()
+
+            pgExecute("INSERT INTO pg_confirm (_id, name) VALUES (3, 'streamed-three')")
+
             eventually(30.seconds) {
                 assertEquals(3, xtQueryDb(node, "cdc", "SELECT _id FROM public.pg_confirm").size, "streamed rows applied")
             }
 
-            // Applied but unblocked, so the leader has imported past the block — which also rules out the
-            // idle walEnd advance, since that requires everything imported to be in a block. Confirming
-            // further here would tell Postgres to recycle WAL for transactions whose only copies are the
-            // replica log and the leader's live index.
-            //
             // `continually`, not a single read: the ack reaches the slot asynchronously, so one sample taken
             // straight after the rows apply passes whether or not the gate is there. Holding the invariant
             // over a window is what makes it fail when confirmation tracks apply.
             continually(5.seconds) {
                 val confirmed = pgSlotConfirmedFlushLsn(slotName)
-                assertTrue(confirmed <= blockLsn, "slot confirmed at $confirmed, past the last durable block at $blockLsn")
+                assertTrue(confirmed < pastFirstStreamed, "slot confirmed at $confirmed, past the streamed transaction below $pastFirstStreamed")
             }
 
             cdc.sendFlushBlockMessage()
-            eventually(30.seconds) {
-                val persisted = PostgresSourceToken.parseFrom(cdc.tableCatalog.externalSourceToken!!).latestCommittedLsn
-                assertTrue(persisted > blockLsn, "second block's token covers the streamed rows")
+            val persisted = eventually(30.seconds) {
+                PostgresSourceToken.parseFrom(cdc.tableCatalog.externalSourceToken!!).latestCommittedLsn
+                    .also { assertTrue(it > blockLsn, "second block's token covers the streamed rows") }
             }
 
             eventually(30.seconds) {
-                assertTrue(pgSlotConfirmedFlushLsn(slotName) > blockLsn, "slot advances once the block is durable")
+                val confirmed = pgSlotConfirmedFlushLsn(slotName)
+                assertTrue(confirmed >= persisted, "slot confirmed at $confirmed, short of the durable extent at $persisted")
             }
         }
     }
@@ -1610,6 +1613,16 @@ class PostgresSourceIntegrationTest {
                         assertTrue(rs.next(), "slot '$slotName' should exist")
                         LogSequenceNumber.valueOf(rs.getString("lsn")).asLong()
                     }
+            }
+        }
+
+    private fun pgCurrentWalLsn(): Long =
+        DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeQuery("SELECT pg_current_wal_lsn()::text AS lsn").use { rs ->
+                    assertTrue(rs.next(), "pg_current_wal_lsn() should return a row")
+                    LogSequenceNumber.valueOf(rs.getString("lsn")).asLong()
+                }
             }
         }
 


### PR DESCRIPTION
Resolves #5974 and #5975.

`slot is confirmed only as far as the last durable block` failed twice on `main` in one day with a green run between them, leaving the Integration Test job intermittently red for every branch rebasing onto it. #5975 was found while investigating that, in the same keepalive path.
