### PR TITLE
build(deps): Kotlin 2.4.10 and micrometer-tracing 1.7.1, with the fixes they need

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import dev.clojurephant.plugin.clojure.tasks.ClojureCompile
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jreleaser.gradle.plugin.dsl.deploy.maven.MavenDeployer
 import org.jreleaser.gradle.plugin.tasks.JReleaserDeployTask
 import org.jreleaser.model.Active
@@ -117,6 +118,14 @@ allprojects {
     group = if (proj.hasProperty("labs")) "com.xtdb.labs" else "com.xtdb"
 
     version = System.getenv("XTDB_VERSION") ?: "2.x-SNAPSHOT"
+
+    // Kotlin 2.4 defaults the JVM module name to `{group}:{name}`, and that name is mangled into the JVM
+    // symbol of every `internal` declaration - at the default, `getPath$xtdb_core` becomes
+    // `getPath$com_xtdb_xtdb_core`, out of reach of the Clojure interop that names those symbols literally.
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        extensions.getByType(KotlinJvmProjectExtension::class.java)
+            .compilerOptions.moduleName.set(proj.name)
+    }
 
     repositories {
         mavenCentral()

--- a/core/src/main/kotlin/xtdb/Metrics.kt
+++ b/core/src/main/kotlin/xtdb/Metrics.kt
@@ -120,8 +120,8 @@ object Metrics {
         val tracer = this
         val span = tracer?.let { t ->
             (if (parentSpan != null) t.nextSpan(parentSpan) else t.nextSpan())
-                .name(name).start()
-                .also { sp -> for ((k, v) in attributes) sp.tag(k, v.toString()) }
+                ?.name(name)?.start()
+                ?.also { sp -> for ((k, v) in attributes) sp.tag(k, v.toString()) }
         }
         val scope = if (tracer != null && span != null) tracer.withSpan(span) else null
 

--- a/core/src/main/kotlin/xtdb/api/ICursor.kt
+++ b/core/src/main/kotlin/xtdb/api/ICursor.kt
@@ -70,10 +70,10 @@ interface ICursor : Spliterator<RelationReader>, AutoCloseable {
                     started = true
                     startTime = clock.instant()
                     if (tracer != null && parentSpan != null) {
-                        span = tracer.nextSpan(parentSpan)!!
-                            .name(spanName ?: "query.cursor.${inner.cursorType}")
-                            .tag("cursor.type", inner.cursorType)
-                            .start()
+                        span = tracer.nextSpan(parentSpan)
+                            ?.name(spanName ?: "query.cursor.${inner.cursorType}")
+                            ?.tag("cursor.type", inner.cursorType)
+                            ?.start()
                     }
                 }
                 val pageStart = clock.instant()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ confluent = "7.8.0"
 # On bump: update docs/src/content/docs/ops/external-sources/kafka-connect/reference.md — it names this version and links kafka.apache.org/<NN>/ docs.
 kafka = "4.3.1"
 kotest = "6.1.11"
-kotlin = "2.3.0"
+kotlin = "2.4.10"
 kotlin-coroutines = "1.11.0"
 dokka = "2.2.0"
 clojurephant = "0.9.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ reitit = "0.10.1"
 muuntaja = "0.6.11"
 testcontainers = "2.0.5"
 micrometer = "1.17.1"
-micrometer-tracing = "1.4.1"
+micrometer-tracing = "1.7.1"
 opentelemetry = "1.65.0"
 transit = "1.1.357"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Lands this week's two blocked dependabot bumps — Kotlin 2.4.10 and micrometer-tracing 1.7.1 — together with the compatibility fixes they need, because both bumps fail CI today and neither failure is anything dependabot can fix for itself. Closes #5986, closes #5980.

Both upstream changes are the same shape: a library or compiler default moved in a way that XTDB's Kotlin↔Clojure interop and null-handling noticed, and in both cases the fix is smaller than the diagnosis.

## Changes

Three commits, in dependency order. Each carries the change its own bump needs in order to build, so no commit leaves the tree broken and each can be read on its own:

1. `build: bump the Gradle wrapper to 8.14.4` — a prerequisite for 3, since Kotlin 2.4.10 deprecates Gradle 8.14.2 and Kotlin 2.5.0 will reject it. It is the one commit here that is not a consequence of a dependabot PR, so it is also the one that can drop out without affecting either bump.
2. `build(deps): bump micrometer-tracing from 1.4.1 to 1.7.1` — with the two `Tracer.nextSpan(Span)` null-safety fixes the new JSpecify annotations require.
3. `build(deps): bump kotlin from 2.3.0 to 2.4.10` — with the module-name pin it requires.

Both fixes are behaviour-preserving at the versions being left behind, so either bump could have been split into prepare-then-bump. They are bundled instead so that each commit is atomic: a reader bisecting through this branch never lands on a tree that does not compile.

## Root cause — Kotlin 2.4.10

- **Two Clojure tests name those symbols literally, and both break**
  `segment_merge_test` calls `.getPath$xtdb_core` and `reader_test` calls `.maybePromote$xtdb_core`. At 2.4's default they become `getPath$com_xtdb_xtdb_core` and `maybePromote$com_xtdb_xtdb_core`, and Clojure's `Reflector` throws `IllegalArgumentException: no matching method`.

- **That is the entire blast radius of the bump**
  On #5986 the failures were 1 of 2258 in `test` and 1 of 27 in `property-test`, with `Integration Test`, both SLT jobs and the non-JVM language tests all green. Nothing else in 2.4 moved under us — notably, the new defaulting rules for use-site annotation targets landed back in 2.2, so we have been running them since 2.3 and 2.4 only marks them Stable.

- **Confirmed by reading the class file rather than inferring it**
  `javap -p 'xtdb.compactor.SegmentMerge$Result'` reports `getPath$com_xtdb_xtdb_core` at 2.4.10 unpinned, and `getPath$xtdb_core` at both 2.3.0 and 2.4.10 with the pin.

## Root cause — micrometer-tracing 1.7.1

micrometer-tracing 1.7 annotates its API with JSpecify, and `Tracer.nextSpan(Span)` is declared `@Nullable` while the no-arg `nextSpan()` is not.

- **The asymmetry is what breaks the chain**
  `Metrics.withSpan` picks between the two overloads in an `if`/`else`, so the expression widens to `Span?` and `.name(name).start()` no longer type-checks — `:xtdb-core:compileKotlin` fails at `Metrics.kt:123`, taking every downstream job on #5980 with it.

- **The null was always reachable**
  At 1.4.1 the same return is an unannotated platform type (a JSR-305 `io.micrometer.common.lang.Nullable` nickname), so the safe-call chain is not tolerating a new null — it is handling one the API could always have returned.

- **`Metrics.withSpan` was the compile error; `TracingCursor` was the real exposure**
  `ICursor.kt` held `tracer.nextSpan(parentSpan)!!` — the only site in the tree that passes a parent span, and so the only one the new annotation actually bites. It compiled fine, because `!!` satisfies the compiler; it would have failed queries with an NPE on the cursor's first `tryAdvance`. `ICursor.wrapTracing` is reached from `xtdb.operator.{scan,project,list,set,distinct,join,rename,apply,let,order_by,group_by}`. The assertion was redundant regardless: `span` is a `Span?` field whose only consumer is `span?.let`. Latent rather than live, since `TracerConfig.openTracer` only ever constructs `OtelTracer`, whose `nextSpan(parent)` does not return null.

## Alternatives considered

- **Rename the two Clojure call sites to `$com_xtdb_xtdb_core`** — rejected. The mangled suffix is ABI: every `internal` symbol the Clojure side resolves moves at once, and only two of them happen to be named in tests today. Renaming trades one hardcoded suffix for a longer one and re-breaks on any future group or module rename, where pinning keeps the upgrade ABI-neutral.

- **Make the two members `@InternalApi` and public**, per the internal-but-public rule in `dev/CODING.adoc` — rejected for this PR, not on the merits. It is the right end state, but `Vector.maybePromote`'s `internal` reaches 11 files and would need a `@file:OptIn` in each, which is not a diff to bundle into a dependency bump.

## Out of scope

- **The two Clojure→`internal` call sites remain a standing violation** of the `@InternalApi`-rather-than-`internal` rule in `dev/CODING.adoc`. Resolving it properly means Kotlin white-box tests or a public seam over `Vector.maybePromote`; the pin makes the tests robust to module naming in the meantime.

- **`@OptIn(ExperimentalUuidApi::class)` in `SingleIidSelectorTest` and `MultiIidSelectorTest` is now removable** — 2.4 makes `kotlin.uuid.Uuid` parsing and formatting Stable, and both files use only `Uuid.parse`. Left for a separate tidy.

- **`xtdb.metrics/start-span` keeps the divergence its own kdoc warns about**
  `Metrics.withSpan`'s doc says "Mirrors `xtdb.metrics/with-span`; keep them in sync until the remaining Clojure callers move across", and the Clojure side still does `(-> (if parent-span (.nextSpan tracer parent-span) (.nextSpan tracer)) (.name span-name) (.start))` — which NPEs on a null. It is unreachable today, because its only caller (`query.clj:432`) passes no `parent-span`, and closing it means making `start-span` nilable and teaching `with-span` to skip tracing. That is a contract change to a separate subsystem, so it wants its own commit rather than a dependency bump's.

## Test plan

- `./gradlew test` and `./gradlew property-test` locally on this branch, and both of the tests the Kotlin bump broke now pass: `xtdb.compactor.segment-merge-test > test-merges-segments` and `xtdb.vector.reader-test > multiple-type-promotions`.
- The module-name pin is checked against the class file rather than inferred, at both Kotlin versions — see Root cause above.
- Two pre-existing load-dependent flakes showed up across the local runs, both with matching open issues, and neither reproducible as a regression:

  - `indexer_test > can-ingest-ts-devices-mini-with-stop-start-and-reach-same-state` failed once at the `:410-415` assertion site, finding six blocks where it expects five — #5876's fixed-sleep race (`Thread/sleep 250` against an async block flush with no completion hook). Worth noting for that issue: `:410-415` is the one of the test's two sleep sites #5876 records as never having been observed failing, and "six where five expected" is the opposite direction to the missing-block failure it documents, so the race is two-sided and raising the sleep would not fix this half. Subsequently passed in a full suite run and 3/3 in isolation.

  - `compactor-test > test-l2+-compaction` and `> test-l2-compaction-badly-distributed` failed with `TimeoutCancellationException` at `Compactor.kt:273` — #5885, by name, with both the 1000 ms and 2000 ms timeouts it documents. Confirmed load-dependent rather than a regression: on this same commit they passed one namespace run (12.0s and 1.7s, matching #5885's recorded idle timings of 9.7–12.8s and 1.4s) and failed the next under a machine load average above 11, with several concurrent Gradle daemons from other worktrees.

  Both also passed on #5986's own CI run, where Kotlin 2.4.10 was the only variable, and nothing in this branch touches indexing or compaction.
- Full CI green on this branch — all nine jobs, including `Integration Test` and both SLT jobs, which the local runs do not cover.

