### PR TITLE
tidy(indexer): the replica-log term fence no longer exempts term 0

### DIFF
--- a/core/src/main/kotlin/xtdb/api/log/LeaderTerm.kt
+++ b/core/src/main/kotlin/xtdb/api/log/LeaderTerm.kt
@@ -29,13 +29,6 @@ object LeaderTerm {
     private const val ELECTION_LIMIT = 1L shl 48
     private const val ELECTION_MASK = ELECTION_LIMIT - 1
 
-    /**
-     * The unset term, and the bottom of the ordering: carried by a record written before terms
-     * existed. Never fenced, so a mixed-version window doesn't discard a not-yet-upgraded leader's
-     * writes — proto3's scalar default yields this for those records for free.
-     */
-    const val NONE = 0L
-
     @JvmStatic
     fun of(termEpoch: Int, election: Long): Long {
         require(termEpoch in 0 until EPOCH_LIMIT) { "Term epoch ($termEpoch) outside [0, $EPOCH_LIMIT)" }

--- a/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
+++ b/core/src/main/kotlin/xtdb/api/log/ReplicaMessage.kt
@@ -28,7 +28,8 @@ import java.time.Instant
 
 sealed interface ReplicaMessage {
 
-    // The leader term that produced this message (0 if unset). Set by the creator; used for read-side fencing. See #5817.
+    // The leader term that produced this message; used for read-side fencing. 0 only on a record written
+    // before terms existed, where proto3's scalar default supplies it. See #5817.
     val termId: Long
 
     fun encode(): ByteArray
@@ -126,7 +127,7 @@ sealed interface ReplicaMessage {
         // their `latestSourceMsgId` in step between block boundaries). Null only on legacy records
         // written before this field existed (see #5586).
         val srcMsgId: MessageId? = null,
-        override val termId: Long = 0,
+        override val termId: Long,
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             resolvedTx = resolvedTx {
@@ -158,7 +159,7 @@ sealed interface ReplicaMessage {
     data class TriesAdded(
         val storageVersion: Int, val storageEpoch: StorageEpoch, val tries: List<TrieDetails>,
         val sourceMsgId: MessageId = 0,
-        override val termId: Long = 0,
+        override val termId: Long,
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             triesAdded = triesAdded {
@@ -173,7 +174,7 @@ sealed interface ReplicaMessage {
     data class BlockBoundary(
         val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId,
         val externalSourceToken: ExternalSourceToken? = null,
-        override val termId: Long = 0,
+        override val termId: Long,
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             blockBoundary = blockBoundary {
@@ -189,7 +190,7 @@ sealed interface ReplicaMessage {
         val blockIndex: BlockIndex, val latestProcessedMsgId: MessageId,
         val tries: List<TrieDetails>,
         val externalSourceToken: ExternalSourceToken? = null,
-        override val termId: Long = 0,
+        override val termId: Long,
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             blockUploaded = blockUploaded {
@@ -206,7 +207,7 @@ sealed interface ReplicaMessage {
     // `srcMsgId` carries the leader's source-log watermark when no other record propagates it
     // (a FlushBlock that finishes no block); followers advance `latestSourceMsgId` on it. Null
     // when used purely as a transition replay-target marker.
-    data class NoOp(val srcMsgId: MessageId? = null, override val termId: Long = 0) : ProtobufMessage() {
+    data class NoOp(val srcMsgId: MessageId? = null, override val termId: Long) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             noOp = noOp { this@NoOp.srcMsgId?.let { srcMsgId = it } }
         }
@@ -215,7 +216,7 @@ sealed interface ReplicaMessage {
     data class TriesDeleted(
         val tableName: String,
         val trieKeys: Set<TrieKey>,
-        override val termId: Long = 0,
+        override val termId: Long,
     ) : ProtobufMessage() {
         override fun toLogMessage() = replicaLogMessage {
             triesDeleted = triesDeleted {

--- a/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
+++ b/core/src/main/kotlin/xtdb/api/tx/BlockDetails.kt
@@ -18,7 +18,7 @@ data class BlockDetails(
     val latestCompletedTx: TransactionKey?,
     val latestProcessedMsgId: MessageId?,
     val boundaryReplicaMsgId: MessageId?,
-    // the leader term that produced this block's boundary; NONE for blocks written before
+    // the leader term that produced this block's boundary; 0 for blocks written before
     // term-fencing (see #5817)
     val termId: Long,
     val externalSourceToken: ExternalSourceToken?,

--- a/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
+++ b/core/src/main/kotlin/xtdb/catalog/TableCatalog.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.updateAndGet
 import org.apache.arrow.vector.types.pojo.Schema
 import xtdb.api.TableRef
 import xtdb.api.TransactionKey
-import xtdb.api.log.LeaderTerm
 import xtdb.api.storage.ObjectStore
 import xtdb.api.tx.BlockDetails
 import xtdb.api.tx.ExternalSourceToken
@@ -190,7 +189,7 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
 
     // the leader term that produced the latest block's boundary; a follower seeds its read-side term
     // fence from here. Default 0 (plain scalar) for blocks written before term-fencing. See #5817.
-    val boundaryTermId: Long get() = snap().block?.termId ?: LeaderTerm.NONE
+    val boundaryTermId: Long get() = snap().block?.termId ?: 0
 
     val externalSourceToken: ExternalSourceToken? get() = snap().block?.externalSourceToken
 
@@ -300,7 +299,7 @@ class TableCatalog(private val bufferPool: BufferPool, initialBlock: Block? = nu
         tables: Collection<TableEntry>,
         secondaryDatabases: Map<String, DatabaseConfig>?,
         externalSourceToken: ExternalSourceToken? = null,
-        termId: Long = LeaderTerm.NONE,
+        termId: Long,
     ): Block {
         val currentBlockIndex = this.currentBlockIndex
         check(currentBlockIndex == null || currentBlockIndex < blockIndex) {

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -100,7 +100,7 @@ internal suspend fun runLeaderTerm(
                                 throw LeaderSupersededException("[$dbName] superseded: read term $termId > our term ${term.leaderTerm} at ${record.msgId}")
 
                             // Below our term should not appear past our replay target; discard defensively.
-                            if (termId != 0L && termId < term.leaderTerm) {
+                            if (termId < term.leaderTerm) {
                                 LOG.debug { "[$dbName] leader: discarding stale-term record ${record.msgId} (term $termId < ${term.leaderTerm})" }
                             } else {
                                 term.applyReplicaMessage(record)
@@ -158,7 +158,7 @@ class LogProcessor(
     private val replicaLog = partitionStorage.replicaLog
     private val hasExternalSource = externalSource != null
 
-    val termFence = TermFence(dbName, partitionState.tableCatalogOrNull?.boundaryTermId ?: LeaderTerm.NONE)
+    val termFence = TermFence(dbName, partitionState.tableCatalogOrNull?.boundaryTermId ?: 0)
 
     private sealed interface TailPos {
         /** The last record the tail finished with, applied or discarded. */

--- a/core/src/main/kotlin/xtdb/indexer/TermFence.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TermFence.kt
@@ -28,13 +28,8 @@ class TermFence(private val dbName: DatabaseName, seed: Long) {
      * Deciding and folding in are one operation because the verdict is against the highest term seen
      * *strictly before* this record: a caller that folded first would have nothing left to compare
      * against.
-     *
-     * [LeaderTerm.NONE] is never fenced, so a not-yet-upgraded leader's writes are still applied during
-     * a mixed-version window; only stamped terms fence each other.
      */
     fun admit(term: Long): Boolean {
-        if (term == LeaderTerm.NONE) return true
-
         val seenBefore = highestSeen
         if (term < seenBefore) return false
 

--- a/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
+++ b/core/src/test/kotlin/xtdb/NodeSimulationTest.kt
@@ -184,7 +184,8 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
                 tables = tableCatalog.resolveTables(listOf(table)),
-                secondaryDatabases = null
+                secondaryDatabases = null,
+                termId = 0
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             tableCatalog.refresh(block)
@@ -242,7 +243,8 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
                 tables = tableCatalog.resolveTables(listOf(table)),
-                secondaryDatabases = null
+                secondaryDatabases = null,
+                termId = 0
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             tableCatalog.refresh(block)
@@ -319,7 +321,8 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
                 tables = tableCatalog.resolveTables(listOf(table)),
-                secondaryDatabases = null
+                secondaryDatabases = null,
+                termId = 0
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             tableCatalog.refresh(block)
@@ -390,7 +393,8 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
                     tables = db.tableCatalog.resolveTables(listOf(table)),
-                    secondaryDatabases = null
+                    secondaryDatabases = null,
+                    termId = 0
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.tableCatalog.refresh(block)
@@ -462,7 +466,8 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
                     tables = db.tableCatalog.resolveTables(listOf(table)),
-                    secondaryDatabases = null
+                    secondaryDatabases = null,
+                    termId = 0
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.tableCatalog.refresh(block)
@@ -557,7 +562,8 @@ class NodeSimulationTest : SimulationTestBase() {
                 latestProcessedMsgId = blockIndex,
                 boundaryReplicaMsgId = null,
                 tables = tableCatalog.resolveTables(listOf(table)),
-                secondaryDatabases = null
+                secondaryDatabases = null,
+                termId = 0
             )
             sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
             tableCatalog.refresh(block)
@@ -608,7 +614,8 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
                     tables = db.tableCatalog.resolveTables(listOf(table)),
-                    secondaryDatabases = null
+                    secondaryDatabases = null,
+                    termId = 0
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.tableCatalog.refresh(block)
@@ -698,7 +705,8 @@ class NodeSimulationTest : SimulationTestBase() {
                     latestProcessedMsgId = blockIndex,
                     boundaryReplicaMsgId = null,
                     tables = db.tableCatalog.resolveTables(listOf(table)),
-                    secondaryDatabases = null
+                    secondaryDatabases = null,
+                    termId = 0
                 )
                 sharedBufferPool.putObjectSync(TableCatalog.blockFilePath(blockIndex), ByteBuffer.wrap(block.toByteArray()))
                 db.tableCatalog.refresh(block)

--- a/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/ExternalSourceTokenTest.kt
@@ -10,10 +10,11 @@ import xtdb.storage.BufferPool
 class ExternalSourceTokenTest {
 
     private val testToken: ByteArray = "kafka-offset:42".toByteArray()
+    private val term = LeaderTerm.of(0, 1)
 
     @Test
     fun `BlockBoundary round-trips external source token`() {
-        val boundary = ReplicaMessage.BlockBoundary(1, 100, testToken)
+        val boundary = ReplicaMessage.BlockBoundary(1, 100, testToken, termId = term)
         val encoded = boundary.encode()
         val decoded = ReplicaMessage.decode(encoded)
 
@@ -27,7 +28,7 @@ class ExternalSourceTokenTest {
 
     @Test
     fun `BlockBoundary round-trips without token`() {
-        val boundary = ReplicaMessage.BlockBoundary(1, 100)
+        val boundary = ReplicaMessage.BlockBoundary(1, 100, termId = term)
         val encoded = boundary.encode()
         val decoded = ReplicaMessage.decode(encoded) as ReplicaMessage.BlockBoundary
 
@@ -38,7 +39,7 @@ class ExternalSourceTokenTest {
 
     @Test
     fun `ReplicaMessage BlockUploaded round-trips external source token`() {
-        val uploaded = ReplicaMessage.BlockUploaded(1, 0, 1, 100, emptyList(), testToken)
+        val uploaded = ReplicaMessage.BlockUploaded(1, 0, 1, 100, emptyList(), testToken, termId = term)
         val encoded = uploaded.encode()
         val decoded = ReplicaMessage.decode(encoded)
 
@@ -58,7 +59,8 @@ class ExternalSourceTokenTest {
             boundaryReplicaMsgId = null,
             tables = emptySet(),
             secondaryDatabases = null,
-            externalSourceToken = testToken
+            externalSourceToken = testToken,
+            termId = term
         )
 
         val parsed = Block.parseFrom(block.toByteArray())
@@ -79,7 +81,8 @@ class ExternalSourceTokenTest {
             boundaryReplicaMsgId = null,
             tables = emptySet(),
             secondaryDatabases = null,
-            externalSourceToken = testToken
+            externalSourceToken = testToken,
+            termId = term
         )
         tableCatalog.refresh(block)
 
@@ -96,7 +99,8 @@ class ExternalSourceTokenTest {
             latestProcessedMsgId = 100,
             boundaryReplicaMsgId = null,
             tables = emptySet(),
-            secondaryDatabases = null
+            secondaryDatabases = null,
+            termId = term
         )
         tableCatalog.refresh(block)
 

--- a/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/InMemoryLogTest.kt
@@ -38,7 +38,7 @@ class InMemoryLogTest {
 
             runBlocking(dispatcher) {
                 withTimeout(5.seconds) {
-                    log.appendMessage(ReplicaMessage.NoOp())
+                    log.appendMessage(ReplicaMessage.NoOp(termId = LeaderTerm.of(0, 1)))
                 }
             }
 

--- a/core/src/test/kotlin/xtdb/api/log/LeaderTermTest.kt
+++ b/core/src/test/kotlin/xtdb/api/log/LeaderTermTest.kt
@@ -29,7 +29,6 @@ class LeaderTermTest {
         // the whole point: a reset election counter still outranks the terms it restarted below
         assertTrue(LeaderTerm.of(1, 1) > LeaderTerm.of(0, (1L shl 48) - 1))
         assertTrue(LeaderTerm.of(0, 9) > LeaderTerm.of(0, 8))
-        assertTrue(LeaderTerm.of(0, 1) > LeaderTerm.NONE)
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
+import xtdb.api.log.LeaderTerm
 import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.Watchers
@@ -30,6 +31,10 @@ import java.time.Instant
 
 private fun FollowerLogProcessor.processRecords(records: List<Log.Record<ReplicaMessage>>) =
     records.forEach { handleRecord(it) }
+
+// The fence is the log processor's, so a bare follower never compares terms — these records only need
+// one that is a term.
+private val TERM = LeaderTerm.of(0, 1)
 
 class FollowerLogProcessorTest {
 
@@ -89,10 +94,10 @@ class FollowerLogProcessorTest {
         val proc = makeProcessor(maxBufferedRecords = 2)
 
         val records = listOf(
-            record(0, ReplicaMessage.BlockBoundary(0, 0)),
-            record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
-            record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
-            record(3, ReplicaMessage.ResolvedTx(3, Instant.now(), true, null, emptyMap())),
+            record(0, ReplicaMessage.BlockBoundary(0, 0, termId = TERM)),
+            record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), termId = TERM)),
+            record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), termId = TERM)),
+            record(3, ReplicaMessage.ResolvedTx(3, Instant.now(), true, null, emptyMap(), termId = TERM)),
         )
 
         assertThrows<Fault> { proc.processRecords(records) }    }
@@ -102,9 +107,9 @@ class FollowerLogProcessorTest {
         watchers = Watchers(latestTxId = 42, latestSourceMsgId = 42)
         val proc = makeProcessor()
 
-        val tx40 = ReplicaMessage.ResolvedTx(40, Instant.now(), true, null, emptyMap(), srcMsgId = 40)
-        val tx42 = ReplicaMessage.ResolvedTx(42, Instant.now(), true, null, emptyMap(), srcMsgId = 42)
-        val tx43 = ReplicaMessage.ResolvedTx(43, Instant.now(), true, null, emptyMap(), srcMsgId = 43)
+        val tx40 = ReplicaMessage.ResolvedTx(40, Instant.now(), true, null, emptyMap(), srcMsgId = 40, termId = TERM)
+        val tx42 = ReplicaMessage.ResolvedTx(42, Instant.now(), true, null, emptyMap(), srcMsgId = 42, termId = TERM)
+        val tx43 = ReplicaMessage.ResolvedTx(43, Instant.now(), true, null, emptyMap(), srcMsgId = 43, termId = TERM)
 
         proc.processRecords(listOf(record(0, tx40), record(1, tx42), record(2, tx43)))
 
@@ -125,12 +130,12 @@ class FollowerLogProcessorTest {
         val proc = makeProcessor()
 
         val staleRecords = listOf(
-            record(0, ReplicaMessage.ResolvedTx(500, Instant.now(), true, null, emptyMap(), srcMsgId = 500)),
-            record(1, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 600)),
-            record(2, ReplicaMessage.BlockBoundary(1, 700)),
-            record(3, ReplicaMessage.BlockUploaded(1, 1, 1, 800, emptyList())),
+            record(0, ReplicaMessage.ResolvedTx(500, Instant.now(), true, null, emptyMap(), srcMsgId = 500, termId = TERM)),
+            record(1, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 600, termId = TERM)),
+            record(2, ReplicaMessage.BlockBoundary(1, 700, termId = TERM)),
+            record(3, ReplicaMessage.BlockUploaded(1, 1, 1, 800, emptyList(), termId = TERM)),
             // at the boundary — should also be skipped
-            record(4, ReplicaMessage.ResolvedTx(1000, Instant.now(), true, null, emptyMap(), srcMsgId = 1000)),
+            record(4, ReplicaMessage.ResolvedTx(1000, Instant.now(), true, null, emptyMap(), srcMsgId = 1000, termId = TERM)),
         )
 
         proc.processRecords(staleRecords)
@@ -153,9 +158,9 @@ class FollowerLogProcessorTest {
 
         val txId = 100L
         proc.processRecords(listOf(
-            record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap())),
-            record(1, ReplicaMessage.BlockBoundary(0, txId)),
-            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, txId, emptyList())),
+            record(0, ReplicaMessage.ResolvedTx(txId, Instant.now(), true, null, emptyMap(), termId = TERM)),
+            record(1, ReplicaMessage.BlockBoundary(0, txId, termId = TERM)),
+            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, txId, emptyList(), termId = TERM)),
         ))
 
         assertEquals(0L, tableCatalog.currentBlockIndex,
@@ -167,11 +172,11 @@ class FollowerLogProcessorTest {
         watchers = Watchers(latestTxId = 1000, latestSourceMsgId = 1000)
         val proc = makeProcessor()
 
-        val tx1001 = ReplicaMessage.ResolvedTx(1001, Instant.now(), true, null, emptyMap(), srcMsgId = 1001)
+        val tx1001 = ReplicaMessage.ResolvedTx(1001, Instant.now(), true, null, emptyMap(), srcMsgId = 1001, termId = TERM)
 
         proc.processRecords(listOf(
             // stale
-            record(0, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 500)),
+            record(0, ReplicaMessage.TriesAdded(1, 1, emptyList(), sourceMsgId = 500, termId = TERM)),
             // current
             record(1, tx1001),
         ))
@@ -190,11 +195,11 @@ class FollowerLogProcessorTest {
         val blockProto = block { blockIndex = 0 }.toByteArray()
         every { bufferPool.getByteArray(TableCatalog.blockFilePath(0)) } returns blockProto
 
-        val extTx = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+        val extTx = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null, termId = TERM)
         proc.processRecords(listOf(
             record(0, extTx),
-            record(1, ReplicaMessage.BlockBoundary(0, -1)),
-            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, -1, emptyList())),
+            record(1, ReplicaMessage.BlockBoundary(0, -1, termId = TERM)),
+            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, -1, emptyList(), termId = TERM)),
         ))
 
         verify { liveIndex.commitTx(match { it.txId == extTx.txId }, any()) }
@@ -207,9 +212,9 @@ class FollowerLogProcessorTest {
     fun `mixed ext-source and source-log ResolvedTxs advance the right watermarks`() = runTest {
         val proc = makeProcessor(hasExternalSource = true)
 
-        val ext0 = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
-        val src1 = ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1)
-        val ext2 = ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+        val ext0 = ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null, termId = TERM)
+        val src1 = ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1, termId = TERM)
+        val ext2 = ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), srcMsgId = null, termId = TERM)
 
         proc.processRecords(listOf(record(0, ext0), record(1, src1), record(2, ext2)))
 
@@ -229,10 +234,10 @@ class FollowerLogProcessorTest {
         every { bufferPool.getByteArray(TableCatalog.blockFilePath(0)) } returns blockProto
 
         proc.processRecords(listOf(
-            record(0, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
-            record(1, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
-            record(2, ReplicaMessage.BlockBoundary(0, 2)),
-            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 2, emptyList())),
+            record(0, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), termId = TERM)),
+            record(1, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), termId = TERM)),
+            record(2, ReplicaMessage.BlockBoundary(0, 2, termId = TERM)),
+            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 2, emptyList(), termId = TERM)),
         ))
 
         fun timerCount(msgType: String) = registry.find("xtdb.replica.process.timer")
@@ -263,11 +268,11 @@ class FollowerLogProcessorTest {
         every { bufferPool.getByteArray(TableCatalog.blockFilePath(0)) } returns blockProto
 
         proc.processRecords(listOf(
-            record(0, ReplicaMessage.BlockBoundary(0, 0)),
+            record(0, ReplicaMessage.BlockBoundary(0, 0, termId = TERM)),
             // these get buffered while we wait for BlockUploaded
-            record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap())),
-            record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap())),
-            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 0, emptyList())),
+            record(1, ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), termId = TERM)),
+            record(2, ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), termId = TERM)),
+            record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 0, emptyList(), termId = TERM)),
         ))
 
         val bufferedRecords = registry.find("xtdb.replica.block.buffered.records").tag("db", "test").summary()

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -127,7 +127,7 @@ internal class LeaderLogProcessorTest : LeaderTermTest() {
         proc.applyReplicaMessage(
             Log.Record(
                 0, 0, Instant.now(),
-                ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null)
+                ReplicaMessage.ResolvedTx(0, Instant.now(), true, null, emptyMap(), srcMsgId = null, termId = 1)
             )
         )
 

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -172,7 +172,11 @@ class LogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         replicaLog.appendMessage(ReplicaMessage.NoOp(termId = LeaderTerm.of(0, 9)))
-        replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
+        replicaLog.appendMessage(
+            ReplicaMessage.ResolvedTx(
+                1, java.time.Instant.now(), true, null, emptyMap(), termId = LeaderTerm.of(0, 9)
+            )
+        )
 
         val scope = CoroutineScope(SupervisorJob())
         val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
@@ -203,7 +207,11 @@ class LogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log with a transaction
-        replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
+        replicaLog.appendMessage(
+            ReplicaMessage.ResolvedTx(
+                1, java.time.Instant.now(), true, null, emptyMap(), termId = LeaderTerm.of(0, 1)
+            )
+        )
 
         val scope = CoroutineScope(SupervisorJob())
         val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
@@ -236,7 +244,11 @@ class LogProcessorTest {
         val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
 
         // Pre-populate the replica log
-        replicaLog.appendMessage(ReplicaMessage.ResolvedTx(1, java.time.Instant.now(), true, null, emptyMap()))
+        replicaLog.appendMessage(
+            ReplicaMessage.ResolvedTx(
+                1, java.time.Instant.now(), true, null, emptyMap(), termId = LeaderTerm.of(0, 1)
+            )
+        )
 
         val scope = CoroutineScope(SupervisorJob())
         val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)

--- a/core/src/test/kotlin/xtdb/indexer/TermFenceTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/TermFenceTest.kt
@@ -30,15 +30,13 @@ class TermFenceTest {
     }
 
     @Test
-    fun `the unset term is never fenced and never counts`() {
-        val fence = TermFence(dbName, LeaderTerm.of(0, 7))
+    fun `term zero is ordered like any other, so a real term fences it`() {
+        val fence = TermFence(dbName, 0)
 
-        assertTrue(fence.admit(LeaderTerm.NONE), "a record from before terms existed is still applied")
-        assertEquals(LeaderTerm.of(0, 7), fence.highestSeen)
+        assertTrue(fence.admit(0), "a record written before terms existed has nothing above it yet")
+        assertTrue(fence.admit(LeaderTerm.of(0, 1)))
 
-        val fresh = TermFence(dbName, LeaderTerm.NONE)
-        assertTrue(fresh.admit(LeaderTerm.NONE))
-        assertEquals(LeaderTerm.NONE, fresh.highestSeen)
+        assertFalse(fence.admit(0))
     }
 
     @Test

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -658,9 +658,6 @@ config {
 -- the newer term's writes are ever confirmed, and the older leader's are discarded, which
 -- is the property that matters — not single-writer-at-the-log.
 --
--- Term 0 (unset) is never fenced, so a mixed-version window doesn't discard a
--- not-yet-upgraded leader's writes.
---
 -- The SOURCE log is not fenced. Stale messages from a previous leader (FlushBlock) or the
 -- compactor (TriesAdded) may appear after a transition. This is safe because:
 --   - FlushBlock is a CAS on expected_block_idx; stale flushes fail the check.
@@ -1080,7 +1077,7 @@ rule LeaderAppliesRecord {
             -- or a routine leadership handover would surface to queries as a failed
             -- database (see ProcessingErrorHaltsNode).
             LeaderSuperseded(resolver: tx_resolver)
-        else if record.term_id != 0 and record.term_id < log_processor.leader_term:
+        else if record.term_id < log_processor.leader_term:
             -- Shouldn't appear past our replay target; discard defensively.
             RecordDiscarded(resolver: tx_resolver)
         else:
@@ -1284,12 +1281,11 @@ rule ExternalSourceIndexesTx {
 
 rule LogProcessorFencesRecord {
     -- The read-side fence, applied to every record read whatever role is live.
-    -- Term 0 is never fenced, so a not-yet-upgraded leader's writes still apply during a mixed-version window.
     -- A discarded record still advances the consume position, so a transition's catch-up await can't hang on it.
     when: ReplicaMessageReceived(record)
 
     ensures:
-        if record.term_id != 0 and record.term_id < log_processor.max_leader_term:
+        if record.term_id < log_processor.max_leader_term:
             RecordDiscarded(record)
         else:
             log_processor.max_leader_term = max(log_processor.max_leader_term, record.term_id)

--- a/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
+++ b/modules/kafka/src/test/kotlin/xtdb/api/log/KafkaClusterTest.kt
@@ -217,7 +217,8 @@ class KafkaClusterTest {
             storageEpoch = 0,
             blockIndex = 42,
             latestProcessedMsgId = 100,
-            tries = tries
+            tries = tries,
+            termId = LeaderTerm.of(0, 1)
         ).also {
             val encodedSize = it.encode().size
             assert(encodedSize > 1024 * 1024) { "Expected >1MB, got $encodedSize bytes" }


### PR DESCRIPTION
The replica-log term fence no longer treats term 0 as a special case. Behaviour on every supported upgrade path is unchanged, and it's landing now because the pending-block ownership restructure — moving `PendingBlock` off `FollowerLogProcessor` and onto `LogProcessor` — otherwise has to argue about a guard this makes plainly dead.

- **Where this sits.**
  Term fencing is the read side of leader election on the replica log: every reader discards a record whose term is below the highest it has seen, so a superseded leader's writes are dropped without needing single-writer-at-the-log. It exists because Azure Event Hubs' Standard tier has no Kafka transactions to enforce that with (#5817). `TermFence.admit` carried one exception — term 0, the unset term — which is now gone.

- **What it unblocks.**
  `LogProcessor.applyPendingBlock` drops a buffered record whose term is below the pending boundary's. That condition was only ever reachable for term 0, so with no unstamped record reachable it becomes dead code the pending-block restructure can delete as equivalence rather than reason about — and that restructure is in turn what #5917 needs before its leadership-churn simulation can go green.

## Problem

The fence had two behaviours — one for term 0, one for every other term — and the case it existed for cannot arise.

`admit` returned true unconditionally for term 0, the unset term a record written before term-fencing carries, so that a mixed-version window wouldn't discard a not-yet-upgraded leader's writes. But the 2.2.0-rc1 release notes require every 2.2.0-rc0 node to be turned down before the upgraded ones come up, offering a bespoke stepping-stone release to anyone needing green/blue instead — which was never built and never requested. An unstamped writer is therefore never concurrent with a stamped one, and 2.1.0 had no replica log at all.

Only concurrent stamped and unstamped writers can put a term-0 record *after* a stamped one in the log, so on any supported upgrade the unstamped records form an unbroken prefix — which a fence admits in full regardless of the exemption, being seeded from a `boundary_term_id` of 0 and reading term 0 against it.

What the exception cost was a rule with a special case, implemented twice in code and twice again in `dev/doc/db.allium`, so any change to it had four sites to keep in step.

## What changes

**Behaviour is unchanged on every supported upgrade path.** The one difference is unreachable by any of them: a term-0 record arriving *after* a stamped term is now discarded rather than applied.

The implementation-model delta is that term 0 is no longer distinguished. `LeaderTerm.NONE` is gone rather than retained — once nothing treats 0 differently, a name for it advertises handling that no longer exists, which is what would invite the branch back. Its two uses were both `?: NONE` fallbacks meaning "nothing persisted yet" and read the same as `?: 0`. A block written before fencing still carries 0, and `BlockDetails.termId` is where that is now said.

`termId` also loses its default of `0` on all six `ReplicaMessage` variants and on `TableCatalog.buildBlock`, so every construction site states a term. That is what `dev/CODING.adoc` asks for on wire-format types, and it is what makes an unstamped record unrepresentable rather than merely unreachable — a caller could previously omit the field and get a value reading as "written before terms existed". No production caller relied on the default; it broke 51 sites, all tests.

## Usage / migration

**The upgrade procedure is unchanged. What changes is what happens if it isn't followed.**

- **2.1.0 → here: unaffected.** There was no replica log, so there are no unstamped records.

- **2.2.0-rc1 or later → here: nothing to do.** Every record those versions append is stamped.

- **2.2.0-rc0 → here: turn every rc0 node down before bringing the upgraded ones up.**
  That is already the requirement in the [2.2.0-rc1 release notes](https://github.com/xtdb/xtdb/releases/tag/v2.2.0-rc1), for the transactionality change that introduced stamping, and it is unchanged by this PR.

**On the configuration that bullet rules out — an rc0 node left running alongside an upgraded one — the failure mode is now different.** Before, the upgraded node applied the rc0 leader's unstamped writes — so both leaders' writes landed, and the two diverged. Now it fences them like any other superseded leader's, so writes the rc0 node had acknowledged to its clients are discarded with nothing logged about the upgrade.

## Consequences

- **Gotcha: the fence rule lives in two code sites, not one.**
  `TermFence.admit` on the tail, for whatever role is live, and again defensively in `runLeaderTerm`'s consume-back against the leader's own term. `dev/doc/db.allium` mirrors both, as `LogProcessorFencesRecord` and `LeaderAppliesRecord`. A change to the rule has four places to keep in step, and this one had to touch all four.

- **A term of 0 is now reported like any other superseded term.**
  Anyone reading a fenced-record debug line for a term-0 record previously saw nothing, because the record was admitted. There is no metric or alert on this, so the change is to log content only.

## Out of scope

Split on: things a reader might expect this to have tidied while it was in the area.

- **The pending-block ownership restructure**, which is what this unblocks rather than part of it. `applyPendingBlock`'s now-dead term guard is deleted there, not here, so that its removal reviews as equivalence.

- **`LeaderTerm.of(0, 0)` remains constructible**, and equals 0. Nothing prevents an `election` of 0, and now nothing names the value either. Every real election counter starts at 1, so no live transport can mint it; adding a `require` would change a public API's behaviour for an unreachable input.

- **`ReplicaMessage.TriesAdded.sourceMsgId` keeps its default of `0`**, the same smell in the same file. A defaulted `TriesAdded` would report source position 0 and trip `Watchers`' monotonicity check, so it is worth removing — but it is a watermark rather than a term, and folding it in would put two review questions on one diff.

## Alternative approaches

Split on: what to do with the exemption, and what to do with the constant.

- **Keep the exemption and leave it dormant.** Reasoned against: it wasn't inert. It made `applyPendingBlock`'s term guard reachable, where that guard dropped the very records the exemption existed to protect and could lose a source message outright once a later buffered record carried `latestSourceMsgId` past the gap.

- **Keep `NONE` as a named constant for the bottom of the ordering.** Reasoned against: with no special handling anywhere, the name documents a distinction the code no longer draws, and the two remaining callers read at least as clearly as `?: 0`.

- **Two commits, equivalence then behaviour.** Tried and abandoned: the 51 explicit-term sites are a pure tidy and landed first, keeping the suite green at each step. Squashed on review — the split bought a second review question without shrinking the behavioural residue, which stays at one sentence either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
