### PR TITLE
scan-perf's _id point lookups bind the id, not the whole row

### DIFF
--- a/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/summary.clj
+++ b/modules/bench/cloud/scripts/src/xtdb/bench/cloud/scripts/summary.clj
@@ -45,13 +45,14 @@
      :total-ms total-ms}))
 
 (defn yakbench-query->query-row
-  [profile {:keys [id mean p50 p90 p99 n sum]}]
+  [profile {:keys [id mean p50 p90 p99 n rows sum]}]
   {:query (str (name profile) "/" id)
    :mean (util/format-duration :nanos mean)
    :p50 (util/format-duration :nanos p50)
    :p90 (util/format-duration :nanos p90)
    :p99 (util/format-duration :nanos p99)
    :n n
+   :rows rows
    :sum sum})
 
 (defn yakbench-summary->query-rows
@@ -386,7 +387,7 @@
   (let [{:keys [rows total-ms]} (yakbench-summary->query-rows summary)]
     (str (util/totals->string total-ms (:benchmark-total-time-ms summary))
          "\n\n"
-         (rows->string [:query :n :p50 :p90 :p99 :mean :percent-of-total] rows))))
+         (rows->string [:query :n :rows :p50 :p90 :p99 :mean :percent-of-total] rows))))
 
 ;; summary->slack multimethod
 
@@ -501,6 +502,7 @@
 
 (defmethod summary->slack "scan-perf" [summary]
   (let [{:keys [rows total-ms]} (yakbench-summary->query-rows summary)
+        columns [:query :rows :p50 :p99 :mean]
         mid (Math/ceil (/ (count rows) 2))
         [first-half second-half] (split-at mid rows)]
     (if (seq second-half)
@@ -508,15 +510,15 @@
        (util/totals->string total-ms (:benchmark-total-time-ms summary))
        "\n\n"
        (util/wrap-slack-code
-        (rows->string [:query :p50 :p99 :mean] first-half))
+        (rows->string columns first-half))
        "\n---SLACK-SPLIT---\n"
        (util/wrap-slack-code
-        (rows->string [:query :p50 :p99 :mean] second-half)))
+        (rows->string columns second-half)))
       (str
        (util/totals->string total-ms (:benchmark-total-time-ms summary))
        "\n\n"
        (util/wrap-slack-code
-        (rows->string [:query :p50 :p99 :mean] rows))))))
+        (rows->string columns rows))))))
 
 ;; summary->github-markdown multimethod
 
@@ -640,6 +642,7 @@
   (let [{:keys [rows total-ms]} (yakbench-summary->query-rows summary)
         columns [{:key :query :header "Query"}
                  {:key :n :header "N"}
+                 {:key :rows :header "Rows"}
                  {:key :p50 :header "P50"}
                  {:key :p90 :header "P90"}
                  {:key :p99 :header "P99"}

--- a/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
@@ -133,13 +133,13 @@
         ;; Pick a length value at the 99th percentile for a narrow BETWEEN (~1%)
         len-p99 (nth lengths (int (* 0.99 n-samples)))
         len-p98 (nth lengths (int (* 0.98 n-samples)))
-        ;; Pick a specific length value from the middle for point equality (~0.05%)
-        len-point (nth lengths (quot n-samples 2))
+        len-median (nth lengths (quot n-samples 2))
 
         timestamps (sort (mapv :item/published-at spread-1000))
         ;; Narrow timestamp window: top ~1% of the range
         ts-p99 (nth timestamps (int (* 0.99 n-samples)))
         ts-p98 (nth timestamps (int (* 0.98 n-samples)))
+        ts-median (nth timestamps (quot n-samples 2))
 
         ;; Pick a single lang for equality (~12.5%)
         lang-single (first langs)
@@ -157,7 +157,7 @@
 
      ;; Integer point equality (~0.05%)
      {:id :length-eq
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$length = ?" len-point])}
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$length = ?" len-median])}
 
      ;; Integer narrow range (~1%)
      {:id :length-range-1pct
@@ -169,11 +169,11 @@
 
      ;; Compound: string + integer (~6%)
      {:id :lang-eq-and-length-gt
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$lang = ? AND item$length > ?" lang-single len-p99])}
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$lang = ? AND item$length > ?" lang-single len-median])}
 
      ;; Compound: string + timestamp (~0.75%)
      {:id :author-and-published-gt
-      :f #(xt/q % ["SELECT _id FROM items WHERE item$author_name = ? AND item$published_at > ?" author-name-single ts-p99])}
+      :f #(xt/q % ["SELECT _id FROM items WHERE item$author_name = ? AND item$published_at > ?" author-name-single ts-median])}
 
      ;; Sparse column (~0.1%)
      {:id :doc-type-not-null

--- a/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
@@ -6,6 +6,7 @@
             [xtdb.bench :as b]
             [xtdb.compactor :as c]
             [xtdb.datasets.scan-items :as scan-items]
+            [xtdb.error :as err]
             [xtdb.test-util :as tu]
             [xtdb.util :as util])
   (:import (java.time Duration)))
@@ -58,50 +59,68 @@
   [{:keys [spread-10]}]
   (for [[i {id :xt/id}] (map-indexed vector spread-10)]
     {:id (keyword (str "scan-p" (* i 10)))
+     :expected-rows 1
      :f #(xt/q % ["SELECT _id FROM items WHERE _id = ?" id])}))
 
 (defn scan-items-set-benchmark-queries
   [{:keys [spread-10 spread-100 spread-1000 clustered-10 clustered-100 clustered-1000]}]
   (let [ids #(mapv :xt/id %)]
     [{:id :scan-spread-in-10
+      :expected-rows (count spread-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 10))] (ids spread-10)))}
      {:id :scan-clustered-in-10
+      :expected-rows (count clustered-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 10))] (ids clustered-10)))}
      {:id :scan-spread-or-10
+      :expected-rows (count spread-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "_id" 10))] (ids spread-10)))}
      {:id :scan-clustered-or-10
+      :expected-rows (count clustered-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "_id" 10))] (ids clustered-10)))}
 
      {:id :scan-spread-in-100
+      :expected-rows (count spread-100)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 100))] (ids spread-100)))}
      {:id :scan-clustered-in-100
+      :expected-rows (count clustered-100)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 100))] (ids clustered-100)))}
 
      {:id :scan-spread-in-1000
+      :expected-rows (count spread-1000)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 1000))] (ids spread-1000)))}
      {:id :scan-clustered-in-1000
+      :expected-rows (count clustered-1000)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE _id IN " (?s 1000))] (ids clustered-1000)))}]))
 
 (defn scan-items-by-content-key-queries
   [{:keys [spread-10 spread-100 spread-1000 clustered-10 clustered-100 clustered-1000]}]
   (let [ckeys #(mapv :item/content-key %)]
+    ;; content_key is a random uuid per item, so an IN over n of them matches n rows just as an _id IN does
     [{:id :content-key-spread-in-10
+      :expected-rows (count spread-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 10))] (ckeys spread-10)))}
      {:id :content-key-clustered-in-10
+      :expected-rows (count clustered-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 10))] (ckeys clustered-10)))}
      {:id :content-key-spread-or-10
+      :expected-rows (count spread-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "item$content_key" 10))] (ckeys spread-10)))}
      {:id :content-key-clustered-or-10
+      :expected-rows (count clustered-10)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE " (or-clause "item$content_key" 10))] (ckeys clustered-10)))}
 
      {:id :content-key-spread-in-100
+      :expected-rows (count spread-100)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 100))] (ckeys spread-100)))}
      {:id :content-key-clustered-in-100
+      :expected-rows (count clustered-100)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 100))] (ckeys clustered-100)))}
 
      {:id :content-key-spread-in-1000
+      :expected-rows (count spread-1000)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 1000))] (ckeys spread-1000)))}
      {:id :content-key-clustered-in-1000
+      :expected-rows (count clustered-1000)
       :f #(xt/q % (into [(str "SELECT _id FROM items WHERE item$content_key IN " (?s 1000))] (ckeys clustered-1000)))}]))
 
 (defn scan-items-filter-queries
@@ -160,23 +179,41 @@
      {:id :doc-type-not-null
       :f #(xt/q % ["SELECT _id FROM items WHERE item$doc_type IS NOT NULL"])}]))
 
-(defn- profile-data [pstats]
+(defn- profile-data [pstats row-counts]
   (let [rows (for [[id {:keys [n min p50 p90 p95 p99 max mean mad sum]}]
                    (get pstats :stats {})]
-               {:id id :n n :min min :p50 p50 :p90 p90 :p95 p95 :p99 p99
+               {:id id :n n :rows (get row-counts id)
+                :min min :p50 p50 :p90 p90 :p95 p95 :p99 p99
                 :max max :mean mean :mad mad :sum sum})]
     (sort-by :sum > rows)))
 
+(defn- check-row-counts!
+  "Runs each query once and returns its row count by id, throwing where that contradicts `:expected-rows`.
+   Doubles as the JIT warm-up, and MUST stay outside `tufte/profiled` so that neither the count nor the check lands in a measurement."
+  [conn suite]
+  (into {} (for [{:keys [id f expected-rows]} suite]
+             (let [n (count (f conn))]
+               (when (and expected-rows (not= expected-rows n))
+                 (throw (err/fault ::unexpected-row-count
+                                   (format "%s matched %d rows, expected %d — it is not querying what its id says, so timing it would measure the wrong thing" id n expected-rows)
+                                   {:query id, :expected expected-rows, :actual n})))
+               [id n]))))
+
 (defn- profile [node iterations suite]
   (with-open [conn (get-conn node)]
-    (let [_warmup (doseq [{:keys [f]} suite] (f conn))
+    (let [row-counts (check-row-counts! conn suite)
           [_ pstats] (tufte/profiled
                       {}
                       (doseq [{:keys [id f]} suite
                               _ (range iterations)]
                         (p id (f conn))))]
-      {:profile (profile-data @pstats)
-       :formatted (tufte/format-pstats pstats)})))
+      {:profile (profile-data @pstats row-counts)
+       ;; tufte owns the stats table and can't carry a rows column, so the counts follow it —
+       ;; the log is where a human reads this stage, and a count nobody sees checks nothing
+       :formatted (str (tufte/format-pstats pstats)
+                       \newline
+                       "rows  " (str/join "  " (for [{:keys [id]} suite]
+                                                 (str id "=" (get row-counts id)))))})))
 
 (defmethod b/cli-flags :scan-perf [_]
   [["-n" "--n-items N_ITEMS" "Number of items to generate"

--- a/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
+++ b/modules/bench/src/main/clojure/xtdb/bench/scan_perf.clj
@@ -56,7 +56,7 @@
 (defn scan-items-point-benchmark-queries
   "Individual point lookups at each 10% position in the index."
   [{:keys [spread-10]}]
-  (for [[i id] (map-indexed vector spread-10)]
+  (for [[i {id :xt/id}] (map-indexed vector spread-10)]
     {:id (keyword (str "scan-p" (* i 10)))
      :f #(xt/q % ["SELECT _id FROM items WHERE _id = ?" id])}))
 


### PR DESCRIPTION
Resolves #6019.

**tl;dr**

- **The nightly Scan Perf job reporting ~90min instead of ~30min was a benchmark bug, not an XTDB regression**
  `scan-perf`'s point-lookup suite bound a whole result row as the `_id = ?` argument, so its ten queries had matched zero rows since February. `588b707d8` stopped the scan narrowing to a bogus all-zeros IID for an eid it can't resolve, which turned a fast wrong answer into a slow one.

- **Two of the numbers this suite publishes are not comparable across this PR, and one of them will rise**
  The `:scan-p*` series is void before it — the queries were empty. `profile-scan-filters` goes up ~18% at 10M, because two compound filters were cutting at `p99` where their annotations describe a median, and now touch ~50x the rows.

- **The suite now checks what it can predict and reports what it can't**
  26 of its 34 queries assert an exact row count taken from the fixture; all 34 emit `:rows` alongside the timings. That check is what found the selectivity bug, on its first run.

## Context

`.github/workflows/scan-perf.yml` runs weeknights against 10M items and posts its total to a Slack channel. It sat around 20min of benchmark time for months and then jumped:

| run | commit | benchmark `summary` |
| --- | --- | --- |
| [33428960454](https://github.com/xtdb/xtdb/actions/runs/33428960454) (08-31) | `45c66b169` | 20m 49s |
| [33547932744](https://github.com/xtdb/xtdb/actions/runs/33547932744) (09-01) | `a53141ea0` | 81m 12s |
| [33671647770](https://github.com/xtdb/xtdb/actions/runs/33671647770) (09-02) | `a53141ea0` | 85m 54s |
| [33794724125](https://github.com/xtdb/xtdb/actions/runs/33794724125) (09-03) | `0d0f52b5b` | 92m 9s |

The whole delta is one stage. #6019 carries the root-cause analysis; what follows is what that meant for the change.

## Implementation

Three commits, in reading order. Each is independently meaningful — squashing would lose the second and third rationales.

- **`2ad59131f` — the point queries measure point lookups**
  `get-distributed-items` returns rows, and the builder bound the element straight through. Every sibling suite in the file already plucks the scalar first (`(mapv :xt/id %)`, `(:item/author-name (first spread-1000))`); the point suite was the only one that didn't.

- **`e4fdbb8b9` — a query matching the wrong rows fails the run rather than reporting a timing**
  `:expected-rows` on the 26 queries whose count the fixture pins — `(count spread-100)` and friends, the same collection whose ids get spliced into the `IN` list, so the expectation cannot drift from the query it guards. Checked in `check-row-counts!`, which replaces the existing `_warmup` doseq: same single execution per query, still outside `tufte/profiled`, so nothing lands in a measurement. The 8 filter queries have only approximate selectivities and get their count reported instead of asserted.

  Every query reports its count in all three places a reader looks: a `rows` line under each stage's tufte table (tufte owns its own columns, and that table is what a human reads in the Actions log), `:rows` in the profile data the cloud pipeline ingests, and a `Rows` column in all three `summary->*` renderers — whose shared `yakbench-query->query-row` rebuilds each row from a whitelist and would otherwise drop it.

- **`aab54e641` — the compound filters cut at the median, as their annotations say**
  `lang = ? AND length > len-p99` was annotated `~6%` and matching 0.106%; `author_name = ? AND published_at > ts-p99` was annotated `~0.75%` and matching 0.023%. Each annotation is exactly its equality conjunct halved (12.5%/2 = 6.25%, 1.5625%/2 = 0.78%), so a median threshold is what was meant — `len-p99` was in scope for the neighbouring `BETWEEN` queries and got reached for. `len-point` becomes `len-median` and `ts-median` is new.

## Test plan

Two full 10M CI runs on this branch, matching the nightly's inputs.

- **[33808472775](https://github.com/xtdb/xtdb/actions/runs/33808472775) — the fix alone**
  `profile-scan-points` 3,634,565ms → 2,333ms, total back to 21m 12s against 20m 49s on 08-31. The restored lookups do real work and cost ~170ms more across all 500 calls than visiting the all-zeros IID did, which is why the broken numbers looked plausible for seven months.

- **[33810981638](https://github.com/xtdb/xtdb/actions/runs/33810981638) — the branch tip**
  All 26 assertions pass at full scale; the run completing is the proof, since a contradicted count throws `err/fault`. Emitted counts: `scan-points` all `1`, `scan-sets` and `scan-content-key` all exactly `{10, 100, 1000}`.

- **Every filter annotation now holds at 10M**

  | query | annotated | measured |
  | --- | --- | --- |
  | `lang-eq` | ~12.5% | 12.499% |
  | `lang-eq-and-length-gt` | ~6% | 6.266% |
  | `author-name-eq` | ~1.5% | 1.562% |
  | `published-range-1pct` | ~1% | 1.199% |
  | `author-and-published-gt` | ~0.75% | 0.821% |
  | `length-range-1pct` | ~1% | 0.799% |
  | `doc-type-not-null` | ~0.1% | 0.101% |
  | `length-eq` | ~0.05% | 0.050% |

## Rollout

Nothing to do, but two published series change meaning at this commit.

- **`profile-scan-filters` rises ~18% — 357.5s to 420.6s at 10M**
  The two compound filters now match 626k and 82k rows instead of ~10k and ~2k. This is the correction working; read it as a new baseline, not a regression.

- **The `:scan-p*` history before this PR is void, not a baseline**
  Ten queries sampled at each 10% position reported the same figure to three significant figures over 50 iterations each. They were one empty lookup ten times over.

## Out of scope

- **A failed count aborts the whole benchmark, discarding stages that already passed**
  `check-row-counts!` throws out of the stage fn, and only the final `:output-profile-data` stage calls `b/log-report` — so a mismatch in the third of four profile stages loses the two completed stages' timings and the multi-hour ingest that produced them, with no `profiles` line emitted at all. Collecting violations, skipping the timed loop for the offending suite, and failing at `:output-profile-data` after the report is logged would keep the loud failure without the collateral loss. Left out here because it changes all four stage call sites on a path that only fires when something is already broken, and this branch is verified by two full 10M runs as it stands. Raised by the review pass on this diff.

- **A benchmark's column set is declared once per renderer per benchmark type**
  Three `summary->*` multimethods x ~13 benchmark types, each restating which columns to show, which is why `:rows` reached the profile data but no rendered table until the review caught it, and why fixing it was a four-site edit. Left alone deliberately: `table` is the only format anyone passes to `bb summarize-log`, and the weeknight job renders none of the three — it greps the log for the summary line and posts a duration, so the `rows` line under each tufte table is the surface that matters there. All three are updated here anyway so they don't diverge again, but collapsing the declarations isn't worth doing until a second format is actually consumed.

- **`:scan-p*` is ~75% per-query overhead**
  A point lookup is ~4.2ms, of which ~1ms is index work — the marginal cost of an id inside `scan-spread-in-10`, which uses the identical ten ids. Aggregated over the stage the run-to-run spread is ±5%, so it still resolves a 2x descent regression at ~5x the noise; it just won't see anything proportional to rows returned. `scan-spread-in-1000` covers that half overhead-free, so the suite has both instruments and neither needs adding to here.
