### PR TITLE
fix(sql): accept keywords as names wherever only a name can appear

### DIFF
--- a/core/src/main/antlr/xtdb/antlr/Sql.g4
+++ b/core/src/main/antlr/xtdb/antlr/Sql.g4
@@ -34,8 +34,8 @@ directlyExecutableStatement
 
     | ASSERT condition=expr (',' message=characterString)? #AssertStatement
 
-    | PREPARE statementName=identifier AS directlyExecutableStatement #PrepareStatement
-    | EXECUTE statementName=identifier executeArgs #ExecuteStatement
+    | PREPARE statementName=objectName AS directlyExecutableStatement #PrepareStatement
+    | EXECUTE statementName=objectName executeArgs #ExecuteStatement
 
     | COPY targetTable FROM STDIN opts=copyOpts # CopyInStmt
     | (START TRANSACTION | BEGIN TRANSACTION?) transactionCharacteristics? # StartTransactionStatement
@@ -43,7 +43,7 @@ directlyExecutableStatement
     | COMMIT (SYNC | ASYNC)? # CommitStatement
     | ROLLBACK # RollbackStatement
     | SET SESSION CHARACTERISTICS AS sessionCharacteristic (',' sessionCharacteristic)* # SetSessionCharacteristicsStatement
-    | SET ROLE ( identifier | NONE ) # SetRoleStatement
+    | SET ROLE ( roleName=objectName | NONE ) # SetRoleStatement
     | SET SESSION? ('TIME' 'ZONE' | 'TIMEZONE') zone=expr # SetTimeZoneStatement
     | SET AWAIT_TOKEN ( TO | '=' ) awaitToken=expr # SetAwaitTokenStatement
     | SET SESSION? identifier ( TO | '=' ) literal # SetSessionVariableStatement
@@ -52,16 +52,16 @@ directlyExecutableStatement
     | SHOW AWAIT_TOKEN # ShowAwaitTokenStatement
     | SHOW SNAPSHOT_TOKEN # ShowSnapshotTokenStatement
     | SHOW CLOCK_TIME # ShowClockTimeStatement
-    | ATTACH DATABASE dbName=identifier (WITH configYaml=characterString)? # AttachDatabaseStatement
-    | DETACH DATABASE dbName=identifier # DetachDatabaseStatement
+    | ATTACH DATABASE dbName=objectName (WITH configYaml=characterString)? # AttachDatabaseStatement
+    | DETACH DATABASE dbName=objectName # DetachDatabaseStatement
 
-    | GRANT roleName=identifier TO userName=identifier # GrantRoleStatement
-    | REVOKE roleName=identifier FROM userName=identifier # RevokeRoleStatement
+    | GRANT roleName=objectName TO userName=objectName # GrantRoleStatement
+    | REVOKE roleName=objectName FROM userName=objectName # RevokeRoleStatement
 
     | CREATE (OR ALTER)? TABLE targetTable ('(' columnNameList ')')? # CreateTableStatement
     ;
 
-targetTable : (schemaName=identifier '.')? tableName=identifier ;
+targetTable : (schemaName=objectName '.')? tableName=objectName ;
 
 executeArgs : ('(' expr (',' expr)* ')')? ;
 
@@ -134,37 +134,64 @@ singleDatetimeField : nonSecondPrimaryDatetimeField | 'SECOND' ( '(' intervalFra
 
 /// §5.4 Identifiers
 
-identifierChain : identifier ( '.' identifier )* ;
+identifierChain : objectName ( '.' objectName )* ;
 
 identifier
-    : (REGULAR_IDENTIFIER
-        | 'START' | 'END'
-        | 'COMMITTED' | 'UNCOMMITTED'
-        | 'TIMEZONE'
-        | 'VERSION'
-        | 'SYSTEM_TIME' | 'VALID_TIME'
-        | 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'ERASE'
-        | 'SETTING'
-        | 'ROLE'
-        | 'USER' | 'PASSWORD'
-        | 'VARBINARY' | 'BYTEA'
-        | 'URI' | 'OID'
-        | 'COPY' | 'FORMAT'
-        | 'ATTACH' | 'DETACH' | 'DATABASE' | 'LEVEL'
-        | 'FILTER'
-        | 'TABLE'
-        | METADATA
-        | SYNC
-        | setFunctionType )
-        # RegularIdentifier
+    : (REGULAR_IDENTIFIER | unreservedKeyword) # RegularIdentifier
     | DELIMITED_IDENTIFIER # DelimitedIdentifier
     ;
 
-columnName : identifier ;
+// Keywords admitted wherever an identifier can appear, the function-name and field-access positions
+// included, which is what makes this the narrower of the two tiers.
+//
+// A word is only eligible if every position the grammar uses it in is reached via a preceding fixed
+// keyword. ANTLR resolves a genuine overlap by alternative order, silently, so an ineligible word
+// changes what a query means rather than failing to parse. A word that opens a construct of its own
+// in expression position therefore belongs in `objectName` instead.
+//
+// xtdb.sql.identifier-test pins this set against the grammar in both directions.
+unreservedKeyword
+    : START | END
+    | COMMITTED | UNCOMMITTED
+    | TIMEZONE
+    | VERSION
+    | SYSTEM_TIME | VALID_TIME
+    | SELECT | INSERT | UPDATE | DELETE | ERASE
+    | SETTING
+    | ROLE
+    | USER | PASSWORD
+    | VARBINARY | BYTEA
+    | URI | OID
+    | COPY | FORMAT
+    | ATTACH | DETACH | DATABASE | LEVEL
+    | FILTER
+    | TABLE
+    | METADATA
+    | SYNC
+    | setFunctionType
+    | primaryDatetimeField
+    | pgExtractField
+    | rankFunctionType
+    | AT | BETWEEN | BY | CURRENT | FIRST | LAST | NEXT | OF | POSITION
+    ;
+
+// A name, in a position where nothing but a name can appear.
+//
+// On top of `identifier` this admits the words that open a construct of their own in expression
+// position, and so can't be reached from there: `PERIOD(a, b)` is the tstzRangeConstructor,
+// `VALUES ROW(1, 2)` a two-column row, `INTERVAL '3' DAY` an interval literal, and every type name
+// below is the leading token of a `dataType` alternative. PostgreSQL draws this same line and calls
+// the tier col_name_keyword.
+objectName
+    : identifier
+    | BIGINT | BOOLEAN | CHAR | DATE | DEC | DECIMAL | DOUBLE | DURATION | FLOAT | INT | INTEGER
+    | INTERVAL | KEYWORD | NUMERIC | OBJECT | PERIOD | PRECISION | REAL | RECORD | REGCLASS
+    | REGPROC | ROW | SMALLINT | TEXT | TIME | TIMESTAMP | TIMESTAMPTZ | TSTZRANGE | UUID | VARCHAR
+    ;
 
 columnLabel
-    : identifier
-    | 'CURRENT_USER'
+    : columnName=objectName
+    | CURRENT_USER
     ;
 
 // §6 Scalar Expressions
@@ -209,7 +236,7 @@ withOrWithoutTimeZone
 
 maximumCardinality : UNSIGNED_INTEGER ;
 
-fieldDefinition : fieldName=identifier dataType ;
+fieldDefinition : fieldName=objectName dataType ;
 
 /// §6.3 <value expression primary>
 
@@ -267,7 +294,7 @@ exprPrimary
     : subquery # ScalarSubqueryExpr
     | '(' expr ')' #WrappedExpr
     | literal # LiteralExpr
-    | exprPrimary '.' fieldName=identifier #FieldAccess
+    | exprPrimary '.' fieldName=objectName #FieldAccess
     | exprPrimary '[' expr ']' #ArrayAccess
     | exprPrimary '::' dataType #PostgresCastExpr
     | exprPrimary '||' exprPrimary #ConcatExpr
@@ -294,28 +321,28 @@ exprPrimary
 
     | 'EXISTS' subquery # ExistsPredicate
 
-    | (identifier '.')? 'HAS_ANY_COLUMN_PRIVILEGE' '('
+    | (schemaName=objectName '.')? 'HAS_ANY_COLUMN_PRIVILEGE' '('
         ( userString=expr ',' )?
         tableString=expr ','
         privilegeString=expr
       ')' # HasAnyColumnPrivilegePredicate
 
-    | (identifier '.')? 'HAS_TABLE_PRIVILEGE' '('
+    | (schemaName=objectName '.')? 'HAS_TABLE_PRIVILEGE' '('
         ( userString=expr ',' )?
         tableString=expr ','
         privilegeString=expr
       ')' # HasTablePrivilegePredicate
 
-    | (identifier '.')? 'HAS_SCHEMA_PRIVILEGE' '('
+    | (schemaName=objectName '.')? 'HAS_SCHEMA_PRIVILEGE' '('
         ( userString=expr ',' )?
         schemaString=expr ','
         privilegeString=expr
       ')' # HasSchemaPrivilegePredicate
 
-    | (schemaName=identifier '.')? 'VERSION' '(' ')' #PostgresVersionFunction
+    | (schemaName=objectName '.')? 'VERSION' '(' ')' #PostgresVersionFunction
 
-    | (identifier '.')? 'PG_GET_USERBYID' '(' relOwner=columnReference ')' # PostgresGetUserByIdFunction
-    | (identifier '.')? 'PG_TABLE_IS_VISIBLE' '(' columnOid=columnReference ')' # PostgresTableIsVisibleFunction
+    | (schemaName=objectName '.')? 'PG_GET_USERBYID' '(' relOwner=columnReference ')' # PostgresGetUserByIdFunction
+    | (schemaName=objectName '.')? 'PG_TABLE_IS_VISIBLE' '(' columnOid=columnReference ')' # PostgresTableIsVisibleFunction
 
     // numeric value functions
     | 'POSITION' '(' expr 'IN' expr ( 'USING' charLengthUnits )? ')' # PositionFunction
@@ -351,13 +378,13 @@ exprPrimary
     | 'REPLACE' '(' source=expr ',' pattern=expr ',' replacement=expr ')' # ReplaceFunction
     | 'REGEXP_REPLACE' '(' source=expr ',' pattern=characterString ',' replacement=characterString (',' start=integerLiteral ( ',' n=integerLiteral )? )? (',' flags=characterString)? ')' # RegexpReplaceFunction
 
-    | (identifier '.')? 'CURRENT_USER' # CurrentUserFunction
-    | (identifier '.')? 'CURRENT_SCHEMA' ('(' ')')? # CurrentSchemaFunction
-    | (identifier '.')? 'CURRENT_SCHEMAS' '(' expr ')' # CurrentSchemasFunction
-    | (identifier '.')? 'CURRENT_CATALOG' ('(' ')')? # CurrentCatalogFunction
-    | (identifier '.')? 'PG_GET_EXPR' ('(' expr ',' expr (',' expr)? ')')? # PgGetExprFunction
-    | (identifier '.')? '_PG_EXPANDARRAY' ('(' expr ')')? # PgExpandArrayFunction
-    | (identifier '.')? 'PG_GET_INDEXDEF' '(' expr (',' expr ',' expr)? ')' # PgGetIndexdefFunction
+    | (schemaName=objectName '.')? 'CURRENT_USER' # CurrentUserFunction
+    | (schemaName=objectName '.')? 'CURRENT_SCHEMA' ('(' ')')? # CurrentSchemaFunction
+    | (schemaName=objectName '.')? 'CURRENT_SCHEMAS' '(' expr ')' # CurrentSchemasFunction
+    | (schemaName=objectName '.')? 'CURRENT_CATALOG' ('(' ')')? # CurrentCatalogFunction
+    | (schemaName=objectName '.')? 'PG_GET_EXPR' ('(' expr ',' expr (',' expr)? ')')? # PgGetExprFunction
+    | (schemaName=objectName '.')? '_PG_EXPANDARRAY' ('(' expr ')')? # PgExpandArrayFunction
+    | (schemaName=objectName '.')? 'PG_GET_INDEXDEF' '(' expr (',' expr ',' expr)? ')' # PgGetIndexdefFunction
     | PG_SLEEP '(' sleepSeconds=expr ')' # PgSleepFunction
     | PG_SLEEP_FOR '(' sleepPeriod=expr ')' # PgSleepForFunction
 
@@ -387,11 +414,11 @@ booleanValue : 'TRUE' | 'FALSE' | 'UNKNOWN' ;
 // spec addition: objectConstructor
 
 objectConstructor
-    : ('RECORD' | 'OBJECT') '(' (objectNameAndValue (',' objectNameAndValue)*)? ')'
-    | '{' (objectNameAndValue (',' objectNameAndValue)*)? '}'
+    : ('RECORD' | 'OBJECT') '(' (objectKeyAndValue (',' objectKeyAndValue)*)? ')'
+    | '{' (objectKeyAndValue (',' objectKeyAndValue)*)? '}'
     ;
 
-objectNameAndValue : objectName=identifier ':' expr ;
+objectKeyAndValue : objectKey=objectName ':' expr ;
 
 parameterSpecification
     : '?' #DynamicParameter
@@ -407,7 +434,7 @@ columnReference : identifierChain ;
 
 /// generate_series function
 
-generateSeries : (identifier '.')? fn=(GENERATE_SERIES | RANGE) '(' seriesStart=expr ',' seriesEnd=expr (',' seriesStep=expr)? ')' ;
+generateSeries : (schemaName=objectName '.')? fn=(GENERATE_SERIES | RANGE) '(' seriesStart=expr ',' seriesEnd=expr (',' seriesStep=expr)? ')' ;
 
 /// §6.10 <window function>
 
@@ -444,7 +471,7 @@ fromFirstOrLast
     | 'FROM' 'LAST' # FromLast
     ;
 
-windowNameOrSpecification : windowName=identifier | windowSpecification ;
+windowNameOrSpecification : windowName=objectName | windowSpecification ;
 
 /// §6.11 <nested window function>
 
@@ -552,6 +579,9 @@ tableReference
 
 withOrdinality : 'WITH' 'ORDINALITY' ;
 
+// `identifier`, not `objectName`, because the `AS` is optional: `FROM foo bar` reaches the name with
+// no preceding fixed keyword, which is the eligibility rule `unreservedKeyword` states. The DML
+// correlation names are optional-`AS` too, and narrow for the same reason.
 tableAlias : 'AS'? correlationName=identifier ;
 tableProjection : '(' columnNameList ')' ;
 
@@ -573,9 +603,9 @@ tableTimePeriodSpecification
     | 'FROM' from=expr 'TO' to=expr # TableFromTo
     ;
 
-fromTableRef : ((identifier '.')? identifier '.')? identifier ;
+fromTableRef : ((objectName '.')? objectName '.')? objectName ;
 
-columnNameList : columnName (',' columnName)* ;
+columnNameList : columnName+=objectName (',' columnName+=objectName)* ;
 
 /// §7.7 <joined table>
 
@@ -609,11 +639,11 @@ havingClause : 'HAVING' searchCondition ;
 windowClause : 'WINDOW' windowDefinitionList ;
 windowDefinitionList : windowDefinition (',' windowDefinition)* ;
 windowDefinition : newWindowName 'AS' windowSpecification ;
-newWindowName : windowName=identifier ;
+newWindowName : windowName=objectName ;
 
 windowSpecification : '(' windowSpecificationDetails ')' ;
 
-windowSpecificationDetails : existingWindowName=identifier? windowPartitionClause? windowOrderClause? windowFrameClause? ;
+windowSpecificationDetails : existingWindowName=objectName? windowPartitionClause? windowOrderClause? windowFrameClause? ;
 
 windowPartitionClause : 'PARTITION' 'BY' windowPartitionColumnReferenceList ;
 windowPartitionColumnReferenceList : columnReference (',' columnReference)* ;
@@ -654,11 +684,11 @@ qualifiedRenameClause
     | 'RENAME' '(' qualifiedRenameColumn (',' qualifiedRenameColumn )* ')'
     ;
 
-qualifiedRenameColumn : identifier asClause ;
+qualifiedRenameColumn : columnName=objectName asClause ;
 
 excludeClause
-    : 'EXCLUDE' identifier
-    | 'EXCLUDE' '(' identifier (',' identifier )* ')'
+    : 'EXCLUDE' columnName+=objectName
+    | 'EXCLUDE' '(' columnName+=objectName (',' columnName+=objectName )* ')'
     ;
 
 derivedColumn : expr asClause? ;
@@ -669,7 +699,7 @@ asClause : 'AS'? columnLabel ;
 queryExpression : withClause? queryExpressionNoWith ;
 queryExpressionNoWith : queryExpressionBody orderByClause? offsetAndLimit?  ;
 withClause : 'WITH' RECURSIVE? withListElement (',' withListElement)* ;
-withListElement : MATERIALIZED? queryName=identifier ('(' columnNameList ')')? 'AS' subquery ;
+withListElement : MATERIALIZED? queryName=objectName ('(' columnNameList ')')? 'AS' subquery ;
 
 queryExpressionBody
     : queryTerm # QueryBodyTerm
@@ -823,7 +853,7 @@ setClauseList : setClause (',' setClause)* ;
 setClause : setTarget '=' updateSource=expr ;
 
 // TODO SQL:2011 supports updating keys within a struct here
-setTarget : columnName ;
+setTarget : columnName=objectName ;
 
 /// §17.3 <transaction characteristics>
 

--- a/core/src/main/clojure/xtdb/sql.clj
+++ b/core/src/main/clojure/xtdb/sql.clj
@@ -26,7 +26,7 @@
            (org.apache.arrow.vector.types.pojo Field)
            (org.apache.commons.codec.binary Hex)
            (xtdb.tx TxOp$PatchDocs TxOp$PutDocs)
-           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$DynamicParameterContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectNameAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
+           (xtdb.antlr Sql$DirectlyExecutableStatementContext Sql$DynamicParameterContext Sql$GroupByClauseContext Sql$HavingClauseContext Sql$JoinSpecificationContext Sql$JoinTypeContext Sql$ObjectKeyAndValueContext Sql$OrderByClauseContext Sql$QualifiedRenameColumnContext Sql$QueryBodyTermContext Sql$QuerySpecificationContext Sql$QueryTailContext Sql$RenameColumnContext Sql$SearchedWhenClauseContext Sql$SelectClauseContext Sql$SetClauseContext Sql$SimpleWhenClauseContext Sql$SortSpecificationContext Sql$SortSpecificationListContext Sql$WhenOperandContext Sql$WhereClauseContext Sql$WithTimeZoneContext SqlLexer SqlVisitor)
            (xtdb.arrow RelationReader VectorReader)
            (xtdb.query ParsedStatement$Dml SqlParser SqlPlanner)
            xtdb.api.TableRef
@@ -59,8 +59,8 @@
                      (visitAsClause [this ctx] (-> (.columnLabel ctx) (.accept this)))
 
                      (visitColumnLabel [this ctx]
-                       (if-let [id (.identifier ctx)]
-                         (.accept id this)
+                       (if-let [cn (.columnName ctx)]
+                         (.accept cn this)
                          (symbol (util/str->normal-form-str (.getText ctx)))))
 
                      (visitTargetTable [this ctx]
@@ -70,7 +70,11 @@
                            tn)))
 
                      (visitTableAlias [this ctx] (-> (.correlationName ctx) (.accept this)))
-                     (visitColumnName [this ctx] (-> (.identifier ctx) (.accept this)))
+
+                     (visitObjectName [this ctx]
+                       (if-let [id (.identifier ctx)]
+                         (.accept id this)
+                         (symbol (util/str->normal-form-str (.getText ctx)))))
 
                      (visitRegularIdentifier [_ ctx] (symbol (util/str->normal-form-str (.getText ctx))))
 
@@ -683,7 +687,7 @@
 (defrecord TableRefVisitor [env scope left-scope]
   SqlVisitor
   (visitBaseTable [{{:keys [!id-count table-chains table-info ctes default-db] :as env} :env} ctx]
-    (let [table-chain (mapv identifier-sym (.identifier (.fromTableRef ctx)))
+    (let [table-chain (mapv identifier-sym (.objectName (.fromTableRef ctx)))
           table-alias (or (identifier-sym (.tableAlias ctx)) (peek table-chain))
           unique-table-alias (symbol (str table-alias "." (swap! !id-count inc)))
           cols (some-> (.tableProjection ctx) (->table-projection))]
@@ -893,17 +897,17 @@
                                                                                (->projected-col-expr col-idx expr)))]))
 
                                                                       (visitQualifiedAsterisk [_ ctx]
-                                                                        (let [[table-name schema-name] (rseq (mapv identifier-sym (.identifier (.identifierChain ctx))))]
+                                                                        (let [[table-name schema-name] (rseq (mapv identifier-sym (.objectName (.identifierChain ctx))))]
                                                                           (when schema-name
                                                                             (throw (UnsupportedOperationException. "schema not supported")))
 
                                                                           (let [excludes (when-let [exclude-ctx (.excludeClause ctx)]
-                                                                                           (into #{} (map identifier-sym) (.identifier exclude-ctx)))]
+                                                                                           (into #{} (map identifier-sym) (.columnName exclude-ctx)))]
 
                                                                             (if-let [table-cols (not-empty (find-cols scope [nil table-name] excludes))]
                                                                               (let [renames (->> (for [^Sql$QualifiedRenameColumnContext rename-pair (some-> (.qualifiedRenameClause ctx)
                                                                                                                                                              (.qualifiedRenameColumn))]
-                                                                                                   (let [sym (find-col scope [(identifier-sym (.identifier rename-pair)) table-name])
+                                                                                                   (let [sym (find-col scope [(identifier-sym (.columnName rename-pair)) table-name])
                                                                                                          out-col-name (.columnLabel (.asClause rename-pair))]
                                                                                                      (MapEntry/create sym (->col-sym (identifier-sym out-col-name)))))
                                                                                                  (into {}))]
@@ -919,7 +923,7 @@
       {:projected-cols (vec (concat (when-let [star-ctx (.selectListAsterisk sl-ctx)]
                                       (let [renames (->> (for [^Sql$RenameColumnContext rename-pair (some-> (.renameClause star-ctx)
                                                                                                             (.renameColumn))]
-                                                           (let [chain (rseq (mapv identifier-sym (.identifier (.identifierChain (.columnReference rename-pair)))))
+                                                           (let [chain (rseq (mapv identifier-sym (.objectName (.identifierChain (.columnReference rename-pair)))))
                                                                  out-col-name (.columnLabel (.asClause rename-pair))
                                                                  sym (find-col scope chain)]
 
@@ -928,7 +932,7 @@
 
                                             excludes (set/union (into #{} (map (comp symbol name :col-sym)) explicitly-projected-cols)
                                                                 (when-let [exclude-ctx (.excludeClause star-ctx)]
-                                                                  (into #{} (map identifier-sym) (.identifier exclude-ctx))))]
+                                                                  (into #{} (map identifier-sym) (.columnName exclude-ctx))))]
 
                                         (->> (find-cols scope nil excludes)
                                              (map-indexed (fn [col-idx sym]
@@ -1346,7 +1350,7 @@
   (visitColumnExpr [this ctx] (-> (.columnReference ctx) (.accept this)))
 
   (visitColumnReference [{{:keys [!id-count]} :env :keys [^Set !ob-col-refs ^Set !unresolved-cr]} ctx]
-    (let [chain (rseq (mapv identifier-sym (.identifier (.identifierChain ctx))))
+    (let [chain (rseq (mapv identifier-sym (.objectName (.identifierChain ctx))))
           matches (find-cols scope chain)]
       (when-let [sym (case (count matches)
                        0 (if (= chain '(user))
@@ -1882,8 +1886,8 @@
   (visitObjectExpr [this ctx] (.accept (.objectConstructor ctx) this))
 
   (visitObjectConstructor [this ctx]
-    (->> (for [^Sql$ObjectNameAndValueContext kv (.objectNameAndValue ctx)]
-           (MapEntry/create (keyword (identifier-sym (.objectName kv)))
+    (->> (for [^Sql$ObjectKeyAndValueContext kv (.objectKeyAndValue ctx)]
+           (MapEntry/create (keyword (identifier-sym (.objectKey kv)))
                             (-> (.expr kv) (.accept this))))
          (into {})))
 
@@ -2514,11 +2518,11 @@
                                                                   (emit-param (dec (parse-long (subs (.getText ctx) 1)))))
 
                                                                 (visitObjectRecord [this ctx]
-                                                                  (->> (.objectNameAndValue (.objectConstructor ctx))
+                                                                  (->> (.objectKeyAndValue (.objectConstructor ctx))
                                                                        (into #{} (map (partial accept-visitor this)))))
 
-                                                                (visitObjectNameAndValue [_ ctx]
-                                                                  (identifier-sym (.objectName ctx))))))
+                                                                (visitObjectKeyAndValue [_ ctx]
+                                                                  (identifier-sym (.objectKey ctx))))))
                                              (distinct))))))
 
           col-keys (mapv keyword col-syms)

--- a/core/src/main/kotlin/xtdb/query/SqlParser.kt
+++ b/core/src/main/kotlin/xtdb/query/SqlParser.kt
@@ -86,6 +86,9 @@ private fun identStr(ctx: Sql.IdentifierContext): String = when (ctx) {
     else -> normalForm(ctx.text)
 }
 
+private fun identStr(ctx: Sql.ObjectNameContext): String =
+    ctx.identifier()?.let(::identStr) ?: normalForm(ctx.text)
+
 // session parameter / variable names are lower-cased rather than normal-formed — mirrors pgwire's session-param-name.
 private fun sessionParamName(ctx: Sql.IdentifierContext): String = when (ctx) {
     is Sql.DelimitedIdentifierContext -> ctx.text.substring(1, ctx.text.length - 1)
@@ -170,7 +173,7 @@ private class ParsedStatementVisitor : SqlBaseVisitor<ParsedStatement>() {
 
     override fun visitCreateTableStatement(ctx: Sql.CreateTableStatementContext): ParsedStatement {
         val tt = ctx.targetTable()
-        val cols = ctx.columnNameList()?.columnName()?.map { identStr(it.identifier()) } ?: emptyList()
+        val cols = ctx.columnNameList()?.columnName?.map(::identStr) ?: emptyList()
         return Dml.CreateTable(ctx, tt.schemaName?.let(::identStr), identStr(tt.tableName), cols)
     }
 

--- a/src/test/clojure/xtdb/sql/grammar_ambiguity_test.clj
+++ b/src/test/clojure/xtdb/sql/grammar_ambiguity_test.clj
@@ -1,0 +1,98 @@
+(ns xtdb.sql.grammar-ambiguity-test
+  (:require [clojure.string :as str]
+            [clojure.test :as t])
+  (:import (org.antlr.v4.runtime BaseErrorListener CharStreams CommonTokenStream DiagnosticErrorListener)
+           (org.antlr.v4.runtime.atn PredictionMode)
+           (xtdb.antlr Sql SqlLexer)))
+
+(defn- keyword-tokens []
+  (let [vocab (SqlLexer/VOCABULARY)]
+    (->> (range 1 (inc (.getMaxTokenType vocab)))
+         (keep (fn [tt]
+                 (when-let [lit (.getLiteralName vocab tt)]
+                   (let [word (subs lit 1 (dec (count lit)))]
+                     (when (re-matches #"[A-Za-z_]+" word)
+                       word)))))
+         (into (sorted-set)))))
+
+(defn- ambiguities
+  "the ambiguous decisions parsing `sql` provokes, as `<rule> ambigAlts={…}` keys.
+
+  `LL_EXACT_AMBIG_DETECTION` is what surfaces these at all: ANTLR otherwise resolves an ambiguity
+  by alternative order and reports nothing, so a grammar that generates cleanly and a suite that
+  passes both say nothing about whether a decision is ambiguous."
+  [sql]
+  (let [!msgs (atom [])
+        lexer (SqlLexer. (CharStreams/fromString sql))
+        parser (Sql. (CommonTokenStream. lexer))]
+    (.removeErrorListeners lexer)
+    (.removeErrorListeners parser)
+    (.addErrorListener parser (DiagnosticErrorListener.))
+    (.addErrorListener parser
+                       (proxy [BaseErrorListener] []
+                         (syntaxError [_recognizer _offending _line _pos msg _e]
+                           (swap! !msgs conj msg))))
+    (.setPredictionMode (.getInterpreter parser) PredictionMode/LL_EXACT_AMBIG_DETECTION)
+    (try
+      (.directSqlStatement parser)
+      (catch Exception _))
+    (->> @!msgs
+         (keep #(when-let [[_ rule alts] (re-matches #"reportAmbiguity d=\d+ \((\w+)\): (ambigAlts=\{[\d, ]+\}).*" %)]
+                  (str rule " " alts)))
+         (into (sorted-set)))))
+
+(def ^:private name-positions
+  [["column ref, bare"        #(str "SELECT " % " FROM docs")]
+   ["column ref, qualified"   #(str "SELECT d." % " FROM docs d")]
+   ["column alias"            #(str "SELECT 1 AS " %)]
+   ["table name"              #(str "SELECT 1 FROM " %)]
+   ["schema-qualified table"  #(str "SELECT 1 FROM sch." %)]
+   ["insert target"           #(str "INSERT INTO " % " (_id) VALUES (1)")]
+   ["insert column list"      #(str "INSERT INTO docs (_id, " % ") VALUES (1, 2)")]
+   ["derived col alias"       #(str "SELECT 1 FROM (VALUES (1)) t(" % ")")]
+   ["set target"              #(str "UPDATE docs SET " % " = 1")]
+   ["cte name"                #(str "WITH " % " AS (SELECT 1 AS a) SELECT * FROM " %)]
+   ["window name"             #(str "SELECT 1 FROM docs WINDOW " % " AS (PARTITION BY a)")]
+   ["record key"              #(str "SELECT {" % ": 1} AS r")]
+   ["field access"            #(str "SELECT d.x." % " FROM docs d")]
+   ["exclude"                 #(str "SELECT * EXCLUDE " % " FROM docs")]
+   ["rename"                  #(str "SELECT * RENAME a AS " % " FROM docs")]
+   ["correlation name"        #(str "SELECT 1 FROM docs AS " %)]
+   ["function name"           #(str "SELECT " % "(1) AS r")]
+   ["prepared stmt name"      #(str "PREPARE " % " AS SELECT 1")]])
+
+(def ^:private baseline-word "zzz_plain")
+
+;; `avg(1)` fits the aggregate alternative and the generic function call alike, so these are
+;; ambiguous as a function name whatever tier they sit in. ANTLR takes the aggregate.
+(def ^:private aggregate-names
+  #{"AVG" "BOOL_AND" "BOOL_OR" "COUNT" "EVERY" "MAX" "MIN"
+    "STDDEV_POP" "STDDEV_SAMP" "SUM" "VAR_POP" "VAR_SAMP"})
+
+(defn- keywords-adding-ambiguity-over [f exempt]
+  (into (sorted-map)
+        (let [baseline (ambiguities (f baseline-word))]
+          (keep (fn [kw]
+                  (let [extra (into (sorted-set) (remove baseline) (ambiguities (f kw)))]
+                    (when (and (seq extra) (not (exempt kw)))
+                      [kw extra])))))
+        (keyword-tokens)))
+
+(t/deftest a-keyword-in-a-name-position-is-no-more-ambiguous-than-a-plain-identifier
+  (t/is (= {}
+           (into (sorted-map)
+                 (for [[label f] name-positions
+                       :let [extra (keywords-adding-ambiguity-over
+                                    f (if (= label "function name") aggregate-names #{}))]
+                       :when (seq extra)]
+                   [label extra])))))
+
+(t/deftest the-aggregate-names-are-the-only-keywords-ambiguous-as-a-function-name
+  (t/is (= aggregate-names
+           (into #{} (filter #(seq (ambiguities (str "SELECT " % "(1) AS r")))) (keyword-tokens)))))
+
+(t/deftest the-grammar-s-own-ambiguities-need-no-keyword-to-provoke-them
+  (doseq [[sql rule] [["SELECT 1 FROM docs" "tableReference"]
+                      ["INSERT INTO docs (_id, foo) VALUES (1, 2)" "insertColumnsAndSource"]
+                      ["SELECT d.x.y FROM docs d" "identifierChain"]]]
+    (t/is (some #(str/starts-with? % rule) (ambiguities sql)) sql)))

--- a/src/test/clojure/xtdb/sql/identifier_test.clj
+++ b/src/test/clojure/xtdb/sql/identifier_test.clj
@@ -1,0 +1,147 @@
+(ns xtdb.sql.identifier-test
+  (:require [clojure.set :as set]
+            [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.test-util :as tu])
+  (:import (xtdb.antlr SqlLexer)))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-node)
+
+;; the words PostgreSQL 16 accepts in every identifier position and XTDB refused in all of them
+(def ^:private semi-reserved
+  '[at between by current date day first hour last minute month next of period
+    position quarter rank row second text time timestamp uuid week year])
+
+(defn- refused-by [f]
+  (->> semi-reserved
+       (remove (fn [word]
+                 (= [{(keyword (str word)) 1}]
+                    (try (xt/q tu/*node* (f word))
+                         (catch Exception _ ::threw)))))
+       vec))
+
+(t/deftest semi-reserved-keywords-are-usable-as-an-as-alias-6014
+  (t/is (= [] (refused-by #(str "SELECT 1 AS " %)))))
+
+(t/deftest semi-reserved-keywords-are-usable-as-a-derived-table-column-alias-6014
+  (t/is (= [] (refused-by #(str "SELECT t." % " FROM (VALUES (1)) t(" % ")")))))
+
+(t/deftest identifier-tier-keywords-still-open-their-own-constructs
+  (doseq [[sql expected]
+          [["SELECT EXTRACT(YEAR FROM DATE '2020-03-04') AS r" 2020]
+           ["SELECT EXTRACT(MONTH FROM DATE '2020-03-04') AS r" 3]
+           ["SELECT EXTRACT(DAY FROM DATE '2020-03-04') AS r" 4]
+           ["SELECT EXTRACT(HOUR FROM TIMESTAMP '2020-03-04 05:06:07') AS r" 5]
+           ["SELECT EXTRACT(MINUTE FROM TIMESTAMP '2020-03-04 05:06:07') AS r" 6]
+           ["SELECT EXTRACT(SECOND FROM TIMESTAMP '2020-03-04 05:06:07') AS r" 7]
+           ["SELECT EXTRACT(WEEK FROM DATE '2020-03-04') AS r" 10]
+           ["SELECT EXTRACT(QUARTER FROM DATE '2020-03-04') AS r" 1]
+           ["SELECT DATE_TRUNC('WEEK', TIMESTAMP '2020-03-04 05:06:07') AS r" #xt/ldt "2020-03-02T00:00"]
+           ["SELECT POSITION('b' IN 'abc') AS r" 2]
+           ["SELECT 2 BETWEEN 1 AND 3 AS r" true]
+           ["SELECT 2 NOT BETWEEN SYMMETRIC 3 AND 1 AS r" false]
+           ["SELECT 1 AS r FETCH FIRST 1 ROWS ONLY" 1]
+           ["SELECT 1 AS r FETCH NEXT 1 ROWS ONLY" 1]
+           ["SELECT 1 AS r ORDER BY r NULLS FIRST" 1]
+           ["SELECT 1 AS r ORDER BY r NULLS LAST" 1]
+           ["SELECT 1 AS r FROM (VALUES (1)) t(x) GROUP BY x" 1]
+           ["SELECT COUNT(*) AS r FROM (VALUES (1)) t(x)" 1]
+           ["SELECT MAX(x) AS r FROM (VALUES (1)) t(x)" 1]]]
+    (t/is (= [{:r expected}] (xt/q tu/*node* sql)) sql)))
+
+(t/deftest object-name-tier-keywords-still-open-their-own-constructs
+  (doseq [[sql expected]
+          [["SELECT DATE '2020-01-01' AS r" #xt/date "2020-01-01"]
+           ["SELECT TIMESTAMP '2020-01-01 12:00:00' AS r" #xt/date-time "2020-01-01T12:00:00"]
+           ["SELECT TIME '12:00:00' AS r" #xt/time "12:00"]
+           ["SELECT UUID '97a392d5-5e3f-406f-9651-a828ee79b156' AS r"
+            #uuid "97a392d5-5e3f-406f-9651-a828ee79b156"]
+           ["SELECT INTERVAL '3' DAY AS r" #xt/interval "P3D"]
+           ["SELECT INTERVAL '1-2' YEAR TO MONTH AS r" #xt/interval "P14M"]
+           ["SELECT INTERVAL '3.5' SECOND(3) AS r" #xt/interval "PT3.5S"]
+           ["SELECT CAST('2020-01-01' AS DATE) AS r" #xt/date "2020-01-01"]
+           ["SELECT CAST(1 AS TEXT) AS r" "1"]
+           ["SELECT CAST('12:00:00' AS TIME(3)) AS r" #xt/time "12:00"]
+           ["SELECT 1 AS r WHERE DATE '2020-01-01' < TIMESTAMP '2020-06-01 00:00:00'" 1]
+           ["SELECT PERIOD(TIMESTAMP '2020-01-01Z', TIMESTAMP '2021-01-01Z') AS r"
+            #xt/tstz-range [#xt/zdt "2020-01-01T00:00Z[UTC]" #xt/zdt "2021-01-01T00:00Z[UTC]"]]
+           ["SELECT PERIOD(TIMESTAMP '2020-01-01Z', TIMESTAMP '2021-01-01Z') CONTAINS TIMESTAMP '2020-06-01Z' AS r"
+            true]]]
+    (t/is (= [{:r expected}] (xt/q tu/*node* sql)) sql))
+
+  (t/is (= [{:a 1, :b 2}] (xt/q tu/*node* "SELECT * FROM (VALUES ROW(1, 2)) AS t(a, b)"))
+        "ROW's row constructor has a function call's exact shape, so ANTLR can't discriminate it"))
+
+(t/deftest keyword-column-names-round-trip-through-dml
+  (xt/execute-tx tu/*node* ["INSERT INTO docs (_id, year, date, text, period, row, interval) VALUES (1, 2020, DATE '2020-01-01', 'a', 2, 3, 4)"])
+
+  (t/is (= [{:xt/id 1, :year 2020, :date #xt/date "2020-01-01", :text "a"
+             :period 2, :row 3, :interval 4}]
+           (xt/q tu/*node* "SELECT _id, year, date, text, period, row, interval FROM docs")))
+
+  (t/is (= [{:period 2}] (xt/q tu/*node* "SELECT d.period FROM docs d WHERE d.row = 3")))
+
+  (xt/execute-tx tu/*node* ["UPDATE docs SET year = 2021, period = 5 WHERE _id = 1"])
+
+  (t/is (= [{:year 2021, :period 5}] (xt/q tu/*node* "SELECT year, period FROM docs"))))
+
+(defn- keyword-tokens []
+  (let [vocab (SqlLexer/VOCABULARY)]
+    (->> (range 1 (inc (.getMaxTokenType vocab)))
+         (keep (fn [tt]
+                 (when-let [lit (.getLiteralName vocab tt)]
+                   (let [word (subs lit 1 (dec (count lit)))]
+                     (when (re-matches #"[A-Za-z_]+" word)
+                       word)))))
+         (into (sorted-set)))))
+
+(defn- accepted-by
+  "asks the grammar, not the key-fn — an underscored word comes back kebab-cased, so compare values"
+  [f]
+  (into (sorted-set)
+        (filter (fn [word]
+                  (= [[1]] (try (mapv (comp vec vals) (xt/q tu/*node* (f word)))
+                                (catch Exception _ ::threw)))))
+        (keyword-tokens)))
+
+(def ^:private identifier-keywords
+  "Sql.g4's `unreservedKeyword` production, with its four sub-productions expanded."
+  (into (sorted-set)
+        (concat ["START" "END" "COMMITTED" "UNCOMMITTED" "TIMEZONE" "VERSION" "SYSTEM_TIME"
+                 "VALID_TIME" "SELECT" "INSERT" "UPDATE" "DELETE" "ERASE" "SETTING" "ROLE"
+                 "USER" "PASSWORD" "VARBINARY" "BYTEA" "URI" "OID" "COPY" "FORMAT" "ATTACH"
+                 "DETACH" "DATABASE" "LEVEL" "FILTER" "TABLE" "METADATA" "SYNC"
+                 "AT" "BETWEEN" "BY" "CURRENT" "FIRST" "LAST" "NEXT" "OF" "POSITION"]
+                ;; setFunctionType
+                ["AVG" "MAX" "MIN" "SUM" "COUNT" "EVERY" "BOOL_AND" "BOOL_OR"
+                 "STDDEV_POP" "STDDEV_SAMP" "VAR_SAMP" "VAR_POP"]
+                ;; primaryDatetimeField
+                ["YEAR" "MONTH" "DAY" "HOUR" "MINUTE" "SECOND"]
+                ;; pgExtractField
+                ["DOW" "ISODOW" "DOY" "WEEK" "QUARTER" "EPOCH"]
+                ;; rankFunctionType
+                ["RANK" "DENSE_RANK" "PERCENT_RANK" "CUME_DIST"])))
+
+(def ^:private object-name-keywords
+  "`identifier`'s tier plus the type-name-shaped words `objectName` adds on top of it."
+  (into identifier-keywords
+        ["BIGINT" "BOOLEAN" "CHAR" "DATE" "DEC" "DECIMAL" "DOUBLE" "DURATION" "FLOAT" "INT"
+         "INTEGER" "INTERVAL" "KEYWORD" "NUMERIC" "OBJECT" "PERIOD" "PRECISION" "REAL" "RECORD"
+         "REGCLASS" "REGPROC" "ROW" "SMALLINT" "TEXT" "TIME" "TIMESTAMP" "TIMESTAMPTZ"
+         "TSTZRANGE" "UUID" "VARCHAR"]))
+
+(t/deftest the-identifier-tier-is-exactly-the-keywords-a-correlation-name-accepts
+  (let [accepted (accepted-by #(str "SELECT 1 AS r FROM (VALUES (1)) AS " %))]
+    (t/is (= [] (vec (set/difference identifier-keywords accepted)))
+          "the tier names a word the grammar won't accept as an identifier")
+
+    (t/is (= [] (vec (set/difference accepted identifier-keywords)))
+          "a keyword is usable as an identifier without the tier naming it")))
+
+(t/deftest the-object-name-tier-is-exactly-the-keywords-a-column-alias-accepts
+  (let [accepted (accepted-by #(str "SELECT 1 AS " %))]
+    (t/is (= [] (vec (set/difference object-name-keywords accepted)))
+          "the tier names a word the grammar won't accept as a name")
+
+    (t/is (= ["CURRENT_USER"] (vec (set/difference accepted object-name-keywords)))
+          "a keyword is usable as a name without the tier naming it - CURRENT_USER is columnLabel's own alternative, not objectName's")))


### PR DESCRIPTION
Resolves #6014

- **A keyword is now usable as a name wherever nothing but a name can appear**
  99 of the lexer's keywords, up from 44, so `date`, `text`, `period`, `row`, `interval`, `year` and the rest work as a column, table, alias, CTE, window or record-key name — while `DATE '2020-01-01'`, `PERIOD(a, b)` and `VALUES ROW(1, 2)` still mean what they meant.

- **The reviewable risk is a silent one**
  ANTLR resolves a keyword/position overlap by alternative order without a diagnostic, so an ineligible word changes what a query means rather than failing to parse. The eligibility rule and the two-directional test are the parts to scrutinise.

## The two tiers

A keyword can be a name only where the parser already knows a name is coming. The two tiers differ on what "already knows" means.

- **`objectName` — 98 words, for a position no expression can start**
  Reached after a token that can only be followed by a name, so there is no construct the word could be mistaken for. This is PostgreSQL's `col_name_keyword`.

- **`identifier` — 68 words, for a position where an expression could start instead**
  A word that opens a construct of its own would be taken as that construct, so the wide tier's 30 additions are excluded here. PostgreSQL's `unreserved_keyword`.

`period` is in the wide tier only, and every line below is asserted by the test suite.

| accepted — the `objectName` positions | |
| --- | --- |
| `SELECT period FROM t` | column reference |
| `SELECT t.period FROM t` | qualified column reference, and field access |
| `SELECT 1 AS period` | column alias |
| `SELECT {period: 1} AS r` | record key |
| `INSERT INTO docs (_id, period) VALUES (1, 2)` | insert column list |
| `UPDATE docs SET period = 1` | update target |
| `SELECT * EXCLUDE period FROM docs` | exclude list |
| `WITH period AS (SELECT 1 AS a) SELECT * FROM period` | CTE name |
| `SELECT 1 FROM period` | table name |

| rejected — the three `identifier`-only positions | |
| --- | --- |
| `SELECT period(1)` | function name. `PERIOD(a, b)` is the tstz-range constructor, and a one-argument call has nothing to discriminate it from a name |
| `SELECT row(1)`, `SELECT date(1)` | function name. Collateral: `ROW` and `DATE` are in the wide tier because of `ROW(a, b)` and `DATE 'literal'`, and the function-name position only reaches the narrow one |
| `SELECT 1 FROM docs AS period` | correlation name. `tableAlias` is `'AS'? correlationName`, so `FROM foo bar` reaches the name with no fixed keyword before it and the eligibility rule doesn't hold |
| `SET period = 1`, `SHOW period` | session variable. Narrow by choice, not by necessity — `SET` and `SHOW` do precede it, but the variable names are a fixed vocabulary |

| the constructs still win where they must | |
| --- | --- |
| `SELECT PERIOD(TIMESTAMP '2020-01-01Z', TIMESTAMP '2021-01-01Z')` | tstz-range constructor, not a function call |
| `SELECT * FROM (VALUES ROW(1, 2)) AS t(a, b)` | a two-column row, not a one-column call |
| `SELECT INTERVAL '3' DAY`, `SELECT DATE '2020-01-01'` | interval and date literals |

| and the narrow tier reaches the narrow positions | |
| --- | --- |
| `SELECT start(1) AS r` | function name |
| `SELECT 1 FROM docs AS start` | correlation name |
| `SET timezone = 'UTC'`, `SHOW timezone` | session variable |
| `SELECT count(1) AS r` | aggregate |

## Root cause

The tier existed but was never written down as a rule.

- **The list was extended a word at a time as reports arrived**
  Nothing recorded what made a word eligible, so each addition was decided from scratch.

- **Nothing checked the list against the grammar**
  A word could be in the list and unusable, or usable and absent from it, and no test would notice either way.

## Implementation notes

- **Eligibility: a word joins `identifier` only if a fixed keyword precedes every position the grammar uses it in**
  `YEAR` only follows `EXTRACT (`, `INTERVAL '…'` or a `date_trunc` field; `FIRST` only follows `NULLS` or `FETCH`; `BY` only follows `GROUP`, `ORDER` or `PARTITION`. None can begin an expression, so ANTLR has no alternative to choose between.

- **`POSITION` looks like a counter-example and isn't**
  It can begin an expression, and survives only because `POSITION(x IN y)` has `IN` to discriminate it from an argument list. `ROW(a, b)` has an argument list's exact shape and nothing left to discriminate on, which is what puts it in the wider tier.

- **`identifierChain`'s segments are `objectName`, which is what makes a bare `SELECT period` work**
  Without that, admitting a word to the wide tier would reach a qualified `t.period` but not an unqualified `period`, and the tier would be useless for the case it exists for.

- **`objectNameAndValue` became `objectKeyAndValue`** to free the name for the tier. Behaviour-preserving; the surrounding rule builds a record, so its parts are keys.

## Dead ends

One entry per approach that was tried and abandoned.

- **Admitting all 25 words the report lists to the single existing tier**
  It passes the SQL suite and emits no ANTLR diagnostic, and is wrong twice over. `PERIOD(a, b)` parses as a function call, breaking 15 tests across four namespaces and the SLT corpus. `VALUES ROW(1, 2)` becomes a one-column function call — `Column count mismatch: expected 2, given 1` — and the full suite stays green, because nothing in it reaches that construct.

- **A separate `typeNameKeyword` production for the wide tier's additions**
  It reads as symmetry with the four productions the narrow tier references, but those exist because the grammar already needed them elsewhere. A production with one reference is a name for a list, so the words sit inline in `objectName`.

## Out of scope

- **The 21 words PostgreSQL also reserves** — genuinely ambiguous, and parity doesn't ask for them.

- **Widening the `SET`/`SHOW` session-variable name** — eligible, but the names are a fixed vocabulary.

## Test plan

- **Both tiers are pinned in both directions, off `SqlLexer.VOCABULARY`**
  `identifier` probed through a correlation name and `objectName` through a column alias, so a keyword added to the lexer can't drift in unnoticed, and a word a tier claims but the grammar rejects fails too.

- **Ambiguity is measured rather than argued, in `xtdb.sql.grammar-ambiguity-test`**
  Every keyword is parsed in all 18 name positions under `LL_EXACT_AMBIG_DETECTION`, and asserted to provoke no ambiguity that a plain identifier in the same position doesn't. A clean ANTLR generation proves nothing here, because ANTLR resolves ambiguity by alternative order and reports it only when asked.

- **The grammar has four ambiguous decisions and this change adds none of them**
  `tableReference` (a bare table name is also a valid expression), `insertColumnsAndSource` (`VALUES` is both a table-value constructor and a query expression) and `identifierChain` (`d.x.y` as a three-segment chain or a chain plus field access) all fire on keyword-free input, asserted directly. The fourth is `setFunctionType`'s twelve words as a function name — `avg(1)` fits the aggregate and the generic call alike — which `main` already admitted to `identifier`.

- **Each tier's constructs are asserted to still resolve to themselves**
  The `EXTRACT` fields, `BETWEEN`, `FETCH FIRST`/`NEXT` and the aggregate names for the narrow tier; the `DATE`/`TIME`/`TIMESTAMP`/`UUID` literals, `INTERVAL`, the `CAST` targets, `PERIOD(a, b)` and `VALUES ROW(1, 2)` for the wide one. `ROW` is the case a green suite doesn't catch.

- **A keyword column name is round-tripped through DML** — insert, qualified and unqualified select, and update, on `period`, `row`, `interval`, `date`, `text` and `year`.

- **Full `./gradlew test` green** — the single failure being flake #5885 (`compactor-test` l2 timeout under build load), confirmed by a 19/19 pass of that namespace in isolation.
