### PR TITLE
refactor(log)!: the log tail polls rather than pushes

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/InMemoryLog.kt
@@ -20,7 +20,7 @@ import xtdb.types.MessageId
 import java.time.Instant
 import java.time.InstantSource
 import java.time.temporal.ChronoUnit.MICROS
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration
 
 class InMemoryLog<M> @JvmOverloads constructor(
     private val instantSource: InstantSource,
@@ -94,7 +94,8 @@ class InMemoryLog<M> @JvmOverloads constructor(
     override suspend fun appendMessage(message: M, partition: Int): MessageMetadata {
         val ps = state(partition)
         return ps.mutex.withLock {
-            val ts = if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
+            val ts =
+                if (message is SourceMessage.Tx || message is SourceMessage.LegacyTx) instantSource.instant() else Instant.now()
             val record = Record(epoch, ++ps.latestSubmittedOffset, ts.truncatedTo(MICROS), message)
             ps.committedCh.emit(record)
             MessageMetadata(epoch, record.logOffset, ts.truncatedTo(MICROS))
@@ -113,30 +114,37 @@ class InMemoryLog<M> @JvmOverloads constructor(
         }
     }
 
-    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
+    override suspend fun <R> withTail(
+        partition: Int, afterMsgId: MessageId, action: suspend (Tail<M>) -> R
+    ): R = coroutineScope {
         var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-        val ch = state(partition).committedCh
-            .filter {
-                val logOffset = it.logOffset
-                check(logOffset <= latestCompletedOffset + 1) {
-                    "InMemoryLog emitted out-of-order record (expected ${latestCompletedOffset + 1}, got $logOffset)"
-                }
-                logOffset > latestCompletedOffset
-            }
-            .onEach { latestCompletedOffset = it.logOffset }
-            .buffer(100)
+        val committed = state(partition).committedCh
+            .dropWhile { it.logOffset <= latestCompletedOffset }
             .produceIn(this)
 
-        while (isActive) {
-            val records = select {
-                ch.onReceiveCatching { if (it.isClosed) emptyList() else listOf(it.getOrThrow()) }
+        try {
+            action(object : Tail<M> {
+                override suspend fun poll(timeout: Duration): List<Record<M>> {
+                    val first = if (timeout <= Duration.ZERO) {
+                        committed.tryReceive().getOrNull()
+                    } else {
+                        withTimeoutOrNull(timeout) { committed.receive() }
+                    } ?: return emptyList()
 
-                @OptIn(ExperimentalCoroutinesApi::class)
-                onTimeout(1.minutes) { emptyList() }
-            }
-
-            processor.processRecords(records)
+                    return buildList {
+                        add(first)
+                        while (true) add(committed.tryReceive().getOrNull() ?: break)
+                    }.also { records ->
+                        check(records.first().logOffset == latestCompletedOffset + 1) {
+                            "InMemoryLog replay buffer rolled past offset ${latestCompletedOffset + 1}"
+                        }
+                        latestCompletedOffset = records.last().logOffset
+                    }
+                }
+            })
+        } finally {
+            committed.cancel()
         }
     }
 
@@ -145,8 +153,9 @@ class InMemoryLog<M> @JvmOverloads constructor(
         for (p in 0 until partitions) {
             launch {
                 try {
-                    val spec = listener.transitionToLeader(p, LeaderTerm.of(termEpoch, elections.incrementAndGet())).await()
-                    tailAll(p, spec.afterMsgId, spec.processor)
+                    val spec =
+                        listener.transitionToLeader(p, LeaderTerm.of(termEpoch, elections.incrementAndGet())).await()
+                    tailAll(p, spec.afterMsgId, processor = spec.processor)
                 } finally {
                     withContext(NonCancellable) { listener.demoteLeader(p) }
                 }

--- a/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LocalLog.kt
@@ -5,9 +5,8 @@ package xtdb.api.log
 import kotlinx.coroutines.*
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -20,6 +19,7 @@ import xtdb.api.log.Log.*
 import xtdb.database.proto.DatabaseConfig
 import xtdb.util.MsgIdUtil
 import xtdb.util.MsgIdUtil.msgIdToOffset
+import xtdb.util.rethrowingChannelInterrupts
 import xtdb.database.proto.localLog
 import xtdb.types.LogOffset
 import xtdb.types.MessageId
@@ -37,7 +37,7 @@ import java.time.InstantSource
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.exists
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.Int.Companion.SIZE_BYTES as INT_BYTES
 import kotlin.Long.Companion.SIZE_BYTES as LONG_BYTES
@@ -130,11 +130,7 @@ class LocalLog<M> @JvmOverloads constructor(
         val logFileChannel: FileChannel =
             FileChannel.open(logFilePath.createParentDirectories(), CREATE, WRITE, APPEND)
         val appendCh = Channel<NewMessage<M>>(capacity = 10)
-        val committedCh = MutableSharedFlow<Record<M>>(extraBufferCapacity = 100)
-        val mutex = Mutex()
-
-        @Volatile
-        var latestSubmittedOffset: LogOffset = readLatestSubmittedOffset(logFilePath)
+        val committedOffset = MutableStateFlow(readLatestSubmittedOffset(logFilePath))
     }
 
     private val partitionStates: List<PartitionState> = List(partitions) { PartitionState(it) }
@@ -143,7 +139,7 @@ class LocalLog<M> @JvmOverloads constructor(
         partitionStates.getOrNull(partition)
             ?: error("no such partition $partition (partitions=$partitions)")
 
-    private fun PartitionState.writeMessages(msgs: List<NewMessage<M>>): Array<Record<M>> {
+    private suspend fun PartitionState.writeMessages(msgs: List<NewMessage<M>>): Array<Record<M>> = runInterruptible {
         val initialOffset = logFileChannel.position()
 
         try {
@@ -173,43 +169,46 @@ class LocalLog<M> @JvmOverloads constructor(
 
             logFileChannel.force(true)
 
-            return res
+            res
+        } catch (e: ClosedByInterruptException) {
+            // Nothing to roll back to: an interrupted channel operation closes the channel as it throws, and
+            // this is the partition's one writer, so `truncate` below would only raise ClosedChannelException
+            // over the top of the cause. Nothing to roll back *for* either — the only thing that interrupts
+            // this writer is the log closing. Re-raised as the interrupt it is, which `runInterruptible`
+            // re-casts to cancellation; an IOException would reach the caller as a fault instead.
+            throw InterruptedException().apply { initCause(e) }
         } catch (t: Throwable) {
-            logFileChannel.truncate(initialOffset)
+            // Never over the top of the cause that got us here — a failed rollback is worth reporting, but
+            // it is the write's failure the caller has to act on.
+            try {
+                logFileChannel.truncate(initialOffset)
+            } catch (e: Throwable) {
+                t.addSuppressed(e)
+            }
+
             throw t
         }
     }
 
-    override fun latestSubmittedOffset(partition: Int): LogOffset = state(partition).latestSubmittedOffset
+    override fun latestSubmittedOffset(partition: Int): LogOffset = state(partition).committedOffset.value
 
     init {
         for (ps in partitionStates) {
             scope.launch {
-                try {
+                while (true) {
+                    val msgs = mutableListOf(ps.appendCh.receive())
+
                     while (true) {
-                        val msgs = mutableListOf(ps.appendCh.receive())
-
-                        while (true) {
-                            if (msgs.size >= 10) break
-                            msgs.add(ps.appendCh.tryReceive().getOrNull() ?: break)
-                        }
-
-                        val records = ps.writeMessages(msgs)
-
-                        msgs.forEachIndexed { idx, msg ->
-                            records[idx].also {
-                                ps.mutex.withLock {
-                                    ps.committedCh.emit(it)
-                                    ps.latestSubmittedOffset = it.logOffset
-                                }
-                                msg.onCommit.complete(it)
-                            }
-                        }
+                        if (msgs.size >= 10) break
+                        msgs.add(ps.appendCh.tryReceive().getOrNull() ?: break)
                     }
-                } catch (_: ClosedByInterruptException) {
-                    cancel()
-                } catch (_: InterruptedException) {
-                    cancel()
+
+                    val records = ps.writeMessages(msgs)
+
+                    ps.committedOffset.value = records.last().logOffset
+                    msgs.forEachIndexed { idx, msg ->
+                        msg.onCommit.complete(records[idx])
+                    }
                 }
             }
         }
@@ -231,10 +230,10 @@ class LocalLog<M> @JvmOverloads constructor(
 
     override fun readLastMessage(partition: Int): M? {
         val ps = state(partition)
-        if (ps.latestSubmittedOffset < 0) return null
+        if (ps.committedOffset.value < 0) return null
 
         return FileChannel.open(ps.logFilePath).use { ch ->
-            ch.position(ps.latestSubmittedOffset)
+            ch.position(ps.committedOffset.value)
             ch.readMessage()?.message
         }
     }
@@ -244,7 +243,7 @@ class LocalLog<M> @JvmOverloads constructor(
         val ps = state(partition)
         val fromOffset = msgIdToOffset(fromMsgId)
         val toOffset = msgIdToOffset(toMsgId)
-        if (fromOffset > ps.latestSubmittedOffset || fromOffset >= toOffset) return@sequence
+        if (fromOffset > ps.committedOffset.value || fromOffset >= toOffset) return@sequence
 
         FileChannel.open(ps.logFilePath).use { ch ->
             ch.position(fromOffset)
@@ -256,65 +255,45 @@ class LocalLog<M> @JvmOverloads constructor(
         }
     }
 
-    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: RecordProcessor<M>) = coroutineScope {
+    private fun PartitionState.readRange(afterOffset: LogOffset, toOffset: LogOffset): List<Record<M>> =
+        rethrowingChannelInterrupts {
+            FileChannel.open(logFilePath).use { fileCh ->
+                if (afterOffset >= 0) {
+                    fileCh.position(afterOffset)
+                    fileCh.readMessage()
+                }
+
+                buildList {
+                    while (fileCh.position() <= toOffset) fileCh.readMessage()?.let { add(it) }
+                }
+            }
+        }
+
+    override suspend fun <R> withTail(
+        partition: Int,
+        afterMsgId: MessageId,
+        action: suspend (Tail<M>) -> R,
+    ): R {
         val ps = state(partition)
         var latestCompletedOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-        val ch = Channel<Record<M>>(100)
+        return action(object : Tail<M> {
+            override suspend fun poll(timeout: Duration): List<Record<M>> {
+                val targetOffset = ps.committedOffset.value.takeIf { it > latestCompletedOffset }
+                    ?: (if (timeout <= Duration.ZERO) null
+                    else withTimeoutOrNull(timeout) { ps.committedOffset.first { it > latestCompletedOffset } })
+                    ?: return emptyList()
 
-        launch {
-            ps.committedCh
-                .onSubscription {
-                    val targetOffset = ps.mutex.withLock { ps.latestSubmittedOffset }
-                    if (targetOffset < 0) return@onSubscription
-
-                    val catchUpRecords = runInterruptible {
-                        FileChannel.open(ps.logFilePath).use { fileCh ->
-                            val latestCompleted = latestCompletedOffset
-                            if (latestCompleted >= 0) {
-                                fileCh.position(latestCompleted)
-                                fileCh.readMessage()
-                            }
-
-                            buildList {
-                                while (fileCh.position() <= targetOffset) {
-                                    fileCh.readMessage()?.let { add(it) }
-                                }
-                            }
-                        }
+                return runInterruptible(Dispatchers.IO) {
+                    ps.readRange(latestCompletedOffset, targetOffset)
+                }.also { records ->
+                    check(records.isNotEmpty()) {
+                        "LocalLog committed offset $targetOffset yielded no records after $latestCompletedOffset"
                     }
-
-                    for (record in catchUpRecords) {
-                        ch.send(record)
-                    }
-
-                    latestCompletedOffset = targetOffset
+                    latestCompletedOffset = records.last().logOffset
                 }
-                .onEach {
-                    if (it.logOffset > latestCompletedOffset) {
-                        latestCompletedOffset = it.logOffset
-                        ch.send(it)
-                    }
-                }
-                .onCompletion { ch.close() }
-                .catch {
-                    try {
-                        throw it
-                    } catch (_: ClosedByInterruptException) {
-                        throw CancellationException()
-                    } catch (_: InterruptedException) {
-                        throw CancellationException()
-                    }
-                }
-                .collect()
-        }
-
-        while (isActive) {
-            val msg = withTimeoutOrNull(1.minutes) {
-                ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
             }
-            processor.processRecords(listOfNotNull(msg))
-        }
+        })
     }
 
     override suspend fun openGroupSubscription(listener: SubscriptionListener<M>) = coroutineScope {
@@ -322,7 +301,7 @@ class LocalLog<M> @JvmOverloads constructor(
             launch {
                 try {
                     val spec = listener.transitionToLeader(p, LeaderTerm.of(termEpoch, elections.incrementAndGet())).await()
-                    tailAll(p, spec.afterMsgId, spec.processor)
+                    tailAll(p, spec.afterMsgId, processor = spec.processor)
                 } finally {
                     withContext(NonCancellable) { listener.demoteLeader(p) }
                 }
@@ -376,13 +355,13 @@ class LocalLog<M> @JvmOverloads constructor(
             LocalLog(path, SourceMessage.Codec, instantSource, epoch, termEpoch, useInstantSourceForNonTx, coroutineContext, partitions = partitions)
 
         override fun openReadOnlySourceLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
-            ReadOnlyLocalLog(path, SourceMessage.Codec, epoch, termEpoch, coroutineContext, partitions = partitions)
+            ReadOnlyLocalLog(path, SourceMessage.Codec, epoch, termEpoch, partitions = partitions)
 
         override fun openReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
             LocalLog(path, ReplicaMessage.Codec, instantSource, epoch, termEpoch, useInstantSourceForNonTx, coroutineContext, baseFileName = "REPLICA_LOG", partitions = partitions)
 
         override fun openReadOnlyReplicaLog(remotes: Map<RemoteAlias, Remote>, partitions: Int) =
-            ReadOnlyLocalLog(path, ReplicaMessage.Codec, epoch, termEpoch, coroutineContext, baseFileName = "REPLICA_LOG", partitions = partitions)
+            ReadOnlyLocalLog(path, ReplicaMessage.Codec, epoch, termEpoch, baseFileName = "REPLICA_LOG", partitions = partitions)
 
         override fun writeTo(dbConfig: DatabaseConfig.Builder) {
             dbConfig.localLog = localLog {

--- a/core/src/main/kotlin/xtdb/api/log/Log.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Log.kt
@@ -3,6 +3,8 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
@@ -23,6 +25,8 @@ import xtdb.util.asPath
 import java.nio.file.Path
 import java.time.Instant
 import java.util.*
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import com.google.protobuf.Any as ProtoAny
 
 
@@ -75,12 +79,21 @@ interface Log<M> : AutoCloseable {
     }
 
     fun interface RecordProcessor<in M> {
-        /**
-         * Called once per read, whether or not it found anything: a read that came back empty arrives
-         * here as an empty list. That is how a consumer tells a quiet log from one it is no longer
-         * being delivered from.
-         */
+        /** Called once per poll, whether or not it found anything: an empty poll arrives as an empty list. */
         suspend fun processRecords(records: List<Record<M>>)
+    }
+
+    /** One consumer's position in a partition, valid only for the duration of [withTail]. */
+    interface Tail<out M> {
+        /**
+         * Waits up to [timeout] for at least one record, then returns it and any records already available.
+         * Returns empty only when no record becomes available before [timeout].
+         *
+         * A [timeout] of zero or less returns what is already buffered without waiting, and
+         * [Duration.INFINITE] waits until a record arrives or the caller is cancelled.
+         * Calls on one tail must not overlap.
+         */
+        suspend fun poll(timeout: Duration): List<Record<M>>
     }
 
     companion object {
@@ -134,7 +147,22 @@ interface Log<M> : AutoCloseable {
      */
     fun readRecords(partition: Int, fromMsgId: MessageId, toMsgId: MessageId): Sequence<Record<M>>
 
-    suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: RecordProcessor<M>)
+    /**
+     * Runs [action] with a tail positioned after [afterMsgId].
+     * The tail and its subscription are valid only until [action] returns.
+     */
+    suspend fun <R> withTail(partition: Int, afterMsgId: MessageId, action: suspend (Tail<M>) -> R): R
+
+    /** Polls a tail until cancelled, handing every poll to [processor], including empty polls. */
+    suspend fun tailAll(
+        partition: Int,
+        afterMsgId: MessageId,
+        pollTimeout: Duration = 1.seconds,
+        processor: RecordProcessor<M>,
+    ): Unit = withTail(partition, afterMsgId) { tail ->
+        while (currentCoroutineContext().isActive) processor.processRecords(tail.poll(pollTimeout))
+    }
+
     suspend fun openGroupSubscription(listener: SubscriptionListener<M>)
 
     /**

--- a/core/src/main/kotlin/xtdb/api/log/PartitionLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/PartitionLog.kt
@@ -13,6 +13,9 @@ import xtdb.types.MessageId
 class PartitionLog<M>(private val log: Log<M>, val partition: Int) {
     suspend fun appendMessage(message: M): Log.MessageMetadata = log.appendMessage(message, partition)
 
+    suspend fun <R> withTail(afterMsgId: MessageId, action: suspend (Log.Tail<M>) -> R): R =
+        log.withTail(partition, afterMsgId, action)
+
     suspend fun tailAll(afterMsgId: MessageId, processor: Log.RecordProcessor<M>) =
-        log.tailAll(partition, afterMsgId, processor)
+        log.tailAll(partition, afterMsgId, processor = processor)
 }

--- a/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReadOnlyLocalLog.kt
@@ -1,29 +1,25 @@
 package xtdb.api.log
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
 import xtdb.api.log.Log.*
 import xtdb.api.error.Incorrect
 import xtdb.types.LogOffset
 import xtdb.types.MessageId
 import xtdb.util.MsgIdUtil
 import xtdb.util.MsgIdUtil.msgIdToOffset
+import xtdb.util.rethrowingChannelInterrupts
 import xtdb.time.InstantUtil.fromMicros
 import java.io.DataInputStream
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
-import java.nio.channels.ClosedByInterruptException
 import java.nio.channels.FileChannel
 import java.nio.file.FileSystems
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption.READ
 import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
-import java.nio.file.WatchKey
-import kotlin.coroutines.CoroutineContext
+import java.util.concurrent.TimeUnit.NANOSECONDS
 import kotlin.io.path.exists
-import kotlin.io.path.name
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration
 import kotlin.Int.Companion.SIZE_BYTES as INT_BYTES
 import kotlin.Long.Companion.SIZE_BYTES as LONG_BYTES
 
@@ -38,12 +34,10 @@ class ReadOnlyLocalLog<M> @JvmOverloads constructor(
     private val codec: MessageCodec<M>,
     override val epoch: Int,
     private val termEpoch: Int = 0,
-    coroutineContext: CoroutineContext = Dispatchers.Default,
     private val baseFileName: String = "LOG",
     val partitions: Int = 1,
 ) : Log<M> {
 
-    private val scope = CoroutineScope(coroutineContext)
     private val elections = java.util.concurrent.atomic.AtomicLong(0)
 
     companion object {
@@ -144,59 +138,59 @@ class ReadOnlyLocalLog<M> @JvmOverloads constructor(
         }
     }
 
-    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
+    override suspend fun <R> withTail(
+        partition: Int,
+        afterMsgId: MessageId,
+        action: suspend (Log.Tail<M>) -> R,
+    ): R {
         requirePartition(partition)
         val filePath = logFilePath(partition)
-        // Watch the partition file's parent — rootPath at N=1, rootPath/LOG at N>1 — because WatchService
-        // events are direct-children only, not recursive. Match against the file's last segment (its name
-        // in that parent), which is baseFileName at N=1 and the partition index at N>1.
         val watchDir = filePath.parent
-        val watchedName = filePath.fileName.toString()
-        val ch = Channel<Log.Record<M>>(100)
 
-        launch {
+        java.nio.file.Files.createDirectories(watchDir)
+
+        return FileSystems.getDefault().newWatchService().use { watchService ->
+            watchDir.register(watchService, ENTRY_MODIFY)
             var currentOffset = MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId)
 
-            FileSystems.getDefault().newWatchService().use { watchService ->
-                // Idempotent — the writer's process may not have created the parent yet at N>1.
-                java.nio.file.Files.createDirectories(watchDir)
-                watchDir.register(watchService, ENTRY_MODIFY)
+            fun readNewMessages(): List<Log.Record<M>> = rethrowingChannelInterrupts {
+                val newLatestOffset = readLatestSubmittedOffset(filePath)
+                if (newLatestOffset <= currentOffset) return@rethrowingChannelInterrupts emptyList()
 
-                try {
-                    readNewMessages(filePath, currentOffset, ch)?.let { currentOffset = it }
+                FileChannel.open(filePath, READ).use { fileCh ->
+                    if (currentOffset >= 0) {
+                        fileCh.position(currentOffset)
+                        fileCh.readMessage()
+                    }
+
+                    buildList {
+                        while (fileCh.position() <= newLatestOffset) fileCh.readMessage()?.let { add(it) }
+                    }
+                }.also { records -> records.lastOrNull()?.let { currentOffset = it.logOffset } }
+            }
+
+            action(object : Log.Tail<M> {
+                override suspend fun poll(timeout: Duration): List<Log.Record<M>> {
+                    val started = kotlin.time.TimeSource.Monotonic.markNow()
+                    var remaining = timeout
 
                     while (true) {
-                        val key: WatchKey = runInterruptible(Dispatchers.IO) { watchService.take() }
+                        runInterruptible(Dispatchers.IO) { readNewMessages() }
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { return it }
 
-                        var logModified = false
-                        for (event in key.pollEvents()) {
-                            val changedPath = event.context() as? Path
-                            if (changedPath?.name == watchedName) {
-                                logModified = true
-                            }
-                        }
+                        if (remaining <= Duration.ZERO) return emptyList()
 
-                        if (logModified) {
-                            readNewMessages(filePath, currentOffset, ch)?.let { currentOffset = it }
-                        }
+                        val key = runInterruptible(Dispatchers.IO) {
+                            watchService.poll(remaining.inWholeNanoseconds, NANOSECONDS)
+                        } ?: return emptyList()
 
-                        if (!key.reset()) {
-                            break
-                        }
+                        key.pollEvents()
+                        check(key.reset()) { "local log watch is no longer valid" }
+                        remaining = timeout - started.elapsedNow()
                     }
-                } catch (_: ClosedByInterruptException) {
-                    cancel()
-                } catch (_: InterruptedException) {
-                    cancel()
                 }
-            }
-        }
-
-        while (isActive) {
-            val msg = withTimeoutOrNull(1.minutes) {
-                ch.receiveCatching().let { if (it.isClosed) null else it.getOrThrow() }
-            }
-            processor.processRecords(listOfNotNull(msg))
+            })
         }
     }
 
@@ -205,7 +199,7 @@ class ReadOnlyLocalLog<M> @JvmOverloads constructor(
             launch {
                 try {
                     val spec = listener.transitionToLeader(p, LeaderTerm.of(termEpoch, elections.incrementAndGet())).await()
-                    tailAll(p, spec.afterMsgId, spec.processor)
+                    tailAll(p, spec.afterMsgId, processor = spec.processor)
                 } finally {
                     withContext(NonCancellable) { listener.demoteLeader(p) }
                 }
@@ -213,31 +207,5 @@ class ReadOnlyLocalLog<M> @JvmOverloads constructor(
         }
     }
 
-    private suspend fun readNewMessages(logFilePath: Path, currentOffset: LogOffset, ch: Channel<Log.Record<M>>): LogOffset? {
-        val newLatestOffset = readLatestSubmittedOffset(logFilePath)
-
-        if (newLatestOffset <= currentOffset) return null
-
-        var lastOffset = currentOffset
-        FileChannel.open(logFilePath, READ).use { fileCh ->
-            if (currentOffset >= 0) {
-                fileCh.position(currentOffset)
-                fileCh.readMessage()
-            }
-
-            while (fileCh.position() <= newLatestOffset) {
-                val record = fileCh.readMessage()
-                if (record != null) {
-                    ch.send(record)
-                    lastOffset = record.logOffset
-                }
-            }
-        }
-
-        return lastOffset
-    }
-
-    override fun close() {
-        runBlocking { withTimeout(5.seconds) { scope.coroutineContext.job.cancelAndJoin() } }
-    }
+    override fun close() = Unit
 }

--- a/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
+++ b/core/src/main/kotlin/xtdb/test/log/RecordingLog.kt
@@ -73,7 +73,11 @@ class RecordingLog<M>(private val instantSource: InstantSource, messages: List<M
         }
     }
 
-    override suspend fun tailAll(partition: Int, afterMsgId: Long, processor: Log.RecordProcessor<M>): Unit = error("tailAll")
+    override suspend fun <R> withTail(
+        partition: Int,
+        afterMsgId: Long,
+        action: suspend (Log.Tail<M>) -> R,
+    ): R = error("withTail")
 
     override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>): Unit = error("openGroupSubscription")
 

--- a/core/src/main/kotlin/xtdb/util/IOUtil.kt
+++ b/core/src/main/kotlin/xtdb/util/IOUtil.kt
@@ -1,5 +1,6 @@
 package xtdb.util
 
+import java.nio.channels.ClosedByInterruptException
 import java.nio.channels.FileChannel
 import java.nio.channels.WritableByteChannel
 import java.nio.file.Files
@@ -10,6 +11,19 @@ import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
 import kotlin.io.path.createTempFile
 import kotlin.io.path.deleteIfExists
+
+/**
+ * Runs [block], re-raising an interrupt reported by an NIO channel as an [InterruptedException].
+ *
+ * `runInterruptible` translates [InterruptedException] into cancellation, but an interrupted channel operation
+ * throws [ClosedByInterruptException] instead.
+ */
+internal inline fun <T> rethrowingChannelInterrupts(block: () -> T): T =
+    try {
+        block()
+    } catch (e: ClosedByInterruptException) {
+        throw InterruptedException("interrupted mid channel operation").apply { initCause(e) }
+    }
 
 internal fun Path.openReadableChannel(): FileChannel = FileChannel.open(this, READ)
 internal fun Path.openWritableChannel(): WritableByteChannel = Files.newByteChannel(this, WRITE, CREATE)

--- a/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
@@ -118,6 +118,28 @@ class InMemoryLogTest {
     }
 
     @Test
+    fun `tail stays subscribed while its caller is between polls`() = runTest(timeout = 10.seconds) {
+        val log = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+
+        log.use {
+            log.withTail(0, -1L) { tail ->
+                val appendJob = backgroundScope.launch {
+                    repeat(5000) { log.appendMessage(txMessage((it % Byte.MAX_VALUE).toByte())) }
+                }
+                yield()
+                assertFalse(appendJob.isCompleted)
+
+                val records = buildList {
+                    while (size < 5000) addAll(tail.poll(1.seconds))
+                }
+
+                appendJob.join()
+                assertEquals((0L until 5000L).toList(), records.map { it.logOffset })
+            }
+        }
+    }
+
+    @Test
     fun `openGroupSubscription drives the listener lifecycle for every partition`() = runTest(timeout = 5.seconds) {
         val log = InMemoryLog<SourceMessage>(InstantSource.system(), 0, partitions = 3)
         log.use {

--- a/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LocalLogTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import xtdb.api.log.Log.Record
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class LocalLogTest {
@@ -43,7 +44,7 @@ class LocalLogTest {
 
         val jobs = List(partitions) { p ->
             launch {
-                log.tailAll(p, -1L, object : Log.RecordProcessor<SourceMessage> {
+                log.tailAll(p, -1L, processor = object : Log.RecordProcessor<SourceMessage> {
                     override suspend fun processRecords(records: List<Record<SourceMessage>>) = Unit
                 })
             }
@@ -155,6 +156,21 @@ class LocalLogTest {
 
             job0.cancelAndJoin()
             job1.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `poll returns the available records and advances the tail`() = runTest {
+        val log = LocalLog.Factory(tempDir.resolve("poll-log")).openSourceLog(emptyMap())
+
+        log.use {
+            log.appendMessage(txMessage(1))
+            log.appendMessage(txMessage(2))
+
+            log.withTail(0, -1L) { tail ->
+                assertEquals(2, tail.poll(Duration.ZERO).size)
+                assertTrue(tail.poll(Duration.ZERO).isEmpty())
+            }
         }
     }
 

--- a/core/src/test/kotlin/xtdb/api/log/ReadOnlyLocalLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/ReadOnlyLocalLogTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import xtdb.api.log.Log.Record
 import java.nio.file.Path
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class ReadOnlyLocalLogTest {
@@ -29,6 +30,25 @@ class ReadOnlyLocalLogTest {
     @Test
     fun `tailAll observes external writes at N greater than 1`(): Unit = runBlocking {
         observesExternalWrites(partitions = 2)
+    }
+
+    @Test
+    fun `poll reads both existing and subsequent external writes`(): Unit = runBlocking {
+        val factory = LocalLog.Factory(tempDir.resolve("poll-log"))
+
+        factory.openSourceLog(emptyMap()).use { writer ->
+            writer.appendMessage(txMessage(1))
+
+            factory.openReadOnlySourceLog(emptyMap()).use { reader ->
+                reader.withTail(0, -1L) { tail ->
+                    assertEquals(1, tail.poll(Duration.ZERO).size)
+
+                    writer.appendMessage(txMessage(2))
+                    assertEquals(1, tail.poll(3.seconds).size)
+                    assertTrue(tail.poll(Duration.ZERO).isEmpty())
+                }
+            }
+        }
     }
 
     // msg1's arrival via catch-up is a synchronisation barrier: it proves the reader has finished

--- a/core/src/test/kotlin/xtdb/indexer/SimLog.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SimLog.kt
@@ -2,6 +2,7 @@ package xtdb.indexer
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.*
 import kotlinx.coroutines.selects.select
 import xtdb.api.log.LeaderTerm
 import xtdb.api.log.Log
@@ -12,6 +13,7 @@ import xtdb.util.debug
 import xtdb.util.error
 import xtdb.util.logger
 import java.time.Instant
+import kotlin.time.Duration
 import kotlin.random.Random
 
 private val LOG = SimLog::class.logger
@@ -175,46 +177,42 @@ internal class SimLog<M>(private val name: String, private val rand: Random) : L
         return topic.subList(fromOffset.coerceAtLeast(0), toOffset.coerceAtMost(topic.size)).asSequence()
     }
 
-    /**
-     * Reads on the caller's own coroutine, as every real [Log] does.
-     *
-     * A shared loop delivering into each consumer from outside its job cannot be cancelled per
-     * consumer: [Log.RecordProcessor.processRecords] suspends until the consumer has applied the
-     * batch, so cancelling one mid-delivery would leave that loop suspended forever and starve
-     * every other subscription behind it.
-     */
-    override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: Log.RecordProcessor<M>) {
+    override suspend fun <R> withTail(
+        partition: Int,
+        afterMsgId: MessageId,
+        action: suspend (Log.Tail<M>) -> R,
+    ): R {
         val startOffset = (MsgIdUtil.afterMsgIdToOffset(epoch, afterMsgId) + 1).toInt()
-        LOG.debug("$name/tailAll: startOffset=$startOffset topicSize=${topic.size}")
+        LOG.debug("$name/withTail: startOffset=$startOffset topicSize=${topic.size}")
         val consumer = PlainConsumer<M>(startOffset)
         plainConsumers += consumer
-        consumer.wake.trySend(Unit)
+        if (startOffset < topic.size) consumer.wake.trySend(Unit)
 
         try {
-            while (true) {
-                consumer.wake.receive()
-                yield()
+            return action(object : Log.Tail<M> {
+                override suspend fun poll(timeout: Duration): List<Log.Record<M>> {
+                    val woke = if (timeout > Duration.ZERO) {
+                        (withTimeoutOrNull(timeout) { consumer.wake.receive() } != null).also { yield() }
+                    } else {
+                        consumer.wake.tryReceive().isSuccess
+                    }
+                    if (!woke) return emptyList()
 
-                val nextOffset = consumer.nextOffset
-                val lag = topic.size - nextOffset
-                if (lag == 0) continue
+                    val nextOffset = consumer.nextOffset
+                    val lag = topic.size - nextOffset
+                    if (lag == 0) return emptyList()
 
-                val messageCount = rand.nextInt(1, lag + 1)
-                LOG.debug("$name/plainConsumer: delivering $messageCount record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
-                try {
-                    processor.processRecords(topic.subList(nextOffset, nextOffset + messageCount).toList())
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Throwable) {
-                    LOG.error(e, "$name/plainConsumer: processRecords failed")
-                    throw e
+                    val messageCount = rand.nextInt(1, lag + 1)
+                    LOG.debug("$name/plainConsumer: delivering $messageCount record(s) [$nextOffset..${nextOffset + messageCount - 1}] (lag=$lag)")
+                    consumer.nextOffset += messageCount
+
+                    if (consumer.nextOffset < topic.size) consumer.wake.trySend(Unit)
+
+                    return topic.subList(nextOffset, nextOffset + messageCount).toList()
                 }
-                consumer.nextOffset += messageCount
-
-                if (consumer.nextOffset < topic.size) consumer.wake.trySend(Unit)
-            }
+            })
         } finally {
-            LOG.debug("$name/tailAll: closing plain subscription")
+            LOG.debug("$name/withTail: closing plain subscription")
             plainConsumers -= consumer
         }
     }

--- a/docs/src/content/docs/ops/config/clojure.md
+++ b/docs/src/content/docs/ops/config/clojure.md
@@ -93,7 +93,6 @@ Main article: [Kafka](/ops/config/log/kafka)
         ;; -- optional
 
         ;; :create-topic? true
-        ;; :poll-duration #xt/duration "PT1S"
         ;; :properties-file "kafka.properties"
         ;; :properties-map {}
         ;; :replication-factor 1

--- a/docs/src/content/docs/ops/config/log/kafka.md
+++ b/docs/src/content/docs/ops/config/log/kafka.md
@@ -36,7 +36,6 @@ v2.1: multi-database support
     bootstrapServers: "localhost:9092"
     topic: "xtdb-log"
     # autoCreateTopic: true
-    # pollDuration: "PT1S"
     # propertiesFile: "kafka.properties"
     # propertiesMap:
 
@@ -45,7 +44,6 @@ v2.1: multi-database support
   logClusters:
     kafkaCluster: !Kafka
   bootstrapServers: "localhost:9092"
-      # pollDuration: "PT1S"
       # propertiesFile: "kafka.properties"
       # propertiesMap:
 
@@ -119,10 +117,6 @@ remotes:
     # initial connection to the Kafka cluster.
     # (Can be set as an !Env value)
     bootstrapServers: "localhost:9092"
-
-    # -- optional
-    # The maximum time to block waiting for records to be returned by the Kafka consumer.
-    # pollDuration: "PT1S"
 
     # Path to a Java properties file containing Kafka connection properties,
     # supplied directly to the Kafka client.

--- a/modules/kafka/src/main/clojure/xtdb/kafka.clj
+++ b/modules/kafka/src/main/clojure/xtdb/kafka.clj
@@ -1,13 +1,11 @@
 (ns xtdb.kafka
-  (:require [xtdb.time :as time]
-            [xtdb.util :as util]
+  (:require [xtdb.util :as util]
             [xtdb.log :as log])
   (:import [xtdb.api.log KafkaCluster$ClusterFactory KafkaCluster$LogFactory]))
 
 (defmethod log/->log-cluster-factory ::cluster
-  [_ {:keys [bootstrap-servers poll-duration properties-map properties-file group-id]}]
+  [_ {:keys [bootstrap-servers properties-map properties-file group-id]}]
   (cond-> (KafkaCluster$ClusterFactory. bootstrap-servers)
-    poll-duration (.pollDuration (time/->duration poll-duration))
     properties-map (.propertiesMap properties-map)
     properties-file (.propertiesFile (util/->path properties-file))
     group-id (.groupId group-id)))

--- a/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
+++ b/modules/kafka/src/main/kotlin/xtdb/api/log/KafkaCluster.kt
@@ -65,11 +65,15 @@ import kotlin.coroutines.resume
 import kotlin.io.path.inputStream
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration as KotlinDuration
 import com.google.protobuf.Any as ProtoAny
 
 private val LOG = KafkaCluster::class.logger
 
 private typealias KafkaConfigMap = Map<String, String>
+
+// One second keeps cancellation responsive without making idle calls a tight loop; tail polls use their caller's timeout.
+private val FETCH_WAIT: Duration = Duration.ofSeconds(1)
 
 private object UnitSerializer : Serializer<Unit> {
     override fun serialize(topic: String?, data: Unit) = null
@@ -207,7 +211,6 @@ private fun AdminClient.warnIfTruncatable(topic: String, replicas: Int) {
 
 class KafkaCluster(
     val kafkaConfigMap: KafkaConfigMap,
-    private val pollDuration: Duration,
     val schemaRegistryUrl: String? = null,
     private val groupId: String = "xtdb",
     coroutineContext: CoroutineContext = Dispatchers.Default
@@ -455,7 +458,7 @@ class KafkaCluster(
         private suspend fun KafkaConsumer<*, ByteArray>.pollRecords() =
             runInterruptible(Dispatchers.IO) {
                 try {
-                    poll(pollDuration)
+                    poll(FETCH_WAIT)
                 } catch (_: WakeupException) {
                     ConsumerRecords.empty()
                 } catch (e: InterruptException) {
@@ -555,7 +558,6 @@ class KafkaCluster(
     @SerialName("!Kafka")
     data class ClusterFactory @JvmOverloads constructor(
         val bootstrapServers: String,
-        var pollDuration: Duration = Duration.ofSeconds(1),
         var propertiesMap: Map<String, String> = emptyMap(),
         var propertiesFile: Path? = null,
         var schemaRegistryUrl: String? = null,
@@ -563,7 +565,6 @@ class KafkaCluster(
         @kotlinx.serialization.Transient var coroutineContext: CoroutineContext = Dispatchers.Default
     ) : Remote.Factory<KafkaCluster> {
 
-        fun pollDuration(pollDuration: Duration) = apply { this.pollDuration = pollDuration }
         fun propertiesMap(propertiesMap: Map<String, String>) = apply { this.propertiesMap = propertiesMap }
         fun propertiesFile(propertiesFile: Path) = apply { this.propertiesFile = propertiesFile }
         fun schemaRegistryUrl(schemaRegistryUrl: String) = apply { this.schemaRegistryUrl = schemaRegistryUrl }
@@ -582,7 +583,7 @@ class KafkaCluster(
                 .plus(propertiesFile?.asPropertiesMap.orEmpty())
 
         override fun open(): KafkaCluster =
-            KafkaCluster(configMap, pollDuration, schemaRegistryUrl, groupId, coroutineContext)
+            KafkaCluster(configMap, schemaRegistryUrl, groupId, coroutineContext)
     }
 
     private inner class KafkaLog<M>(
@@ -627,7 +628,7 @@ class KafkaCluster(
                 c.assign(listOf(tp))
                 c.seek(tp, lastOffset)
 
-                val records = c.poll(pollDuration).records(topic)
+                val records = c.poll(FETCH_WAIT).records(topic)
                 records.firstOrNull()?.let { record -> codec.decode(record.value()) }
             }
 
@@ -648,7 +649,7 @@ class KafkaCluster(
                 c.seek(tp, fromOffset)
 
                 while (c.position(tp) < effectiveToOffset) {
-                    for (rec in c.poll(pollDuration).records(topic)) {
+                    for (rec in c.poll(FETCH_WAIT).records(topic)) {
                         if (rec.offset() >= effectiveToOffset) return@sequence
                         val msg = codec.decode(rec.value()) ?: continue
                         yield(Log.Record(epoch, rec.offset(), ofEpochMilli(rec.timestamp()), msg))
@@ -657,9 +658,9 @@ class KafkaCluster(
             }
         }
 
-        private fun KafkaConsumer<*, ByteArray>.pollRecords(): List<Log.Record<M>> =
+        private fun KafkaConsumer<*, ByteArray>.pollRecords(timeout: Duration): List<Log.Record<M>> =
             try {
-                poll(pollDuration)
+                poll(timeout)
                     .records(topic)
                     .mapNotNull { rec ->
                         Log.Record(
@@ -673,17 +674,34 @@ class KafkaCluster(
                 throw InterruptedException().initCause(e)
             }
 
-        override suspend fun tailAll(partition: Int, afterMsgId: MessageId, processor: Log.RecordProcessor<M>) = coroutineScope {
-            kafkaConfigMap.openConsumer().use { c ->
-                val tp = TopicPartition(topic, 0)
-                c.assign(listOf(tp))
-                c.seekToAfterMsgId(tp, epoch, afterMsgId)
+        override suspend fun <R> withTail(
+            partition: Int,
+            afterMsgId: MessageId,
+            action: suspend (Log.Tail<M>) -> R,
+        ): R = kafkaConfigMap.openConsumer().use { c ->
+            val tp = TopicPartition(topic, 0)
+            c.assign(listOf(tp))
+            c.seekToAfterMsgId(tp, epoch, afterMsgId)
 
-                while (isActive) {
-                    val records = runInterruptible(Dispatchers.IO) { c.pollRecords() }
-                    processor.processRecords(records)
+            action(object : Log.Tail<M> {
+                override suspend fun poll(timeout: KotlinDuration): List<Log.Record<M>> {
+                    val started = kotlin.time.TimeSource.Monotonic.markNow()
+                    var remaining = timeout
+
+                    do {
+                        // Millis rather than `toJavaDuration`, which renders an infinite timeout as a
+                        // seconds-and-nanos pair that overflows the `toMillis` the consumer does internally.
+                        val waitFor = Duration.ofMillis(remaining.coerceAtLeast(KotlinDuration.ZERO).inWholeMilliseconds)
+
+                        val records = runInterruptible(Dispatchers.IO) { c.pollRecords(waitFor) }
+                        if (records.isNotEmpty()) return records
+
+                        remaining = timeout - started.elapsedNow()
+                    } while (remaining > KotlinDuration.ZERO)
+
+                    return emptyList()
                 }
-            }
+            })
         }
 
         override suspend fun openGroupSubscription(listener: Log.SubscriptionListener<M>) {

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -96,12 +96,11 @@ class KafkaClusterTest {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
                     .use { log ->
-                        val job = launch { log.tailAll(0, -1, subscriber) }
+                        val job = launch { log.tailAll(0, -1, processor = subscriber) }
                         try {
                             val txPayload = ByteBuffer.allocate(9).put(-1).putLong(42).flip().array()
                             log.appendMessage(SourceMessage.LegacyTx(txPayload))
@@ -152,7 +151,6 @@ class KafkaClusterTest {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
@@ -167,7 +165,6 @@ class KafkaClusterTest {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
@@ -186,7 +183,6 @@ class KafkaClusterTest {
         val topicName = "test-topic-${UUID.randomUUID()}"
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openSourceLog(mapOf("my-cluster" to cluster))
@@ -272,12 +268,11 @@ class KafkaClusterTest {
                             "max.partition.fetch.bytes" to fourMB.toString()
                         )
                     )
-                    .pollDuration(Duration.ofMillis(100))
                     .open().use { cluster ->
                         KafkaCluster.LogFactory("my-cluster", topicName, autoCreateTopic = false)
                             .openReplicaLog(mapOf("my-cluster" to cluster))
                             .use { log ->
-                                val job = launch { log.tailAll(0, -1, subscriber) }
+                                val job = launch { log.tailAll(0, -1, processor = subscriber) }
                                 try {
                                     log.appendMessage(blockUploaded)
 
@@ -312,7 +307,6 @@ class KafkaClusterTest {
 
         // Default producer max.request.size is 1MB — sending a >1MB message should fail
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topicName)
                     .openReplicaLog(mapOf("my-cluster" to cluster))
@@ -331,7 +325,6 @@ class KafkaClusterTest {
     ) {
         val cluster =
             KafkaCluster.ClusterFactory(container.bootstrapServers)
-                .pollDuration(Duration.ofMillis(100))
                 .open()
 
         cluster.use {
@@ -751,7 +744,6 @@ class KafkaClusterTest {
         val caught = AtomicReference<Throwable?>(null)
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topic)
                     .openSourceLog(mapOf("my-cluster" to cluster))
@@ -763,7 +755,7 @@ class KafkaClusterTest {
                         val completed = supervisorScope {
                             val job = launch {
                                 try {
-                                    log.tailAll(0, anchorInTruncatedPrefix, subscriber)
+                                    log.tailAll(0, anchorInTruncatedPrefix, processor = subscriber)
                                 } catch (e: Throwable) {
                                     caught.set(e)
                                 }
@@ -800,7 +792,6 @@ class KafkaClusterTest {
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topic)
                     .openSourceLog(mapOf("my-cluster" to cluster))
@@ -899,7 +890,6 @@ class KafkaClusterTest {
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topic)
                     .openSourceLog(mapOf("my-cluster" to cluster))
@@ -909,7 +899,7 @@ class KafkaClusterTest {
                         log.appendMessage(txMessage(2))
                         log.appendMessage(txMessage(3))
 
-                        val job = launch { log.tailAll(0, -1L, subscriber) }
+                        val job = launch { log.tailAll(0, -1L, processor = subscriber) }
                         try {
                             withTimeoutOrNull(5.seconds) {
                                 while (synchronized(msgs) { msgs.flatten().size } < 3) delay(100.milliseconds)
@@ -937,7 +927,6 @@ class KafkaClusterTest {
         }
 
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .open().use { cluster ->
                 KafkaCluster.LogFactory("my-cluster", topic)
                     .openSourceLog(mapOf("my-cluster" to cluster))

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaConsumerGroupKeepaliveTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaConsumerGroupKeepaliveTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import xtdb.api.log.Log.SubscriptionListener
 import xtdb.api.log.Log.TailSpec
-import java.time.Duration
 import java.util.UUID
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -62,7 +61,6 @@ class KafkaConsumerGroupKeepaliveTest {
      */
     private suspend fun leadThenLeave(groupId: String, topic: String): Long =
         KafkaCluster.ClusterFactory(container.bootstrapServers)
-            .pollDuration(Duration.ofMillis(100))
             .groupId(groupId)
             .open()
             .use { cluster ->

--- a/src/test/clojure/xtdb/kafka_test.clj
+++ b/src/test/clojure/xtdb/kafka_test.clj
@@ -70,7 +70,6 @@
 (t/deftest ^:integration test-kafka-setup-with-provided-opts
   (let [test-uuid (random-uuid)]
     (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                        :poll-duration "PT2S"
                                                                         :properties-map {}
                                                                         :properties-file nil}]}
                                       :log [:kafka {:cluster :my-kafka
@@ -83,7 +82,6 @@
   (let [test-uuid (random-uuid)]
     (util/with-tmp-dirs #{path}
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
                                         :log [:kafka {:cluster :my-kafka
@@ -115,7 +113,6 @@
     (util/with-tmp-dirs #{local-disk-path}
       ;; Node with storage and log topic
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
                                         :log [:kafka {:cluster :my-kafka
@@ -145,7 +142,6 @@
         IllegalStateException
         #"Database 'xtdb' failed to start due to an invalid transaction log state \(the log is empty\)"
         (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                           :poll-duration "PT2S"
                                                            :properties-map {}
                                                            :properties-file nil}]}
                          :log [:kafka {:cluster :my-kafka
@@ -155,7 +151,6 @@
 
       ;; Node with intact storage and topic 2 (ie, empty topic) along with setting log offset
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
                                         :log [:kafka {:cluster :my-kafka
@@ -180,7 +175,6 @@
           (t/is (nil? (tu/flush-block! node)))))
 
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
                                         :log [:kafka {:cluster :my-kafka
@@ -211,8 +205,7 @@
 
     (util/with-tmp-dirs #{local-disk-path}
       ;; Start a node, write a few transactions to the original topic
-      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"}]}
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                         :log [:kafka {:cluster :my-kafka, :topic original-topic}]
                                         :storage [:local {:path local-disk-path}]})]
         (xt/execute-tx node [[:put-docs :xt_docs {:xt/id :foo}]])
@@ -232,8 +225,7 @@
       ;; Setup a "stale log":
       ;; - Start a node with a new topic and memory storage.
       ;; - Submit two txes to it.
-      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"}]}
+      (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                         :log [:kafka {:cluster :my-kafka
                                                       :topic stale-topic
                                                       :create-topic? true}]
@@ -246,8 +238,7 @@
        (thrown-with-msg?
         IllegalStateException
         #"Database 'xtdb' failed to start due to an invalid transaction log state \(epoch=0, offset=1\) that does not correspond with the latest processed message \(epoch=0 and offset=\d+\)"
-        (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                           :poll-duration "PT2S"}]}
+        (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                          :log [:kafka {:cluster :my-kafka
                                        :topic stale-topic
                                        :create-topic? false}]
@@ -255,7 +246,6 @@
 
       ;; Attempt to restart the node with intact storage, a new topic + new epoch
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
                                         :log [:kafka {:cluster :my-kafka
@@ -282,7 +272,6 @@
 
 ;; Restarting the node again with the same new log path and epoch 1
       (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                          :poll-duration "PT2S"
                                                                           :properties-map {}
                                                                           :properties-file nil}]}
                                         :log [:kafka {:cluster :my-kafka
@@ -314,8 +303,7 @@
   (let [topic (str "xtdb.kafka-test." (random-uuid))]
     (util/with-tmp-dirs #{local-disk-path}
       (t/testing "Start a node, write a number of transactions to the topic - ensure block is cut"
-        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                           :log [:kafka {:cluster :my-kafka, :topic topic}]
                                           :storage [:local {:path local-disk-path}]
                                           :indexer {:rows-per-block 20}
@@ -331,8 +319,7 @@
                      (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))
 
       (t/testing "Restart the node, ensure it picks up from the correct position in the log"
-        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                           :log [:kafka {:cluster :my-kafka, :topic topic}]
                                           :storage [:local {:path local-disk-path}]
                                           :indexer {:rows-per-block 20}
@@ -354,8 +341,7 @@
   (let [topic (str "xtdb.kafka-test." (random-uuid))]
     (util/with-tmp-dirs #{local-disk-path}
       (t/testing "Start a node, write a number of transactions to the log - ensure block is cut"
-        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                           :log [:kafka {:cluster :my-kafka, :topic topic}]
                                           :storage [:local {:path local-disk-path}]
                                           :compactor {:threads 0}})]
@@ -369,8 +355,7 @@
             (t/is (= ["l00-rc-b00.arrow"] (tu/read-files-from-bp-path node "tables/public$docs/meta/"))))))
 
       (t/testing "Restart the node, ensure it picks up from the correct position in the log"
-        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
+        (with-open [node (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                           :log [:kafka {:cluster :my-kafka, :topic topic}]
                                           :storage [:local {:path local-disk-path}]
                                           :compactor {:threads 0}})]
@@ -386,13 +371,11 @@
 (t/deftest ^:integration test-implicit-conn-awaiting
   (let [topic (str "xtdb.kafka-test." (random-uuid))]
     (util/with-tmp-dirs #{local-disk-path}
-      (with-open [node-1 (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
+      (with-open [node-1 (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                           :log [:kafka {:cluster :my-kafka, :topic topic}]
                                           :storage [:local {:path local-disk-path}]
                                           :compactor {:threads 0}})
-                  node-2 (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*
-                                                                            :poll-duration "PT2S"}]}
+                  node-2 (xtn/start-node {:log-clusters {:my-kafka [:kafka {:bootstrap-servers *bootstrap-servers*}]}
                                           :log [:kafka {:cluster :my-kafka, :topic topic}]
                                           :storage [:local {:path local-disk-path}]
                                           :compactor {:threads 0}})
@@ -415,4 +398,3 @@
         (jdbc/execute! xtdb-conn-2 ["INSERT INTO foo RECORDS {_id: 'primary3'}"])
         (t/is (= #{{:_id "primary"} {:_id "primary2"} {:_id "primary3"}}
                  (set (jdbc/execute! xtdb-conn-2 ["SELECT * FROM foo"]))))))))
-


### PR DESCRIPTION
Part of #5917. The election work that needs this is #5927, stacked on top; this lands ahead of it on its own because it changes existing `Log` callers rather than adding API nothing yet uses.

## tl;dr

Log consumers now poll a scoped tail, and an empty poll is a fact about the log rather than about the consumer — without turning the cursor into another active object with its own coroutine lifecycle.

## Future state

- **Make quiet progress observable without adding another active object.**
  - **Keep lifecycle ownership in `LogProcessor`.**
  - **Let each log implementation retain its natural source of truth.**
    - `InMemoryLog` holds one shared-flow subscription for the scoped action, so a slow consumer remains subscribed rather than falling out of replay.
  - **Put the timeout policy in the caller's hands, across its whole range.**
    - One cadence for every consumer of a cluster is what `pollDuration` was, so it goes rather than acquiring a second meaning.
  - **Polling on the caller's coroutine makes an interrupt the caller's to classify.**

<details>
<summary><strong>Alternatives tried: returning a tail from <code>openTail</code></strong></summary>

An escaping `openTail(): Tail` cannot own the subscription cleanly.

- Collecting the shared flow separately for every `poll` call does not stay subscribed between polls, so a slow in-memory consumer can roll out of the replay window.
- Reading `replayCache` directly has the same retention problem: it is a snapshot, not a subscription.
- Giving `Tail` a private coroutine scope makes a passive cursor into an active object and requires a manually paired `close`.
- Passing a caller scope into `openTail` leaks lifecycle ownership across the boundary.

`withTail` instead gives the log a lexical region in which its collector, watcher, or Kafka consumer is valid, while the caller continues to own the coroutine running the work.

</details>

## Compatibility

- **Kotlin implementations:** this changes the public `Log` implementation contract.
- **Kafka configuration:** remove `pollDuration` / `:poll-duration`; no replacement is required because each consumer now supplies its polling timeout.
- **Existing consumers:** `tailAll` retains continuous delivery behaviour.

## Out of scope

- This PR provides the polling boundary; the self-election state machine that uses quiet polls remains part of the wider #5917 work.

## Verification

- `test`, `integration-test` and `property-test`, plus `kafka-test` for the consumer changes.
- The interrupt paths are reached only by interrupting a channel operation mid-flight: `LocalLogTest`'s repeated close-under-subscription cases do it on the read side, and the postgres-source simulations close a node with a write still in flight.
- Required code-review pass: no actionable findings.
