### PR TITLE
reflection and boxed math in EE-generated code are now reported per commit

### DIFF
--- a/.claude/skills/xtdb-testing/SKILL.md
+++ b/.claude/skills/xtdb-testing/SKILL.md
@@ -204,6 +204,8 @@ Budget for compilation and reporting overhead as well as the tests themselves.
   ./gradlew -q codegen-report > /dev/null 2>&1; cat build/codegen-report.txt
   ```
   **Its coverage is the coverage of the tests it runs**: silence about an emitter branch you have just added means no test reached it, not that it is clean. Exercising the new branch is a precondition of checking it, not a follow-up.
+  For ordinary Clojure outside the EE, `./gradlew reflection-check -Pns=xtdb.pgwire` compiles that namespace from source with the flag on and prints file and line. It warns about the whole transitive cone, so grep for your own file.
+  Between the two, don't add a type hint speculatively on a reviewer's say-so — check it.
 
 ## When a test fails
 

--- a/.claude/skills/xtdb-testing/SKILL.md
+++ b/.claude/skills/xtdb-testing/SKILL.md
@@ -196,9 +196,14 @@ Budget for compilation and reporting overhead as well as the tests themselves.
   The root project has no `src/main/clojure` at all, so `:compileClojure` has nothing to compile and goes green without loading a line.
   `:compileTestClojure` and `:compileTestFixturesClojure` AOT-compile every test and fixture namespace — no `--tests` filter applies — which loads everything those namespaces require, module Clojure included, so a namespace that no longer loads fails there.
   Module `main` Clojure is not AOT-compiled and nothing checks it in its own right; a test namespace requiring it is what catches it.
-- **A green run does not prove absence of reflection.**
-  The Gradle build never sets `*warn-on-reflection*` — only the dev REPL does, via `src/dev/clojure/user.clj`.
-  If reflection is the question, answer it in the REPL; don't add type hints speculatively on a reviewer's say-so.
+- **A green run does not prove absence of reflection or boxed math.**
+  `test` never sets `*warn-on-reflection*`, and `*unchecked-math*` reaches only the files that `set!` it themselves.
+  `./gradlew codegen-report` (~90s, reports and always exits 0) covers the code the expression engine generates at runtime — the per-row path, which no load-time check can see, because a template compiles cleanly whatever the form it emits compiles to.
+  **Discard its stdout and read the file** — the console copy is preceded by several thousand lines of node logs, and `build/codegen-report.txt` is the whole report including any namespace that failed to load or died part-way:
+  ```
+  ./gradlew -q codegen-report > /dev/null 2>&1; cat build/codegen-report.txt
+  ```
+  **Its coverage is the coverage of the tests it runs**: silence about an emitter branch you have just added means no test reached it, not that it is clean. Exercising the new branch is a precondition of checking it, not a follow-up.
 
 ## When a test fails
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,39 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  codegen-report:
+    name: Codegen Report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      # this job reports, it never gates - so a JVM that dies on its way to the report
+      # (OOM, timeout, a namespace that won't load) must not turn a push red either
+      - name: Report
+        run: ./gradlew -q codegen-report
+        timeout-minutes: 15
+        continue-on-error: true
+
+      - name: Publish to job summary
+        if: success() || failure()
+        run: |
+          {
+            echo '### Reflection and boxed math in EE-generated code'
+            echo ''
+            echo '```'
+            cat build/codegen-report.txt || echo 'no report produced - see the Report step'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   lang-test:
     name: Non-JVM language tests
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -970,6 +970,23 @@ tasks.register<JavaExec>("codegen-report") {
     args("-m", "xtdb.codegen-report")
 }
 
+// the dev classpath carries Clojure as source dirs rather than AOT output, so a require here
+// actually compiles; on the test classpath it would load from `.class` and warn about nothing
+tasks.register<JavaExec>("reflection-check") {
+    description = "Compiles a namespace from source with reflection warnings on: -Pns=xtdb.pgwire"
+    dependsOn(":xtdb-core:compileClojure", ":xtdb-core:compileKotlin")
+
+    classpath = sourceSets.dev.get().runtimeClasspath
+    mainClass.set("clojure.main")
+    jvmArgs(defaultJvmArgs + sixGBJvmArgs)
+
+    doFirst {
+        val ns = project.findProperty("ns")?.toString()
+            ?: error("reflection-check needs a namespace, e.g. -Pns=xtdb.pgwire")
+        args("-e", "(set! *warn-on-reflection* true) (require '$ns)")
+    }
+}
+
 tasks.register("printClasspath") {
     description = "Prints the dev classpath for clojure-lsp integration"
     doLast {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -960,6 +960,16 @@ tasks.register<JavaExec>("readBlockFile") {
         args(project.property("file") as? String ?: error("file property must be a string"))
 }
 
+tasks.register<JavaExec>("codegen-report") {
+    description = "Reports reflection and boxed-math warnings in EE-generated code"
+    dependsOn(":xtdb-core:compileClojure", ":xtdb-core:compileKotlin")
+
+    classpath = sourceSets.dev.get().runtimeClasspath
+    mainClass.set("clojure.main")
+    jvmArgs(defaultJvmArgs + sixGBJvmArgs)
+    args("-m", "xtdb.codegen-report")
+}
+
 tasks.register("printClasspath") {
     description = "Prints the dev classpath for clojure-lsp integration"
     doLast {

--- a/dev/CODING.adoc
+++ b/dev/CODING.adoc
@@ -187,7 +187,8 @@ A *resolved* Java instance-method call already carries its declared return type,
 So `(with-open [conn (.connect node db-name)] (.submitTx conn ops opts))` needs no `^Xtdb$Connection`: `.connect` resolves off a typed `node` with return type `Xtdb$Connection`, `conn` is tagged from that, and `.submitTx`/`.close` resolve off `conn`.
 +
 Where you're unsure whether an expression reflects, verify rather than pre-empting.
-The dev REPL sets `*warn-on-reflection*` (`src/dev/clojure/user.clj`); the Gradle build does not, so a green test run proves nothing either way.
+`./gradlew test` never sets `*warn-on-reflection*`, so a green run proves nothing either way.
+The dev REPL sets it (`src/dev/clojure/user.clj`), and `./gradlew codegen-report` covers the code the expression engine generates at runtime, which neither of the other two can reach.
 
 Use `.getX`, not `.x`, for Kotlin `val` properties::
 +

--- a/dev/CODING.adoc
+++ b/dev/CODING.adoc
@@ -188,7 +188,7 @@ So `(with-open [conn (.connect node db-name)] (.submitTx conn ops opts))` needs 
 +
 Where you're unsure whether an expression reflects, verify rather than pre-empting.
 `./gradlew test` never sets `*warn-on-reflection*`, so a green run proves nothing either way.
-The dev REPL sets it (`src/dev/clojure/user.clj`), and `./gradlew codegen-report` covers the code the expression engine generates at runtime, which neither of the other two can reach.
+`./gradlew reflection-check -Pns=xtdb.pgwire` compiles one namespace from source under the flag, and `./gradlew codegen-report` covers the code the expression engine generates at runtime, which no load-time check can reach.
 
 Use `.getX`, not `.x`, for Kotlin `val` properties::
 +

--- a/src/dev/clojure/xtdb/codegen_report.clj
+++ b/src/dev/clojure/xtdb/codegen_report.clj
@@ -1,0 +1,140 @@
+(ns xtdb.codegen-report
+  "Reports reflection and boxed-math warnings in the code the expression engine generates at runtime.
+
+   Runs the EE test namespaces as a code generator - the warnings come from the compiler at the
+   moment the EE `eval`s a generated form, so the tests' own verdicts are neither read nor reported.
+   Reports; never gates."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :as t]
+            [clojure.tools.namespace.find :as ns-find])
+  (:import (java.io PrintWriter StringWriter)))
+
+(def ^:private generator-ns-prefixes
+  ["xtdb.expression" "xtdb.operator" "xtdb.sql"])
+
+(def ^:private excluded-ns-prefixes
+  ["xtdb.sql.logic-test"])
+
+;; `t/test-vars` honours no JUnit tags, so nothing here inherits the exclusions `test` applies
+;; in build.gradle.kts - a var carrying one of these would run, and some of them want Docker.
+(def ^:private excluded-var-tags
+  [:integration :property :jdbc :timescale :s3 :minio :slt :docker :azure :google-cloud])
+
+(def ^:private warning-pattern
+  #"^(Reflection|Boxed math) warning, (\S+?):\d+:\d+ - (.+)$")
+
+(defn- generator-nses []
+  (->> (ns-find/find-namespaces-in-dir (io/file "src/test/clojure"))
+       (filter (fn [n]
+                 (let [nm (str n)]
+                   (and (some #(str/starts-with? nm %) generator-ns-prefixes)
+                        (not-any? #(str/starts-with? nm %) excluded-ns-prefixes)))))
+       sort))
+
+(defn- runnable-vars [ns-sym]
+  (->> (ns-publics ns-sym)
+       vals
+       (filter (comp :test meta))
+       (remove (fn [v] (some (meta v) excluded-var-tags)))
+       (sort-by (comp :name meta))))
+
+(defn- generate-code! []
+  (let [nses (generator-nses)
+        failures (atom [])]
+    (doseq [n nses]
+      (try
+        (require n)
+        (catch Throwable t
+          (swap! failures conj (format "%s failed to load: %s" n (ex-message t))))))
+
+    ;; only once loading is done: `:warn-on-boxed` also selects the unchecked arithmetic ops, so from
+    ;; here the EE's generated code wraps on overflow instead of raising ::overflow-error.
+    ;; that is why the test verdicts below are discarded, and why this can never be folded into `test`.
+    (alter-var-root #'*unchecked-math* (constantly :warn-on-boxed))
+
+    (doseq [n nses]
+      ;; into the same stream the compiler writes to, so each warning can be attributed to the
+      ;; namespace that was running - which is a repro recipe, since that one from cold recompiles
+      ;; the shape the whole run only compiles once.
+      (doto ^java.io.Writer *err*
+        (.write (str "### " n "\n"))
+        (.flush))
+
+      (binding [*out* (StringWriter.), t/*test-out* (StringWriter.)]
+        (try
+          (t/test-vars (runnable-vars n))
+          (catch Throwable t
+            (swap! failures conj (format "%s died part-way: %s" n (ex-message t)))))))
+
+    {:ns-count (count nses), :failures @failures}))
+
+(defn- parse-warnings [captured]
+  (:warnings
+   (reduce (fn [{:keys [ns-sym] :as acc} line]
+             (if (str/starts-with? line "### ")
+               (assoc acc :ns-sym (subs line 4))
+               (if-let [[_ kind loc msg] (re-matches warning-pattern line)]
+                 (update acc :warnings conj
+                         ;; a generated form has no file: the compiler reports whatever `*file*` the
+                         ;; compiling thread holds, and the EE compiles off any load context.
+                         {:generated? (= "NO_SOURCE_PATH" loc)
+                          :kind (if (= "Reflection" kind) :reflection :boxed)
+                          :message msg
+                          :ns-sym ns-sym})
+                 acc)))
+           {:ns-sym nil, :warnings []}
+           (str/split-lines captured))))
+
+(defn- report [{:keys [ns-count failures]} captured]
+  (let [warnings (parse-warnings captured)
+        {generated true, elsewhere false} (group-by :generated? warnings)
+        by-kind (group-by :kind generated)]
+
+    (with-out-str
+      (println (format "%d namespaces, %d generated warnings (%d reflection, %d boxed), %d elsewhere"
+                       ns-count (count generated)
+                       (count (:reflection by-kind)) (count (:boxed by-kind))
+                       (count elsewhere)))
+
+      ;; in the report rather than on the console, so that the file is the whole of what a run found -
+      ;; a namespace that didn't run is missing coverage, which matters as much as any warning here.
+      (when (seq failures)
+        (println)
+        (println (format "did not complete (%d)" (count failures)))
+        (doseq [failure failures]
+          (println (format "  %s" failure))))
+
+      (doseq [[title ws] [["generated - reflection" (:reflection by-kind)]
+                          ["generated - boxed math" (:boxed by-kind)]
+                          ["elsewhere - ordinary load-time compilation" elsewhere]]]
+        (println)
+        (println (format "%s (%d)" title (count ws)))
+        (doseq [[message ws] (->> ws (group-by :message) (sort-by (comp - count val)))]
+          (println (format "  %4d  %s" (count ws) message))
+          (doseq [ns-sym (sort (distinct (keep :ns-sym ws)))]
+            (println (format "          repro: %s" ns-sym))))))))
+
+(defn -main [& _]
+  (let [sw (StringWriter.)
+        result (atom nil)]
+
+    ;; roots rather than `binding`/`set!`, with the work on a plain thread so that nothing shadows them.
+    ;; clojure.main binds both flags for its own thread, and the EE compiles on threads that inherit no bindings from ours; a raw Thread conveys none either, so here every thread reads the root.
+    (alter-var-root #'*warn-on-reflection* (constantly true))
+    (alter-var-root #'*err* (constantly (PrintWriter. sw)))
+
+    (doto (Thread. #(reset! result (generate-code!)))
+      (.start)
+      (.join))
+
+    ;; to a file as well as the console: stdout also carries whatever the nodes these tests stand up
+    ;; logged, so the file is the copy anything downstream should read.
+    (let [report (report @result (str sw))
+          out-file (io/file "build" "codegen-report.txt")]
+      (print report)
+      (io/make-parents out-file)
+      (spit out-file report)))
+
+  (shutdown-agents)
+  (System/exit 0))


### PR DESCRIPTION
Part of #6041

## tl;dr

Two Gradle tasks. `codegen-report` runs the expression engine's test namespaces as a code generator and reports the reflection and boxed math in the code they cause it to emit; `reflection-check -Pns=…` compiles one namespace from source under `*warn-on-reflection*` for everything else. A per-commit CI job publishes the first one's inventory, which currently stands at 45 reflection and 63 boxed-math warnings in generated code.

## What changes

Previously nothing in the build set `*warn-on-reflection*`, and `*unchecked-math*` reached only the files that `set!` it themselves — so the code the EE compiles at runtime was checked by nothing, and a namespace clean at load could emit a form that reflects on every row.

- **`codegen-report` runs tests purely to make the EE emit code, and discards their verdicts**
  31 namespaces, about 90 seconds locally and 4m40s on a cold CI runner. Three groups on stdout: generated reflection, generated boxed math, and everything else, each message counted and carrying `repro:` lines naming a namespace that reproduces it from cold.

- **The work runs on a plain thread so that only roots need setting**
  `clojure.main` binds both flags for its own thread and the EE compiles on threads that inherit nothing from ours, so a thread-local write reaches one and a root write reaches the other. A raw `Thread` conveys no bindings either, so on one every thread reads the root and a single `alter-var-root` per flag covers everything. Setting only the thread binding loses three warnings that `xtdb.sql.expr-test` produces elsewhere.

- **`reflection-check` covers what `codegen-report` cannot**
  Requiring a namespace on the dev classpath compiles it from source, so `-Pns=xtdb.pgwire` reports `xtdb/pgwire.clj:1749:24 - call to java.util.concurrent.ThreadPoolExecutor ctor can't be resolved` with a real file and line. It warns about the whole transitive cone, so you grep for your own file.

## Usage

```
./gradlew codegen-report
./gradlew reflection-check -Pns=xtdb.pgwire
```

`codegen-report`'s console output is interleaved with the logs of the nodes its tests stand up; the same report lands clean in `build/codegen-report.txt`, which is what the CI job publishes.

## Consequences

- **`codegen-report`'s coverage is the coverage of the tests it runs**
  Silence about an emitter branch just added means no test reached it, not that it is clean. The skill says so, because that failure reads as verification.

- **`clojure.tools.namespace` reaches the dev classpath transitively, via `integrant-repl`**
  `user.clj` has relied on the same path for a long time, so this adds no new exposure — but an integrant-repl bump that drops it breaks `codegen-report` with no local signal.

## Alternative approaches

Implementation roads, one entry each; the design-level ones are on #6041.

- **Draining the capture buffer per namespace** — reasoned against once it forced a lock.
  It was how warnings got attributed, but compile threads write to that buffer concurrently, so a read-and-reset needed synchronising. A marker line written into the same stream attributes them with no shared-state problem, and the buffer is read once after the run.

- **`t/run-tests` rather than `t/test-vars`** — tried, and it ran things `./gradlew test` excludes.
  `t/run-tests` honours no JUnit tags, so `^:integration`, `^:property` and the SLT namespaces all executed. Filtering vars by tag brought the selection back in line, 35 namespaces to 31.

- **Letting `reflection-check` inherit the flag from `user.clj`** — reasoned against on the failure mode.
  The dev classpath auto-loads it and it sets the root, so the task works with nothing set. That puts the check at the mercy of a file whose job is REPL setup: losing the setting there leaves this reporting clean rather than failing.
