### PR TITLE
fix(xtql): an inline XTQL fn's params are numbered in the statement's source order

### DIFF
--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -1284,6 +1284,22 @@
     (-> (.expr filter-ctx)
         (.accept (assoc this :!aggs nil, :scope (assoc scope :!implied-gicrs nil))))))
 
+(defn- ->param-idx-visitor
+  "Resolves a `parameterSpecification` to its index into the args relation.
+
+  A `?`'s index comes from the pre-pass rather than a counter bumped on visit:
+  the planner visits WHERE before the select list, and a subquery before the projection that wraps it,
+  so allocating on visit binds arguments to the wrong placeholders."
+  ^SqlVisitor [{:keys [^Map dynamic-param-idxs]}]
+  (reify SqlVisitor
+    (visitDynamicParameter [_ ctx] (long (.get dynamic-param-idxs ctx)))
+    (visitPostgresParameter [_ ctx] (dec (parse-long (subs (.getText ^ParserRuleContext ctx) 1))))))
+
+(defn- ->param-sym [{:keys [!param-count]} param-idx]
+  (swap! !param-count max (inc (long param-idx)))
+  (-> (symbol (str "?_" param-idx))
+      (vary-meta assoc :param? true)))
+
 (defrecord ExprPlanVisitor [env scope]
   SqlVisitor
   (visitSearchCondition [this ctx] (list* 'and (mapv (partial accept-visitor this) (.expr ctx))))
@@ -1364,20 +1380,13 @@
 
   (visitParamExpr [this ctx] (-> (.parameterSpecification ctx) (.accept this)))
 
-  ;; the index comes from the pre-pass rather than a counter bumped here:
-  ;; the planner visits WHERE before the select list, and a subquery before the projection that wraps it,
-  ;; so allocating on visit binds arguments to the wrong placeholders.
-  (visitDynamicParameter [{{:keys [!param-count ^Map dynamic-param-idxs]} :env} ctx]
-    (let [param-idx (long (.get dynamic-param-idxs ctx))]
-      (swap! !param-count max (inc param-idx))
-      (-> (symbol (str "?_" param-idx))
-          (vary-meta assoc :param? true))))
+  (visitDynamicParameter [{:keys [env]} ctx]
+    (->> (.accept ^ParserRuleContext ctx (->param-idx-visitor env))
+         (->param-sym env)))
 
-  (visitPostgresParameter [{{:keys [!param-count]} :env} ctx]
-    (-> (symbol (str "?_" (let [param-idx (parse-long (subs (.getText ctx) 1))]
-                            (swap! !param-count max param-idx)
-                            (dec param-idx))))
-        (vary-meta assoc :param? true)))
+  (visitPostgresParameter [{:keys [env]} ctx]
+    (->> (.accept ^ParserRuleContext ctx (->param-idx-visitor env))
+         (->param-sym env)))
 
   (visitStaticLiteral [this ctx] (-> (.literal ctx) (.accept this)))
   (visitStaticParam [this ctx] (-> (.parameterSpecification ctx) (.accept this)))
@@ -2507,11 +2516,10 @@
                          (->> (.recordValueConstructor ctx)
                               (into [] (comp (mapcat (partial accept-visitor
                                                               (reify SqlVisitor
-                                                                (visitParameterRecord [this ctx] (.accept (.parameterSpecification ctx) this))
-
-                                                                (visitDynamicParameter [_ ctx] (emit-param (long (.get ^Map (:dynamic-param-idxs env) ctx))))
-                                                                (visitPostgresParameter [_ ctx]
-                                                                  (emit-param (dec (parse-long (subs (.getText ctx) 1)))))
+                                                                (visitParameterRecord [_ ctx]
+                                                                  (-> (.parameterSpecification ctx)
+                                                                      (.accept (->param-idx-visitor env))
+                                                                      (emit-param)))
 
                                                                 (visitObjectRecord [this ctx]
                                                                   (->> (.objectNameAndValue (.objectConstructor ctx))

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -26,9 +26,10 @@
            (org.apache.arrow.vector.types.pojo Field)
            (org.apache.commons.codec.binary Hex)
            (xtdb.tx TxOp$PatchDocs TxOp$PutDocs)
-           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$DynamicParameterContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
+           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$DynamicParameterContext Sql$XtqlQueryContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
            (xtdb.arrow RelationReader VectorReader)
            (xtdb.query ParsedStatement$Dml SqlParser SqlPlanner)
+           (xtdb.xtql QueryWithParams)
            xtdb.api.TableRef
            xtdb.util.StringUtil))
 
@@ -2892,12 +2893,25 @@
                         (mapv #(->col-sym (str unique-table-alias) (str %)))))))
 
   (visitXtqlQuery [_ ctx]
-    (let [{:keys [ra-plan]} (-> (edn/read-string {:readers *data-readers*}
-                                                 (.accept (.xtqlQuery ctx) string-literal-visitor))
-                                (xtql/parse-query env)
-                                (xtql.plan/compile-query {:table-info (:table-info env)}))]
+    (let [param-idxs (if-let [xtql-params (.xtqlParams ctx)]
+                       (mapv (fn [^ParserRuleContext param-ctx]
+                               (long (.accept param-ctx (->param-idx-visitor env))))
+                             (.parameterSpecification xtql-params))
+                       (.get ^Map (:dynamic-param-idxs env) ctx))
 
-      (->QueryExpr ra-plan (mapv symbol (lp/relation-columns ra-plan)))))
+          parsed (-> (edn/read-string {:readers *data-readers*}
+                                      (.accept (.xtqlQuery ctx) string-literal-visitor))
+                     (xtql/parse-query (assoc env :param-idxs param-idxs)))]
+
+      ;; the placeholders are never planned as expressions, so this is the only place the statement's
+      ;; param count hears about them - and only once the query has turned out to be a fn that takes
+      ;; them, since otherwise nothing consumes the arguments they stand for.
+      (when (instance? QueryWithParams parsed)
+        (doseq [param-idx param-idxs]
+          (swap! (:!param-count env) max (inc (long param-idx)))))
+
+      (let [{:keys [ra-plan]} (xtql.plan/compile-query parsed {:table-info (:table-info env)})]
+        (->QueryExpr ra-plan (mapv symbol (lp/relation-columns ra-plan))))))
 
   (visitSubquery [this ctx] (-> (.queryExpression ctx) (.accept this)))
 
@@ -3393,15 +3407,50 @@
   (doseq [warning @!warnings]
     (log/debug (error-string warning))))
 
+(defn- xtql-arg-count
+  "How many arguments an inline XTQL query consumes, where its top-level form is a fn.
+
+  A string that doesn't read counts zero, leaving the error for `visitXtqlQuery` to raise where it
+  has the reader's context."
+  [^Sql$XtqlQueryContext ctx]
+  (or (try
+        (-> (edn/read-string {:readers *data-readers*}
+                             (.accept (.xtqlQuery ctx) string-literal-visitor))
+            (xtql/fn-arity))
+        (catch Exception _))
+      0))
+
 (defn- ->dynamic-param-idxs
-  "Maps each `?` in the tree to its ordinal among the tree's `?`s, in source order."
+  "Maps each node that consumes positional arguments to the indices it takes, in source order.
+
+  A `?` takes one, keyed to the index itself. An inline XTQL query written without `xtqlParams` takes
+  one per param of its top-level fn, keyed to the vector of them: those params are what the arguments
+  bind to, and there is no placeholder standing in for each. Numbering them here rather than counting
+  from zero within the query is what stops them colliding with the statement's own `?`s."
   ^Map [^ParseTree tree]
-  (let [idxs (IdentityHashMap.)]
-    (letfn [(walk! [^ParseTree node]
-              (if (instance? Sql$DynamicParameterContext node)
-                (.put idxs node (.size idxs))
-                (dotimes [child-idx (.getChildCount node)]
-                  (walk! (.getChild node child-idx)))))]
+  (let [idxs (IdentityHashMap.)
+        !next-idx (int-array 1)]
+    (letfn [(claim! [node arg-count]
+              (let [idx (aget !next-idx 0)]
+                (aset !next-idx 0 (+ idx (int arg-count)))
+                idx))
+
+            (walk-children! [^ParseTree node]
+              (dotimes [child-idx (.getChildCount node)]
+                (walk! (.getChild node child-idx))))
+
+            (walk! [^ParseTree node]
+              (condp instance? node
+                Sql$DynamicParameterContext (.put idxs node (claim! node 1))
+
+                Sql$XtqlQueryContext (let [^Sql$XtqlQueryContext xtql-ctx node]
+                                       (if (.xtqlParams xtql-ctx)
+                                         (walk-children! node)
+                                         (let [arg-count (xtql-arg-count xtql-ctx)
+                                               base (claim! node arg-count)]
+                                           (.put idxs node (vec (range base (+ base arg-count)))))))
+
+                (walk-children! node)))]
       (walk! tree))
     idxs))
 

--- a/core/src/main/clojure/xtdb/xtql.clj
+++ b/core/src/main/clojure/xtdb/xtql.clj
@@ -17,6 +17,16 @@
 
 (defn- query-type? [q] (seq? q))
 
+(defn fn-arity
+  "The number of arguments `query` takes, where its top-level form is a fn; nil otherwise."
+  [query]
+  (when (query-type? query)
+    (let [[op params] query]
+      (when (and (contains? '#{fn fn*} op)
+                 (vector? params)
+                 (every? symbol? params))
+        (count params)))))
+
 (defmulti parse-query
   #_{:clj-kondo/ignore [:unused-binding]}
   (fn [query env]
@@ -273,20 +283,28 @@
 (defn- unparse-arg-binding [{:keys [expr]}]
   (unparse expr))
 
-(defmethod parse-query 'fn* [[_fn params body] {:keys [!param-count subq?] :as env}]
+(defmethod parse-query 'fn* [[_fn params body] {:keys [param-idxs subq?] :as env}]
   (when-not (and (vector? params)
                  (every? symbol? params))
     (throw (err/incorrect :xtql/malformed-fn-params "Malformed fn params" {:params params})))
 
+  (when (and param-idxs (not subq?) (not= (count params) (count param-idxs)))
+    (throw (err/incorrect :xtql/fn-arity-error
+                          (format "XTQL fn expects %d argument(s), got %d" (count params) (count param-idxs))
+                          {:params params, :arg-count (count param-idxs)})))
+
+  ;; `param-idxs` says where each param's argument sits in the args relation, and belongs to this fn
+  ;; alone - a nested fn's params are the apply's, so it is dissoc'd rather than inherited.
+  ;; It is absent only for `XTQL $$…$$`, which carries no placeholders to take indices from.
   (let [env (-> env
+                (dissoc :param-idxs)
                 (update :params (fnil into {})
-                        (cond
-                          subq? (map (fn [sym]
-                                       [sym (symbol (str "?_sq_" sym))]))
-                          !param-count (map (fn [sym]
-                                              [sym (symbol (str "?_" (dec (swap! !param-count inc))))]))
-                          :else (map-indexed (fn [idx sym]
-                                               [sym (symbol (str "?_" idx))])))
+                        (if subq?
+                          (map (fn [sym]
+                                 [sym (symbol (str "?_sq_" sym))]))
+                          (let [param-idxs (or param-idxs (range (count params)))]
+                            (map-indexed (fn [idx sym]
+                                           [sym (symbol (str "?_" (nth param-idxs idx)))]))))
                         params))]
     (->QueryWithParams params (parse-query body env))))
 

--- a/src/test/clojure/xtdb/sql_test.clj
+++ b/src/test/clojure/xtdb/sql_test.clj
@@ -3283,7 +3283,67 @@ UNION ALL
       (t/is (= {:xt/id 2, :y "baz"}
                (jdbc/execute-one! conn [(format "XTQL ($$ %s $$, ?)" (pr-str '#(from :bar [{:xt/id %} *]))) 2]
                                   {:builder-fn xt-jdbc/builder-fn}))
-            "XTQL params through PGJDBC"))))
+            "XTQL params through PGJDBC")))
+
+  (t/testing "fn params take their index from the placeholder that supplies them, 5995"
+    (t/is (= [{:xt/id 2, :y "baz", :x "x"}]
+             (xt/q tu/*node* [(format "SELECT ? AS x, t.* FROM (XTQL ($$ %s $$, ?)) t"
+                                      (pr-str '#(from :bar [{:xt/id %} *])))
+                              "x" 2]))
+          "a placeholder ahead of the XTQL clause")
+
+    (t/is (= [{:xt/id 2, :y "baz", :x "x"}]
+             (xt/q tu/*node* [(format "SELECT ? AS x, t.* FROM (XTQL ($$ %s $$, ?, ?)) t"
+                                      (pr-str '#(from :bar [{:xt/id %1, :y %2} *])))
+                              "x" 2 "baz"]))
+          "several fn params")
+
+    (t/is (= [{:xt/id 2, :y "baz", :x "x"}]
+             (xt/q tu/*node* [(format "SELECT $1 AS x, t.* FROM (XTQL ($$ %s $$, $2)) t"
+                                      (pr-str '#(from :bar [{:xt/id %} *])))
+                              "x" 2]))
+          "numbered placeholders")
+
+    (t/is (anomalous? [:incorrect :xtql/fn-arity-error
+                       "XTQL fn expects 1 argument(s), got 2"]
+                      (xt/q tu/*node* [(format "XTQL ($$ %s $$, ?, ?)" (pr-str '#(from :bar [{:xt/id %} *])))
+                                       2 3]))
+          "more placeholders than the fn takes"))
+
+  (t/testing "written without `xtqlParams`, a fn's params are numbered from where the query sits"
+    (t/is (= [{:xt/id 2, :y "baz", :x "x"}]
+             (xt/q tu/*node* [(format "SELECT ? AS x, t.* FROM (XTQL $$ %s $$) t"
+                                      (pr-str '#(from :bar [{:xt/id %} *])))
+                              "x" 2]))
+          "a placeholder ahead of the XTQL clause")
+
+    (t/is (= [{:xt/id 2, :y "baz", :x "x"}]
+             (xt/q tu/*node* [(format "FROM (XTQL $$ %s $$) t SELECT *, ? AS x"
+                                      (pr-str '#(from :bar [{:xt/id %} *])))
+                              2 "x"]))
+          "a placeholder after it")
+
+    (t/is (= [{:xt/id 2, :y "baz", :x "x"}]
+             (xt/q tu/*node* [(format "SELECT ? AS x, t.* FROM (XTQL $$ %s $$) t"
+                                      (pr-str '#(from :bar [{:xt/id %1, :y %2} *])))
+                              "x" 2 "baz"]))
+          "several fn params"))
+
+  (t/testing "a statement's param count covers the placeholders the fn consumes, and only those"
+    (letfn [(param-count [sql]
+              (:param-count (meta (sql/plan sql {:table-info {#xt/table bar #{"_id" "y"}}}))))]
+
+      (t/is (= 1 (param-count (format "XTQL ($$ %s $$, ?)" (pr-str '#(from :bar [{:xt/id %} *]))))))
+
+      (t/is (= 1 (param-count (format "XTQL $$ %s $$" (pr-str '#(from :bar [{:xt/id %} *])))))
+            "a fn's params count even where no placeholder stands in for them")
+
+      (t/is (= 2 (param-count (format "SELECT ? AS x, t.* FROM (XTQL $$ %s $$) t"
+                                      (pr-str '#(from :bar [{:xt/id %} *])))))
+            "and they take a slot of their own rather than sharing the statement's")
+
+      (t/is (= 0 (param-count "XTQL ($$(from :bar [*])$$, ?)"))
+            "a query that is not a fn consumes no arguments"))))
 
 (t/deftest use-parent-left-scope-in-nested-join-table-4131
   (t/is (=plan-file


### PR DESCRIPTION
Resolves #5995.

## tl;dr

An XTQL `fn` param embedded in SQL now takes an argument slot of its own, rather than one it shared with the statement's `?`s or took from a counter.

- **Picked up directly off #5988**, which landed the source-order pre-pass this reuses.

## What changes

- **`parse-query`'s `fn*` method no longer allocates argument indices at all.**
  `visitXtqlQuery` resolves the `xtqlParams` placeholders through the same pre-pass `?`s use, and passes the indices down.

- **The pre-pass now numbers argument slots rather than `?` tokens.**
  `XTQL $$…$$` carries no placeholder for each of its fn's params, so those params were numbered from zero within the query and collided with the statement's own `?`s. They now claim a run at the query's own position, which is the only allocation that holds whichever side of the statement the XTQL clause sits on.

- **`param-idxs` is scoped to one fn rather than to the query.**
  A nested fn belongs to a subquery and its params are bound by the apply, so the key is dropped on recursion and the arity check skips `subq?`. Left in the env it reached them too.

- **The statement's param count is settled after parsing, not while resolving.**
  Only a query that parses to a `QueryWithParams` consumes the arguments its placeholders stand for, so `XTQL ($$(from :bar [*])$$, ?)` reports no params despite carrying one.

- **A placeholder/param mismatch is now an error rather than an out-of-bounds.**
  `:xtql/fn-arity-error`, naming both counts.

- **The first commit is a tidy** — one place now resolves a placeholder to its argument index, where three had a copy each. It is the seam the fix needed and changes no behaviour.

## Usage / migration

Writing the XTQL clause ahead of every other placeholder gave the right answer before, and still does. Nothing needs changing to adopt this.

## Consequences

- **`XTQL ($$…$$, ?, ?)` against a fn taking one param now fails where it used to bind quietly.**
  Anything relying on surplus placeholders being ignored will start erroring.

- **A parenless XTQL query inside a larger statement now reports one more param than it did.**
  Its fn's params and the statement's `?`s were previously the same slots, so the statement claimed fewer arguments than it consumes.

- **Gotcha: the param count is bumped after parsing because a non-fn query consumes nothing.**
  Bumping it while resolving is the obvious shape and it makes `XTQL ($$(from :bar [*])$$, ?)` claim a param that nothing reads, which pgwire's `Describe` then advertises.

- **`param-count` is the only place two of these defects were visible.**
  Query results were identical to `main` for the non-fn shape; `xt/q` tolerates a wrong count where `Describe` and `OpenTx.checkArgCount` do not. A test now pins the count for each shape.

- **The pre-pass reads the XTQL string to get the fn's arity, which `visitXtqlQuery` then reads again.**
  A string that doesn't read counts zero, leaving the syntax error to surface from the planner.

## Alternative approaches

The rule: one entry per way of giving a fn's params their indices that was considered and not taken.

- **Bump `!param-count` from `fn*`'s positional branch, keeping the counter as the fallback allocator.**
  Reasoned against: it leaves `xtdb.xtql` reaching into the SQL planner's counter, and puts the count in two places that have to agree. Resolving the placeholders in `visitXtqlQuery` gives the caller both the indices and the count from one walk.

- **Make a parenless `fn` an error pointing at `XTQL (…, ?)`.**
  Reasoned against: it keeps the pre-pass free of XTQL, and `xtql->sql` only ever emits the parenthesised form so nothing generated would break. But the form works today, hand-written SQL may use it, and of the two syntaxes the one to drop is not the one that silently mis-binds.

- **Allocate the fn's params a run after the statement's `?`s.**
  Reasoned against: arguments are supplied in source order, so a run at the end is correct only where the XTQL clause is last. `FROM (XTQL $$…$$) t SELECT ?` swaps the two.
