### PR TITLE
fix(scan): _id equality against a cast or a non-ID literal finds the row again

### DIFF
--- a/core/src/main/clojure/xtdb/operator/scan.clj
+++ b/core/src/main/clojure/xtdb/operator/scan.clj
@@ -125,20 +125,20 @@
         (= '_id (nth eid-select 2))
         (second eid-select)))
 
-(def ^:private dummy-iid (byte-array 16))
+(defn- resolve-eid-to-iid
+  "nil where we can't prove the eid resolves to a single IID, so the caller must not narrow the scan.
+   A value of a type no ID can have is one of those: `_id = 7.0` still matches an integer ID of 7."
+  ^bytes [eid ^RelationReader args-rel]
+  (cond
+    (and (s/valid? ::lp/value eid) (util/valid-iid? eid))
+    (util/->iid eid)
 
-(defn- resolve-eid-to-iid ^bytes [eid ^RelationReader args-rel]
-  (or (cond
-        (and (s/valid? ::lp/value eid) (util/valid-iid? eid))
-        (util/->iid eid)
-
-        (s/valid? ::lp/param eid)
-        (when-let [eid-rdr (.vectorForOrNull args-rel (name eid))]
-          (when (= 1 (.getValueCount eid-rdr))
-            (let [eid-val (.getObject eid-rdr 0)]
-              (when (util/valid-iid? eid-val)
-                (util/->iid eid-val))))))
-      dummy-iid))
+    (s/valid? ::lp/param eid)
+    (when-let [eid-rdr (.vectorForOrNull args-rel (name eid))]
+      (when (= 1 (.getValueCount eid-rdr))
+        (let [eid-val (.getObject eid-rdr 0)]
+          (when (util/valid-iid? eid-val)
+            (util/->iid eid-val)))))))
 
 (defn- flatten-or
   [expr]
@@ -161,20 +161,18 @@
 
 (defn selects->iid-set ^SortedSet [selects ^RelationReader args-rel]
   (when-let [eid-select (get selects "_id")]
-    (cond
-      ;; Single equality: (== _id value)
-      (= '== (first eid-select))
-      (when-let [eid (eid-select->eid eid-select)]
-        (doto (TreeSet. Bytes/COMPARATOR)
-          (.add (resolve-eid-to-iid eid args-rel))))
+    (when-let [eids (cond
+                      ;; Single equality: (== _id value)
+                      (= '== (first eid-select))
+                      (some-> (eid-select->eid eid-select) vector)
 
-      ;; OR chain: (or (== _id v1) (== _id v2) ...)
-      (= 'or (first eid-select))
-      (when-let [eids (extract-id-eqs-from-or eid-select)]
-        (let [iid-set (TreeSet. Bytes/COMPARATOR)]
-          (doseq [eid eids]
-            (.add iid-set (resolve-eid-to-iid eid args-rel)))
-          iid-set)))))
+                      ;; OR chain: (or (== _id v1) (== _id v2) ...)
+                      (= 'or (first eid-select))
+                      (extract-id-eqs-from-or eid-select))]
+      (let [iids (mapv #(resolve-eid-to-iid % args-rel) eids)]
+        (when (every? some? iids)
+          (doto (TreeSet. Bytes/COMPARATOR)
+            (.addAll iids)))))))
 
 (defn filter-pushdown-bloom-page-idx-pred ^IntPredicate [^PageMetadata page-metadata, pushdown-blooms, ^String col-name]
   (when-let [^MutableRoaringBitmap pushdown-bloom (get pushdown-blooms (symbol col-name))]

--- a/core/src/main/clojure/xtdb/util.clj
+++ b/core/src/main/clojure/xtdb/util.clj
@@ -186,7 +186,8 @@
 (defn ->iid ^bytes [eid]
   (Iid/getAsIid eid))
 
-(def valid-iid? (some-fn uuid? string? keyword? integer?))
+;; `int?` rather than `integer?`: `Iid/getAsIid` throws on BigInt and BigInteger.
+(def valid-iid? (some-fn uuid? string? keyword? int?))
 
 (defn ->lex-hex-string
   "Turn a long into a lexicographically-sortable hex string by prepending the length"

--- a/src/test/clojure/xtdb/operator/scan_test.clj
+++ b/src/test/clojure/xtdb/operator/scan_test.clj
@@ -404,7 +404,7 @@
 
     (with-open [^RelationReader args-rel (tu/open-args {:search-uuid [#uuid "00000000-0000-0000-0000-000000000000"
                                                                       #uuid "80000000-0000-0000-0000-000000000000"]})]
-      (t/is (nil? (scan/selects->iid-set '{_id (== _id ?search_uuid)} args-rel))))
+      (t/is (nil? (scan/selects->iid-set '{"_id" (== _id ?search_uuid)} args-rel))))
 
     (let [old-selects->iid-set scan/selects->iid-set]
       (with-redefs [scan/selects->iid-set
@@ -483,6 +483,35 @@
                                                                       (list '== '_id uuid1)
                                                                       (list '== '_id uuid2))}]}]
                                      {:node tu/*node*})))))))))
+
+(t/deftest test-id-equality-against-an-unresolvable-eid-still-finds-the-row-5987
+  (xt/execute-tx tu/*node* ["INSERT INTO docs RECORDS {_id: 7, name: 'seven'}, {_id: 'abc', name: 'abc'}"])
+
+  (t/testing "no IID to narrow to"
+    (t/is (nil? (scan/selects->iid-set '{"_id" (== _id (cast 7 #xt/type :i64))} vw/empty-args))
+          "an expression we don't evaluate here")
+
+    (t/is (nil? (scan/selects->iid-set {"_id" (list '== '_id 7.0)} vw/empty-args))
+          "no ID can be a double, but = can still match the integer 7")
+
+    (t/is (nil? (scan/selects->iid-set {"_id" (list '== '_id 7N)} vw/empty-args))
+          "Iid/getAsIid rejects a BigInt, so we must decline rather than throw")
+
+    (t/is (nil? (scan/selects->iid-set '{"_id" (or (== _id 7) (== _id (cast 8 #xt/type :i64)))} vw/empty-args))
+          "one unresolvable branch poisons the whole OR chain"))
+
+  (t/testing "the row comes back anyway"
+    (doseq [q ["SELECT * FROM docs WHERE _id = 7"
+               "SELECT * FROM docs WHERE _id = 7::bigint"
+               "SELECT * FROM docs WHERE _id = CAST(7 AS BIGINT)"
+               "SELECT * FROM docs WHERE 7::bigint = _id"
+               "SELECT * FROM docs WHERE _id = 7.0"
+               "SELECT * FROM docs WHERE _id = COALESCE(7::bigint, 0)"]]
+      (t/is (= [{:xt/id 7, :name "seven"}] (xt/q tu/*node* q)) q))
+
+    (t/is (= [{:xt/id 7, :name "seven"}] (xt/q tu/*node* ["SELECT * FROM docs WHERE _id = ?::bigint" 7])))
+
+    (t/is (= [{:xt/id "abc", :name "abc"}] (xt/q tu/*node* "SELECT * FROM docs WHERE _id = 'abc'::text")))))
 
 (t/deftest test-iid-fast-path-block-boundary
   (let [before-uuid #uuid "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
Resolves #5987.

The IID fast path narrows a scan to the IIDs an `(== _id …)` select can match, and `resolve-eid-to-iid` had no way to report that it couldn't work one out — it fell back to `dummy-iid`, sixteen zero bytes, so "the eid is IID x" and "I can't resolve this eid" were the same return value. Dropping the dummy and returning nil is the whole fix; the rest of this is why nil has to propagate as far as it does.

- **The narrowing was never returning wrong rows — it was hiding right ones**
  `col-preds` re-checks every row the scan visits, so a bogus IID can only ever cost recall. That is what makes the failure silent rather than an error.

- **`_id = 7.0` fails the same way with no cast in it**
  Not in the issue as filed; found while tracing the cast case. `valid-iid?` rejected the double so it took the dummy too — but `=` between i64 `7` and f64 `7.0` is true, so the integer ID 7 was a row the predicate would have matched.

- **So `dummy-iid` goes entirely, rather than being kept for values that can't be IDs**
  "No ID can *be* 7.0" and "no ID can *equal* 7.0" are different claims, and the fast path was relying on the second. The narrowing that remains is sound because `Iid.getAsIid` runs at index time, so no row can hold an `_id` of a type it rejects.

## Implementation notes

- **The union of a set of IIDs with an unknown is unknown**
  One unresolvable branch of an OR chain therefore disables narrowing for the whole chain, rather than narrowing to the branches that did resolve.

- **The function whose contract is now "nil where we can't prove an IID" could otherwise throw instead**
  `integer?` admits `BigInt` and `BigInteger`, which `Iid.getAsIid` rejects with `xtdb/invalid-id`. `int?` matches `getAsIid`'s Long/Integer/Short/Byte exactly, and `resolve-eid-to-iid` is its only caller.

- **A pre-existing test was asserting nothing**
  `test-iid-fast-path` keyed its `selects` map on the symbol `_id` rather than the string `"_id"`, so `(get selects "_id")` missed and the `nil?` assertion held whatever the args were. It is in this commit rather than a separate tidy because with the right key it fails *before* the fix.

## Out of scope

- **The point-lookup plan — #3849**
  `_id = $1::bigint` is correct now but plans as a full scan. #3849 now carries it, alongside the temporal half it already covered.

- **`join.clj`'s unguarded build-side `->iid`**
  `build-pushdowns` calls `util/->iid` on a build-side key value with no `valid-iid?` check, so a join between `docs._id` and a double column throws `Invalid ID type: java.lang.Double` during the build phase. Pre-existing, and it fails loud rather than silently, so it wants its own card rather than widening this change.

## Test plan

- Full `./gradlew test` green, verified from the JUnit XML rather than the console: 1732 tests, 0 failures, 0 errors.
- `xtdb.operator.scan` reloads clean under `*warn-on-reflection*`.
