### PR TITLE
fix(healthz): /healthz/started ignores non-critical databases (resolves #5909)

### DIFF
--- a/core/src/main/clojure/xtdb/healthz.clj
+++ b/core/src/main/clojure/xtdb/healthz.clj
@@ -62,8 +62,8 @@
                 ["/healthz/started" {:name :started
                                      :get (fn [{:keys [^Database$Catalog db-cat initial-target-message-ids]}]
                                             (let [catching-up (for [[^String db-name, target-msg-ids] initial-target-message-ids
-                                                                    :let [db (.databaseOrNull db-cat db-name)]
-                                                                    :when db
+                                                                    :let [^Database db (.databaseOrNull db-cat db-name)]
+                                                                    :when (and db (.isCritical db))
                                                                     :let [lpm-id (.getLatestProcessedMsgId db)]
                                                                     :when (some #(< lpm-id (long %)) target-msg-ids)]
                                                                 {:db db-name, :current lpm-id, :targets target-msg-ids})]

--- a/src/test/clojure/xtdb/healthz_test.clj
+++ b/src/test/clojure/xtdb/healthz_test.clj
@@ -222,6 +222,26 @@
     (t/is (= [] (#'healthz/all-databases db-cat))
           "a name that no longer resolves must not reach the callers that dereference it")))
 
+(t/deftest test-started-ignores-non-critical-catchup-5909
+  (util/with-tmp-dirs #{local-path}
+    (with-open [node (tu/->local-node {:node-dir local-path})]
+      (let [^Database$Catalog db-cat (db/<-node node)]
+        (.attach db-cat "critical-db" (-> (Database$Config.) (.critical true)))
+        (.attach db-cat "non-critical-db" (Database$Config.))
+
+        (let [h (healthz/handler {:db-cat db-cat})
+              still-catching-up [Long/MAX_VALUE]]
+
+          (t/testing "non-critical db still catching up doesn't block /healthz/started"
+            (let [resp (h {:request-method :get, :uri "/healthz/started"
+                           :initial-target-message-ids {"non-critical-db" still-catching-up}})]
+              (t/is (= 200 (:status resp)))))
+
+          (t/testing "critical db still catching up does block /healthz/started"
+            (let [resp (h {:request-method :get, :uri "/healthz/started"
+                           :initial-target-message-ids {"critical-db" still-catching-up}})]
+              (t/is (= 503 (:status resp))))))))))
+
 (t/deftest test-alive-primary-always-critical
   (util/with-tmp-dirs #{local-path}
     (with-open [node (tu/->local-node {:node-dir local-path})]


### PR DESCRIPTION
Resolves #5909

- **`/healthz/started` now skips non-critical databases when deciding whether the node is still catching up**, the same way `/healthz/alive` already skips them when deciding whether the node is unhealthy.
  - Hit in practice: a non-critical secondary stuck catching up held a node's startup probe unhealthy, blocking the node from coming up.
  - `initial-target-message-ids` is a snapshot taken once when the healthz server opens; a database's `critical` flag doesn't change afterwards, but filtering at the point that already resolves `db-name` → `Database` (to read `getLatestProcessedMsgId`) keeps that resolution and the criticality check together, rather than pre-filtering a map the handler still has to resolve database-by-database anyway.
- **Test drives `healthz/handler` directly with a synthetic `initial-target-message-ids`**, instead of racing a real node's catch-up window the way the existing `test-started-catchup-4273` does.
  `open-server` builds that map once from the databases attached at server-open time, so a database attached afterwards — as the existing `test-alive-critical-secondary` does for `/healthz/alive` — never reaches it; reaching the catching-up state at all needs a target planted before the request.

tl;dr

- **Filters `/healthz/started`'s catching-up check by `critical`**, matching `/healthz/alive`'s existing behaviour, so a stuck non-critical secondary no longer blocks node startup.
