### PR TITLE
feat(sql): an in-band way to identify an XTDB node

### DIFF
--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -1426,14 +1426,6 @@
      :->call-code (fn [[include-implicit?]]
                     `(current-schemas ~include-implicit?))})
 
-(defn parse-version [version-str]
-  (let [[^long major, ^long minor, ^long patch] (->> (re-find #"^(\d+)\.(\d+)\.(\d+)" version-str)
-                                                     rest
-                                                     (map parse-long))]
-    (+ (* major 1000000)
-       (* minor 1000)
-       patch)))
-
 (defn current-setting [setting-name]
   (case setting-name
     "server_version_num" "160000"

--- a/core/src/main/clojure/xtdb/expression.clj
+++ b/core/src/main/clojure/xtdb/expression.clj
@@ -46,12 +46,15 @@
 (defn xtdb-server-version []
   (util/xtdb-version-string))
 
+(defn postgres-version-string []
+  (str "PostgreSQL " postgres-server-version " (XTDB " (util/xtdb-version) ")"))
+
 (defn form->expr [form {:keys [var-types param-types locals] :as env}]
   (cond
     (symbol? form) (cond
                      (= 'xtdb/start-of-time form) {:op :literal, :literal time/start-of-time}
                      (= 'xtdb/end-of-time form) {:op :literal, :literal time/end-of-time}
-                     (= 'xtdb/postgres-server-version form) {:op :literal, :literal (str "PostgreSQL " postgres-server-version)}
+                     (= 'xtdb/postgres-server-version form) {:op :literal, :literal (postgres-version-string)}
                      (= 'xtdb/xtdb-server-version form) {:op :literal, :literal (str "XTDB @ " (xtdb-server-version))}
                      (contains? locals form) {:op :local, :local form}
                      (contains? param-types form) {:op :param, :param form,
@@ -1430,6 +1433,7 @@
   (case setting-name
     "server_version_num" "160000"
     "search_path" (str/join ", " explicit-search-path)
+    "xtdb.version" (util/xtdb-version)
     (throw (err/unsupported ::unsupported-setting (str "Setting not supported: " setting-name)
                             {:setting-name setting-name}))))
 

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -514,18 +514,24 @@
     (when attributes
       (.getValue attributes "Implementation-Version"))))
 
+(defn xtdb-version []
+  (or (some-> (System/getenv "XTDB_VERSION") str/trim not-empty)
+      (manifest-version)
+      "2.x"))
+
+(defn xtdb-git-sha []
+  (or (some-> (System/getenv "GIT_SHA") str/trim not-empty (subs 0 7))
+      (when-let [{:keys [out ^long exit]} (try
+                                            (sh/sh "git" "rev-parse" "--short" "HEAD")
+                                            (catch IOException _))] ; couldn't start git
+        (when (zero? exit)
+          (str/trim out)))))
+
 (defn xtdb-version-string []
-  (let [version (or (some-> (System/getenv "XTDB_VERSION") str/trim not-empty)
-                    (manifest-version)
-                    "2.x")
-        git-sha (or (some-> (System/getenv "GIT_SHA") str/trim not-empty (subs 0 7))
-                    (when-let [{:keys [out ^long exit]} (try
-                                                          (sh/sh "git" "rev-parse" "--short" "HEAD")
-                                                          (catch IOException _))] ; couldn't start git
-                      (when (zero? exit)
-                        (str/trim out))))]
-    (str/join " " [version
-                   (when git-sha (str "[" git-sha "]"))])))
+  (let [version (xtdb-version)]
+    (if-let [git-sha (xtdb-git-sha)]
+      (str version " [" git-sha "]")
+      version)))
 
 (def unconstraint-temporal-metadata
   (let [^TemporalMetadata$Builder builder (TemporalMetadata/newBuilder)]

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -514,18 +514,24 @@
     (when attributes
       (.getValue attributes "Implementation-Version"))))
 
+(def ^:private !xtdb-version
+  (delay (or (some-> (System/getenv "XTDB_VERSION") str/trim not-empty)
+             (manifest-version)
+             "2.x")))
+
 (defn xtdb-version []
-  (or (some-> (System/getenv "XTDB_VERSION") str/trim not-empty)
-      (manifest-version)
-      "2.x"))
+  @!xtdb-version)
+
+(def ^:private !xtdb-git-sha
+  (delay (or (some-> (System/getenv "GIT_SHA") str/trim not-empty (subs 0 7))
+             (when-let [{:keys [out ^long exit]} (try
+                                                   (sh/sh "git" "rev-parse" "--short" "HEAD")
+                                                   (catch IOException _))] ; couldn't start git
+               (when (zero? exit)
+                 (str/trim out))))))
 
 (defn xtdb-git-sha []
-  (or (some-> (System/getenv "GIT_SHA") str/trim not-empty (subs 0 7))
-      (when-let [{:keys [out ^long exit]} (try
-                                            (sh/sh "git" "rev-parse" "--short" "HEAD")
-                                            (catch IOException _))] ; couldn't start git
-        (when (zero? exit)
-          (str/trim out)))))
+  @!xtdb-git-sha)
 
 (defn xtdb-version-string []
   (let [version (xtdb-version)]

--- a/docs/src/content/docs/reference/main/stdlib/other.md
+++ b/docs/src/content/docs/reference/main/stdlib/other.md
@@ -5,9 +5,18 @@ title: Other Functions
 <details>
 <summary>Changelog (last updated v2.2)</summary>
 
+v2.2: `version()` names XTDB
+
+: [`version()`](#postgresql-built-in-functions) returns `'PostgreSQL 16 (XTDB 2.2.0)'`, and [`current_setting('xtdb.version')`](#postgresql-built-in-functions) returns the XTDB version on its own.
+
+  Previously `version()` returned a bare `'PostgreSQL 16'`, indistinguishable from a real PostgreSQL.
+  A client that speaks both dialects has to know which engine it has reached before it sends dialect-specific SQL, and with no intentional probe to ask, it was left keying on incidental behaviour that changes between releases.
+
+  Upgrade: a client matching `version()` against a prefix such as `/^PostgreSQL (\d+)/` is unaffected; one matching the whole string needs to allow for the parenthetical.
+
 v2.2: `current_database` requires parentheses
 
-: `current_database` is now a function — [`current_database()`](#postgresql-compatibility-functions) — rather than a bare keyword.
+: `current_database` is now a function — [`current_database()`](#postgresql-built-in-functions) — rather than a bare keyword.
 
   Previously `SELECT current_database` parsed as a reference to a reserved keyword.
   Now it's a regular function call, which lets tools like Metabase use `SELECT current_database() AS current_database` (same name as keyword and column alias) without a parse error.
@@ -85,4 +94,23 @@ v2.2: `current_database` requires parentheses
 `current_setting(name)` (v2.2+)
 : returns the value of a GUC parameter.
 
-  XTDB recognises a fixed set of parameter names — e.g. `'search_path'` returns `'"$user", public'`, `'server_version_num'` returns the reported PostgreSQL version.
+  XTDB recognises a fixed set of parameter names, and throws on any other:
+
+  - `'search_path'` returns `'public'`.
+  - `'server_version_num'` returns `'160000'` — the PostgreSQL version XTDB reports compatibility with, not XTDB's own version.
+  - `'xtdb.version'` returns XTDB's own version, e.g. `'2.2.0'`.
+
+`version()`
+: returns `'PostgreSQL 16 (XTDB 2.2.0)'`.
+
+  The `PostgreSQL 16` prefix is the wire-protocol compatibility level XTDB claims; the parenthetical names the engine answering, in the position PostgreSQL fills with build information.
+
+  Also spelled `pg_catalog.version()`.
+
+## XTDB functions
+
+`xt.version()`
+: returns XTDB's version and build, e.g. `'XTDB @ 2.2.0 [a1b2c3d]'`.
+
+  The bracketed value is the build's short git SHA, and is omitted where the build doesn't carry one.
+  For the version on its own, use [`current_setting('xtdb.version')`](#postgresql-built-in-functions).

--- a/src/test/clojure/xtdb/sql/expr_test.clj
+++ b/src/test/clojure/xtdb/sql/expr_test.clj
@@ -1,5 +1,6 @@
 (ns xtdb.sql.expr-test
-  (:require [clojure.test :as t]
+  (:require [clojure.string :as str]
+            [clojure.test :as t]
             [next.jdbc :as jdbc]
             [xtdb.api :as xt]
             [xtdb.basis :as basis]
@@ -1062,6 +1063,14 @@
 
   (t/is (= [{:v "160000"}]
            (xt/q tu/*node* "SELECT current_setting('server_version_num') AS v")))
+
+  (let [version (:v (first (xt/q tu/*node* "SELECT current_setting('xtdb.version') AS v")))]
+    (t/is (not (str/blank? version))
+          "xtdb.version resolves rather than throwing")
+
+    (t/is (str/starts-with? (:version (first (xt/q tu/*node* "SELECT xt.version()")))
+                            (str "XTDB @ " version))
+          "xtdb.version agrees with the version xt.version() reports"))
 
   (t/is (anomalous? [:unsupported ::expr/unsupported-setting]
                     (xt/q tu/*node* "SELECT current_setting('block_size') AS v"))))

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -2492,8 +2492,9 @@ SELECT PERIOD(DATE '2022-12-31', TIMESTAMP '2023-01-02') CONTAINS (DATE '2023-01
   (t/is (= [{:transaction-isolation "read committed"}]
            (xt/q tu/*node* "SHOW TRANSACTION ISOLATION LEVEL")))
 
-  (t/is (= [{:version "PostgreSQL 16"}]
-           (xt/q tu/*node* "SELECT pg_catalog.version()")))
+  (t/is (re-matches #"PostgreSQL 16 \(XTDB .+\)"
+                    (:version (first (xt/q tu/*node* "SELECT pg_catalog.version()"))))
+        "version() names XTDB in PostgreSQL's build-info parenthetical")
 
   (t/is (= [{:timezone "America/New_York"}]
            (xt/q tu/*node* "SHOW TIME ZONE"


### PR DESCRIPTION
Resolves #5991.

## tl;dr

- **`version()` now names the engine, and `current_setting('xtdb.version')` reports the version on its own**
  `PostgreSQL 16 (XTDB 2.2.0)` and `2.2.0` respectively. A client choosing between a Postgres dialect and an XTDB one can ask directly instead of keying on behaviour that changes between releases.

- **The compatibility claim a Postgres-targeting client reads is unchanged**
  `PostgreSQL 16` is still the prefix, and the parenthetical is where real PostgreSQL puts build information. A client matching `/^PostgreSQL (\d+)/` needs no change; one matching the whole string does.

## Usage

Three probes, none of which needs an XTDB-specific driver:

```sql
SELECT version();                         -- 'PostgreSQL 16 (XTDB 2.2.0)'
SELECT current_setting('xtdb.version');   -- '2.2.0'
SELECT xt.version();                      -- 'XTDB @ 2.2.0 [a1b2c3d]'
```

`current_setting('xtdb.version')` is the one to compare against a version you know about; the other two carry the compatibility claim and the build sha alongside it. Against a real PostgreSQL it raises `0A000` "unrecognized configuration parameter", the same as any GUC belonging to an extension that isn't installed.

No adoption steps — nothing to configure, migrate or enable.

## Implementation notes

### Why the parenthetical, and not a new function

The issue offered three options, and `version()`'s parenthetical won on the reporter's own argument: real PostgreSQL puts build information there — `PostgreSQL 16.15 (Debian 16.15-1.pgdg120+1)` — so a parser that already tolerates a Debian build string tolerates `(XTDB 2.2.0)`, and the compatibility level stays exactly where a Postgres-targeting client looks for it.

A dedicated `xtdb_version()` is the option dropped. `xt.version()` has occupied that role since 2.0.0, so a second spelling of it would be surface for nothing.

### The version string had to be split before either surface could use it

`util/xtdb-version-string` answered `2.2.0 [a1b2c3d]`, and neither new surface wants the sha: it buries the compatibility claim in `version()`'s parenthetical, and it makes a GUC value something the client has to split before it can compare. `xtdb-version` and `xtdb-git-sha` are now separate, with the joined form kept for the startup banner and `xt.version()`, where the build is the point.

### `current_setting` is per-row, which made a latent wart acute

`codegen-call [:current_setting :utf8]` emits `(current-setting (resolve-string …))` into the row loop — the setting name is an arbitrary expression rather than a literal, and nothing folds constants ahead of codegen. `util/xtdb-version` opens and parses the first `META-INF/MANIFEST.MF` on the classpath, and `xtdb-git-sha` forks a `git rev-parse`, so `SELECT current_setting('xtdb.version') FROM big_table` would have done both per row.

Both are now behind a `delay`, which also takes a `git rev-parse` fork off every plan of `xt.version()` — that one predates this branch.

## Out of scope

- **`xtdb.version` as a pgwire `ParameterStatus` message at connect**
  `pgwire.clj` already sends `server_version` = `16` in the startup set, and `xtdb.version` alongside it would tell a client the engine before it sends a single query — which is where the reporter actually is, choosing a dialect at connect time. Recorded as an open question on #5991.

- **`current_setting('server_version')` still throws while `ParameterStatus` reports `16`**
  The same GUC with two answers depending which way you ask. Left alone deliberately: the reporter's present workaround depends on that refusal, so making it consistent would break the thing this change exists to retire — and not as a side effect of adding an intentional probe.

## Changes

Commits 1–3 are behaviour-preserving apart from the two notes below; the user-visible change is entirely in 4.

1. `tidy(ee):` drop `expr/parse-version` — the packed-integer computation behind the `2001000` that 2.1.0 answered `server_version_num` with, orphaned when that answer became a hardcoded `160000`.
2. `tidy(util):` split `xtdb-version-string` into `xtdb-version`, `xtdb-git-sha` and the joined form. One behaviour change comes with it: no trailing space on a build with no sha, which `(str/join " " [version nil])` used to produce.
3. `fix(util):` read the version and the sha once per process.
4. `feat(sql):` the two new surfaces, the reference entries for all three probes, and the tests. Also corrects the documented `current_setting('search_path')` result — `explicit-search-path` is `["public"]`, not the `"$user", public` the page claimed.

## Test plan

- `xtdb.sql-test/show-canned-responses` asserts `version()` against `#"PostgreSQL 16 \(XTDB .+\)"` — by shape, since the version is whatever the build carries.
- `xtdb.sql.expr-test/test-current-setting` asserts `xtdb.version` resolves non-blank and agrees with what `xt.version()` reports, so the two can't drift apart.
- `./gradlew test`: 1731 tests, 1730 passing. The failure is `xtdb.compactor-test/test-l2+-compaction` timing out at 2000 ms, tracked as flaky in #5885 — same test, same coroutine failure mode, and compaction is untouched here. Confirmed by re-running that namespace twice on an idle machine: 19/19 both times, with `test-l2+-compaction` at 9.6s and 9.8s against the 9.7s and 12.8s #5885 records for its own idle runs.
- `integration-test` and `property-test` not run: the change reaches neither indexing, compaction nor GC, and no integration surface.
