### PR TITLE
the leader's block cycle is its own component, and LogProcessor holds it

### DIFF
--- a/core/src/main/kotlin/xtdb/indexer/BlockCutter.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockCutter.kt
@@ -1,0 +1,110 @@
+package xtdb.indexer
+
+import xtdb.api.DatabaseName
+import xtdb.api.log.ReplicaMessage.BlockBoundary
+import xtdb.api.tx.ExternalSourceToken
+import xtdb.database.PartitionState
+import xtdb.types.MessageId
+
+/**
+ * Where a leader term is in the block it is filling: [Filling] → [Cut] → [Uploading] → [Filling].
+ *
+ * Resolution is armed only in [Filling] — see [acceptingResolution] — so no tx can interleave between a
+ * boundary and its upload, which is what keeps the follower's bounded pending-block buffer empty.
+ *
+ * The term's coroutine is both the sole writer and the sole reader, so nothing here is published across
+ * coroutines.
+ */
+internal class BlockCutter(
+    partitionState: PartitionState,
+    private val dbName: DatabaseName,
+    private val leaderTerm: Long,
+    private val replicaAppender: ReplicaLogAppender,
+    private val blockUploader: BlockUploader,
+) {
+    private val liveIndex = partitionState.liveIndex
+    private val tableCatalog = partitionState.tableCatalog
+
+    private sealed interface BlockState
+
+    /**
+     * Accumulating rows towards the cut, [rows] of them so far.
+     *
+     * The boundary is cut off this rather than `liveIndex.isFull()`, which lags — it reflects only APPLIED
+     * (consume-back) txs. Seeded from the rows already applied into the open block, because a new leader
+     * inherits a partially-filled block from replay and must cut it where the old leader would have, or
+     * block sizes drift across restarts (the #5817 stop/start off-by-one).
+     */
+    private class Filling(val rows: Long) : BlockState
+
+    /** The boundary is queued for append, and has not been read back yet. */
+    private data object Cut : BlockState
+
+    /** The boundary has been applied and the upload is in flight. */
+    private data object Uploading : BlockState
+
+    private var blockState: BlockState = Filling(liveIndex.blockRowCount)
+
+    // From the live index, not the node config: the two agree in production, but they are one value and the
+    // live index is what owns the block being filled.
+    private val rowsPerBlock = liveIndex.rowsPerBlock
+
+    /**
+     * Whether this term will take resolution work right now.
+     *
+     * False for the length of a block cut, so nothing interleaves between the boundary and its upload —
+     * which is what keeps the follower's bounded pending-block buffer empty.
+     */
+    val acceptingResolution get() = blockState is Filling
+
+    /**
+     * Whether the block being filled has reached [rowsPerBlock], and so wants [cut].
+     *
+     * An empty block is never full, whatever the threshold. Without that, a `rowsPerBlock` of 0 leaves
+     * the term cutting an empty block, re-opening an empty one and cutting that — live-locked, never
+     * arming resolution again.
+     */
+    val isFull get() = (blockState as? Filling)?.let { it.rows > 0 && it.rows >= rowsPerBlock } == true
+
+    /** Account [rows] more towards the block being filled. */
+    fun addRows(rows: Long) {
+        blockState = when (val state = blockState) {
+            is Filling -> Filling(state.rows + rows)
+
+            // Only reachable from clauses the term arms in Filling alone, so getting here means the
+            // arm-set and this state have come apart.
+            Cut, Uploading -> error("[$dbName] tx resolved during a block cut")
+        }
+    }
+
+    /**
+     * Cut the block: inject a boundary covering the source log up to [latestProcessedMsgId] and the
+     * external source up to [extToken], and pause resolution until that boundary has been read back and
+     * uploaded.
+     *
+     * Both watermarks are the resolve side's, so the caller supplies them — this reads only the block
+     * index the boundary follows on from. Queued through the append pump rather than appended directly, so
+     * it lands in resolution order: after this block's txs and before the next block's.
+     */
+    suspend fun cut(latestProcessedMsgId: MessageId, extToken: ExternalSourceToken?) {
+        val boundary = BlockBoundary(
+            (tableCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, extToken,
+            termId = leaderTerm
+        )
+        replicaAppender.append(ControlItem(boundary))
+        blockState = Cut
+    }
+
+    /**
+     * Close the block that [boundary] cut, read back at [boundaryMsgId], and re-arm resolution behind it.
+     *
+     * The live index holds exactly this block's txs by now, in log order; snapshotting it, appending the
+     * matching `BlockUploaded` and rolling the index all happen inside [BlockUploader.uploadBlock].
+     */
+    suspend fun upload(boundaryMsgId: MessageId, boundary: BlockBoundary) {
+        blockState = Uploading
+        blockUploader.uploadBlock(boundaryMsgId, leaderTerm, boundary)
+        // Straight after the upload, so a demote landing here hands on nothing: the block is done.
+        blockState = Filling(0)
+    }
+}

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -73,8 +73,16 @@ class BlockUploader(
         }
     }
 
+    /**
+     * Snapshot the live index into block files, append [boundary]'s matching `BlockUploaded`, and roll the
+     * index. Returns the `BlockUploaded`'s replica-log position.
+     *
+     * [uploadingTermId] is not always [boundary]'s: a transition finishes the previous leader's pending
+     * block, and the `BlockUploaded` must carry the new term, or followers that have already advanced
+     * would fence it and never complete the block.
+     */
     suspend fun uploadBlock(
-        boundaryReplicaMsgId: MessageId, termId: Long,
+        boundaryReplicaMsgId: MessageId, uploadingTermId: Long,
         boundary: BlockBoundary,
     ): MessageId {
         val latestProcessedMsgId = boundary.latestProcessedMsgId
@@ -128,7 +136,7 @@ class BlockUploader(
         val block = tableCatalog.buildBlock(
             blockIdx, liveIndex.latestCompletedTx, latestProcessedMsgId,
             boundaryReplicaMsgId, entries.values, secondaryDatabasesForBlock,
-            externalSourceToken, termId
+            externalSourceToken, uploadingTermId
         )
 
         bufferPool.putObject(TableCatalog.blockFilePath(blockIdx), ByteBuffer.wrap(block.toByteArray()))
@@ -141,7 +149,7 @@ class BlockUploader(
                 Storage.VERSION, bufferPool.epoch,
                 blockIdx, latestProcessedMsgId,
                 addedTries, externalSourceToken,
-                termId = termId,
+                termId = uploadingTermId,
             )
         ).msgId
 

--- a/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderDriver.kt
@@ -4,7 +4,6 @@ import xtdb.api.TableRef
 import xtdb.api.TransactionKey
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
-import xtdb.api.log.ReplicaMessage.BlockBoundary
 import xtdb.api.log.SourceMessage
 import xtdb.arrow.RelationReader
 import xtdb.database.PartitionState
@@ -12,16 +11,16 @@ import xtdb.database.PartitionStorage
 import xtdb.types.MessageId
 
 /**
- * The leader term's observable external effects, behind one seam.
- *
- * These are driven from the log processor's work loop, and reach the outside world only through
- * here — so a test can stall an upload or fail an append, neither of which the real logs express in
- * memory.
+ * The leader term's log appends and live-index writes, behind one seam — so a test can fail or stall one,
+ * which the real in-memory logs never do.
  *
  * Deliberately narrow. In-memory state mutations that happen to sit on the leader's path —
  * `trieCatalog`, `dbCatalog`, `watchers`, the GC signals — stay on the processor, as do reads of
  * in-memory state (`liveIndex.isFull()`, `tableCatalog.currentBlockIndex`). A wrapper holds real
  * state objects, so those reads stay consistent with what the driver has applied.
+ *
+ * The block upload is deliberately not here either: it is [BlockCutter]'s, through [BlockUploader], and it
+ * reaches both logs and object storage of its own accord.
  */
 internal interface LeaderDriver {
 
@@ -37,16 +36,6 @@ internal interface LeaderDriver {
     /** Commit a resolved tx's writes into the durable live index. */
     suspend fun applyTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>)
 
-    /**
-     * Snapshot the live index into block files, append the [BlockBoundary]'s matching `BlockUploaded`,
-     * and roll the index. Returns the `BlockUploaded`'s replica-log position.
-     *
-     * [termId] is the *appending* term, which is not always [boundary]'s: a transition finishes the
-     * previous leader's pending block, and the `BlockUploaded` must carry the new term or followers
-     * that have already advanced would fence it and never complete the block.
-     */
-    suspend fun uploadBlock(boundaryMsgId: MessageId, termId: Long, boundary: BlockBoundary): MessageId
-
     /** Ask the source log to cut a block, on the flush-timeout path. Returns the message's position. */
     suspend fun requestFlushBlock(expectedBlockIdx: Long): MessageId
 }
@@ -54,7 +43,6 @@ internal interface LeaderDriver {
 internal class RealLeaderDriver(
     partitionStorage: PartitionStorage,
     partitionState: PartitionState,
-    private val blockUploader: BlockUploader,
 ) : LeaderDriver {
 
     private val sourceLog = partitionStorage.sourceLog
@@ -66,9 +54,6 @@ internal class RealLeaderDriver(
 
     override suspend fun applyTx(txKey: TransactionKey, tables: Map<TableRef, RelationReader>) =
         liveIndex.commitTx(txKey, tables)
-
-    override suspend fun uploadBlock(boundaryMsgId: MessageId, termId: Long, boundary: BlockBoundary): MessageId =
-        blockUploader.uploadBlock(boundaryMsgId, termId, boundary)
 
     override suspend fun requestFlushBlock(expectedBlockIdx: Long): MessageId =
         sourceLog.appendMessage(SourceMessage.FlushBlock(expectedBlockIdx)).msgId

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -103,21 +103,9 @@ internal class LeaderLogProcessor(
     private data object Cut : BlockState
 
     /** The boundary has been applied and the upload is in flight. */
-    private class Uploading(val pendingBlock: PendingBlock) : BlockState
+    private data object Uploading : BlockState
 
     private var blockState: BlockState = Filling(liveIndex.blockRowCount)
-
-    /**
-     * The block this term would have to hand on, were it demoted right now.
-     *
-     * Read from the transport's serialization point rather than from the work loop, and after this term has
-     * been cancelled and closed — so it must not touch anything allocator-backed.
-     */
-    val pendingBlock: PendingBlock?
-        get() = when (val state = blockState) {
-            is Filling, Cut -> null
-            is Uploading -> state.pendingBlock
-        }
 
     // From the live index, not the node config: the two agree in production, but they are one value and the
     // live index is what owns the block being filled.
@@ -195,7 +183,7 @@ internal class LeaderLogProcessor(
             is ReplicaMessage.TriesAdded -> watchers.notifyApplied(record.msgId, msg.sourceMsgId)
 
             is BlockBoundary -> {
-                blockState = Uploading(PendingBlock(record.msgId, msg))
+                blockState = Uploading
                 // liveIndex now holds exactly this block's txs (by log order); snapshot, upload the files,
                 // append BlockUploaded and roll the index — all inside uploadBlock.
                 driver.uploadBlock(record.msgId, leaderTerm, msg)
@@ -272,7 +260,7 @@ internal class LeaderLogProcessor(
             is Filling -> state.rows + resolvedTx.allTables.sumOf { it.relation.rowCount.toLong() }
             // Only reachable from clauses this term arms in Filling alone, so getting here means the
             // arm-set and this state have come apart — and the gauge it would feed no longer exists.
-            Cut, is Uploading -> error("[$dbName] tx resolved during a block cut")
+            Cut, Uploading -> error("[$dbName] tx resolved during a block cut")
         }
 
         replicaAppender.append(TxItem(resolvedTx, leaderTerm))

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -44,6 +44,7 @@ internal class LeaderLogProcessor(
     partitionState: PartitionState,
     private val dbName: DatabaseName,
     private val driver: LeaderDriver,
+    private val blockCutter: BlockCutter,
     private val watchers: Watchers,
 
     private val replicaAppender: ReplicaLogAppender,
@@ -65,7 +66,6 @@ internal class LeaderLogProcessor(
     }
 
     private val partition = partitionStorage.partition
-    private val liveIndex = partitionState.liveIndex
 
     private val tableCatalog = partitionState.tableCatalog
 
@@ -79,37 +79,6 @@ internal class LeaderLogProcessor(
             resolvedSrcMsgId = watchers.latestSourceMsgId, resolvedExtToken = watchers.externalSourceToken,
             instantSource
         )
-
-    /**
-     * Where this term is in the block it is filling: `Filling` → `Cut` → `Uploading` → `Filling`.
-     *
-     * Resolution is armed only in [Filling], so no tx can interleave between a boundary and its upload —
-     * which keeps the follower's bounded pending-block buffer empty. That is also why the row gauge is
-     * [Filling]'s alone: outside it, nothing can move the gauge.
-     */
-    private sealed interface BlockState
-
-    /**
-     * Accumulating rows towards the cut, [rows] of them so far.
-     *
-     * The boundary is cut off this rather than `liveIndex.isFull()`, which lags — it reflects only APPLIED
-     * (consume-back) txs. Seeded from the rows already applied into the open block, because a new leader
-     * inherits a partially-filled block from replay and must cut it where the old leader would have, or
-     * block sizes drift across restarts (the #5817 stop/start off-by-one).
-     */
-    private class Filling(val rows: Long) : BlockState
-
-    /** The boundary is queued for append, and has not been read back yet. */
-    private data object Cut : BlockState
-
-    /** The boundary has been applied and the upload is in flight. */
-    private data object Uploading : BlockState
-
-    private var blockState: BlockState = Filling(liveIndex.blockRowCount)
-
-    // From the live index, not the node config: the two agree in production, but they are one value and the
-    // live index is what owns the block being filled.
-    private val rowsPerBlock = liveIndex.rowsPerBlock
 
     val gc = GarbageCollector(
         nodeBase, partitionStorage, partitionState, dbName, leaderTerm, replicaAppender, gcDispatcher
@@ -183,12 +152,7 @@ internal class LeaderLogProcessor(
             is ReplicaMessage.TriesAdded -> watchers.notifyApplied(record.msgId, msg.sourceMsgId)
 
             is BlockBoundary -> {
-                blockState = Uploading
-                // liveIndex now holds exactly this block's txs (by log order); snapshot, upload the files,
-                // append BlockUploaded and roll the index — all inside uploadBlock.
-                driver.uploadBlock(record.msgId, leaderTerm, msg)
-                // Straight after the upload, so a demote landing here hands on nothing: the block is done.
-                blockState = Filling(0)
+                blockCutter.upload(record.msgId, msg)
 
                 // the block's covered source position, as the follower does
                 watchers.notifyApplied(record.msgId, msg.latestProcessedMsgId)
@@ -242,45 +206,25 @@ internal class LeaderLogProcessor(
 
     // ---- resolution ----
 
-    // Cut a block: inject the boundary (in resolution order, so it lands after this block's txs and before
-    // the next block's) and pause resolution until it is read back and uploaded.
-    private suspend fun cutBlock(latestProcessedMsgId: MessageId) {
-        val boundary = BlockBoundary(
-            (tableCatalog.currentBlockIndex ?: -1) + 1, latestProcessedMsgId, txResolver.resolvedExtToken,
-            termId = leaderTerm
-        )
-        replicaAppender.append(ControlItem(boundary))
-        blockState = Cut
-    }
+    private suspend fun cutBlock(latestProcessedMsgId: MessageId) =
+        blockCutter.cut(latestProcessedMsgId, txResolver.resolvedExtToken)
 
-    // Hand a freshly-resolved tx to the append pump, cutting a block if this tx filled one — which the
-    // caller is told about, because a source batch mid-flight has to stop where that happens.
+    // Hand a freshly-resolved tx to the append pump, answering whether it filled the block — which the
+    // caller needs, because a source batch mid-flight has to stop where that happens.
     private suspend fun appendTx(resolvedTx: ResolvedTx): Boolean {
-        val rows = when (val state = blockState) {
-            is Filling -> state.rows + resolvedTx.allTables.sumOf { it.relation.rowCount.toLong() }
-            // Only reachable from clauses this term arms in Filling alone, so getting here means the
-            // arm-set and this state have come apart — and the gauge it would feed no longer exists.
-            Cut, Uploading -> error("[$dbName] tx resolved during a block cut")
-        }
+        blockCutter.addRows(resolvedTx.allTables.sumOf { it.relation.rowCount.toLong() })
 
         replicaAppender.append(TxItem(resolvedTx, leaderTerm))
 
-        if (rows < rowsPerBlock) {
-            blockState = Filling(rows)
-            return false
-        }
-
-        cutBlock(txResolver.resolvedSrcMsgId)
-        return true
+        return blockCutter.isFull
     }
 
-    /**
-     * Whether this term will take resolution work right now.
-     *
-     * False for the length of a block cut, so nothing interleaves between the boundary and its upload —
-     * which is what keeps the follower's bounded pending-block buffer empty.
-     */
-    val acceptingResolution get() = blockState is Filling
+    val acceptingResolution get() = blockCutter.acceptingResolution
+
+    val blockFilled get() = blockCutter.isFull
+
+    /** Cut the block this term has filled, sealing it at the resolve side's current watermarks. */
+    suspend fun cutFilledBlock() = cutBlock(txResolver.resolvedSrcMsgId)
 
     /**
      * Fail everything staged on this term, because it has ended with [cause].

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -85,7 +85,11 @@ internal suspend fun runLeaderTerm(
         coroutineScope {
             launch(CoroutineName("$dbName-replica-appender")) { appender.run() }
 
-            while (true)
+            while (true) {
+                // Ahead of the arming below, not after it: a filled block must admit nothing else, and
+                // the GC clause would otherwise slip a TriesDeleted in ahead of the boundary.
+                if (term.blockFilled) term.cutFilledBlock()
+
                 selectUnbiased {
                     replicaMsgs.onReceive { pending ->
                         try {
@@ -117,6 +121,7 @@ internal suspend fun runLeaderTerm(
                         term.gc.run { armSelect() }
                     }
                 }
+            }
         }
     } catch (t: Throwable) {
         when {
@@ -321,11 +326,14 @@ class LogProcessor(
                         following.proc.close()
                     }
 
-                    val driver = RealLeaderDriver(partitionStorage, partitionState, blockUploader)
+                    val driver = RealLeaderDriver(partitionStorage, partitionState)
                     val replicaAppender = ReplicaLogAppender(driver)
+                    val blockCutter =
+                        BlockCutter(partitionState, dbName, termId, replicaAppender, blockUploader)
 
                     val proc = LeaderLogProcessor(
-                        allocator, base, partitionStorage, crashLogger, partitionState, dbName, driver, watchers,
+                        allocator, base, partitionStorage, crashLogger, partitionState, dbName, driver,
+                        blockCutter, watchers,
                         replicaAppender,
                         externalSource,
                         skipTxs, dbCatalog,
@@ -334,7 +342,7 @@ class LogProcessor(
                         gcDispatcher = gcDispatcher,
                     )
 
-                    pendingBlock?.let { proc.applyPendingBlock(it) }
+                    pendingBlock?.let { proc.applyPendingBlock(blockCutter, it) }
 
                     LOG.debug("[${dbName}] transition: building leader processor")
                     val resumeAfterMsgId = watchers.latestSourceMsgId
@@ -370,10 +378,14 @@ class LogProcessor(
         }
     }
 
-    private suspend fun LeaderLogProcessor.applyPendingBlock(pendingBlock: PendingBlock) {
+    private suspend fun LeaderLogProcessor.applyPendingBlock(
+        blockCutter: BlockCutter, pendingBlock: PendingBlock,
+    ) {
         var oldTerm = pendingBlock.boundaryMessage.termId
         LOG.debug("[${dbName}] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
-        blockUploader.uploadBlock(pendingBlock.boundaryMsgId, leaderTerm, pendingBlock.boundaryMessage)
+        // Through the cutter, not the uploader: closing a block is what resets the row gauge, and this
+        // block was cut before the gauge was seeded from a live index that still held it.
+        blockCutter.upload(pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage)
         LOG.debug("[${dbName}] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records")
 
         pendingBlock.bufferedRecords.forEach {

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -398,11 +398,9 @@ class LogProcessor(
         }
 
         LOG.info("[$dbName] demote — tearing down leader, re-opening follower")
-        // Cancel first: `pendingBlock` stays readable after the cancel/close — it isn't allocator-backed
-        // — so we free the old term before reading it to seed the follower.
         leader.job.cancelAndJoin()
         leader.proc.close()
-        state = openFollower(leader.proc.pendingBlock)
+        state = openFollower()
     }
 
     override fun close() = state.proc.close()

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -30,6 +30,7 @@ import xtdb.api.IndexerConfig
 import xtdb.api.error.Incorrect
 import xtdb.indexer.BlockUploader
 import xtdb.indexer.CrashLogger
+import xtdb.indexer.BlockCutter
 import xtdb.indexer.LeaderDriver
 import xtdb.indexer.LeaderLogProcessor
 import xtdb.indexer.LeaderSupersededException
@@ -121,18 +122,15 @@ class ExternalSourceTest {
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
         val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", compactor, null, null, backgroundScope)
-        val driver = wrapDriver(
-            RealLeaderDriver(
-                partitionStorage, partitionState, blockUploader
-            )
-        )
+        val driver = wrapDriver(RealLeaderDriver(partitionStorage, partitionState))
 
         val crashLogger = mockk<CrashLogger>(relaxed = true)
         val replicaAppender = ReplicaLogAppender(driver)
+        val blockCutter = BlockCutter(partitionState, "test", 0, replicaAppender, blockUploader)
 
         return LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, crashLogger,
-            partitionState, "test", driver, watchers, replicaAppender,
+            partitionState, "test", driver, blockCutter, watchers, replicaAppender,
             extSource,
             skipTxs = emptySet(), dbCatalog = null,
             flushTimeout = IndexerConfig().flushDuration,

--- a/core/src/test/kotlin/xtdb/indexer/BlockCutterTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/BlockCutterTest.kt
@@ -1,0 +1,131 @@
+package xtdb.indexer
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import xtdb.api.log.InMemoryLog
+import xtdb.api.log.Log
+import xtdb.api.log.ReplicaMessage
+import xtdb.api.log.SourceMessage
+import xtdb.api.log.Watchers
+import xtdb.api.tx.TxIndexer
+import xtdb.log.proto.trieMetadata
+import xtdb.table.fromSchemaAndTable
+import java.time.Instant
+import java.time.InstantSource
+import java.time.ZoneId
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The leader's block cycle: what the boundary it cuts carries, and what reaches the replica log by the
+ * time the block is closed.
+ *
+ * Driven through a running term, because the cycle spans the resolve side and the consume-back — the
+ * boundary is appended by one and the upload is triggered by the other reading it.
+ */
+internal class BlockCutterTest : LeaderTermTest() {
+
+    @Test
+    fun `block finishing writes BlockBoundary + BlockUploaded to replica log`() = runTest {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val finishedBlock = LiveTable.FinishedBlock(
+            vecTypes = emptyMap(),
+            rowCount = 10,
+            hllDeltas = emptyMap(),
+            writtenTrie = LiveTable.FinishedBlock.WrittenTrie(
+                trieKey = "test-trie",
+                dataFileSize = 42,
+                trieMetadata = trieMetadata {}
+            )
+        )
+        val tableRef = fromSchemaAndTable("public/foo")
+
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler),
+            replicaLog = replicaLog,
+            liveIndex = liveIndexMock {
+                coEvery { finishBlock(any(), any()) } returns mapOf(tableRef to finishedBlock)
+                every { latestCompletedTx } returns null
+            },
+            watchers = watchers,
+            extSource = null,
+        )
+
+        lp.srcLogProc.processRecords(listOf(
+            Log.Record(0, 0, Instant.now(), SourceMessage.FlushBlock(-1))
+        ))
+        watchers.awaitSource(0)
+
+        val replicaMessages = mutableListOf<ReplicaMessage>()
+        backgroundScope.launch {
+            replicaLog.tailAll(0, -1) { records -> replicaMessages.addAll(records.map { it.message }) }
+        }
+
+        delay(200)
+
+        assertEquals(2, replicaMessages.size, "expected 2 replica messages, got: $replicaMessages")
+        assertTrue(replicaMessages[0] is ReplicaMessage.BlockBoundary)
+        assertTrue(replicaMessages[1] is ReplicaMessage.BlockUploaded)
+
+        val boundary = replicaMessages[0] as ReplicaMessage.BlockBoundary
+        assertEquals(0, boundary.blockIndex)
+
+        val uploaded = replicaMessages[1] as ReplicaMessage.BlockUploaded
+        assertEquals(0, uploaded.blockIndex)
+        assertTrue(uploaded.tries.isNotEmpty(), "BlockUploaded should contain trie details")
+    }
+
+    @Test
+    fun `block boundaries carry the latest external-source token, not the last tx's`() = runTest(timeout = 5.seconds) {
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
+
+        val lp = leaderProc(
+            StandardTestDispatcher(testScheduler),
+            replicaLog = replicaLog,
+            liveIndex = liveIndexMock {
+                coEvery { finishBlock(any(), any()) } returns emptyMap()
+                every { latestCompletedTx } returns null
+            },
+            watchers = watchers,
+            extSource = mockk(relaxed = true),
+            skipTxs = setOf(10),
+        )
+
+        val token = byteArrayOf(1, 2, 3)
+
+        // The ext-source tx carries the CDC resume token; awaiting its durability (txId 0) pins the
+        // ordering — it resolves and applies before the token-less source-log tx that follows.
+        lp.extSrcProc!!.submitTx(token) { TxIndexer.TxResult.Committed() }
+        watchers.awaitTx(0)
+
+        // A token-less source-log tx (msgId 10; skipTxs covers it, so no Arrow payload needed, and its
+        // txId must exceed the ext tx's for watchers' monotonicity). It resolves behind the ext tx.
+        lp.srcLogProc.processRecords(listOf(
+            Log.Record(0, 10, Instant.now(), SourceMessage.Tx(ByteArray(0), null, ZoneId.of("UTC"), null, null))
+        ))
+
+        // Force the cut with a FlushBlock: the block's last tx is the token-less source-log tx, so the
+        // boundary must carry the earlier ext tx's token (the last non-null token seen), not a null one.
+        lp.srcLogProc.processRecords(listOf(
+            Log.Record(0, 11, Instant.now(), SourceMessage.FlushBlock(-1))
+        ))
+        watchers.awaitSource(11)
+
+        val boundaries = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
+            .mapNotNull { it.message as? ReplicaMessage.BlockBoundary }.toList()
+
+        assertEquals(1, boundaries.size, "exactly one BlockBoundary should be written")
+        assertArrayEquals(
+            token, boundaries.single().externalSourceToken,
+            "BlockBoundary must carry the ext-source tx's token, not the source-log tx's null token"
+        )
+    }
+}

--- a/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
@@ -158,8 +158,8 @@ internal abstract class LeaderTermTest {
         compactor: Compactor.ForDatabase = mockk(relaxed = true),
         watchers: Watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1),
         // These tests submit through the processor rather than driving an adapter, so the source only has
-        // to exist for the processor to.
-        extSource: ExternalSource = mockk(relaxed = true),
+        // to exist for the processor to. Null names a database without one.
+        extSource: ExternalSource? = mockk(relaxed = true),
         skipTxs: Set<MessageId> = emptySet(),
         leaderTerm: Long = 1,
         // A leader may only hold one if it is the primary's, so supplying one names this database 'xtdb'.
@@ -176,17 +176,18 @@ internal abstract class LeaderTermTest {
                 partitionStorage, partitionState, "xtdb", compactor, null, null,
                 backgroundScope, uploadDispatcher
             )
-        val driver = wrapDriver(RealLeaderDriver(partitionStorage, partitionState, blockUploader))
+        val driver = wrapDriver(RealLeaderDriver(partitionStorage, partitionState))
 
         val termScope = backgroundScope + termJob
         val replicaAppender = ReplicaLogAppender(driver)
+        val blockCutter = BlockCutter(partitionState, dbName, leaderTerm, replicaAppender, blockUploader)
 
         return termScope.startTerm(
             partitionStorage, replicaAppender, watchers,
             LeaderLogProcessor(
                 allocator, nodeBase, partitionStorage, mockk(relaxed = true),
                 partitionState, dbName,
-                driver, watchers, replicaAppender, extSource,
+                driver, blockCutter, watchers, replicaAppender, extSource,
                 skipTxs = skipTxs, dbCatalog = dbCatalog,
                 leaderTerm = leaderTerm,
                 flushTimeout = IndexerConfig().flushDuration,
@@ -214,12 +215,13 @@ internal abstract class LeaderTermTest {
             partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null,
             backgroundScope, StandardTestDispatcher(testScheduler)
         )
-        val leaderDriver = driver(RealLeaderDriver(partitionStorage, partitionState, blockUploader))
+        val leaderDriver = driver(RealLeaderDriver(partitionStorage, partitionState))
         val appender = ReplicaLogAppender(leaderDriver)
+        val blockCutter = BlockCutter(partitionState, "test", 1, appender, blockUploader)
 
         val proc = LeaderLogProcessor(
             allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-            partitionState, "test", leaderDriver, watchers, appender,
+            partitionState, "test", leaderDriver, blockCutter, watchers, appender,
             extSource,
             skipTxs = emptySet(), dbCatalog = null,
             leaderTerm = 1,

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -2,7 +2,6 @@ package xtdb.indexer
 
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -27,6 +26,7 @@ import xtdb.database.DatabaseLogs
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.storage.BufferPool
+import xtdb.util.closeAll
 import java.time.Instant
 import java.time.InstantSource
 import java.util.concurrent.TimeUnit
@@ -37,6 +37,10 @@ class LogProcessorTest {
     private lateinit var nodeBase: NodeBase
     private lateinit var allocator: BufferAllocator
 
+    // Each test cancel-and-joins its own scope and closes its processor, so everything here is
+    // quiescent by teardown — and freed before `allocator`, which the live indexes are children of.
+    private val partitionStates = mutableListOf<PartitionState>()
+
     @BeforeEach
     fun setUp() {
         nodeBase = openBase(openMeterRegistry = false)
@@ -45,6 +49,7 @@ class LogProcessorTest {
 
     @AfterEach
     fun tearDown() {
+        partitionStates.closeAll()
         allocator.close()
         nodeBase.close()
     }
@@ -52,16 +57,15 @@ class LogProcessorTest {
     private fun mockBufferPool(epoch: Int = 0) =
         mockk<BufferPool>(relaxed = true) { every { this@mockk.epoch } returns epoch }
 
-    private fun newPartitionState(
-        liveIndex: LiveIndex = mockk(relaxed = true),
-        boundaryTermId: Long? = null,
-    ) = PartitionState(
-        boundaryTermId
+    private fun newPartitionState(boundaryTermId: Long? = null): PartitionState {
+        val tableCatalog = boundaryTermId
             ?.let { TableCatalog(mockBufferPool(), block { blockIndex = 0; termId = it }) }
-            ?: TableCatalog(mockBufferPool()),
-        createTrieCatalog(),
-        liveIndex
-    )
+            ?: TableCatalog(mockBufferPool())
+        val trieCatalog = createTrieCatalog()
+
+        return PartitionState(tableCatalog, trieCatalog, LiveIndex.open(allocator, tableCatalog, trieCatalog))
+            .also { partitionStates += it }
+    }
 
     private fun logProcessor(
         partitionStorage: PartitionStorage,
@@ -162,8 +166,7 @@ class LogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0, termEpoch = 1)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
-        val liveIndex = mockk<LiveIndex>(relaxed = true) { every { latestCompletedTx } returns null }
-        val partitionState = newPartitionState(liveIndex = liveIndex)
+        val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
@@ -178,7 +181,10 @@ class LogProcessorTest {
 
         // term 1.1 outranks 0.9, so the transition goes through and replays the log
         watchers.awaitTx(1)
-        verify { liveIndex.commitTx(any(), any()) }
+        assertEquals(
+            1L, partitionState.liveIndex.latestCompletedTx?.txId,
+            "the replayed tx is committed into the live index"
+        )
 
         scope.coroutineContext.job.cancelAndJoin()
         logProc.close()
@@ -191,10 +197,7 @@ class LogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
         val bufferPool = mockBufferPool()
-        val liveIndex = mockk<LiveIndex>(relaxed = true) {
-            every { latestCompletedTx } returns null
-        }
-        val partitionState = newPartitionState(liveIndex = liveIndex)
+        val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
@@ -210,7 +213,10 @@ class LogProcessorTest {
         // wait for the follower→leader transition to complete (runs on Dispatchers.Default)
         watchers.awaitTx(1)
 
-        verify { liveIndex.commitTx(any(), any()) }
+        assertEquals(
+            1L, partitionState.liveIndex.latestCompletedTx?.txId,
+            "the replayed tx is committed into the live index"
+        )
 
         // Teardown: cancel+join the scope reaps the subscription and the live term, then free it.
         scope.coroutineContext.job.cancelAndJoin()
@@ -224,10 +230,7 @@ class LogProcessorTest {
         val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 1)
         val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 1)
         val bufferPool = mockBufferPool(epoch = 1)
-        val liveIndex = mockk<LiveIndex>(relaxed = true) {
-            every { latestCompletedTx } returns null
-        }
-        val partitionState = newPartitionState(liveIndex = liveIndex)
+        val partitionState = newPartitionState()
         val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
         val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
@@ -242,7 +245,10 @@ class LogProcessorTest {
 
         watchers.awaitTx(1)
 
-        verify { liveIndex.commitTx(any(), any()) }
+        assertEquals(
+            1L, partitionState.liveIndex.latestCompletedTx?.txId,
+            "the replayed tx is committed into the live index"
+        )
 
         // Teardown: cancel+join the scope reaps the subscription and the live term, then free it.
         scope.coroutineContext.job.cancelAndJoin()

--- a/core/src/test/kotlin/xtdb/indexer/SourceLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/SourceLogProcessorTest.kt
@@ -1,42 +1,26 @@
 package xtdb.indexer
 
-import io.mockk.coEvery
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
 import xtdb.api.DatabaseName
-import xtdb.api.IndexerConfig
 import xtdb.api.log.InMemoryLog
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
 import xtdb.api.log.Watchers
 import xtdb.api.storage.Storage
-import xtdb.api.tx.TxIndexer
-import xtdb.catalog.TableCatalog
-import xtdb.compactor.Compactor
 import xtdb.database.Database
-import xtdb.database.DatabaseLogs
-import xtdb.database.PartitionState
-import xtdb.database.PartitionStorage
 import xtdb.log.proto.TrieDetails
 import xtdb.log.proto.trieMetadata
-import xtdb.storage.BufferPool
 import xtdb.table.fromSchemaAndTable
 import xtdb.trie.Trie
 import java.time.Instant
 import java.time.InstantSource
-import java.time.ZoneId
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -200,141 +184,5 @@ internal class SourceLogProcessorTest : LeaderTermTest() {
             .mapNotNull { it.message as? ReplicaMessage.BlockBoundary }.toList()
 
         assertEquals(emptyList<ReplicaMessage.BlockBoundary>(), boundaries)
-    }
-
-    @Test
-    fun `block finishing writes BlockBoundary + BlockUploaded to replica log`() = runTest {
-        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
-        val finishedBlock = LiveTable.FinishedBlock(
-            vecTypes = emptyMap(),
-            rowCount = 10,
-            hllDeltas = emptyMap(),
-            writtenTrie = LiveTable.FinishedBlock.WrittenTrie(
-                trieKey = "test-trie",
-                dataFileSize = 42,
-                trieMetadata = trieMetadata {}
-            )
-        )
-        val tableRef = fromSchemaAndTable("public/foo")
-
-        val liveIndex = liveIndexMock {
-            coEvery { finishBlock(any(), any()) } returns mapOf(tableRef to finishedBlock)
-            every { latestCompletedTx } returns null
-        }
-        val trieCatalog = createTrieCatalog()
-        val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
-        val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
-        val tableCatalog = TableCatalog(bufferPool)
-        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val partitionState = PartitionState(tableCatalog, trieCatalog, liveIndex)
-        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(
-            partitionStorage, partitionState, "xtdb", compactor, null, null,
-            backgroundScope, StandardTestDispatcher(testScheduler)
-        )
-        val driver = RealLeaderDriver(partitionStorage, partitionState, blockUploader)
-        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
-
-        val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
-        val replicaAppender = ReplicaLogAppender(driver)
-        val lp = termScope.startTerm(
-            partitionStorage, replicaAppender, watchers,
-            LeaderLogProcessor(
-                allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-                partitionState, "test", driver, watchers, replicaAppender,
-                extSource = null,
-                skipTxs = emptySet(), dbCatalog = null,
-                flushTimeout = IndexerConfig().flushDuration,
-            )
-        )
-
-        lp.srcLogProc.processRecords(listOf(
-            Log.Record(0, 0, Instant.now(), SourceMessage.FlushBlock(-1))
-        ))
-        watchers.awaitSource(0)
-
-        val replicaMessages = mutableListOf<ReplicaMessage>()
-        backgroundScope.launch {
-            replicaLog.tailAll(0, -1) { records -> replicaMessages.addAll(records.map { it.message }) }
-        }
-
-        delay(200)
-
-        assertEquals(2, replicaMessages.size, "expected 2 replica messages, got: $replicaMessages")
-        assertTrue(replicaMessages[0] is ReplicaMessage.BlockBoundary)
-        assertTrue(replicaMessages[1] is ReplicaMessage.BlockUploaded)
-
-        val boundary = replicaMessages[0] as ReplicaMessage.BlockBoundary
-        assertEquals(0, boundary.blockIndex)
-
-        val uploaded = replicaMessages[1] as ReplicaMessage.BlockUploaded
-        assertEquals(0, uploaded.blockIndex)
-        assertTrue(uploaded.tries.isNotEmpty(), "BlockUploaded should contain trie details")
-    }
-
-    @Test
-    fun `block boundaries carry the latest external-source token, not the last tx's`() = runTest(timeout = 5.seconds) {
-        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
-
-        val liveIndex = liveIndexMock {
-            coEvery { finishBlock(any(), any()) } returns emptyMap()
-            every { latestCompletedTx } returns null
-        }
-        val trieCatalog = createTrieCatalog()
-        val compactor = mockk<Compactor.ForDatabase>(relaxed = true)
-        val bufferPool = mockk<BufferPool>(relaxed = true) { every { epoch } returns 0 }
-        val tableCatalog = TableCatalog(bufferPool)
-        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
-        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1, latestReplicaMsgId = -1)
-
-        val partitionState = PartitionState(tableCatalog, trieCatalog, liveIndex)
-        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
-        val blockUploader = BlockUploader(
-            partitionStorage, partitionState, "xtdb", compactor, null, null,
-            backgroundScope, StandardTestDispatcher(testScheduler)
-        )
-        val driver = RealLeaderDriver(partitionStorage, partitionState, blockUploader)
-
-        val termScope = backgroundScope + SupervisorJob(backgroundScope.coroutineContext.job)
-        val replicaAppender = ReplicaLogAppender(driver)
-        val lp = termScope.startTerm(
-            partitionStorage, replicaAppender, watchers,
-            LeaderLogProcessor(
-                allocator, nodeBase, partitionStorage, mockk(relaxed = true),
-                partitionState, "test", driver, watchers, replicaAppender,
-                extSource = mockk(relaxed = true),
-                skipTxs = setOf(10), dbCatalog = null,
-                flushTimeout = IndexerConfig().flushDuration,
-            )
-        )
-
-        val token = byteArrayOf(1, 2, 3)
-
-        // The ext-source tx carries the CDC resume token; awaiting its durability (txId 0) pins the
-        // ordering — it resolves and applies before the token-less source-log tx that follows.
-        lp.extSrcProc!!.submitTx(token) { TxIndexer.TxResult.Committed() }
-        watchers.awaitTx(0)
-
-        // A token-less source-log tx (msgId 10; skipTxs covers it, so no Arrow payload needed, and its
-        // txId must exceed the ext tx's for watchers' monotonicity). It resolves behind the ext tx.
-        lp.srcLogProc.processRecords(listOf(
-            Log.Record(0, 10, Instant.now(), SourceMessage.Tx(ByteArray(0), null, ZoneId.of("UTC"), null, null))
-        ))
-
-        // Force the cut with a FlushBlock: the block's last tx is the token-less source-log tx, so the
-        // boundary must carry the earlier ext tx's token (the last non-null token seen), not a null one.
-        lp.srcLogProc.processRecords(listOf(
-            Log.Record(0, 11, Instant.now(), SourceMessage.FlushBlock(-1))
-        ))
-        watchers.awaitSource(11)
-
-        val boundaries = replicaLog.readRecords(0, 0, replicaLog.latestSubmittedMsgId() + 1)
-            .mapNotNull { it.message as? ReplicaMessage.BlockBoundary }.toList()
-
-        assertEquals(1, boundaries.size, "exactly one BlockBoundary should be written")
-        assertArrayEquals(
-            token, boundaries.single().externalSourceToken,
-            "BlockBoundary must carry the ext-source tx's token, not the source-log tx's null token"
-        )
     }
 }

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -225,8 +225,6 @@ variant Leader : LogProcessor {
     -- interleaves between the boundary and its upload, keeping the follower's bounded
     -- pending-block buffer empty. See live-index.allium "Block cut".
     block_in_progress: Boolean
-
-    pending_block: PendingBlock?  -- set between BlockBoundary and BlockUploaded during the upload
 }
 
 variant Follower : LogProcessor {
@@ -429,16 +427,13 @@ value TableEntry {
 
 value PendingBlock {
     -- Captures the state between BlockBoundary and BlockUploaded.
-    -- In the follower: also buffers subsequent replica messages, up to
-    -- max_buffered_records — overflow is a fault (xtdb.indexer/follower-buffer-overflow),
-    -- which the leader's block-cut pause is what keeps unreachable.
-    -- In the leader: set during the upload, cleared after it completes.
-    -- Passed from leader to follower on revocation, and from follower to
-    -- transition processor on assignment.
+    -- Held by the follower, which also buffers subsequent replica messages, up to max_buffered_records.
+    -- Overflow is a fault (xtdb.indexer/follower-buffer-overflow) that the leader's block-cut pause keeps unreachable.
+    -- Passed from follower to transition processor on assignment.
     -- See: indexer/PendingBlock.kt
     boundary_msg_id: MessageId
     boundary_message: BlockBoundaryMessage
-    buffered_records: List<ReplicaMessage>   -- follower only; leader creates with no buffer
+    buffered_records: List<ReplicaMessage>
     max_buffered_records: Integer
 }
 
@@ -825,13 +820,11 @@ rule TransitionToFollower {
         if tx_resolver != null:
             CloseResolver(tx_resolver)
 
-        -- The leader's pending_block is passed to the new follower. If the leader was
-        -- mid-upload when revoked (between BlockBoundary and BlockUploaded), the follower
-        -- picks up the pending state. The watermark fields stay readable after the close —
-        -- they are not allocator-backed.
+        -- The new follower carries no pending block.
+        -- Cancelling the leader leaves the boundary's apply incomplete, so that record is offered again and the follower opens the block itself.
+        -- The watermark fields stay readable after the close — they are not allocator-backed.
         log_processor.mode = Follower.created(
             latest_replica_msg_id: log_processor.latest_replica_msg_id,
-            pending_block: log_processor.pending_block,
             max_leader_term: table_catalog.boundary_term_id
         )
 }

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -175,6 +175,11 @@ entity LogProcessor {
     --   resolve-side one, ahead of it, on the Leader variant. Two watermarks that lead
     --   and lag each other are two fields, not one.
     --
+    -- max_leader_term: the READ-SIDE TERM FENCE — the highest leader term seen so far.
+    --   A record BELOW it was written by a superseded leader and is discarded (see the Fencing section).
+    --   Seeded from the persisted block boundary (table_catalog.boundary_term_id) so it survives restart.
+    --   Scoped to the partition for its whole life rather than to a role — log-processor-lifecycle.allium's LeaderTerm carries why.
+    --
     -- Transitions are driven by the transport's group subscription:
     --   transitionToLeader → TransitionToLeader (off the serialization point)
     --   demoteLeader       → TransitionToFollower (at the serialization point)
@@ -183,6 +188,7 @@ entity LogProcessor {
     -- For local log, the single node is always immediately assigned.
     mode: Leader | Follower
     latest_replica_msg_id: MessageId
+    max_leader_term: Integer
 }
 
 variant Leader : LogProcessor {
@@ -235,12 +241,6 @@ variant Follower : LogProcessor {
     -- errors, so a transition's catch-up await advances even on failure.
     -- See: indexer/FollowerLogProcessor.kt
     pending_block: PendingBlock?
-
-    -- READ-SIDE TERM FENCE: the highest leader term seen so far, seeded from the last
-    -- persisted block boundary (table_catalog.boundary_term_id) so it survives restart.
-    -- A record BELOW this was written by a superseded leader and is discarded. See the
-    -- Fencing section.
-    max_leader_term: Integer
 }
 
 entity TxResolver {
@@ -280,7 +280,7 @@ entity TableCatalog {
     -- Derived
     current_block_index: latest_block?.block_index
     boundary_replica_msg_id: latest_block?.boundary_replica_msg_id
-    -- Seeds a follower's max_leader_term, which is what makes the fence survive restart.
+    -- Seeds the log processor's max_leader_term, which is what makes the fence survive restart.
     boundary_term_id: latest_block?.term_id ?? 0
 }
 
@@ -324,7 +324,7 @@ entity BlockUploader {
     --      table catalog knows — not only the tables from step 1. Block GC's per-table
     --      sweep depends on this (block-gc.allium, EveryTableBlockAtCurrentIndex)
     --   4. Builds and persists the block file — carrying termId, which is what seeds a
-    --      restarted follower's fence
+    --      restarted log processor's fence
     --   5. Refreshes the table catalog, then appends BlockUploaded to the replica log
     --      (a PLAIN, term-stamped append — there is no producer)
     --   6. Calls liveIndex.nextBlock()
@@ -407,10 +407,8 @@ value Block {
     latest_processed_msg_id: MessageId         -- source log
     boundary_replica_msg_id: MessageId?        -- replica log; msg id of the BlockBoundary message
     external_source_token: ExternalSourceToken?  -- last token seen by the external source at block time
-    -- The term that APPENDED this block's BlockUploaded. Persisting it is what makes the
-    -- read-side fence survive a restart: a follower seeds max_leader_term from here, so a
-    -- leader claiming a regressed election counter is refused rather than silently ignored
-    -- (see log-processor-lifecycle.allium step 2a).
+    -- The term that APPENDED this block's BlockUploaded.
+    -- Persisting it is what makes the read-side fence survive a restart: the log processor seeds max_leader_term from here, so a leader claiming a regressed election counter is refused rather than silently ignored (see log-processor-lifecycle.allium step 2a).
     term_id: Integer
     -- Every table this block covers, and where each one's files live. See contract TableEntries.
     tables: List<TableEntry>
@@ -662,14 +660,12 @@ config {
 -- over (epoch, election), and every comparison site stays a Long.
 --
 -- The fence bites in two places:
---   - The LEADER, on CONSUME-BACK (Raft's ReadIndex): it applies and acknowledges a write
---     only once it has read that write back at its OWN term. A HIGHER term read back means
---     a newer leader has superseded it, so it RESIGNS without acknowledging its
---     outstanding writes; a LOWER term is discarded, still advancing the consume position.
---   - A FOLLOWER, on read: a record below the highest term it has seen is DISCARDED, its
---     consume position still advancing (so a transition catch-up can never hang on a
---     fenced no-op). Its high-water term is seeded from the last persisted block, so the
---     fence survives restart.
+--   - The partition's REPLICA TAIL, on READ, over every record whatever role is live: a record below the highest term the tail has seen is DISCARDED.
+--     One at or above it folds the highest-seen term upward and is dispatched to the live role.
+--     A discarded record still advances the consume position, so a transition catch-up can never hang on a fenced no-op.
+--     That high-water term is seeded from the last persisted block, so the fence survives restart.
+--   - The LEADER, on CONSUME-BACK (Raft's ReadIndex), additionally over what the tail dispatches to it and against its OWN term: it applies and acknowledges a write only once it has read that write back at that term.
+--     A HIGHER term read back means a newer leader has superseded it, so it RESIGNS without acknowledging its outstanding writes; a LOWER term is discarded, still advancing the consume position.
 --
 -- Two nodes may therefore briefly both believe themselves leader and both APPEND. Only
 -- the newer term's writes are ever confirmed, and the older leader's are discarded, which
@@ -748,7 +744,7 @@ rule TransitionToLeader {
         log_processor.awaitReplicaMsgId(replay_target)
 
         -- Refuse a term the replica log has already moved past. Our own claim has just
-        -- been read back, so the follower's max term is expected to BE this term; a higher
+        -- been read back, so the log processor's max term is expected to BE this term; a higher
         -- one is another leader's, and leading under a fenced term would index nothing.
         -- Fails with xtdb/leader-term-fenced, naming the epoch to raise. Checked here —
         -- after the catch-up, before the follower is stopped — so a refusal takes the
@@ -824,8 +820,7 @@ rule TransitionToFollower {
         -- Cancelling the leader leaves the boundary's apply incomplete, so that record is offered again and the follower opens the block itself.
         -- The watermark fields stay readable after the close — they are not allocator-backed.
         log_processor.mode = Follower.created(
-            latest_replica_msg_id: log_processor.latest_replica_msg_id,
-            max_leader_term: table_catalog.boundary_term_id
+            latest_replica_msg_id: log_processor.latest_replica_msg_id
         )
 }
 
@@ -1305,11 +1300,8 @@ rule ExternalSourceIndexesTx {
 ---- Rules: Replica Message Handling
 
 -- A follower and the transition processor both apply already-durable messages, so they
--- import straight into the durable live index and advance the watchers as they go. Both
--- run two checks before dispatch:
---   1. The TERM FENCE (see Fencing): a record below the highest term seen is discarded,
---      its consume position still advancing.
---   2. STALENESS (see Staleness): a message whose effect is already applied is skipped.
+-- import straight into the durable live index and advance the watchers as they go.
+-- The TERM FENCE (see Fencing) has already run on the tail that dispatched the record, so the only check left to either of them is STALENESS (see Staleness): a message whose effect is already applied is skipped.
 --
 -- In the follower, staleness is checked OUTSIDE the pending block guard: if in pending
 -- mode, the pending block handler runs first (buffers, or matches BlockUploaded). Only
@@ -1322,12 +1314,11 @@ rule ExternalSourceIndexesTx {
 --    buffer it (overflowing the cap is a fault). Return in either case.
 -- 2. Staleness check: if the message is stale, skip. Otherwise processRecord.
 
-rule FollowerFencesRecord {
-    -- The read-side fence. Term 0 is never fenced, so a not-yet-upgraded leader's writes
-    -- still apply during a mixed-version window. A discarded record still advances the
-    -- consume position, so a transition's catch-up await can't hang on it.
+rule LogProcessorFencesRecord {
+    -- The read-side fence, applied to every record read whatever role is live.
+    -- Term 0 is never fenced, so a not-yet-upgraded leader's writes still apply during a mixed-version window.
+    -- A discarded record still advances the consume position, so a transition's catch-up await can't hang on it.
     when: ReplicaMessageReceived(record)
-    requires: log_processor.mode = Follower
 
     ensures:
         if record.term_id != 0 and record.term_id < log_processor.max_leader_term:
@@ -1663,7 +1654,7 @@ deferred CloseResolver               -- phase 2 of the leader's two-phase close 
                                      -- buffers of any un-applied staged tx; demotion is exactly this
                                      -- teardown, with no separate runtime drop.
                                      -- See: live-index.allium CloseResolver
-deferred CheckTermUnfenced           -- follower.checkTermUnfenced(term): refuse a claimed leader term the
+deferred CheckTermUnfenced           -- log_processor.checkTermUnfenced(term): refuse a claimed leader term the
                                      -- replica log has already moved past, naming the term epoch to raise
                                      -- (xtdb/leader-term-fenced). Refusing costs liveness only, never
                                      -- safety. See: log-processor-lifecycle.allium step 2a

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -196,7 +196,7 @@ variant Leader : LogProcessor {
     -- messages and external-source txs, appends them (plain, term-stamped), reads them
     -- back and applies them. Also owns block finishing via BlockUploader, and the trie
     -- and block garbage collectors.
-    -- See: indexer/LeaderLogProcessor.kt, indexer/LeaderDriver.kt
+    -- See: indexer/LeaderLogProcessor.kt, indexer/BlockCutter.kt, indexer/LeaderDriver.kt
     --
     -- A promotion's pending block is finished through this processor, before it reads its first source message.
     --   - The boundary the outgoing leader cut is uploaded under the INCOMING term — see BlockUploader.


### PR DESCRIPTION
## tl;dr

A leader promoted over an unfinished block mis-sizes its first block, and nothing above the leader term can ask where the block cycle has got to — because the cycle had no object of its own. `BlockCutter` now owns it, and `LogProcessor` holds it, which fixes the mis-sizing and is a prerequisite for the follower-stall fix below.

- **This comes out of asking where the follower's pending block belongs**, off the back of #5917 ("The replica log should elect its own leader, not Kafka's consumer group") and the read-only-node simulation work in "the leader needs no simulation, because it drives no loop".
  Two commits below this one on the branch narrowed that question: the leader stopped handing its pending block to the follower a demote opens, and `db.allium` stopped modelling the term fence as the follower's. What was left was the observation that the leader's block phase and the follower's `PendingBlock` are two views of one cycle at two levels.

- **It unblocks the term-fence exemption fix, which is the defect that started this.**
  When a follower is waiting on the `BlockUploaded` that closes its pending block, the term fence can discard that very record — the follower then waits forever, silently at first, and eventually tips `Watchers` into its absorbing `Failed` state, which leaves a read replica unqueryable for the life of the process. The fix needs the replica tail to ask whether a pending block is open before the fence gets a verdict, and that question has no one to ask while the phase is private to `LeaderLogProcessor`.

## Problem

- **A leader promoted over an unfinished block counts the previous block's rows as its own.**
  The gauge that decides when to cut is seeded from the live index at the moment the term is built, and the block the outgoing leader left unfinished is closed *after* that. Closing a block is what resets the gauge, so the new term starts believing its fresh, empty block already holds however many rows the old one did — and cuts its first block early by that much. Block sizes then drift across a role change. assumption: #5876 — a flaky test counting 10 of 11 blocks after a stop/start — is the same phenomenon; nothing has confirmed that, and this PR does not.

- **Nothing above the term can ask where the cycle has got to.**
  The phase, the row gauge, the cut and the upload were four members and four methods of `LeaderLogProcessor`, private to it. `LogProcessor` owns the replica tail, which is the thing that needs the answer for the fix above, and it had nowhere to direct the question.

- **The cycle sat between two components that already existed**, which is the shape of the gap.
  `BlockFlusher` decides when a flush timeout should cut; `BlockUploader` performs the upload and was already constructed at partition level. Only the phase and the cut decision were stuck on the term.

## What changes

Behaviour is unchanged except in the three places named under Consequences.

- **`BlockCutter` holds the phase — `Filling(rows) | Cut | Uploading` — the threshold, the row accounting, the cut and the upload.**
  `LogProcessor` constructs it in `transitionToLeader` alongside the `LeaderDriver` and the append pump, and passes it to `LeaderLogProcessor`. It is a passive object with a single writer and a single reader, both the term's coroutine. Its lifetime is still the term's.

- **The "block is full, cut it" decision moved out of `appendTx` into `runLeaderTerm`'s loop.**
  `addRows` used to answer "and you must now call `cut`", which is an obligation the types let a caller walk away from — and the external-source path did exactly that, discarding the verdict and relying on the cut happening inline. The loop now drains a full block at the top of each iteration, however the rows arrived, and `addRows` only accounts.

- **`uploadBlock` is gone from `LeaderDriver`; `BlockUploader` is injected into `BlockCutter`.**
  All three test wrappers of `LeaderDriver` override `appendToReplica` alone, so nothing has ever substituted an upload through that seam, and "the leader needs no simulation, because it drives no loop" rejected adding a leader stall on exactly that ground. The interface loses the method and the claim in its kdoc that a test can stall one; the paragraph about the *appending* term moves onto `BlockUploader.uploadBlock`, whose parameter is now `uploadingTermId`.

- **`LeaderLogProcessor` no longer holds a `LiveIndex`.**
  Seeding the gauge and reading the threshold were its only two uses of one.

- **`LogProcessorTest` opens a real `LiveIndex`, and three mock-call assertions went with the mocks.**
  A `LiveIndex` is a passive object, so there was little reason to mock one. Each bespoke mock only stubbed `latestCompletedTx`, which a real index answers from a fresh table catalog; each test's `verify { liveIndex.commitTx(any(), any()) }` becomes an assertion on `latestCompletedTx` — the outcome rather than the call. Two block-cycle tests moved from `SourceLogProcessorTest` into a new `BlockCutterTest`, losing about 25 lines of hand-rolled fixture each.

## Consequences

- **A promotion over an unfinished block now cuts its first block at the right size.**
  `applyPendingBlock` closes the inherited block through `blockCutter.upload`, so the phase reaches `Filling(0)` wherever a block is closed rather than only on the term's own path.

- **An empty block is never full, whatever the threshold** — and this one is load-bearing rather than cosmetic.
  `rowsPerBlock` comes from `IndexerConfig` and nothing stops an operator setting it to 0. Under the old code that merely cut a block on every transaction, because a cut needed a transaction to trigger it. Checked from the loop it live-locks instead: cut an empty block, re-open an empty one, cut that, and never arm resolution again. So `isFull` requires `rows > 0`, which is a no-op at the default threshold of 102400.

- **A `cut` that throws while a source batch is paused now fails that batch as a cancellation rather than as itself.**
  The cut used to run inside `runTaskGuarded`, which completes the batch's handle exceptionally; from the loop it reaches the handle through `shutdown` → `SourceBatch.abandon` instead. Per that method's own documentation the cancellation is the kind the transport's poll thread needs — anything else unwinds `processRecords` into the database scope's handler, which calls `notifyError` and poisons queries — so this moves the right way, but it moves.

- **The cut MUST stay ahead of the arming in `runLeaderTerm`'s loop, not after the select returns.**
  While a full block is uncut nothing may be armed, or the GC clause slips a `TriesDeleted` in between the rows that filled the block and the boundary that closes it.

- **`Cut` and `Uploading` are indistinguishable at runtime, and both are kept because double-buffering (#4495) needs the distinction.**
  Nothing branches on the difference today — `acceptingResolution` is false throughout both, and `Uploading` stopped carrying anything when the leader's pending block went. Under #4495's dual-slot `LiveTable` the tx thread seals the current slot and returns, with the upload running in the background against the sealed one, so `Uploading` will admit resolution into the fresh slot where `Cut` still must not: the boundary has to land in resolution order ahead of block N+1's transactions. Collapsing them now would have to be undone there.

- **accepted risk: no test pins the first-block sizing fix.**
  Reaching it needs a promotion over a pending block whose own block was full, and then an assertion on where the next boundary falls. `LogProcessorSimTest`'s `single node processes txs and flush-blocks with rebalances` and `multi-node leadership changes preserve block catalog consistency` both drive the transition paths, but neither asserts anything about block sizes.

- **`leaderTerm` is now held by three of the term's objects** — `LeaderLogProcessor`, `GarbageCollector` and `BlockCutter` — all set from one local at one construction site.
  It is immutable and never rewritten, so it is not a second source of truth today. A second construction site would make it one.

## Out of scope

Split by the four things a reader might reasonably expect this to have finished.

- **The term-fence exemption fix itself.**
  The shape settled on is that the buffer stays on the follower and the replica tail asks whether the record it is about to fence would close an open block — a new question on `LogProcessor.State`, not yet written, so nothing in the tree carries that name yet. This PR is the prerequisite, not the fix.

- **Moving the cycle's lifetime to the partition.**
  `BlockCutter` is still built per term. Whether the phase should outlive a term and absorb the follower's `PendingBlock` is the question this extraction was meant to make answerable; the seams are now visible and the argument is not yet made. Note that #4495 deletes `PendingBlock` outright rather than absorbing it, by giving leader and follower the same dual-slot mechanism — so that card, not this one, is where the convergence lands. The row gauge probably should not go either way: it is a resolve-side projection, and only a leader resolves.

- **Buffered records reporting their consume position while they wait.**
  It is what makes the follower stall silent rather than loud, and `awaitReplicaMsg`'s semantics currently depend on it. It belongs to the fence-exemption fix, which is where it bites, rather than here.

- **Reconciling `db.allium` with the sealed phase.**
  The spec models the cycle behaviourally, as `rows_since_block` and `block_in_progress` on `variant Leader`, and this PR moves neither; only `variant Leader`'s `See:` line gains the new file. The two fields predate this work and can be set independently there, where `Filling(rows) | Cut | Uploading` cannot — so nothing in the spec says `rows_since_block` has no meaning mid-cut.

## Alternative approaches

Split by the four decisions where a different road was open.

- **Leaving the cut inside `appendTx` — reasoned against.**
  It works, and it is the smaller diff. What ruled it out is that the obligation stays with every caller: `Filling(n ≥ rowsPerBlock)` is a state nothing prevents a caller leaving in place, and the external-source path already ignored the verdict. It also cost a kdoc paragraph documenting a contract that the loop now enforces structurally.

- **Keeping `uploadBlock` on `LeaderDriver` — reasoned against.**
  It preserves the driver's stated invariant that the term's external effects all go through one seam. Against that: the method is a pass-through, no test has ever overridden it, and its kdoc documented the *transition* case, whose caller does not go through the driver at all. The seam was describing a caller it did not have.

- **Constructing `BlockCutter` inside `LeaderLogProcessor` — tried, then changed.**
  This is where it started, and it matches its five siblings (`txResolver`, `gc`, `srcLogProc`, `extSrcProc`) which are all built in the same initialiser from the term's own fields. It was abandoned because `applyPendingBlock` then has no cutter to close the inherited block through, which is the mis-sizing above.

- **`BlockCutter` reading the boundary's external-source token off `TxResolver` — tried and abandoned.**
  It kept `cut`'s signature down to one argument. It also had the cutter reaching into the term's resolution state for a single field while its caller was already passing the other watermark in, and it is what made the cutter unconstructible from `LogProcessor`. Both watermarks are the resolve side's, so `cut` takes both.
