### PR TITLE
test(query): the 4570 test exercises a schema change again (#5854)

### DIFF
--- a/src/test/clojure/xtdb/node_test.clj
+++ b/src/test/clojure/xtdb/node_test.clj
@@ -784,6 +784,19 @@ VALUES(1, OBJECT (foo: OBJECT(bibble: true), bar: OBJECT(baz: 1001)))"]])
               (with-open [cursor (.openQuery stmt)]
                 (t/is (= res (tu/<-cursor cursor)))))
 
+            (t/testing "a column that didn't exist when the query was prepared"
+              (xt/execute-tx conn [[:put-docs :bar {:xt/id 1}]])
+
+              (with-open [bar-stmt (.prepareStatement ^Xtdb$Connection conn "SELECT * FROM bar ORDER BY _id")]
+                (with-open [cursor (.openQuery bar-stmt)]
+                  (t/is (= [[{:xt/id 1}]] (tu/<-cursor cursor))))
+
+                (xt/execute-tx conn [[:put-docs :bar {:xt/id 2, :my-col "foo"}]])
+
+                (with-open [cursor (.openQuery bar-stmt)]
+                  (t/is (= [[{:xt/id 1} {:xt/id 2, :my-col "foo"}]]
+                           (tu/<-cursor cursor))))))
+
             (t/testing "a -> union, but prepared query is still fine outside of pgwire"
               (xt/execute-tx conn [[:put-docs :foo {:xt/id 3 :a 1 :b 4}]])
 

--- a/src/test/clojure/xtdb/pgwire_test.clj
+++ b/src/test/clojure/xtdb/pgwire_test.clj
@@ -257,28 +257,20 @@
         (is (= false (.next rs)))))))
 
 (t/deftest prepared-stmt-sees-new-cols-4570
-  (with-open [conn (jdbc-conn {"prepareThreshold" 1})]
-    ;; my_col is declared (untyped) up front - #4467 means a query can't reference an undeclared
-    ;; column - and a re-planned prepared statement picks up its values as they're inserted
-    (jdbc/execute! conn ["CREATE TABLE docs (_id, my_col)"])
+  ;; -1 server-prepares from the first execution, so the second reuses its plan across the schema
+  ;; change - at the default threshold both executions re-parse and the test passes without ever
+  ;; exercising a stale plan.
+  (with-open [conn (jdbc-conn {"prepareThreshold" -1})]
     (jdbc/execute! conn ["INSERT INTO docs RECORDS {_id: 1}"])
 
-    (t/is (= [{:_id 1, :my_col nil}]
-             (jdbc/execute! conn ["SELECT _id, my_col FROM docs"])))
-
-    (with-open [stmt (.prepareStatement conn "FROM docs SELECT my_col ORDER BY _id")
-                star-stmt (.prepareStatement conn "FROM docs ORDER BY _id")]
-      (with-open [rs (.executeQuery stmt)
-                  rs-star (.executeQuery star-stmt)]
-        (t/is (= [{:my_col nil}] (resultset-seq rs)))
-        (t/is (= [{:_id 1, :my_col nil}] (resultset-seq rs-star))))
+    (with-open [stmt (.prepareStatement conn "SELECT * FROM docs ORDER BY _id")]
+      (with-open [rs (.executeQuery stmt)]
+        (t/is (= [{:_id 1}] (resultset-seq rs))))
 
       (jdbc/execute! conn ["INSERT INTO docs RECORDS {_id: 2, my_col: 'foo'}"])
 
-      (with-open [rs (.executeQuery stmt)
-                  rs-star (.executeQuery star-stmt)]
-        (t/is (= [{:my_col nil} {:my_col "foo"}] (resultset-seq rs)))
-       (t/is (= [{:_id 1, :my_col nil} {:_id 2, :my_col "foo"}] (resultset-seq rs-star)))))))
+      (with-open [rs (.executeQuery stmt)]
+        (t/is (= [{:_id 1, :my_col nil} {:_id 2, :my_col "foo"}] (resultset-seq rs)))))))
 
 (deftest parameterized-query-test
   (with-open [conn (jdbc-conn)


### PR DESCRIPTION
`prepared-stmt-sees-new-cols-4570` passed with the mechanism it guards removed — replacing `openQuery`'s `(reset! !table-info (->table-info min-basis))` with `@!table-info` left it green. Two things independently defanged it, both introduced as test fallout by #4467.

- **The column was declared before either statement was prepared.** `CREATE TABLE docs (_id, my_col)` put `my_col` into table-info up front, so table-info was identical across the two executions and the plan cache — keyed on it since 37290b7f6 — never saw it move. What the test observed instead was `scan-vec-types` refreshing that column's type, which happens per execution either way.

- **No execution ever reused a plan.**

The named-column half is deleted rather than repaired, because after #4467 the two halves want opposite things from one table: `FROM docs SELECT my_col` can only be prepared if the column is declared, and the star statement only exercises anything if it isn't. What that half still covered — a declared column's type moving from `Nothing` to `utf8` — is pinned by `test-prepared-statements` and by the `0A000` case further down `pgwire_test.clj`.

The node-level case goes in `test-prepared-statements`' "statement invalidation" section, which already covers new rows, an unrelated table and a widening union, but not a column appearing. That is the lowest surface expressing it: over the wire the re-plan changes the result shape, pgwire rejects it with `0A000`, and pgjdbc transparently re-preps and retries, so the wire-level assertion sits two mechanisms downstream of the one under test.

#5854 asks whether the per-execution re-derivation is needed at all, and that cannot be settled against a test that passes either way — hence this first. The answer it gives is that the re-derivation is load-bearing: both cases fail without it.