### PR TITLE
fix(logical-plan): decorrelate a correlated EXISTS whose subquery projects a constant

### DIFF
--- a/core/src/main/clojure/xtdb/logical_plan.clj
+++ b/core/src/main/clojure/xtdb/logical_plan.clj
@@ -1258,10 +1258,19 @@
     [:apply opts i
      [:project project-opts dependent-relation]]
     ;;=>
-    (let [{:keys [mode]} opts
+    (let [{:keys [mode mark-join-projection]} opts
           {:keys [projections]} project-opts]
-      (when (and (contains? #{:semi-join :anti-join} mode)
-                 (every? symbol? projections))
+      (when (or (and (contains? #{:semi-join :anti-join} mode)
+                     (every? symbol? projections))
+
+                ;; `EXISTS (SELECT 1 ...)` projects a constant, which discards the correlated column
+                ;; and strands the select below it where the mark-join rules can't reach - and a
+                ;; mark on the constant true reads nothing from the dependent side, so the
+                ;; projection can go. Restricted to constants: dropping a rename moves other plans
+                ;; to a worse fixpoint, and an IN marks on a dependent column it would strand.
+                (and (= mode :mark-join)
+                     (every? true? (vals mark-join-projection))
+                     (every? #(and (map? %) (not (symbol? (val (first %))))) projections)))
         [:apply (->apply-opts opts) i dependent-relation]))
 
     [:semi-join join-opts i

--- a/src/test/clojure/xtdb/sql/exists_decorrelation_test.clj
+++ b/src/test/clojure/xtdb/sql/exists_decorrelation_test.clj
@@ -1,0 +1,50 @@
+(ns xtdb.sql.exists-decorrelation-test
+  (:require [clojure.test :as t]
+            [xtdb.api :as xt]
+            [xtdb.serde]
+            [xtdb.sql :as sql]
+            [xtdb.test-util :as tu]
+            [xtdb.types]))
+
+(t/use-fixtures :each tu/with-mock-clock tu/with-node)
+
+(defn- operators [plan]
+  (->> plan (tree-seq vector? seq) (filter keyword?) set))
+
+(defn- plan-ops [sql]
+  (operators (sql/plan sql {:table-info {#xt/table x #{"y" "z"} #xt/table y #{"z"}}})))
+
+(t/deftest correlated-exists-over-a-constant-projection-reaches-semi-join-6012
+  (doseq [[sql join-op]
+          [["SELECT x.y FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.z = x.y)" :semi-join]
+           ["SELECT x.y FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE y.z = x.y)" :anti-join]
+           ["SELECT x.y FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.z = x.y AND y.z > 2)" :semi-join]]]
+    (let [ops (plan-ops sql)]
+      (t/is (contains? ops join-op) sql)
+      (t/is (not (contains? ops :apply)) sql))))
+
+(t/deftest correlated-exists-over-a-column-projection-still-reaches-semi-join
+  (let [ops (plan-ops "SELECT x.y FROM x WHERE EXISTS (SELECT y.z FROM y WHERE y.z = x.y)")]
+    (t/is (contains? ops :semi-join))
+    (t/is (not (contains? ops :apply)))))
+
+(t/deftest decorrelated-exists-returns-the-rows-the-apply-plan-returned
+  (xt/execute-tx tu/*node* ["INSERT INTO x RECORDS {_id: 1, y: 1}, {_id: 2, y: 2}, {_id: 3, y: 9}"
+                            "INSERT INTO y RECORDS {_id: 1, z: 1}, {_id: 2, z: 2}, {_id: 3, z: 2}"])
+
+  (t/is (= [{:y 1} {:y 2}]
+           (xt/q tu/*node* "SELECT x.y FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.z = x.y) ORDER BY x.y"))
+        "EXISTS matches once per outer row however many inner rows match")
+
+  (t/is (= [{:y 9}]
+           (xt/q tu/*node* "SELECT x.y FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE y.z = x.y) ORDER BY x.y")))
+
+  (t/is (= (xt/q tu/*node* "SELECT x.y FROM x WHERE x.y IN (SELECT y.z FROM y) ORDER BY x.y")
+           (xt/q tu/*node* "SELECT x.y FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.z = x.y) ORDER BY x.y"))
+        "the two spellings now compile to the same operator and must still agree"))
+
+;; EXISTS as a projected value keeps its mark-join: a semi-join can't carry the null the
+;; three-valued result needs
+(t/deftest exists-in-a-projection-keeps-its-mark-join
+  (let [ops (plan-ops "SELECT EXISTS (SELECT 1 FROM y WHERE y.z = x.y) AS e FROM x")]
+    (t/is (not (contains? ops :semi-join)))))


### PR DESCRIPTION
Resolves #6012

- **A correlated `EXISTS` whose subquery projects a constant now compiles to `semi-join`**
  It was an `apply-mark-join`, re-executing the subquery once per outer row. `NOT EXISTS` gets `anti-join`.

- **`EXISTS` itself was never the problem, which is where the issue misdiagnoses it**
  It already decorrelates when the subquery projects the correlated column — `exists-in-where.edn` and TPC-H q04 both do. `SELECT 1` discards that column, and that is the whole of the defect.

- **Rows are unchanged; only the plan is**
  Asserted directly rather than inferred, because returning something different is a plan rewrite's entire risk.

## Root cause

The correlated select ends up below a projection that can't carry it, and out of reach of every rule that would have used it.

- **`pull-correlated-selection-up-towards-apply` can only lift a select through a projection it can rewrite the predicate against**
  `SELECT y.z` projects `[{z y.3/z}]`, so the predicate's `z` has an image and the rule fires. `SELECT 1` projects `[{_column_1 1}]`, so it doesn't.

- **Declining leaves nothing downstream able to act**
  `pull-apply-mark-join-select->mark-join-cond` only matches a select directly under the `:apply`, and `apply-mark-join->mark-join` stays blocked while the dependent side still references the correlation param.

- **The predicate buried in the inner scan is a symptom, not the cause**
  `EXPLAIN` shows `(== customer_id ?_sq__id_3)` inside the scan's predicates, which suggests a rewrite would have to dig it back out. It doesn't: that burial happens in the optimise pass, which runs after decorrelation has already given up. During the decorrelate pass it's still a first-class `:select`.

## Dead ends

- **Allowing any projection through, not just constant ones**
  The obvious first cut, since a mark-join's dependent relation contributes no columns at all. It also drops renames, and `push-semi-and-anti-joins-down-test` then came out as an `:apply` where it had been a semi-join — a broader gate here pessimises plans that already decorrelated.

## Out of scope

- **The projection that keeps *some* of the correlated columns**
  `push-semi-and-anti-joins-down-test` carries a `;; TODO I think this should be decorr'able?` over a two-conjunct correlation where only one column is projected. That wants the pull-up rule to widen a projection rather than a neighbour to delete one, and its plan is unchanged here.

## Implementation

- **The mark being the constant `true` is what separates `EXISTS` from `IN`**
  Both arrive as `:apply {:mode :mark-join}` over a projected dependent side. `IN` marks on `(== ?_needle z)`, so its projection is holding `z` up for the mark to read; dropping it would leave the mark referring to nothing.

- **Restricting to computed projections is what keeps the rest of the fixpoint where it was**
  The rules run to a fixpoint that isn't confluent, so firing earlier changes where other rules land. Constants can't be carrying a column anything above wants, which is the property that makes the drop safe rather than merely convenient.

- **`NOT EXISTS` needed nothing**
  `select-mark-join->semi-join` already emits `:anti-join` for the negated shape once the mark-join is reachable.

## Test plan

- **Plan shape, for the shapes that should decorrelate and the one that must not**
  `exists-in-a-projection-keeps-its-mark-join` is the exclusion, and it's there because a semi-join can't carry the null an `EXISTS` used as a value needs.

- **Rows, not just plans**
  A plan rewrite that returns different rows is the failure a plan-shape assertion can't catch, so the `EXISTS` and `IN` spellings are asserted equal on data with duplicate inner matches.

- **No committed plan expectation changed**, and full `./gradlew test` green — 1740 tests, 0 failures.
