### PR TITLE
fix(logical-plan): EXPLAIN ANALYZE reports every branch of the plan it ran

### DIFF
--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -193,7 +193,8 @@
                      ^ComparatorFactory cmp-factory, ^JoinType join-type]
   ICursor
   (getCursorType [_] (.getJoinTypeName join-type))
-  (getChildCursors [_] (into [build-cursor] (.getChildCursors hash-join-cursor)))
+  (getChildCursors [_] (cond-> [build-cursor]
+                         hash-join-cursor (into (.getChildCursors hash-join-cursor))))
 
   (tryAdvance [this c]
     (when-not hash-join-cursor

--- a/core/src/main/clojure/xtdb/operator/join.clj
+++ b/core/src/main/clojure/xtdb/operator/join.clj
@@ -234,7 +234,8 @@
                          pushdown-blooms]
   ICursor
   (getCursorType [_] "mark-join")
-  (getChildCursors [_] [build-cursor])
+  (getChildCursors [_] (cond-> [build-cursor]
+                         probe-cursor (conj probe-cursor)))
 
   (tryAdvance [this c]
 

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -238,7 +238,8 @@
                                                                   "scan_pages_pruned" :i64, "scan_pages_used" :i64
                                                                   "scan_rows_read" :i64}]
                                   "total_time" #xt/type [:duration :micro]
-                                  "time_to_first_page" #xt/type [:duration :micro]
+                                  ;; null for a branch the plan never advanced — a LIMIT 0 above it, or an unreferenced CTE
+                                  "time_to_first_page" #xt/type [:? :duration :micro]
                                   "page_count" #xt/type :i64
                                   "row_count" #xt/type :i64
                                   "pushdowns" #xt/type :transit})))

--- a/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
+++ b/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
@@ -55,7 +55,7 @@ class LetCursorFactory(
 
     fun wrapBodyCursor(bodyCursor: ICursor) = object : ICursor by bodyCursor {
         override val cursorType get() = "let"
-        override val childCursors get() = listOf(bodyCursor)
+        override val childCursors get() = listOf(boundCursor, bodyCursor)
 
         override fun close() {
             bodyCursor.close()

--- a/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
+++ b/core/src/main/kotlin/xtdb/operator/LetCursorFactory.kt
@@ -35,7 +35,7 @@ class LetCursorFactory(
     override fun open() = object : ICursor {
         private val batches = boundBatches.spliterator()
 
-        override val cursorType get() = "let"
+        override val cursorType get() = "relation"
         override val childCursors get() = emptyList<ICursor>()
 
         override fun tryAdvance(c: Consumer<in RelationReader>): Boolean =
@@ -54,7 +54,7 @@ class LetCursorFactory(
     }
 
     fun wrapBodyCursor(bodyCursor: ICursor) = object : ICursor by bodyCursor {
-        override val cursorType get() = "let-wrapper"
+        override val cursorType get() = "let"
         override val childCursors get() = listOf(bodyCursor)
 
         override fun close() {

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -530,6 +530,20 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
         (t/is (>= scan-rows-read (:row-count scan-row)))
         (t/is (pos? scan-rows-read) "read at least the row we emitted")))))
 
+(t/deftest test-explain-analyze-covers-the-whole-plan
+  (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 7 :name "seven"}]
+                           [:put-docs :docs {:xt/id 8 :name "eight"}]])
+
+  (letfn [(nodes [prefix q]
+            ;; frequencies rather than the sequence: a join cursor reports its build side first, where the plan reports left first
+            (frequencies (map (juxt :depth :op) (xt/q tu/*node* (str prefix q)))))]
+
+    (doseq [q ["SELECT d._id FROM docs d WHERE d._id IN (SELECT v.x FROM (VALUES (1),(7)) v(x)) OR d.name IS NULL"
+               "WITH MATERIALIZED shared AS (SELECT _id, name FROM docs WHERE name IS NOT NULL) SELECT a._id FROM shared a JOIN shared b ON a._id = b._id"
+               "SELECT d._id FROM docs d WHERE d._id IN (SELECT _id FROM docs)"
+               "SELECT d._id FROM docs d JOIN docs e ON d._id = e._id"]]
+      (t/is (= (nodes "EXPLAIN " q) (nodes "EXPLAIN ANALYZE " q)) q))))
+
 (t/deftest test-explain-analyze-of-an-unadvanced-plan
   (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 7 :name "seven"}]])
 

--- a/src/test/clojure/xtdb/api_test.clj
+++ b/src/test/clojure/xtdb/api_test.clj
@@ -530,6 +530,19 @@ VALUES (2, DATE '2022-01-01', DATE '2021-01-01')"])
         (t/is (>= scan-rows-read (:row-count scan-row)))
         (t/is (pos? scan-rows-read) "read at least the row we emitted")))))
 
+(t/deftest test-explain-analyze-of-an-unadvanced-plan
+  (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 7 :name "seven"}]])
+
+  (doseq [[what q] {"a join the limit never advances"
+                    "SELECT d._id FROM docs d JOIN docs e ON d._id = e._id LIMIT 0"
+
+                    "a materialized CTE nothing references"
+                    "WITH MATERIALIZED unused AS (SELECT _id FROM docs) SELECT 1 AS one"}]
+    (let [rows (xt/q tu/*node* (str "EXPLAIN ANALYZE " q))]
+      (t/is (seq rows) what)
+      (t/is (every? (comp zero? :row-count) (filter (comp nil? :time-to-first-page) rows))
+            (str what " — an unadvanced operator reports no first page and no rows")))))
+
 (t/deftest test-explain-analyze-pushdowns
   (let [id1 #uuid "00000000-0000-0000-0000-000000000001"
         id2 #uuid "00000000-0000-0000-0000-000000000002"


### PR DESCRIPTION
Resolves #5989

`EXPLAIN ANALYZE` reports every branch of the plan it executed, where it previously dropped whole sub-trees with no marker.

- **The walk follows the cursor tree, and a cursor that omits a child omits its whole sub-tree**
  Plain `EXPLAIN` walks the emitted plan's `:children` instead, which is why only `ANALYZE` was affected — and why the two trees can be compared against each other to detect a recurrence.

- **Two of the three offending cursors are fixed here; `apply` is #5993**
  `mark-join` creates its probe cursor lazily inside the first `tryAdvance`, and the `WITH MATERIALIZED` wrapper held its bound cursor privately. Both now list what they have.

- **A second defect fell out of the same walk**
  `EXPLAIN ANALYZE` over a join under `LIMIT 0` returned an `xtdb.api.error.Fault` rather than a plan.

## What changes

- **Two operators are named differently in the `op` column**
  The node holding a CTE binding was `let-wrapper` and is now `let`; each reference to that binding was `let` and is now `relation`. Those are the names plain `EXPLAIN` has always used, so `let` no longer means the binding in one command's output and a reference to it in the other's. Neither old string is matched anywhere else in the repo.

- **`time_to_first_page` is nullable, and the other three counters are not**
  An operator that never ran has no time to its first page. `total_time`, `page_count` and `row_count` stay non-null, because zero is a meaningful reading for each of those.

- **The `LIMIT 0` fault was that nullability, unenforced**
  `JoinCursor` builds its hash-join cursor on the first `tryAdvance`, `TopCursor` with a limit of zero never advances its input, and the walk then read the field while it was still null. The NPE reached the client as a `Fault`.

## Usage / migration

A branch the plan never advanced now appears in the output with a null `time_to_first_page`:

```sql
EXPLAIN ANALYZE WITH MATERIALIZED unused AS (SELECT _id FROM docs) SELECT 1 AS one;
```

Anything reading that column has to accept null. pgwire's row description now declares it nullable, where before it declared non-null and the write silently promoted the vector behind that declaration — so a client that trusted the description was already being lied to on this path.

## Consequences

- **The two commands agree on the set of nodes, and not on their order**
  The join cursors report the build side first where the plan reports the left side first, so a comparison between `EXPLAIN` and `EXPLAIN ANALYZE` has to be over node frequencies rather than sequences. The regression test is written that way.

- **`getChildCursors` is load-bearing for diagnostics, not just for teardown**
  A cursor that creates a child lazily has to guard the accessor rather than omit the field, or it silently truncates the analyzed tree. Nothing enforces this.

## Out of scope

Split by whether the work is a defect in this walk or a decision of its own.

- **Correlated subqueries — #5993**
  Same truncation, different cause: `apply` opens and closes its dependent cursor once per input row, so there is no field to expose. Reporting it means first deciding what the counters mean summed over N instances.

- **The child-order difference above**
  Both commands list the same nodes, so the shape is recoverable; only the branch order disagrees.

## Alternative approaches

- **Reporting zero for an operator that never produced a page — rejected**
  It is indistinguishable from an operator that produced its first page instantly, and the truncation this PR fixes is exactly the class of bug where a fabricated zero reads as a measurement. Null is the honest reading, at the cost of a nullable column.

## Open questions

- **Q1: nothing checks that a new lazily-created child cursor is guarded rather than omitted.** The node-parity test catches it for the query shapes it covers; a new operator with a lazy child would reintroduce the truncation for any shape the test doesn't reach.
