### PR TITLE
fix(indexer): the term fence folds when a record is acted on, not when it is read

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -57,9 +57,9 @@
 --          - FENCE BY TERM. A record whose term is GREATER than the leader's own term
 --            means a newer leader has superseded us → the leader RESIGNS (its
 --            unconfirmed writes are never acknowledged; the transport re-follows on
---            the next rebalance). A record with a LOWER term is discarded (still
---            advancing the consume cursor). An EQUAL-term record is our own — terms
---            are unique per leader.
+--            the next rebalance).
+--            Anything else the leader folds into the partition's high-water term as it acts on it, discarding what the fence refuses (still advancing the consume cursor).
+--            An EQUAL-term record is our own — terms are unique per leader.
 --          - For our own ResolvedTx: import from the QUEUE HEAD (we still hold its
 --            relations, so no re-materialisation), advancing the durable basis
 --            (LiveIndex.latest_completed_tx) and the consume cursor, notifying
@@ -700,11 +700,17 @@ rule ApplyRecord {
     --     failed by the fail-pending leg, see FailPendingHandles), and the transport
     --     re-follows on the next rebalance. This is EXPECTED — not a query-facing fault,
     --     so it does NOT poison the watchers.
-    --   - term LOWER than ours: shouldn't appear past our replay target; discarded
-    --     defensively, still advancing the consume cursor (RecordDiscarded).
+    --   - term below the partition's HIGH-WATER: the fence refuses it, and it is discarded, still
+    --     advancing the consume cursor (RecordDiscarded). Folding and testing happen here, where
+    --     the leader acts on the record; our own claim folded before the term opened, so the
+    --     high-water is our own term throughout and what the fence refuses sits below it.
     --   - term EQUAL to ours (the common case; terms are unique per leader, so an
     --     equal-term record IS our own): dispatched to ApplyResolvedTx (for a tx) or
     --     the block-upload path (for a BlockBoundary), etc.
+    --
+    -- The high-water itself is db.allium's to hold and to fold (LogProcessor.max_leader_term,
+    -- LeaderAppliesRecord), because it spans the partition rather than the leader's own term.
+    -- This rule names our_term, which the high-water equals for the length of a confirmed term.
     when: ApplyRecord(resolver, record_term, our_term)
 
     ensures:

--- a/allium/log-processor-lifecycle.allium
+++ b/allium/log-processor-lifecycle.allium
@@ -336,11 +336,23 @@ rule TransitionToLeader {
         -- Step 3: stop the follower (cancel + close its term).
         FollowerStopped(follower_term: listener.follower_term)
 
+        -- Step 3a: ask again whether the claim still stands, before anything is built or appended.
+        -- Step 2a's answer goes stale: it is given while the follower is still live, and the follower advances the highest term seen until it stops.
+        -- The records the follower was holding are asked too, having been held rather than acted on and so counting towards that highest term at no point.
+        -- Either above this transition's term refuses the claim, as step 2a does, and takes the same failure path.
+        ClaimStillUnfenced(follower_term: listener.follower_term, term: term)
+
         -- Step 4: finish any dangling block.
-        -- If the follower was mid-block (an old leader died before uploading it), the incoming leader uploads the block and replays its buffered records, with leader-upload semantics.
+        -- If the follower was mid-block (an old leader died before uploading it), the incoming leader uploads the block and then replays the records the follower was holding, with leader-upload semantics.
         -- Requires the follower stopped (step 3) so it cannot double-process.
         if listener.follower_term.mid_block:
-            DanglingBlockFinished(follower_term: listener.follower_term)
+            DanglingBlockUploaded(follower_term: listener.follower_term)
+
+            -- The block is finished on this node once the upload lands, so the transition stops carrying it here, between the upload and the replay.
+            -- The failure path below re-opens a follower from what the transition is carrying, and one still holding this block would match the upload just appended and finish the same block a second time.
+            listener.follower_term.mid_block = false
+
+            HeldRecordsReplayed(follower_term: listener.follower_term)
 
         -- Step 5: build the leader term, carrying the fencing term, and publish it as the role.
         -- Replica records reach it from the Listener's read, continuing from where the follower left off.
@@ -421,10 +433,12 @@ rule RecoverFollowerOnTransitionCancelled {
 
     ensures:
         -- Re-open a live follower seeded from the (now stale) follower position, so
-        -- the role is backed by a live replica consumer again.
+        -- the role is backed by a live replica consumer again. It carries the dangling block
+        -- forward while that block is still unfinished — up to step 4's upload and not past it,
+        -- which is what step 4 clears the flag between the upload and the replay for.
         listener.follower_term = FollowerTerm.created(
             replica_pos: listener.follower_term.replica_pos,
-            mid_block: false
+            mid_block: listener.follower_term.mid_block
         )
         listener.state = following
 }

--- a/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockUploader.kt
@@ -78,8 +78,8 @@ class BlockUploader(
      * index. Returns the `BlockUploaded`'s replica-log position.
      *
      * [uploadingTermId] is not always [boundary]'s: a transition finishes the previous leader's pending
-     * block, and the `BlockUploaded` must carry the new term, or followers that have already advanced
-     * would fence it and never complete the block.
+     * block, and the `BlockUploaded` carries the term of whoever appends it, because a leader confirms a
+     * write only on reading it back at its own term.
      */
     suspend fun uploadBlock(
         boundaryReplicaMsgId: MessageId, uploadingTermId: Long,

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -37,6 +37,7 @@ class FollowerLogProcessor @JvmOverloads constructor(
     private val watchers: Watchers,
     private val dbCatalog: Database.Catalog?,
     pendingBlock: PendingBlock?,
+    private val termFence: TermFence,
     private val hasExternalSource: Boolean,
     private val meterRegistry: MeterRegistry? = null,
     private val maxBufferedRecords: Int = 1024,
@@ -183,44 +184,63 @@ class FollowerLogProcessor @JvmOverloads constructor(
 
     }
 
+    private fun ReplicaMessage.BlockUploaded.closes(pending: PendingBlock) =
+        blockIndex == pending.blockIdx && storageVersion == Storage.VERSION && storageEpoch == bufferPool.epoch
+
     fun handleRecord(record: Log.Record<ReplicaMessage>) {
         val msg = record.message
         LOG.trace { "[$dbName] follower: message ${record.msgId} (${msg::class.simpleName})" }
 
-        pendingBlock?.let { pendingBlock ->
-            val pendingBlockIdx = pendingBlock.blockIdx
-            if (msg is ReplicaMessage.BlockUploaded
-                && msg.blockIndex == pendingBlockIdx
-                && msg.storageVersion == Storage.VERSION
-                && msg.storageEpoch == bufferPool.epoch
-            ) {
-                LOG.debug("[$dbName] block uploaded b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} (${pendingBlock.bufferedRecords.size} buffered)")
-                val bufferedRecords = blockUploadedTimer.timed {
-                    val block = parseFrom(bufferPool.getByteArray(blockFilePath(pendingBlockIdx)))
-
-                    addTries(msg.tries, record.logTimestamp)
-                    tableCatalog.refresh(block, liveIndex.blockMetadata())
-                    liveIndex.nextBlock()
-                    compactor.signalBlock()
-
-                    val bufferedRecords = pendingBlock.bufferedRecords
-                    bufferedRecordsSummary?.record(bufferedRecords.size.toDouble())
-                    blockBufferTimer?.let { blockBufferStartSample?.stop(it) }
-                    blockBufferStartSample = null
-                    this.pendingBlock = null
-                    bufferedRecords
-                }
-
-                bufferedRecords.forEach { held -> handleRecord(held) }
-            } else {
-                LOG.trace { "[$dbName] follower: buffering message ${record.msgId} (${msg::class.simpleName}) during pending block b${pendingBlockIdx} (${pendingBlock.bufferedRecords.size + 1} buffered)" }
-                pendingBlock += record
+        pendingBlock?.let { pending ->
+            // Held, not fenced: a record behind an open block has not been acted on yet, so the fence
+            // hears about it when it drains. Folding it here would move the high-water past the term
+            // that cut this block, and the upload closing it — written by that same term — would then
+            // be fenced away, leaving the block open for good.
+            if (msg is ReplicaMessage.BlockUploaded && msg.closes(pending)) closeBlock(pending, record, msg)
+            else {
+                LOG.trace { "[$dbName] follower: buffering message ${record.msgId} (${msg::class.simpleName}) during pending block b${pending.blockIdx} (${pending.bufferedRecords.size + 1} buffered)" }
+                pending += record
             }
 
             return
         }
 
+        if (!termFence.admit(msg.termId)) {
+            LOG.debug {
+                "[$dbName] follower: discarding fenced record ${record.msgId} " +
+                        "(term ${LeaderTerm.format(msg.termId)} < ${LeaderTerm.format(termFence.highestSeen)})"
+            }
+            return
+        }
+
         if (!msg.stale) processRecord(record)
+    }
+
+    private fun closeBlock(
+        pending: PendingBlock, record: Log.Record<ReplicaMessage>, msg: ReplicaMessage.BlockUploaded,
+    ) {
+        LOG.debug("[$dbName] block uploaded b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} (${pending.bufferedRecords.size} buffered)")
+
+        val bufferedRecords = blockUploadedTimer.timed {
+            val block = parseFrom(bufferPool.getByteArray(blockFilePath(pending.blockIdx)))
+
+            addTries(msg.tries, record.logTimestamp)
+            tableCatalog.refresh(block, liveIndex.blockMetadata())
+            liveIndex.nextBlock()
+            compactor.signalBlock()
+
+            val bufferedRecords = pending.bufferedRecords
+            bufferedRecordsSummary?.record(bufferedRecords.size.toDouble())
+            blockBufferTimer?.let { blockBufferStartSample?.stop(it) }
+            blockBufferStartSample = null
+            pendingBlock = null
+            bufferedRecords
+        }
+
+        // The closer goes round again behind what it was holding, so each term folds at its own position
+        // in the log — the held records first, then this one, where it sat. Second time round it applies
+        // nothing: it is either fenced by what the drain has just folded, or stale by block index.
+        (bufferedRecords + record).forEach { held -> handleRecord(held) }
     }
 
     override fun close() {

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -80,6 +80,7 @@ internal suspend fun runLeaderTerm(
     term: LeaderLogProcessor,
     replicaMsgs: ReceiveChannel<ReplicaApply>,
     appender: ReplicaLogAppender,
+    termFence: TermFence,
 ) {
     try {
         coroutineScope {
@@ -99,9 +100,12 @@ internal suspend fun runLeaderTerm(
                             if (termId > term.leaderTerm)
                                 throw LeaderSupersededException("[$dbName] superseded: read term $termId > our term ${term.leaderTerm} at ${record.msgId}")
 
-                            // Below our term should not appear past our replay target; discard defensively.
-                            if (termId < term.leaderTerm) {
-                                LOG.debug { "[$dbName] leader: discarding stale-term record ${record.msgId} (term $termId < ${term.leaderTerm})" }
+                            // Our own claim folded before this term opened, so the fence's high-water is
+                            // our term and anything it refuses is below ours — which shouldn't appear
+                            // past our replay target anyway. The fold has to happen here whatever the
+                            // verdict, or the high-water would stand still for the length of the term.
+                            if (!termFence.admit(termId)) {
+                                LOG.debug { "[$dbName] leader: discarding fenced record ${record.msgId} (term $termId < ${term.leaderTerm})" }
                             } else {
                                 term.applyReplicaMessage(record)
                             }
@@ -231,39 +235,30 @@ class LogProcessor(
         try {
             replicaLog.tailAll(tailPos.value.msgId) { recs ->
                 recs.forEach { record ->
-                    // Folded outside the retry below, so a record offered again is not folded twice.
-                    if (termFence.admit(record.message.termId)) {
-                        // A role ending cancels the handle mid-record, so the record is offered again to
-                        // whatever replaces that role.
-                        while (true) {
-                            this@coroutineScope.ensureActive()
-                            val role = state
+                    // A role ending cancels the handle mid-record, so the record is offered again to
+                    // whatever replaces that role.
+                    while (true) {
+                        this@coroutineScope.ensureActive()
+                        val role = state
 
-                            try {
-                                role.handleReplicaMessage(record)
-                                break
-                            } catch (_: CancellationException) {
-                                stateFlow.first { it !== role }
-                            } catch (e: Throwable) {
-                                LOG.error(
-                                    e,
-                                    "[$dbName] failed to process replica record ${record.msgId} (${record.message::class.simpleName})"
-                                )
-                                throw e
-                            }
-                        }
-                    } else {
-                        // Discard suppresses application, not consumption: the position below advances
-                        // anyway, so a transition catch-up can't hang on a fenced no-op.
-                        LOG.debug {
-                            "[$dbName] discarding fenced record ${record.msgId} " +
-                                    "(term ${LeaderTerm.format(record.message.termId)} < " +
-                                    "${LeaderTerm.format(termFence.highestSeen)})"
+                        try {
+                            role.handleReplicaMessage(record)
+                            break
+                        } catch (_: CancellationException) {
+                            stateFlow.first { it !== role }
+                        } catch (e: Throwable) {
+                            LOG.error(
+                                e,
+                                "[$dbName] failed to process replica record ${record.msgId} (${record.message::class.simpleName})"
+                            )
+                            throw e
                         }
                     }
 
                     // Above the apply, this would advance past a record a role cancellation left
-                    // unapplied, and that record would be skipped for good.
+                    // unapplied, and that record would be skipped for good. A record the live role
+                    // fenced or held advances it all the same, so a transition's catch-up can't hang
+                    // waiting for one to be applied.
                     tailPos.value = Reading(record.msgId)
                 }
             }
@@ -291,7 +286,7 @@ class LogProcessor(
 
         val proc = FollowerLogProcessor(
             allocator, partitionStorage.bufferPool, partitionState, dbName, compactor, watchers,
-            dbCatalog, pendingBlock,
+            dbCatalog, pendingBlock, termFence,
             hasExternalSource = hasExternalSource,
             meterRegistry = base.meterRegistry,
         )
@@ -348,7 +343,7 @@ class LogProcessor(
             try {
                 claimLeadership(termId)
 
-                val pendingBlock = following.proc.pendingBlock
+                var pendingBlock: PendingBlock? = null
 
                 // The point of no return. Once the follower is stopped, `state` references a dead term until
                 // Leading is published, so any early exit — a revoke cancelling us mid-cutover — has to
@@ -356,12 +351,20 @@ class LogProcessor(
                 // rather than flag-guarded: reaching the catch below *is* "the follower was stopped".
                 try {
                     LOG.debug("[${dbName}] transition: closing follower")
-                    // Guards the release alone: the follower's allocator must close cleanly once teardown has
-                    // begun, whatever the cancellation. Bounded — its coroutines only unwind.
+                    // A cancellation landing inside the join would close the allocator with the follower's
+                    // coroutines still unwinding, and Arrow won't close a parent allocator while a child
+                    // buffer is live. Bounded — those coroutines only unwind.
                     withContext(NonCancellable) {
                         following.job.cancelAndJoin()
                         following.proc.close()
+
+                        // Read after the join, not before it: the follower goes on applying records until
+                        // then, and one of them may be the upload that closes this very block. Taking the
+                        // block while it can still be closed underneath us finishes it a second time.
+                        pendingBlock = following.proc.pendingBlock
                     }
+
+                    checkNotSuperseded(termId, pendingBlock)
 
                     val driver = RealLeaderDriver(partitionStorage, partitionState)
                     val replicaAppender = ReplicaLogAppender(driver)
@@ -379,7 +382,21 @@ class LogProcessor(
                         gcDispatcher = gcDispatcher,
                     )
 
-                    pendingBlock?.let { proc.applyPendingBlock(blockCutter, it) }
+                    pendingBlock?.let { pending ->
+                        LOG.debug("[${dbName}] transition: finishing pending block b${pending.blockIdx} with ${pending.bufferedRecords.size} held records")
+
+                        // Through the cutter, not the uploader: closing a block is what resets the row
+                        // gauge, and this block was cut before the gauge was seeded from a live index that
+                        // still held it.
+                        blockCutter.upload(pending.boundaryMsgId, pending.boundaryMessage)
+
+                        // The block is closed on this node from here — catalog refreshed, live index
+                        // rolled — so a failure below must not hand it to a re-opened follower, which
+                        // would match the upload we have just appended and close it a second time.
+                        pendingBlock = null
+
+                        proc.replayHeldRecords(pending)
+                    }
 
                     LOG.debug("[${dbName}] transition: building leader processor")
                     val resumeAfterMsgId = watchers.latestSourceMsgId
@@ -393,7 +410,7 @@ class LogProcessor(
                         launch { proc.gc.runGc() }
                         proc.extSrcProc?.let { extSrcProc -> launch { extSrcProc.run() } }
 
-                        runLeaderTerm(dbName, watchers, proc, replicaMsgs, replicaAppender)
+                        runLeaderTerm(dbName, watchers, proc, replicaMsgs, replicaAppender, termFence)
                     }
 
                     val leading = Leading(proc, roleScope(termJob), replicaMsgs).also { state = it }
@@ -405,32 +422,53 @@ class LogProcessor(
                     throw e
                 }
             } catch (e: Throwable) {
-                // Cutover already restored a live `state` if it had to; here we only report.
-                if (!e.isShutdownSignal) {
-                    LOG.error(e, "[${dbName}] transition: failed to prepare leader")
-                    watchers.notifyError(e)
+                // Cutover already restored a live `state` if it had to; here we only report. A
+                // supersession is reported the way a term reports its own — this node is merely not the
+                // leader, and poisoning the watchers over it would leave a healthy database unqueryable.
+                when {
+                    e is LeaderSupersededException -> LOG.info("[$dbName] transition: ${e.message}")
+
+                    !e.isShutdownSignal -> {
+                        LOG.error(e, "[${dbName}] transition: failed to prepare leader")
+                        watchers.notifyError(e)
+                    }
                 }
                 throw e
             }
         }
     }
 
-    private suspend fun LeaderLogProcessor.applyPendingBlock(
-        blockCutter: BlockCutter, pendingBlock: PendingBlock,
-    ) {
-        var oldTerm = pendingBlock.boundaryMessage.termId
-        LOG.debug("[${dbName}] transition: finishing pending block b${pendingBlock.blockIdx} with ${pendingBlock.bufferedRecords.size} buffered records")
-        // Through the cutter, not the uploader: closing a block is what resets the row gauge, and this
-        // block was cut before the gauge was seeded from a live index that still held it.
-        blockCutter.upload(pendingBlock.boundaryMsgId, pendingBlock.boundaryMessage)
-        LOG.debug("[${dbName}] transition: replaying ${pendingBlock.bufferedRecords.size} buffered records")
+    /**
+     * Refuse a cutover the log has already moved past, before it builds or appends anything.
+     *
+     * The claim's own unfenced check goes stale: it runs while the follower is still live, and the
+     * follower folds until the join. So the fence is asked again here — and asked, separately, of the
+     * records the follower was holding, which have not met it at all.
+     */
+    private fun checkNotSuperseded(termId: Long, pendingBlock: PendingBlock?) {
+        val seen = termFence.highestSeen
+        if (seen > termId)
+            throw LeaderSupersededException(
+                "[$dbName] superseded before cutover: log at ${LeaderTerm.format(seen)} " +
+                        "> our term ${LeaderTerm.format(termId)}"
+            )
 
-        pendingBlock.bufferedRecords.forEach {
-            val msgTermId = it.message.termId
-            // A superseded leader's record — dropped, as the fence drops one live.
-            if (msgTermId < oldTerm) return@forEach
-            oldTerm = msgTermId
-            applyReplicaMessage(it)
+        pendingBlock?.bufferedRecords?.forEach { held ->
+            val heldTerm = held.message.termId
+            if (heldTerm > termId)
+                throw LeaderSupersededException(
+                    "[$dbName] superseded before cutover: held term ${LeaderTerm.format(heldTerm)} " +
+                            "> our term ${LeaderTerm.format(termId)} at ${held.msgId}"
+                )
+        }
+    }
+
+    /** Fold and apply what the follower was holding behind its block, in the order the log had it. */
+    private suspend fun LeaderLogProcessor.replayHeldRecords(pendingBlock: PendingBlock) {
+        LOG.debug("[${dbName}] transition: replaying ${pendingBlock.bufferedRecords.size} held records")
+
+        pendingBlock.bufferedRecords.forEach { held ->
+            if (termFence.admit(held.message.termId)) applyReplicaMessage(held)
         }
     }
 

--- a/core/src/main/kotlin/xtdb/indexer/TermFence.kt
+++ b/core/src/main/kotlin/xtdb/indexer/TermFence.kt
@@ -13,8 +13,10 @@ import xtdb.api.log.LeaderTerm
  * seeded afresh from the persisted block boundary would forget every term written since the last
  * block flush — so the same term could be admitted twice, once either side of a demote.
  *
- * Threading: [admit] is called only from the partition's single replica-log reader, while [highestSeen]
- * is read from the transition coroutine, hence the volatile.
+ * Threading: [admit] is called by whichever role the partition's single replica-log reader is dispatching
+ * to, one record at a time, and by the transition while both roles are down — so there is one writer at
+ * any moment, though not one for the fence's whole life. [highestSeen] is read from the transition
+ * coroutine, hence the volatile.
  */
 class TermFence(private val dbName: DatabaseName, seed: Long) {
 

--- a/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
+++ b/core/src/test/kotlin/xtdb/api/tx/ExternalSourceTest.kt
@@ -38,6 +38,7 @@ import xtdb.indexer.LiveIndex
 import xtdb.indexer.RealLeaderDriver
 import xtdb.indexer.ReplicaApply
 import xtdb.indexer.ReplicaLogAppender
+import xtdb.indexer.TermFence
 import xtdb.indexer.applyAndAwait
 import xtdb.indexer.runLeaderTerm
 import xtdb.storage.MemoryStorage
@@ -148,7 +149,7 @@ class ExternalSourceTest {
                 }
 
                 try {
-                    runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender)
+                    runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender, TermFence("test", 0))
                 } finally {
                     reader.cancel()
                 }

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -32,8 +32,8 @@ import java.time.Instant
 private fun FollowerLogProcessor.processRecords(records: List<Log.Record<ReplicaMessage>>) =
     records.forEach { handleRecord(it) }
 
-// The fence is the log processor's, so a bare follower never compares terms — these records only need
-// one that is a term.
+// The term most of these records carry. The fence starts at 0, so it admits them all, and only the
+// tests that name a second term are saying anything about fencing.
 private val TERM = LeaderTerm.of(0, 1)
 
 class FollowerLogProcessorTest {
@@ -48,6 +48,7 @@ class FollowerLogProcessorTest {
     private lateinit var tableCatalog: TableCatalog
     private lateinit var trieCatalog: TrieCatalog
     private lateinit var partitionState: PartitionState
+    private lateinit var termFence: TermFence
 
     // runTest cancels and joins backgroundScope before tearDown, so the followers are quiescent here
     // and freed before `allocator` closes.
@@ -63,6 +64,7 @@ class FollowerLogProcessorTest {
         trieCatalog = createTrieCatalog()
         partitionState = PartitionState(tableCatalog, trieCatalog, liveIndex)
         watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+        termFence = TermFence(dbName, 0)
 
         every { bufferPool.epoch } returns 1
     }
@@ -80,7 +82,7 @@ class FollowerLogProcessorTest {
     ) =
         FollowerLogProcessor(
             allocator, bufferPool, partitionState, dbName, compactor,
-            watchers, null, null,
+            watchers, null, null, termFence,
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,
             maxBufferedRecords = maxBufferedRecords,
@@ -101,6 +103,31 @@ class FollowerLogProcessorTest {
         )
 
         assertThrows<Fault> { proc.processRecords(records) }    }
+
+    @Test
+    fun `a held record meets the fence when it drains, and the upload that closes the block never does`() =
+        runTest {
+            val proc = makeProcessor()
+
+            every { bufferPool.getByteArray(TableCatalog.blockFilePath(0)) } returns block { blockIndex = 0 }.toByteArray()
+
+            val claimant = LeaderTerm.of(0, 2)
+            val fromNewTerm = ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1, termId = claimant)
+            val superseded = ReplicaMessage.ResolvedTx(2, Instant.now(), true, null, emptyMap(), srcMsgId = 2, termId = TERM)
+
+            proc.processRecords(listOf(
+                record(0, ReplicaMessage.BlockBoundary(0, 0, termId = TERM)),
+                record(1, fromNewTerm),
+                record(2, superseded),
+                // written by the term that cut the boundary, which `fromNewTerm` has superseded
+                record(3, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 0, emptyList(), termId = TERM)),
+            ))
+
+            assertEquals(0L, tableCatalog.currentBlockIndex, "the block closed, so the follower stopped buffering")
+            verify { liveIndex.commitTx(match { it.txId == fromNewTerm.txId }, any()) }
+            verify(exactly = 0) { liveIndex.commitTx(match { it.txId == superseded.txId }, any()) }
+            assertEquals(claimant, termFence.highestSeen, "the drain folded what it was holding")
+        }
 
     @Test
     fun `ResolvedTx skips already-applied transactions`() = runTest {

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -88,7 +88,7 @@ internal class LeaderLogProcessorTest : LeaderTermTest() {
         appender.append(ControlItem(ReplicaMessage.NoOp(termId = 1)))
 
         // returns once the pump's failure has ended the term
-        runLeaderTerm("test", watchers, proc, Channel(), appender)
+        runLeaderTerm("test", watchers, proc, Channel(), appender, TermFence("test", 0))
 
         assertNull(
             watchers.exception,

--- a/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
@@ -141,7 +141,7 @@ internal abstract class LeaderTermTest {
                 }
 
                 try {
-                    runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender)
+                    runLeaderTerm("test", watchers, proc, replicaMsgs, replicaAppender, TermFence("test", 0))
                 } finally {
                     reader.cancel()
                 }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -20,6 +21,7 @@ import xtdb.NodeBase
 import xtdb.NodeBase.Companion.openBase
 import xtdb.api.log.*
 import xtdb.SimulationTestUtils.Companion.createTrieCatalog
+import xtdb.api.storage.Storage
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.DatabaseLogs
@@ -354,6 +356,127 @@ class LogProcessorTest {
         assertEquals(1L, watchers.latestTxId, "the superseded leader's tx was never applied")
         assertEquals(LeaderTerm.of(0, 2), logProc.termFence.highestSeen)
         assertTrue(leader.msgId < superseded.msgId)
+
+        scope.coroutineContext.job.cancelAndJoin()
+        logProc.close()
+        sourceLog.close()
+        replicaLog.close()
+    }
+
+    @Test
+    fun `a block closes even once the fence has moved past the term that cut it`() = runTest {
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val bufferPool = mockBufferPool()
+        val partitionState = newPartitionState()
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        every { bufferPool.getByteArray(TableCatalog.blockFilePath(0)) } returns block { blockIndex = 0 }.toByteArray()
+
+        val scope = CoroutineScope(SupervisorJob())
+        val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
+
+        val cutter = LeaderTerm.of(0, 4)
+        replicaLog.appendMessage(ReplicaMessage.BlockBoundary(0, 0, termId = cutter))
+        // a claim landing between the boundary and its upload is what moves the fence past `cutter`,
+        // and under self-election it lands there routinely
+        replicaLog.appendMessage(ReplicaMessage.NoOp(termId = LeaderTerm.of(0, 5)))
+        val uploaded = replicaLog.appendMessage(
+            ReplicaMessage.BlockUploaded(Storage.VERSION, 0, 0, 0, emptyList(), termId = cutter)
+        )
+
+        logProc.awaitReplicaMsg(uploaded.msgId)
+
+        assertEquals(
+            0L, partitionState.tableCatalog.currentBlockIndex,
+            "b0 is closed, so the follower is no longer buffering behind it"
+        )
+        assertEquals(
+            LeaderTerm.of(0, 5), logProc.termFence.highestSeen,
+            "the claim it held back still folded, so every reader agrees on what the log has reached"
+        )
+
+        scope.coroutineContext.job.cancelAndJoin()
+        logProc.close()
+        sourceLog.close()
+        replicaLog.close()
+    }
+
+    @Test
+    fun `a promotion finishes the block it inherits and applies what was held behind it`() = runTest {
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val bufferPool = mockBufferPool()
+        val partitionState = newPartitionState()
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        val scope = CoroutineScope(SupervisorJob())
+        val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
+
+        // the leader that cut b0 died before uploading it, so the follower is still holding the block —
+        // and the tx behind it, unfolded. That tx carries the boundary's own source position: the block
+        // cut pauses resolution, so nothing the leader resolves can land between a boundary and its
+        // upload, and a held record that moved the source watermark on would walk it backwards when the
+        // upload is read back at the boundary's position.
+        val cutter = LeaderTerm.of(0, 4)
+        replicaLog.appendMessage(ReplicaMessage.BlockBoundary(0, 1, termId = cutter))
+        replicaLog.appendMessage(
+            ReplicaMessage.ResolvedTx(1, Instant.now(), true, null, emptyMap(), srcMsgId = 1, termId = cutter)
+        )
+
+        val incoming = LeaderTerm.of(0, 5)
+        logProc.transitionToLeader(0, incoming).await()
+
+        assertEquals(
+            0L, partitionState.tableCatalog.currentBlockIndex,
+            "the incoming leader finished the block its predecessor left open"
+        )
+        watchers.awaitTx(1)
+        assertEquals(
+            incoming, logProc.termFence.highestSeen,
+            "the held records folded on replay, up to this leader's own claim"
+        )
+
+        scope.coroutineContext.job.cancelAndJoin()
+        logProc.close()
+        sourceLog.close()
+        replicaLog.close()
+    }
+
+    @Test
+    fun `a promotion resigns on a superseding term the follower was holding`() = runTest {
+        val sourceLog = InMemoryLog<SourceMessage>(InstantSource.system(), 0)
+        val replicaLog = InMemoryLog<ReplicaMessage>(InstantSource.system(), 0)
+        val bufferPool = mockBufferPool()
+        val partitionState = newPartitionState()
+        val partitionStorage = PartitionStorage(DatabaseLogs(sourceLog, replicaLog), bufferPool, null)
+        val blockUploader = BlockUploader(partitionStorage, partitionState, "xtdb", mockk(relaxed = true), null, null, backgroundScope)
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+
+        val scope = CoroutineScope(SupervisorJob())
+        val logProc = logProcessor(partitionStorage, partitionState, watchers, blockUploader, scope)
+
+        // b0 stays open, so everything after it is held and the fence stays at the boundary's term —
+        // which is what lets the claim below pass its own unfenced check
+        replicaLog.appendMessage(ReplicaMessage.BlockBoundary(0, 0, termId = LeaderTerm.of(0, 4)))
+        replicaLog.appendMessage(ReplicaMessage.NoOp(termId = LeaderTerm.of(0, 9)))
+
+        assertThrows<LeaderSupersededException> {
+            logProc.transitionToLeader(0, LeaderTerm.of(0, 5)).await()
+        }
+
+        assertNull(
+            watchers.exception,
+            "being superseded is not an ingestion fault, so the database stays queryable"
+        )
+        assertEquals(
+            LeaderTerm.of(0, 4), logProc.termFence.highestSeen,
+            "the held records were never folded, so nothing was applied at the superseding term either"
+        )
 
         scope.coroutineContext.job.cancelAndJoin()
         logProc.close()

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -177,6 +177,7 @@ entity LogProcessor {
     --
     -- max_leader_term: the READ-SIDE TERM FENCE — the highest leader term seen so far.
     --   A record BELOW it was written by a superseded leader and is discarded (see the Fencing section).
+    --   Folded and tested by whichever role is live, as it acts on the record: the tail dispatches one record at a time and awaits it, so there is a single caller at any moment.
     --   Seeded from the persisted block boundary (table_catalog.boundary_term_id) so it survives restart.
     --   Scoped to the partition for its whole life rather than to a role — log-processor-lifecycle.allium's LeaderTerm carries why.
     --
@@ -200,7 +201,7 @@ variant Leader : LogProcessor {
     --
     -- A promotion's pending block is finished through this processor, before it reads its first source message.
     --   - The boundary the outgoing leader cut is uploaded under the INCOMING term — see BlockUploader.
-    --   - The follower's buffered records then replay in log order; one whose term is below the highest the replay has reached is dropped, as the fence drops one live.
+    --   - The block is released once the upload returns, and the records the follower was holding replay behind it: each folds at its own position in the log and is applied where the fence admits it.
     --
     -- external_source is present iff the database has one configured; it makes this
     -- leader external-source-fed rather than client-driven (see the header).
@@ -332,10 +333,8 @@ entity BlockUploader {
     --      source-log buffer saturates at a boundary.
     --   Returns the replica msg_id of the BlockUploaded message.
     --
-    -- termId is the APPENDING term, which is not always the boundary's: a transition
-    -- finishes the previous leader's pending block, and its BlockUploaded must carry the
-    -- NEW term or followers that have already advanced would fence it and never complete
-    -- the block.
+    -- termId is the APPENDING term, which is not always the boundary's: a transition finishes the previous leader's pending block.
+    -- The BlockUploaded carries the term of whoever appends it, because a leader confirms a write only on reading it back at its own term.
     --
     -- See: indexer/BlockUploader.kt
 }
@@ -424,6 +423,8 @@ value TableEntry {
 value PendingBlock {
     -- Captures the state between BlockBoundary and BlockUploaded.
     -- Held by the follower, which also buffers subsequent replica messages, up to max_buffered_records.
+    -- A buffered record is stored, and nothing else: it is neither folded into the term fence nor tested against it, because it has not been acted on.
+    -- It meets the fence when the block drains (FollowerHandlesBlockUploaded), or when a promotion inherits the block (TransitionToLeader).
     -- Overflow is a fault (xtdb.indexer/follower-buffer-overflow) that the leader's block-cut pause keeps unreachable.
     -- Passed from follower to transition processor on assignment.
     -- See: indexer/PendingBlock.kt
@@ -646,13 +647,20 @@ config {
 -- epoch dominates the ordering — so plain numeric comparison is already lexicographic
 -- over (epoch, election), and every comparison site stays a Long.
 --
--- The fence bites in two places:
---   - The partition's REPLICA TAIL, on READ, over every record whatever role is live: a record below the highest term the tail has seen is DISCARDED.
---     One at or above it folds the highest-seen term upward and is dispatched to the live role.
---     A discarded record still advances the consume position, so a transition catch-up can never hang on a fenced no-op.
---     That high-water term is seeded from the last persisted block, so the fence survives restart.
---   - The LEADER, on CONSUME-BACK (Raft's ReadIndex), additionally over what the tail dispatches to it and against its OWN term: it applies and acknowledges a write only once it has read that write back at that term.
---     A HIGHER term read back means a newer leader has superseded it, so it RESIGNS without acknowledging its outstanding writes; a LOWER term is discarded, still advancing the consume position.
+-- The fence is applied by whichever ROLE is live, as it acts on the record: a record below the highest term seen so far is DISCARDED, and one at or above it folds that high-water upward and is acted on.
+-- The partition's replica tail reads each record, hands it to the live role and awaits it, so the fence has a single caller at any moment.
+-- The high-water is the partition's, seeded from the last persisted block, so the fence survives restart.
+-- A discarded record still advances the consume position, so a transition catch-up can never hang on a fenced no-op.
+--
+-- A record a follower holds behind an OPEN PENDING BLOCK is stored, and nothing else: it has not been acted on, so the fence has not heard of it.
+-- Those records meet the fence when the block drains, each folding at its own position in the log — or, where a promotion inherits the block, as the incoming leader replays them (see TransitionToLeader).
+-- So while a block is open the high-water stands at the term that cut the boundary, and the upload that closes the block reaches the follower with nothing folded ahead of it.
+-- The block closes on the MATCH — block index, storage version and storage epoch — with the fence not consulted for that record at that point.
+-- The closer's own term folds on the replay, behind the records it was holding and at the position it occupied in the log, where the drain may already have folded a higher one and the fence refuse it.
+-- Refusing it there costs nothing: the block is closed, and a refused record applies nothing.
+--
+-- The LEADER additionally tests against its OWN term on CONSUME-BACK (Raft's ReadIndex): it applies and acknowledges a write only once it has read that write back at that term.
+-- A HIGHER term read back means a newer leader has superseded it, so it RESIGNS without acknowledging its outstanding writes.
 --
 -- Two nodes may therefore briefly both believe themselves leader and both APPEND. Only
 -- the newer term's writes are ever confirmed, and the older leader's are discarded, which
@@ -705,8 +713,7 @@ config {
 -- Stale messages are skipped entirely before dispatch. This replaces per-type
 -- idempotency checks within the handler.
 --
--- The term fence is a SEPARATE, earlier check (see Fencing): a fenced record is discarded
--- before staleness is even considered.
+-- The term fence is a SEPARATE check, run first (see Fencing): a record the fence discards never reaches the staleness comparison.
 
 rule TransitionToLeader {
     -- db.allium's view of the transition: what it means for THIS database's pipeline.
@@ -740,7 +747,16 @@ rule TransitionToLeader {
 
         -- Capture the follower's pending block state (if it saw BlockBoundary
         -- but not BlockUploaded before the replay target).
+        -- The read follows the close: the follower goes on applying records until then, and one of them may be the upload that closes this very block.
         let pending_block = log_processor.pending_block
+
+        -- Refuse a cutover the log has already moved past, before anything is built or appended.
+        -- Two sources, asked together here. The fence's high-water, because CheckTermUnfenced's answer goes stale — it is given while the follower is still live, and the follower folds every record it acts on until it stops.
+        -- And the records the follower was holding, which have met the fence at no point.
+        -- Either above this term means a newer leader, and the promotion RESIGNS — reported the way a leader term reports its own supersession rather than as an ingestion fault, so it leaves the watchers alone.
+        if log_processor.max_leader_term > term
+           or (pending_block != null and pending_block.buffered_records.any(held => held.term_id > term)):
+            LeaderSuperseded(resolver: tx_resolver)
 
         -- Switch to leader mode.
         -- It resumes the SOURCE log from the durable watermark (which the replay below advances), and its consume pump tails the REPLICA log from the replay target.
@@ -761,15 +777,19 @@ rule TransitionToLeader {
 
         -- The new leader finishes the block the outgoing one left behind, before it reads a source message.
         --   - The block's data is already in the live index (applied before BlockBoundary), but the block file was never persisted.
-        --   - The BlockUploaded is appended under the INCOMING term, not the term that cut the boundary: followers have already advanced past that term and would fence it, never completing the block.
-        --   - The buffered records then replay through this same leader, which uploads on a BlockBoundary among them rather than entering the follower's pending mode.
+        --   - The BlockUploaded is appended under the INCOMING term, because a leader confirms a write only on reading it back at its own term (see BlockUploader).
+        --   - The upload and the replay are separate steps, with the block released between them.
+        --     Once the upload returns, this node's catalog is refreshed and its live index rolled, so the block is closed here and the transition stops carrying it.
+        --     A failure during the replay therefore re-opens a follower holding no block; one still holding it would match the BlockUploaded just appended and close the same block a second time.
+        --   - The replay is where the held records meet the fence: each folds at its own position in the log and is applied where the fence admits it, through this same leader, which uploads on a BlockBoundary among them rather than entering the follower's pending mode.
         if pending_block != null:
             block_uploader.uploadBlock(
                 pending_block.boundary_msg_id,
                 term,
                 pending_block.boundary_message
             )
-            log_processor.applyPendingBlock(pending_block)
+            log_processor.pending_block = null
+            log_processor.replayHeldRecords(pending_block)
 
         log_processor.start(after_source: watchers.latest_source_msg_id, after_replica: replay_target)
 
@@ -1062,7 +1082,7 @@ rule AppendReplicaMessage {
 
 rule LeaderAppliesRecord {
     -- Apply one record read back off our own replica log, fenced by TERM.
-    -- Discarding suppresses application, not consumption: the tail advances past a discarded record all the same, so a catch-up can never hang on a fenced one (see LogProcessorFencesRecord).
+    -- Discarding suppresses application, not consumption: the tail advances past a discarded record all the same, so a catch-up can never hang on a fenced one (see LogProcessorDispatchesRecord).
     when: ReplicaMessageReceived(record)
     requires: log_processor.mode = Leader
 
@@ -1077,13 +1097,20 @@ rule LeaderAppliesRecord {
             -- or a routine leadership handover would surface to queries as a failed
             -- database (see ProcessingErrorHaltsNode).
             LeaderSuperseded(resolver: tx_resolver)
-        else if record.term_id < log_processor.leader_term:
-            -- Shouldn't appear past our replay target; discard defensively.
+        else if record.term_id < log_processor.max_leader_term:
+            -- The fence, applied here because this is where the leader acts on the record.
+            -- Our own claim folded before the term opened, so the high-water is this leader's own
+            -- term throughout, and what the fence refuses is what sits below it.
             RecordDiscarded(resolver: tx_resolver)
         else:
             -- Equal term (the common case): terms are unique per leader, so this record is
             -- our own.
             ApplyOwnRecord(record)
+
+            -- The fence folds in the same step as it admits, here as on a follower: the leader folds
+            -- every record it acts on, so the high-water holds the terms the log has reached and a
+            -- later demote re-seeds a follower from them.
+            log_processor.max_leader_term = max(log_processor.max_leader_term, record.term_id)
 }
 
 rule LeaderAppliesOwnTx {
@@ -1266,80 +1293,102 @@ rule ExternalSourceIndexesTx {
 
 -- A follower and the transition processor both apply already-durable messages, so they
 -- import straight into the durable live index and advance the watchers as they go.
--- The TERM FENCE (see Fencing) has already run on the tail that dispatched the record, so the only check left to either of them is STALENESS (see Staleness): a message whose effect is already applied is skipped.
+-- The TERM FENCE (see Fencing) runs here, on the record the tail dispatched, and STALENESS (see Staleness) after it: a message whose effect is already applied is skipped.
 --
--- In the follower, staleness is checked OUTSIDE the pending block guard: if in pending
--- mode, the pending block handler runs first (buffers, or matches BlockUploaded). Only
--- non-pending, non-stale messages reach processRecord.
+-- Both sit OUTSIDE the pending block guard: if in pending mode, the pending block handler runs first (holds the record, or matches BlockUploaded).
+-- Only non-pending, admitted, non-stale messages reach processRecord.
 
 -- == Follower handleRecord dispatch ==
 --
 -- 1. Pending block guard: if pending_block is set, check whether the message is the
---    matching BlockUploaded. If so, finish the block and replay the buffer. Otherwise
---    buffer it (overflowing the cap is a fault). Return in either case.
--- 2. Staleness check: if the message is stale, skip. Otherwise processRecord.
+--    matching BlockUploaded. If so, finish the block and drain what it was holding. Otherwise
+--    hold it (overflowing the cap is a fault). Return in either case — a held record is stored
+--    and nothing else, so the fence has not heard of it.
+-- 2. Term fence: discard the message if its term is below the high-water, and otherwise fold it in.
+--    Return on a discard.
+-- 3. Staleness check: if the message is stale, skip. Otherwise processRecord.
 
-rule LogProcessorFencesRecord {
-    -- The read-side fence, applied to every record read whatever role is live.
-    -- A discarded record still advances the consume position, so a transition's catch-up await can't hang on it.
+rule LogProcessorDispatchesRecord {
+    -- The partition's replica tail: read one record, hand it to whichever role is live, await it, advance.
+    -- Dispatching one at a time and awaiting it is what leaves the term fence with a single caller.
     when: ReplicaMessageReceived(record)
 
     ensures:
-        if record.term_id < log_processor.max_leader_term:
-            RecordDiscarded(record)
-        else:
-            log_processor.max_leader_term = max(log_processor.max_leader_term, record.term_id)
-            HandleReplicaMessage(record)
+        HandleReplicaMessage(record)
 
-        -- One advance per record, discarded or not, once the fence or the live role has finished with it — this is what awaitReplicaMsg waits on.
+        -- One advance per record, whatever the live role did with it — this is what awaitReplicaMsg waits on.
+        -- A record the role fenced or held advances it all the same, so a transition's catch-up await can't hang on one.
         -- A faulting apply does not advance it: it ends the tail.
         log_processor.latest_replica_msg_id = record.msg_id
 }
 
+rule FollowerHoldsRecordBehindPendingBlock {
+    -- A record that arrives while a block is open is STORED, and nothing else — see PendingBlock.
+    -- Subscribes to the same dispatch event as HandleReplicaMessage and overrides it, as
+    -- FollowerHandlesBlockUploaded does for the record that closes the block.
+    when: HandleReplicaMessage(msg)
+    requires: log_processor.mode = Follower
+    requires: log_processor.pending_block != null
+    requires: not (msg.kind = BlockUploadedMessage
+                   and msg.block_index = log_processor.pending_block.boundary_message.block_index
+                   and msg.storage_version = storage_format.storage_version
+                   and msg.storage_epoch = storage_format.storage_epoch)
+
+    ensures:
+        log_processor.pending_block.buffered_records =
+            log_processor.pending_block.buffered_records.append(msg)
+}
+
 rule HandleReplicaMessage {
-    -- Dispatches a single replica message that has passed the fence, the pending-block
-    -- guard and the staleness check. The transition processor overrides BlockBoundary
-    -- (see Transition rules below).
+    -- Dispatches a single replica message the tail has read, applying the term fence to it and then
+    -- the staleness check. The pending-block guard overrides this rule while a block is open
+    -- (FollowerHoldsRecordBehindPendingBlock, FollowerHandlesBlockUploaded).
     when: HandleReplicaMessage(msg)
 
     ensures:
-        if msg.kind = ResolvedTxMessage:
-            live_index.importTx(msg)
-            if msg.committed:
-                if msg.db_op.kind = Attach:
-                    database.catalog.attach(msg.db_op.db_name, msg.db_op.config)
-                if msg.db_op.kind = Detach:
-                    database.catalog.detach(msg.db_op.db_name)
-            -- src_msg_id where present. On a pre-#5586 record it is absent, and the
-            -- fallback differs by database: an external-source tx_id is an independent
-            -- counter, so it says nothing about the source log and the tracked watermark
-            -- has to stand in; a source-log tx_id IS a source-log position.
-            let effective_src_msg_id =
-                msg.src_msg_id
-                    ?? (if database.external_source != null:
-                            watchers.latest_source_msg_id
-                        else: msg.tx_id)
-            watchers.notifyTx(msg.result, effective_src_msg_id, msg.external_source_token)
+        if msg.term_id < log_processor.max_leader_term:
+            -- Written by a leader the log has since moved past.
+            RecordDiscarded(msg)
+        else:
+            log_processor.max_leader_term = max(log_processor.max_leader_term, msg.term_id)
 
-        if msg.kind = TriesAddedMessage:
-            if msg.storage_version = storage_format.storage_version
-               and msg.storage_epoch = storage_format.storage_epoch:
-                trie_cat/trie_catalog.addTries(msg.tries, msg.log_timestamp)
-            watchers.notifyMsg(msg.source_msg_id)
+            if msg.kind = ResolvedTxMessage:
+                live_index.importTx(msg)
+                if msg.committed:
+                    if msg.db_op.kind = Attach:
+                        database.catalog.attach(msg.db_op.db_name, msg.db_op.config)
+                    if msg.db_op.kind = Detach:
+                        database.catalog.detach(msg.db_op.db_name)
+                -- src_msg_id where present. On a pre-#5586 record it is absent, and the
+                -- fallback differs by database: an external-source tx_id is an independent
+                -- counter, so it says nothing about the source log and the tracked watermark
+                -- has to stand in; a source-log tx_id IS a source-log position.
+                let effective_src_msg_id =
+                    msg.src_msg_id
+                        ?? (if database.external_source != null:
+                                watchers.latest_source_msg_id
+                            else: msg.tx_id)
+                watchers.notifyTx(msg.result, effective_src_msg_id, msg.external_source_token)
 
-        if msg.kind = TriesDeletedMessage:
-            -- Set-removal, so unconditional and idempotent: no storage-version guard and
-            -- no staleness check.
-            trie_cat/trie_catalog.deleteTries(msg.table_name, msg.trie_keys)
+            if msg.kind = TriesAddedMessage:
+                if msg.storage_version = storage_format.storage_version
+                   and msg.storage_epoch = storage_format.storage_epoch:
+                    trie_cat/trie_catalog.addTries(msg.tries, msg.log_timestamp)
+                watchers.notifyMsg(msg.source_msg_id)
 
-        if msg.kind = BlockBoundaryMessage:
-            -- Follower: enters pending mode. Subsequent messages (except the matching
-            -- BlockUploaded) are buffered by the pending block guard above.
-            log_processor.pending_block = PendingBlock(msg.msg_id, msg)
-            watchers.notifyMsg(msg.latest_processed_msg_id)
+            if msg.kind = TriesDeletedMessage:
+                -- Set-removal, so unconditional and idempotent: no storage-version guard and
+                -- no staleness check.
+                trie_cat/trie_catalog.deleteTries(msg.table_name, msg.trie_keys)
 
-        if msg.kind = NoOpMessage and msg.src_msg_id != null:
-            watchers.notifyMsg(msg.src_msg_id)
+            if msg.kind = BlockBoundaryMessage:
+                -- Follower: enters pending mode. Subsequent messages (except the matching
+                -- BlockUploaded) are buffered by the pending block guard above.
+                log_processor.pending_block = PendingBlock(msg.msg_id, msg)
+                watchers.notifyMsg(msg.latest_processed_msg_id)
+
+            if msg.kind = NoOpMessage and msg.src_msg_id != null:
+                watchers.notifyMsg(msg.src_msg_id)
 }
 
 rule FollowerHandlesBlockUploaded {
@@ -1348,6 +1397,9 @@ rule FollowerHandlesBlockUploaded {
     -- buffer pool), not from the message. The BlockUploaded message is just a signal.
     -- Subscribes to the same dispatch event as HandleReplicaMessage (which has no
     -- BlockUploadedMessage branch of its own) and overrides it for the pending-block case.
+    -- The block closes on the match alone, with the fence not consulted for this record here. Nothing has
+    -- folded since the boundary, everything since having been held, so the record reaches the match rather
+    -- than being discarded ahead of it (see Fencing).
     when: HandleReplicaMessage(msg)
     requires: msg.kind = BlockUploadedMessage
     requires: log_processor.mode = Follower
@@ -1365,12 +1417,18 @@ rule FollowerHandlesBlockUploaded {
         live_index.nextBlock()
         CompactorSignalled()
 
-        -- Clear pending mode and replay buffered records; their typed notifications are
-        -- what advance the watermarks.
+        -- Clear pending mode, then drain what the block was holding back through the dispatch above;
+        -- their typed notifications are what advance the watermarks.
+        -- Each held record therefore folds at its own position in the log.
         let buffered = log_processor.pending_block.buffered_records
         log_processor.pending_block = null
         for record in buffered:
             HandleReplicaMessage(record)
+
+        -- This record goes round again behind them, where it sat in the log: that is where its own term
+        -- meets the fence. It applies nothing second time round — either the drain has folded a term above
+        -- it, or it is stale by block index.
+        HandleReplicaMessage(msg)
 }
 
 ---- Rules: Compaction Orchestration


### PR DESCRIPTION
The replica-log term fence now folds when the live role acts on a record rather than when the partition's tail reads it, so a record a follower is holding behind an open block is not counted against the fence until it drains. That stops a block being left open for the life of the process when the upload completing it is written by a term the log has since moved past — and it lands now because self-election (#5917) turns that from a rarity into a routine, and that branch carries a simulation wedge it cannot shed until this is in.

- **What was broken.**
  A `BlockUploaded` carries the term of whoever appended it. A claim landing between a boundary and its upload folded the high-water past that term, the tail discarded the upload, and the follower went on buffering — through every later block cycle, until the 1024-record cap faulted or a promotion turned the buffer into duplicate uploads and latched the database `Failed`.

- **What holds now.**
  Holding a record is not acting on it, so a held record is stored and nothing else. The high-water therefore stands at the boundary's own term for as long as the block is open — nothing can fold past a closing upload while it is in flight, so no verdict moves under it before the match is tried, and nothing has to be exempted from the fence to make that so.

## Symptoms

- **A database latched `Failed`, unqueryable on that node until the process restarts.**
  `Ingestion stopped: srcMsgId 9 < latestSourceMsgId 12` or similar — a source watermark walking backwards. `Watchers`' `Failed` is absorbing, so the node never recovers.

- **Duplicate `BlockUploaded` records on the replica log**, the same block index announced twice from two different terms, with the second carrying the first's source watermark.

- **On a healthy-looking node, a follower buffer that only grows.**
  `xtdb.replica.block.buffered.records` climbs and never resets; `xtdb.replica.block.buffer.timer` records no completed window. Left long enough, `xtdb.indexer/follower-buffer-overflow` at 1024 records.

- **Not #5332, which produced the same overflow from a different cause** — a revoked leader orphaning a `BlockBoundary`, so two boundaries met one upload. That one is closed. This is a single boundary whose upload is discarded, so the pairing on the log is intact and only the reader's verdict is wrong.

## Root cause

The tail folded the fence before dispatching, so a record was counted against the high-water whether or not the live role did anything with it.

- **A follower behind an open pending block does nothing with a record but store it.**
  Folding it there advanced the high-water past the term that cut the block. The upload completing that block was written by that same term, so it arrived below the high-water and was discarded before the follower could match it — and the pending-block match is the only thing that closes a block.

- **The buffer then spans block cycles**, which is the state everything downstream assumes cannot happen.
  A promotion replays the buffer through the leader's apply path, and that path uploads on every `BlockBoundary` it meets. Several boundaries in one buffer means each is re-announced at the new term with its original source watermark, which is the watermark regression above.

- **Rare on `main`, routine under self-election.**
  A term only advances on a Kafka group rebalance today, and the block cut pauses resolution, so the window between a boundary and its upload is close to empty. #5917 advances a term on every quiet interval, so a claim one record after a boundary is ordinary — which is why its `leadership churn leaves one leader, and each term one writer` simulation wedges roughly once in a thousand iterations.

## What changes

- **The fold moves off the tail and onto the live role.**
  The tail reads, dispatches and advances the consume position. `FollowerLogProcessor.handleRecord` and `runLeaderTerm` each fold what they are given. Still exactly once per record and in log order, because the tail hands over one record at a time and awaits it.

- **A held record is stored, and nothing else.**
  Not folded, not tested. It meets the fence when the block drains — the drain replays the held records, and the closing record behind them, back through `handleRecord`, so each term folds at the position it occupied in the log. Second time round the closer applies nothing: it is either fenced by what the drain just folded, or stale by block index. The block itself closed on the match, before any of that.

- **The leader's discard becomes the fence's refusal.**
  `runLeaderTerm` dropped a record whose term was below its own; it now drops what the fence refuses. The two coincide — a term reads its own claim back and checks it unfenced before it opens, so the high-water is that term — and this leaves one rule in one place, which `term 0 is an ordinary leader term` flagged as the thing to fix next time the fence changed.

- **A promotion inheriting a buffer meets it at the fence for the first time.**
  `checkNotSuperseded` reads the held records for a term above the incoming leader's, alongside the high-water, and resigns on either. `replayHeldRecords` then folds each held record and applies what the fence admits, replacing a guard that dropped a record below the highest the replay had reached — unreachable while the tail fenced ahead of the buffer, and wrong once folding the buffer is the replay's own job.

- **A promotion also re-asks the fence once the follower is stopped.**
  `claimLeadership` checks its claim unfenced while the follower is still live, so the answer can change under it — a superseding record arriving in that window is folded by the follower and consumed before the leader could ever see it. The term then comes up already fenced: its own writes are refused on read-back and their durability handles never complete, while the record that would have told it to resign has gone by. That hang predates this change; nothing folds between the join and the cutover, so the check goes there and resigns instead. Both resignations are reported as supersessions rather than ingestion faults, so a routine handover leaves the database queryable — the surrounding handler now distinguishes them, where it previously poisoned the watchers for any transition failure.

- **The transition takes the pending block after stopping the follower**, which is what `db.allium` already specified and the code did not. Reading it first was safe only while the fence was over-eager enough to stop the follower closing the block underneath the read.

## Usage / migration

Nothing to do. No configuration, wire format, on-disk format or public API changes, and no upgrade ordering constraint: the change is entirely in what a reader does with records the log already carries, so it writes exactly what it wrote before and a node running it interoperates with one that isn't. During a rolling upgrade an un-upgraded node keeps the bug — its own block can still be stranded — which is a reason to finish the roll, not to order it.

## Consequences

- **Gotcha: the fence has two call sites now, not one.**
  `FollowerLogProcessor.handleRecord` and `runLeaderTerm`. They are never concurrent — the tail awaits each dispatch, and a role change cancel-and-joins the old role before publishing the new one — but "folded exactly once per record" is now a discipline across two files rather than a property of having one caller. `TermFence`'s kdoc says so.

- **The buffer now holds records that will be fenced when they drain.**
  The tail used to drop those before they were buffered. Under sustained churn behind an open block the 1024-record cap is therefore reached marginally sooner. The cap is a fault, so this is a slightly wider path to an existing failure rather than a new one — and the change makes the buffer far shorter-lived, which dominates.

- **A promotion can now fail with a supersession.**
  `transitionToLeader`'s handle completes exceptionally where before the buffer was replayed regardless. The transport re-follows on the next rebalance, as it does for any failed promotion, and the watchers are left alone.

- **`runLeaderTerm` takes the fence**, so the three test harnesses that drive it construct a real one instead of implying an empty fence.

## Out of scope

Split on: things reachable from this code that this deliberately leaves alone.

- **Pending-block ownership.** The block is still the follower's, threaded to the transition by constructor and getter, and the leader's apply path still uploads on a `BlockBoundary` it replays. Moving it onto the log processor is what would make the duplicate upload unrepresentable rather than untriggered; it needs the leader's block cycle to stop rolling the live index inside `uploadBlock`, which is #4495's territory.

- **The other way a block stays open.** A `BlockUploaded` whose storage version or epoch doesn't match is held rather than matched, so a storage epoch bump mid-block strands a block exactly as the fence used to. Same symptom, different cause, untouched here.

- **The wider double-close on the transition's failure path is fixed rather than left**, because the review found it and it is three lines: the transition drops its reference to the pending block the moment the upload returns, so a failure during the replay re-opens a follower with no block rather than one it would close a second time.

## Alternative approaches

Split on: what to do about the closer, and where to fold.

- **Exempt the matching `BlockUploaded` from the fence's discard.** Built and then abandoned. It fixes the same symptom in fewer lines and needs nothing from the promotion path, but it leaves the fence carrying a rule about block indices — a record type it otherwise knows nothing about, whose justification lives in another object. Not folding a record until it is acted on reaches the same place from a rule the fence can state on its own.

- **Keep the fold on the tail and carry the verdict to the role.** Also built and abandoned. It preserves a single `admit` call site, but a held record must not be folded twice, so the follower needs one entry point that folds and one that doesn't — which is the same split, spelled as a parameter on a public method rather than kept private. Folding where the record is acted on makes the held case fall out instead of being handled.

- **Defer the fold and leave the promotion's replay alone.** This is what the change was originally scoped as, and it is unsafe: the promotion replays the inherited buffer through `applyReplicaMessage`, which checks no terms, so a higher term held in that buffer is applied and forgotten. The node leads at a superseded term and never learns, because the record that would have told it is the one it swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
