### PR TITLE
fix(sql): EXPLAIN works for plans containing window functions or UNNEST

### DIFF
--- a/core/src/main/clojure/xtdb/operator/group_by.clj
+++ b/core/src/main/clojure/xtdb/operator/group_by.clj
@@ -591,11 +591,11 @@
                                                              #(.getType ^AggregateSpec$Factory %))))))]
           {:op :group-by
            :children [inner-rel]
-           :explain {:group-by (mapv str group-cols)
+           :explain {:group-by (vec group-cols)
                      :aggregates (->> aggs
                                       (mapv (fn [[_ agg]]
                                               (let [[to-column agg-form] (first agg)]
-                                                [(str to-column) (pr-str agg-form)]))))}
+                                                [to-column (pr-str agg-form)]))))}
            :vec-types out-vec-types
 
            :->cursor (fn [{:keys [allocator args schema explain-analyze? tracer query-span]} in-cursor]

--- a/core/src/main/clojure/xtdb/operator/rename.clj
+++ b/core/src/main/clojure/xtdb/operator/rename.clj
@@ -52,7 +52,7 @@
     (lp/with-col-mapping
       {:op :rename
        :children [emitted-child-relation]
-       :explain {:prefix (some-> prefix str), :columns (some-> columns pr-str)}
+       :explain {:prefix prefix, :columns (some-> columns pr-str)}
        :vec-types out-vec-types
        :stats (:stats emitted-child-relation)
        :col-mapping col-mapping

--- a/core/src/main/clojure/xtdb/query.clj
+++ b/core/src/main/clojure/xtdb/query.clj
@@ -2,6 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [xtdb.basis :as basis]
             [xtdb.error :as err]
             [xtdb.expression :as expr]
@@ -212,7 +213,8 @@
             (lazy-seq
              (cons {:depth (str (str/join (repeat depth "  ")) "->")
                     :op op
-                    :explain explain}
+                    ;; a symbol left in an explain value throws in `asVectorType` when the rows are typed
+                    :explain (walk/postwalk #(cond-> % (symbol? %) str) explain)}
                    (->> (for [child children]
                           (->explain-plan* child (inc depth)))
                         (sequence cat)))))]

--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -543,6 +543,40 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
            (xt/q tu/*node*
                  "EXPLAIN SELECT u._id, u.foo FROM users u WHERE u.a + u.b = 12 AND u.b = 1"))))
 
+(t/deftest test-explain-plan-window-fn-5990
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO docs RECORDS {_id: 7, name: 'seven'}"]])
+
+  (t/is (= [{:depth "->", :op :project
+             :explain {:project "[{_id t.1/_id} {rk xt$row_number_2}]", :append? false}}
+            {:depth "  ->", :op :window
+             :explain {:partition-by ["t.1/_id"]
+                       :order-by "[[_ob4 {:direction :desc, :null-ordering :nulls-first}]]"
+                       :window-functions [["xt$row_number_2" "[:nullary {:f row-number}]"]]}}
+            {:depth "    ->", :op :project
+             :explain {:project "[{_ob4 t.1/_id}]", :append? true}}
+            {:depth "      ->", :op :rename
+             :explain {:prefix "t.1"}}
+            {:depth "        ->", :op :scan
+             :explain {:table "xtdb.public.docs", :columns ["_id"], :predicates []}}]
+           (xt/q tu/*node*
+                 "EXPLAIN SELECT t._id, row_number() OVER (PARTITION BY t._id ORDER BY t._id DESC) AS rk FROM docs t"))))
+
+(t/deftest test-explain-plan-unnest-5990
+  (xt/execute-tx tu/*node* [[:sql "INSERT INTO arrs RECORDS {_id: 1, xs: [1, 2, 3]}"]])
+
+  (t/is (= [{:depth "->", :op :project
+             :explain {:project "[{_id a.1/_id} {x u.3/x}]", :append? false}}
+            {:depth "  ->", :op :unnest
+             :explain {:from "unnest", :to "u.3/x", :ordinality "u.3/o"}}
+            {:depth "    ->", :op :project
+             :explain {:project "[{unnest a.1/xs}]", :append? true}}
+            {:depth "      ->", :op :rename
+             :explain {:prefix "a.1"}}
+            {:depth "        ->", :op :scan
+             :explain {:table "xtdb.public.arrs", :columns ["xs" "_id"], :predicates []}}]
+           (xt/q tu/*node*
+                 "EXPLAIN SELECT a._id, u.x FROM arrs a, UNNEST(a.xs) WITH ORDINALITY AS u(x, o)"))))
+
 (t/deftest test-normalising-nested-cols-2483
   (xt/submit-tx tu/*node* [[:put-docs :docs {:xt/id 1 :foo {:a/b "foo"}}]])
   (t/is (= [{:foo {:a/b "foo"}}] (xt/q tu/*node* "SELECT docs.foo FROM docs")))


### PR DESCRIPTION
Resolves #5990.

- **`EXPLAIN` now works for the two operators it threw on**, and the stringification that made it work lives in one place instead of thirteen.
  A reviewer of the explain path should know that `:explain` maps may now contain plan-native values — `->explain-plan` renders them.

- **Nothing else about `EXPLAIN` changes.**
  `xtdb.node-test/test-explain-plan-sql` and `xtdb.api-test/test-explain-plan-2383` assert the existing output verbatim and are untouched.

## Context

#5990's other two parts turned out to be different problems and are split out — #6001 (plain `EXPLAIN` not decodable by a generic FlightSQL client) and #6002 (`EXPLAIN ANALYZE` crashing server-side over ADBC). Part C, parameters over the pgwire simple protocol, is working as intended.

The bug predates v2.1.0 (65bf426b, which introduced the per-operator `:explain` maps), so it is not an rc regression.

## Implementation notes

- **The fix is at the boundary, not at the two broken sites**
  `xtdb.operator.window` and `xtdb.operator.unnest` put raw column-name symbols into `:explain`; `ValueTypes.asVectorType` has no `Symbol` branch, so `explain-plan-types` threw while deriving the result struct type. The other ten operators each stringified by hand, so the requirement was known at ten sites and missed at two — which is the argument for moving it rather than adding an eleventh. `->explain-plan` is where an emitted plan becomes a result relation, so rendering plan-native values is its job.

- **`pr-str` stays at the emit sites, `str` does not**
  How to show a predicate or an aggregate form is a readability choice belonging to the operator. Symbol-to-string is a representation requirement of the result relation, and belongs to whoever builds it.

- **Both `->explain-plan` callers normalise identically, which is load-bearing**
  It feeds `explain-plan-types` at prepare time and the result rows at execute time, so plain `EXPLAIN` cannot develop a split between the column types it declares and the rows it returns. #6002 is that split, for `EXPLAIN ANALYZE`, which declares its types as a literal instead.

- **The second commit is a pure equivalence change**, and a candidate for cherry-picking to `main` independently of the fix.

## Dead ends

- **Fixing `window.clj` and `unnest.clj` in place** was the first shape, and it was rejected once the count came out at ten-versus-two — it leaves the same trap for the next operator, and a code-review pass separately flagged that the two coexisting conventions give the next author no signal which to follow. That finding is what turned the tidy from optional into the second commit.

## Test plan

- `xtdb.node-test/test-explain-plan-window-fn-5990` — the reported query, asserting the whole plan.
- `xtdb.node-test/test-explain-plan-unnest-5990` — `UNNEST … WITH ORDINALITY`, which fails identically on `main` and was not in the report.
- `./gradlew test` — 1,736 tests, no failures.
