### PR TITLE
refactor(indexer): the leader adopts a block on reading its own upload back

### DIFF
--- a/allium/live-index.allium
+++ b/allium/live-index.allium
@@ -85,10 +85,16 @@
 --   it reflects only consumed-back txs). When the gauge crosses rows_per_block the
 --   resolver injects a BlockBoundary (in resolution order, so it lands after this
 --   block's txs and before the next block's) and PAUSES resolution — the source-log,
---   ext-source and GC select arms are EXCLUDED — until the boundary is read back and its
---   block uploaded. This pause keeps the follower's bounded pending-block buffer from
---   overflowing (no tx interleaves between the boundary and its upload). The pause is
---   deliberately the status quo; block double-buffering is separate future work (#4495).
+--   ext-source and GC select arms are EXCLUDED — until the block's own BlockUploaded is
+--   read back and the block adopted.
+--   The pause carries two obligations.
+--   It keeps the follower's bounded pending-block buffer from overflowing, no tx
+--   interleaving between the boundary and its upload.
+--   And it keeps anything from applying between FinishBlock and NextBlock, where the live
+--   tables have been written to block storage and are about to be cleared — rows applied
+--   there would be written nowhere.
+--   The pause is deliberately the status quo; block double-buffering is separate future
+--   work (#4495).
 --
 --   Two heads, two homes — callers choose:
 --     - the RESOLVED head, TxResolver.latest_completed_tx: the highest tx RESOLVED (and
@@ -936,9 +942,9 @@ rule FinishBlock {
     -- read back, resumes any resolution paused by CutBlock). Rows remain in memory
     -- until NextBlock.
     --
-    -- Because resolution paused at the boundary and stays paused until this upload,
-    -- nothing was staged-and-applied between the boundary and here — a durable L0 block
-    -- never contains rows from a later block.
+    -- Because resolution paused at the boundary and stays paused until this upload is read
+    -- back, nothing was staged-and-applied between the boundary and here — a durable L0
+    -- block never contains rows from a later block.
     when: FinishBlock(index, block_idx)
 
     -- Writes current (durable) live table contents to block storage.

--- a/allium/log-processor-lifecycle.allium
+++ b/allium/log-processor-lifecycle.allium
@@ -43,7 +43,9 @@ external entity FollowerTerm {
     -- Reading the replica log is the Listener's: one read feeds whichever role is live, a follower building state and a leader confirming its own writes alike.
     -- The position it has reached is the partition's, so a role change continues from it rather than restarting.
     replica_pos: MessageId
-    mid_block: Boolean   -- true if an old leader died before uploading its block
+
+    -- A block is in flight on this node: a boundary read but not yet confirmed, whether the block behind it is still to be produced or was produced by a term that ended before reading its own confirmation back.
+    mid_block: Boolean
 }
 
 external entity LeaderTerm {
@@ -67,6 +69,10 @@ external entity LeaderTerm {
     -- term could be admitted twice, once either side of a demote.
     term: Integer
     replay_target: MessageId
+
+    -- A block this term has produced and not yet adopted: produced in step 4, adopted on reading a confirmation of it back, which is after step 5 published this term.
+    -- A term ending in between hands it to the role that replaces it (DemoteLeader).
+    mid_block: Boolean
 }
 
 external entity RecordProcessor {
@@ -342,23 +348,22 @@ rule TransitionToLeader {
         -- Either above this transition's term refuses the claim, as step 2a does, and takes the same failure path.
         ClaimStillUnfenced(follower_term: listener.follower_term, term: term)
 
-        -- Step 4: finish any dangling block.
-        -- If the follower was mid-block (an old leader died before uploading it), the incoming leader uploads the block and then replays the records the follower was holding, with leader-upload semantics.
+        -- Step 4: produce any dangling block.
+        -- If the follower was mid-block (an old leader died before uploading it, or a term on this node produced it and never read it back), the incoming leader uploads the block's files and appends its confirmation under its own term.
         -- Requires the follower stopped (step 3) so it cannot double-process.
+        -- The block stays in flight: this term adopts it, and replays the records the follower was holding, on reading a confirmation of it back — which is after step 5, the Listener's read being what delivers it to the term. db.allium owns the adopt (LeaderAdoptsOwnBlock).
+        -- That confirmation is this term's own, or the outgoing leader's where that term got one away before it ended: both confirm the same block, and the adopt takes whichever arrives first.
+        -- So the block is carried into the leader term below, and a term that ends before adopting it hands it on again (DemoteLeader, RecoverFollowerOnTransitionCancelled).
+        --   A block produced and not adopted MUST reach the role that replaces this one: the adopt is what moves this node's catalog past the block, so the confirmation does not read as stale, and a role holding no block to match it against stops the partition's read.
         if listener.follower_term.mid_block:
-            DanglingBlockUploaded(follower_term: listener.follower_term)
-
-            -- The block is finished on this node once the upload lands, so the transition stops carrying it here, between the upload and the replay.
-            -- The failure path below re-opens a follower from what the transition is carrying, and one still holding this block would match the upload just appended and finish the same block a second time.
-            listener.follower_term.mid_block = false
-
-            HeldRecordsReplayed(follower_term: listener.follower_term)
+            DanglingBlockProduced(follower_term: listener.follower_term)
 
         -- Step 5: build the leader term, carrying the fencing term, and publish it as the role.
         -- Replica records reach it from the Listener's read, continuing from where the follower left off.
         listener.leader_term = LeaderTerm.created(
             term: term,
-            replay_target: target
+            replay_target: target,
+            mid_block: listener.follower_term.mid_block
         )
         listener.follower_term = null
         listener.state = leading
@@ -392,9 +397,11 @@ rule DemoteLeader {
         -- Re-open a follower seeded from the leader's replica position (the durable
         -- live index is untouched; see live-index.allium). RHS reads the pre-rule
         -- leader_term, captured before the field is cleared.
+        -- A block the term produced and did not adopt goes with it, so the follower closes it on a confirmation of that block, whichever term wrote it.
+        -- It is read once the term is joined, as step 4 reads the follower's: the term goes on applying records until then, and one of them may be that confirmation.
         listener.follower_term = FollowerTerm.created(
             replica_pos: listener.leader_term.replay_target,
-            mid_block: false
+            mid_block: listener.leader_term.mid_block
         )
         listener.leader_term = null
         listener.state = following
@@ -434,8 +441,7 @@ rule RecoverFollowerOnTransitionCancelled {
     ensures:
         -- Re-open a live follower seeded from the (now stale) follower position, so
         -- the role is backed by a live replica consumer again. It carries the dangling block
-        -- forward while that block is still unfinished — up to step 4's upload and not past it,
-        -- which is what step 4 clears the flag between the upload and the replay for.
+        -- forward, step 4's produce having run or not: either way the block is in flight and this node's catalog has not moved past it, so the re-opened follower is what closes it.
         listener.follower_term = FollowerTerm.created(
             replica_pos: listener.follower_term.replica_pos,
             mid_block: listener.follower_term.mid_block

--- a/core/src/main/kotlin/xtdb/api/log/Watchers.kt
+++ b/core/src/main/kotlin/xtdb/api/log/Watchers.kt
@@ -81,8 +81,8 @@ class Watchers(
 
         state.updateIfActive {
             if (txId != null) check(txId > it.latestTxId) { "txId $txId <= latestTxId ${it.latestTxId}" }
-            // >= not >: BlockBoundary can carry the same source msgId as the preceding ResolvedTx
-            // when the block was triggered by isFull() (no FlushBlock in between)
+            // >= not >: the BlockUploaded closing a block can carry the same source msgId as the
+            // preceding ResolvedTx, when the block was cut by the row gauge with no FlushBlock in between
             if (srcMsgId != null) check(srcMsgId >= it.latestSourceMsgId) {
                 "srcMsgId $srcMsgId < latestSourceMsgId ${it.latestSourceMsgId}"
             }

--- a/core/src/main/kotlin/xtdb/indexer/BlockCutter.kt
+++ b/core/src/main/kotlin/xtdb/indexer/BlockCutter.kt
@@ -13,6 +13,7 @@ import xtdb.api.log.ReplicaMessage.BlockUploaded
 import xtdb.api.log.SourceMessage
 import xtdb.api.storage.Storage
 import xtdb.api.tx.ExternalSourceToken
+import xtdb.block.proto.Block
 import xtdb.catalog.TableCatalog
 import xtdb.compactor.Compactor
 import xtdb.database.Database
@@ -32,13 +33,16 @@ private val LOG = BlockCutter::class.logger
 private const val MAX_CONCURRENT_BLOCK_UPLOADS = 16
 
 /**
- * Where a leader term is in the block it is filling: [Filling] → [Cut] → [Uploading] → [Filling].
+ * Where a leader term is in the block it is filling: [Filling] → [Cut] → [Uploading] → [Filling], the
+ * last step driven by reading our own `BlockUploaded` back rather than by finishing the upload.
  *
  * Resolution is armed only in [Filling] — see [acceptingResolution] — so no tx can interleave between a
- * boundary and its upload, which is what keeps the follower's bounded pending-block buffer empty.
+ * boundary and its upload. That is what keeps the follower's bounded pending-block buffer empty, and now
+ * also what keeps anything from applying inside [Uploading], where the live index holds a block already
+ * snapshotted into L0.
  *
- * The term's coroutine is both the sole writer and the sole reader, so nothing here is published across
- * coroutines.
+ * The term's coroutine is the sole writer and, [pendingBlock] apart, the sole reader; a demotion reads
+ * that one only after joining the term, which is the edge that publishes it.
  */
 internal class BlockCutter(
     partitionStorage: PartitionStorage,
@@ -92,10 +96,36 @@ internal class BlockCutter(
     /** The boundary is queued for append, and has not been read back yet. */
     private data object Cut : BlockState
 
-    /** The boundary has been applied and the upload is in flight. */
-    private data object Uploading : BlockState
+    /**
+     * The block's files are in storage and its `BlockUploaded` is appended, but this node has not read
+     * that message back — so its catalog and live index are still on the block.
+     *
+     * Everything [closeBlock] needs is here, because the produce step is the only thing that can compute
+     * it and the close runs a whole log round-trip later.
+     */
+    private class Uploading(
+        val pendingBlock: PendingBlock, val block: Block, val addedTries: List<TrieDetails>,
+    ) : BlockState
 
     private var blockState: BlockState = Filling(liveIndex.blockRowCount)
+
+    /**
+     * The block this term has produced and is waiting to read back, holding whatever arrived behind its
+     * boundary — null unless an upload is in flight.
+     *
+     * A demotion hands this to the next follower, which then closes the block on the same message this
+     * term was waiting for. Without the handover the block would be left open on a node with nothing to
+     * close it: the upload is not stale, because [closeBlock] is what moves the catalog past it, so it
+     * would reach the follower's `processRecord` with no block to match and stop the partition's tail.
+     */
+    val pendingBlock get() = (blockState as? Uploading)?.pendingBlock
+
+    /** Whether [msg] is the upload this term is waiting for — the follower's test, applied to our own write. */
+    fun closes(msg: BlockUploaded) =
+        (blockState as? Uploading)?.pendingBlock?.let {
+            msg.blockIndex == it.blockIdx
+                    && msg.storageVersion == Storage.VERSION && msg.storageEpoch == bufferPool.epoch
+        } == true
 
     // From the live index, not the node config: the two agree in production, but they are one value and the
     // live index is what owns the block being filled.
@@ -125,7 +155,7 @@ internal class BlockCutter(
 
             // Only reachable from clauses the term arms in Filling alone, so getting here means the
             // arm-set and this state have come apart.
-            Cut, Uploading -> error("[$dbName] tx resolved during a block cut")
+            Cut, is Uploading -> error("[$dbName] tx resolved during a block cut")
         }
     }
 
@@ -152,19 +182,62 @@ internal class BlockCutter(
     }
 
     /**
-     * Close the block that [boundary] cut, read back at [boundaryMsgId], and re-arm resolution behind it.
+     * Produce the block that [pendingBlock]'s boundary cut: snapshot the live index into block files and
+     * append the matching `BlockUploaded`.
      *
-     * The live index holds exactly this block's txs by now, in log order, so this snapshots it into block
-     * files, queues the matching `BlockUploaded` and rolls the index.
+     * The live index holds exactly this block's txs by now, in log order — which is what the block-cut
+     * pause buys. What this does *not* do is adopt the result: the catalog refresh and the index roll
+     * wait for [closeBlock], on reading that message back.
+     *
+     * Deferring them is what leaves a term dying here recoverable. Its catalog has not moved past the
+     * block, so the next leader can produce it again — where `TableCatalog.buildBlock` refuses a second
+     * attempt at an index the catalog already holds.
      */
-    suspend fun upload(boundaryMsgId: MessageId, boundary: BlockBoundary) {
-        blockState = Uploading
-        uploadBlock(boundaryMsgId, boundary)
-        // Straight after the upload, so a demote landing here hands on nothing: the block is done.
-        blockState = Filling(0)
+    suspend fun upload(pendingBlock: PendingBlock) {
+        blockState = uploadBlock(pendingBlock)
     }
 
-    private suspend fun uploadBlock(boundaryReplicaMsgId: MessageId, boundary: BlockBoundary) {
+    /**
+     * Adopt the block [msg] confirms, re-open the one behind it, and hand back what was held meanwhile.
+     *
+     * The caller applies those held records only after this returns. They belong to the block opening
+     * here, and a tx applied between `finishBlock` and `nextBlock` would land in live tables already
+     * snapshotted into L0 and about to be cleared — so the rows would be written nowhere.
+     */
+    fun closeBlock(msg: BlockUploaded): PendingBlock {
+        val uploading = blockState as? Uploading
+            ?: error("[$dbName] BlockUploaded b${msg.blockIndex.asLexHex} arrived with no block in flight")
+
+        tableCatalog.refresh(uploading.block)
+        liveIndex.nextBlock()
+
+        // Publish L0 tries to the source log so that all nodes — including multi-writer nodes running
+        // concurrently with a single-writer leader — see the L0 before any compaction L1C on the source
+        // log (see #5395). Once we drop support for multi-writer clusters running concurrently with
+        // single-writer, this source-log post is no longer required and can be removed.
+        //
+        // Both off the persister coroutine, in one launch: this runs on the source log's sole consumer, so
+        // appending inline self-deadlocks when the source-log buffer saturates at a block boundary — the
+        // consumer would wait on room only it can make. The launch lets the close return so the persister
+        // drains and the append's emit finds room; running signalBlock after it in the same coroutine keeps
+        // compaction's L1C strictly behind the L0 without a separate join.
+        scope.launch {
+            sourceLog.appendMessage(
+                SourceMessage.TriesAdded(Storage.VERSION, bufferPool.epoch, uploading.addedTries)
+            )
+            compactor.signalBlock()
+        }
+
+        blockState = Filling(0)
+
+        LOG.debug("finished block: 'b${msg.blockIndex.asLexHex}'.")
+
+        return uploading.pendingBlock
+    }
+
+    private suspend fun uploadBlock(pendingBlock: PendingBlock): Uploading {
+        val boundary = pendingBlock.boundaryMessage
+        val boundaryReplicaMsgId = pendingBlock.boundaryMsgId
         val latestProcessedMsgId = boundary.latestProcessedMsgId
         val blockIdx = boundary.blockIndex
         LOG.debug("finishing block: 'b${blockIdx.asLexHex}'...")
@@ -220,13 +293,12 @@ internal class BlockCutter(
         )
 
         bufferPool.putObject(TableCatalog.blockFilePath(blockIdx), ByteBuffer.wrap(block.toByteArray()))
-        tableCatalog.refresh(block)
         lastUploadEpochSeconds.set(Instant.now().epochSecond)
 
-        // Awaited, and not through the append pump: every follower is buffering behind the boundary until
-        // this lands, and `nextBlock` below commits this node to the block. Queued instead, a term ending
-        // in between would drop it — leaving this node past the block with nothing on the log to release
-        // the followers, and unable to re-cut it because its own catalog has moved on.
+        // Awaited, and not through the append pump: this is the message the whole cluster is waiting on
+        // to close the block, this node now included. Queued, a term ending in between would drop it —
+        // the pump's shutdown discards whatever it still holds. Awaited, a failure to append reaches the
+        // term instead, which leaves the boundary unapplied for the next role to pick up and re-produce.
         val uploadedMsgId = logsDriver.appendToReplica(
             BlockUploaded(
                 Storage.VERSION, bufferPool.epoch,
@@ -241,22 +313,7 @@ internal class BlockCutter(
         LOG.debug("block uploaded b${blockIdx.asLexHex}: source=$latestProcessedMsgId, replica=$uploadedMsgId")
 
         blockUploadTimer?.let { timer?.stop(it) }
-        liveIndex.nextBlock()
 
-        // Publish L0 tries to the source log so that all nodes — including multi-writer nodes running
-        // concurrently with a single-writer leader — see the L0 before any compaction L1C on the source
-        // log (see #5395). Once we drop support for multi-writer clusters running concurrently with
-        // single-writer, this source-log post is no longer required and can be removed.
-        //
-        // Both off the persister coroutine, in one launch: this runs on the source log's sole consumer, so
-        // appending inline self-deadlocks when the source-log buffer saturates at a block boundary — the
-        // consumer would wait on room only it can make. The launch lets the upload return so the persister
-        // drains and the append's emit finds room; running signalBlock after it in the same coroutine keeps
-        // compaction's L1C strictly behind the L0 without a separate join.
-        scope.launch {
-            sourceLog.appendMessage(SourceMessage.TriesAdded(Storage.VERSION, bufferPool.epoch, addedTries))
-            compactor.signalBlock()
-        }
-        LOG.debug("finished block: 'b${blockIdx.asLexHex}'.")
+        return Uploading(pendingBlock, block, addedTries)
     }
 }

--- a/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/FollowerLogProcessor.kt
@@ -167,7 +167,6 @@ class FollowerLogProcessor @JvmOverloads constructor(
             is ReplicaMessage.BlockBoundary -> blockBoundaryTimer.timed {
                 pendingBlock = PendingBlock(record.msgId, msg, maxBufferedRecords)
                 LOG.debug("[$dbName] block boundary b${msg.blockIndex.asLexHex}: source=${msg.latestProcessedMsgId}, replica=${record.msgId} — waiting for BlockUploaded...")
-                watchers.notifyApplied(msg.latestProcessedMsgId)
                 blockBufferStartSample = meterRegistry?.let { Timer.start(it) }
             }
 
@@ -228,6 +227,10 @@ class FollowerLogProcessor @JvmOverloads constructor(
             tableCatalog.refresh(block, liveIndex.blockMetadata())
             liveIndex.nextBlock()
             compactor.signalBlock()
+
+            // Ahead of the drain below, whose records carry later source positions — behind it, this one
+            // would go backwards and trip the watchers' monotonicity check.
+            watchers.notifyApplied(msg.latestProcessedMsgId)
 
             val bufferedRecords = pending.bufferedRecords
             bufferedRecordsSummary?.record(bufferedRecords.size.toDouble())

--- a/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LeaderLogProcessor.kt
@@ -24,6 +24,7 @@ import xtdb.database.Database
 import xtdb.database.PartitionState
 import xtdb.database.PartitionStorage
 import xtdb.types.MessageId
+import xtdb.util.StringUtil.asLexHex
 import xtdb.util.debug
 import xtdb.util.error
 import xtdb.util.info
@@ -101,6 +102,14 @@ internal class LeaderLogProcessor(
             )
         }
 
+    /**
+     * The block this term has produced and not yet read back, if any.
+     *
+     * A demotion hands it to the next follower — see [BlockCutter.pendingBlock] for what goes wrong
+     * without that.
+     */
+    val pendingBlock get() = blockCutter.pendingBlock
+
     private fun applyResolvedTx(msg: ReplicaMessage.ResolvedTx) {
         val txKey = TransactionKey(msg.txId, msg.systemTime)
 
@@ -169,6 +178,18 @@ internal class LeaderLogProcessor(
         if (msgTermId > leaderTerm)
             throw LeaderSupersededException("[$dbName] superseded: read term $msgTermId > our term $leaderTerm at ${record.msgId}")
 
+        // Ahead of the fence, as the follower does: a record held behind an open block has not been acted
+        // on, so folding it here would move the high-water past the term that cut the boundary — and the
+        // upload closing the block, written by that same term, would then be fenced away.
+        blockCutter.pendingBlock?.let { pending ->
+            val msg = record.message
+
+            if (msg is ReplicaMessage.BlockUploaded && blockCutter.closes(msg)) closeBlock(msg)
+            else pending += record
+
+            return
+        }
+
         // Our own claim folded before this term opened, so the fence's high-water is
         // our term and anything it refuses is below ours — which shouldn't appear
         // past our replay target anyway. The fold has to happen here whatever the
@@ -196,19 +217,23 @@ internal class LeaderLogProcessor(
                 is ReplicaMessage.TriesAdded -> watchers.notifyApplied(msg.sourceMsgId)
 
                 is BlockBoundary -> {
-                    blockCutter.upload(record.msgId, msg)
-
-                    // the block's covered source position, as the follower does
-                    watchers.notifyApplied(msg.latestProcessedMsgId)
-
-                    gc.signal()
-
-                    srcLogProc.blockUploaded()
+                    // Produce only: the catalog refresh, the index roll, the source watermark and the
+                    // resolution resume all wait for the `BlockUploaded` this appends to come back — see
+                    // [closeBlock].
+                    blockCutter.upload(PendingBlock(record.msgId, msg))
                 }
 
-                // Our own BlockUploaded, read back after uploadBlock already rolled the index — nothing to do
-                // but advance the watermark.
-                is ReplicaMessage.BlockUploaded -> watchers.notifyApplied(msg.latestProcessedMsgId)
+                // Two terms can produce one block index: a promoting follower still holding the boundary
+                // produces that block itself, and `closes` matches on index, version and epoch rather
+                // than on term, so a role adopts on whichever upload reaches it first and the loser
+                // arrives here. Stale by the test every other reader applies — only an index the catalog
+                // has not reached is left unexplained.
+                is ReplicaMessage.BlockUploaded ->
+                    if (msg.blockIndex > (tableCatalog.currentBlockIndex ?: -1))
+                        error(
+                            "[$dbName] BlockUploaded b${msg.blockIndex.asLexHex} at ${record.msgId} " +
+                                    "with no block in flight"
+                        )
 
                 is ReplicaMessage.NoOp -> watchers.notifyApplied(msg.srcMsgId)
 
@@ -216,6 +241,25 @@ internal class LeaderLogProcessor(
                 is ReplicaMessage.TriesDeleted -> {}
             }
         }
+    }
+
+    /**
+     * Adopt the block our own upload confirms, then apply what its boundary was holding back.
+     *
+     * The drain goes back through [applyReplicaMessage] rather than applying the records directly, so a
+     * boundary among them opens the next block there and the records behind it are held again instead of
+     * being applied into a block already snapshotted.
+     */
+    private suspend fun closeBlock(msg: ReplicaMessage.BlockUploaded) {
+        val pending = blockCutter.closeBlock(msg)
+
+        watchers.notifyApplied(msg.latestProcessedMsgId)
+
+        gc.signal()
+
+        srcLogProc.blockUploaded()
+
+        pending.bufferedRecords.forEach { applyReplicaMessage(it) }
     }
 
     // ---- resolution ----

--- a/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
+++ b/core/src/main/kotlin/xtdb/indexer/LogProcessor.kt
@@ -354,19 +354,15 @@ class LogProcessor(
                     )
 
                     pendingBlock?.let { pending ->
-                        LOG.debug("[${dbName}] transition: finishing pending block b${pending.blockIdx} with ${pending.bufferedRecords.size} held records")
+                        LOG.debug("[${dbName}] transition: producing pending block b${pending.blockIdx} with ${pending.bufferedRecords.size} held records")
 
-                        // Through the cutter, not the uploader: closing a block is what resets the row
-                        // gauge, and this block was cut before the gauge was seeded from a live index that
-                        // still held it.
-                        blockCutter.upload(pending.boundaryMsgId, pending.boundaryMessage)
-
-                        // The block is closed on this node from here — catalog refreshed, live index
-                        // rolled — so a failure below must not hand it to a re-opened follower, which
-                        // would match the upload we have just appended and close it a second time.
-                        pendingBlock = null
-
-                        proc.replayHeldRecords(pending)
+                        // Produced here, but closed — and its held records applied — only once the term
+                        // below reads this upload back. So the block stays held throughout, and a failure
+                        // in between hands it to a re-opened follower that closes it on the same message.
+                        // The held records cannot apply any earlier than that: their rows belong to the
+                        // block this one is about to open, and the live index has already snapshotted the
+                        // one it is still on.
+                        blockCutter.upload(pending)
                     }
 
                     val resumeAfterMsgId = watchers.latestSourceMsgId
@@ -427,15 +423,6 @@ class LogProcessor(
         }
     }
 
-    /** Fold and apply what the follower was holding behind its block, in the order the log had it. */
-    private suspend fun LeaderLogProcessor.replayHeldRecords(pendingBlock: PendingBlock) {
-        LOG.debug("[${dbName}] transition: replaying ${pendingBlock.bufferedRecords.size} held records")
-
-        pendingBlock.bufferedRecords.forEach { held ->
-            if (termFence.admit(held.message.termId)) applyReplicaMessage(held)
-        }
-    }
-
     override suspend fun demoteLeader(partition: Int) {
         val leader = when (val s = state) {
             is Following -> {
@@ -448,8 +435,13 @@ class LogProcessor(
 
         LOG.info("[$dbName] demote — tearing down leader, re-opening follower")
         leader.job.cancelAndJoin()
+
+        // After the join, as the promotion reads the follower's: the term applies until then, and one of
+        // those applies may be the adopt that closes this block.
+        val pendingBlock = leader.proc.pendingBlock
+
         leader.proc.close()
-        state = openFollower()
+        state = openFollower(pendingBlock)
     }
 
     override fun close() = state.close()

--- a/core/src/test/kotlin/xtdb/indexer/BlockCutterTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/BlockCutterTest.kt
@@ -79,7 +79,7 @@ internal class BlockCutterTest {
         private val ioDispatcher: CoroutineDispatcher,
     ) : AutoCloseable {
         private val bufferPool = MemoryStorage(allocator, epoch = 0)
-        private val tableCatalog = TableCatalog(bufferPool)
+        val tableCatalog = TableCatalog(bufferPool)
         private val trieCatalog = createTrieCatalog()
 
         val liveIndex = LiveIndex.open(
@@ -163,7 +163,7 @@ internal class BlockCutterTest {
         assertEquals(7, boundary.latestProcessedMsgId)
         assertArrayEquals(token, boundary.externalSourceToken)
 
-        cutter.upload(boundaryMsgId = 0, boundary = boundary)
+        cutter.upload(PendingBlock(boundaryMsgId = 0, boundaryMessage = boundary))
         runCurrent()
 
         val uploaded = assertInstanceOf(BlockUploaded::class.java, term.appended.last())
@@ -178,7 +178,7 @@ internal class BlockCutterTest {
     }
 
     @Test
-    fun `nothing resolves between a cut and its upload`() = runTest {
+    fun `nothing resolves between a cut and the upload reading back`() = runTest {
         val term = term()
         val cutter = term.cutter(backgroundScope)
 
@@ -187,11 +187,46 @@ internal class BlockCutterTest {
         cutter.cut(latestProcessedMsgId = 0, extToken = null)
         runCurrent()
 
-        assertFalse(cutter.acceptingResolution, "resolution is refused for the length of the cut")
+        assertFalse(cutter.acceptingResolution, "resolution is refused from the cut")
         assertThrows<IllegalStateException> { cutter.addRows(1) }
 
-        cutter.upload(0, term.appended.single() as BlockBoundary)
-        assertTrue(cutter.acceptingResolution, "the upload re-opens the block behind it")
+        cutter.upload(PendingBlock(0, term.appended.single() as BlockBoundary))
+        runCurrent()
+
+        assertFalse(
+            cutter.acceptingResolution,
+            "and still refused once produced: the live index is holding a block already snapshotted into L0"
+        )
+        assertThrows<IllegalStateException> { cutter.addRows(1) }
+
+        cutter.closeBlock(term.appended.last() as BlockUploaded)
+        assertTrue(cutter.acceptingResolution, "the read-back re-opens the block behind it")
+    }
+
+    @Test
+    fun `the catalog and the live index move on the read-back, not on the upload`() = runTest {
+        val term = term()
+        val cutter = term.cutter(backgroundScope)
+
+        term.applyRows(txId = 0, rows = 1)
+        assertEquals(2, term.liveIndex.blockRowCount, "the put, and the tx's own row in the txs table")
+
+        cutter.cut(latestProcessedMsgId = 0, extToken = null)
+        runCurrent()
+        cutter.upload(PendingBlock(0, term.appended.single() as BlockBoundary))
+        runCurrent()
+
+        assertNull(
+            term.tableCatalog.currentBlockIndex,
+            "the block file has landed, but this node hasn't adopted it — so the block stays re-producible"
+        )
+        assertEquals(2, term.liveIndex.blockRowCount, "and the rows are still the open block's")
+
+        val held = cutter.closeBlock(term.appended.last() as BlockUploaded)
+
+        assertEquals(0, term.tableCatalog.currentBlockIndex)
+        assertEquals(0, term.liveIndex.blockRowCount)
+        assertTrue(held.bufferedRecords.isEmpty(), "a block this term cut itself holds nothing back")
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/FollowerLogProcessorTest.kt
@@ -79,10 +79,11 @@ class FollowerLogProcessorTest {
         maxBufferedRecords: Int = 1024,
         hasExternalSource: Boolean = false,
         meterRegistry: MeterRegistry? = null,
+        pendingBlock: PendingBlock? = null,
     ) =
         FollowerLogProcessor(
             allocator, bufferPool, partitionState, dbName, compactor,
-            watchers, null, null, termFence,
+            watchers, null, pendingBlock, termFence,
             hasExternalSource = hasExternalSource,
             meterRegistry = meterRegistry,
             maxBufferedRecords = maxBufferedRecords,
@@ -128,6 +129,27 @@ class FollowerLogProcessorTest {
             verify(exactly = 0) { liveIndex.commitTx(match { it.txId == superseded.txId }, any()) }
             assertEquals(claimant, termFence.highestSeen, "the drain folded what it was holding")
         }
+
+    @Test
+    fun `a block inherited from the role before it closes on that role's own upload`() = runTest {
+        every { bufferPool.getByteArray(TableCatalog.blockFilePath(0)) } returns
+                block { blockIndex = 0 }.toByteArray()
+
+        val inherited = PendingBlock(0, ReplicaMessage.BlockBoundary(0, 0, termId = TERM))
+        inherited += record(
+            1, ReplicaMessage.ResolvedTx(3, Instant.now(), true, null, emptyMap(), srcMsgId = 2, termId = TERM)
+        )
+
+        val proc = makeProcessor(pendingBlock = inherited)
+
+        proc.handleRecord(
+            record(2, ReplicaMessage.BlockUploaded(Storage.VERSION, 1, 0, 0, emptyList(), termId = TERM))
+        )
+
+        assertNull(proc.pendingBlock)
+        assertEquals(0L, tableCatalog.currentBlockIndex, "the inherited block closed on the upload it was waiting for")
+        assertEquals(3L, watchers.latestTxId, "and the record it was holding applied behind it")
+    }
 
     @Test
     fun `ResolvedTx skips already-applied transactions`() = runTest {

--- a/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderLogProcessorTest.kt
@@ -21,6 +21,7 @@ import xtdb.api.log.Log
 import xtdb.api.log.ReplicaMessage
 import xtdb.api.log.SourceMessage
 import xtdb.api.log.Watchers
+import xtdb.api.storage.Storage
 import xtdb.database.Database
 import java.time.Instant
 import java.time.InstantSource
@@ -130,6 +131,59 @@ internal class LeaderLogProcessorTest : LeaderTermTest() {
         )
 
         assertEquals(-1L, watchers.latestSourceMsgId)
+    }
+
+    private fun record(msgId: Long, msg: ReplicaMessage) = Log.Record(0, msgId, Instant.now(), msg)
+
+    private fun uploaded(blockIdx: Long, latestProcessedMsgId: Long) =
+        ReplicaMessage.BlockUploaded(
+            Storage.VERSION, 0, blockIdx, latestProcessedMsgId, emptyList(), termId = 1
+        )
+
+    @Test
+    fun `a block is held from its boundary until its own upload reads back`() = runTest(timeout = 5.seconds) {
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+        val (proc, _, partitionState) = unstartedTerm(watchers)
+
+        proc.applyReplicaMessage(record(0, ReplicaMessage.BlockBoundary(0, 5, termId = 1)))
+
+        assertNotNull(
+            proc.pendingBlock,
+            "the block file has landed and the upload is appended, but this node has not adopted it"
+        )
+        assertNull(
+            partitionState.tableCatalog.currentBlockIndex,
+            "so the catalog has not moved past the block, which is what keeps it re-producible"
+        )
+
+        proc.applyReplicaMessage(record(1, uploaded(blockIdx = 0, latestProcessedMsgId = 5)))
+
+        assertNull(proc.pendingBlock)
+        assertEquals(0L, partitionState.tableCatalog.currentBlockIndex)
+    }
+
+    @Test
+    fun `a record arriving behind an open block applies once the block closes`() = runTest(timeout = 5.seconds) {
+        val watchers = Watchers(latestTxId = -1, latestSourceMsgId = -1)
+        val (proc, _, _) = unstartedTerm(watchers)
+
+        proc.applyReplicaMessage(record(0, ReplicaMessage.BlockBoundary(0, 5, termId = 1)))
+
+        proc.applyReplicaMessage(
+            record(
+                1,
+                ReplicaMessage.ResolvedTx(7, Instant.now(), true, null, emptyMap(), srcMsgId = 6, termId = 1)
+            )
+        )
+
+        assertEquals(
+            -1L, watchers.latestTxId,
+            "held: its rows belong to the block opening behind this one, and the live index is still on the one already snapshotted"
+        )
+
+        proc.applyReplicaMessage(record(2, uploaded(blockIdx = 0, latestProcessedMsgId = 5)))
+
+        assertEquals(7L, watchers.latestTxId, "and applied on the drain, behind the close")
     }
 
     @Test

--- a/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LeaderTermTest.kt
@@ -224,8 +224,10 @@ internal abstract class LeaderTermTest {
             flushTimeout = IndexerConfig().flushDuration,
         )
         leadersToClose += proc
-        return UnstartedTerm(proc, appender)
+        return UnstartedTerm(proc, appender, partitionState)
     }
 
-    protected data class UnstartedTerm(val proc: LeaderLogProcessor, val appender: ReplicaLogAppender)
+    protected data class UnstartedTerm(
+        val proc: LeaderLogProcessor, val appender: ReplicaLogAppender, val partitionState: PartitionState,
+    )
 }

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorSimTest.kt
@@ -275,7 +275,9 @@ class LogProcessorSimTest : SimulationTestBase() {
 
     private fun assertBlockBoundariesMatchUploads(replicaMessages: List<ReplicaMessage>) {
         val boundaries = replicaMessages.filterIsInstance<ReplicaMessage.BlockBoundary>().map { it.blockIndex }
-        val uploads = replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>().map { it.blockIndex }
+        // Distinct because one boundary can be produced by two terms, so an index can be uploaded twice.
+        val uploads =
+            replicaMessages.filterIsInstance<ReplicaMessage.BlockUploaded>().map { it.blockIndex }.distinct()
         assertEquals(boundaries, uploads, "every BlockBoundary should have a matching BlockUploaded")
         assertEquals(
             boundaries.indices.map { it.toLong() }, boundaries,

--- a/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
+++ b/core/src/test/kotlin/xtdb/indexer/LogProcessorTest.kt
@@ -419,11 +419,14 @@ class LogProcessorTest {
         val incoming = LeaderTerm.of(0, 5)
         logProc.transitionToLeader(0, incoming).await()
 
+        // Ahead of the assertion below: the held tx applies behind the adopt, so this is what says the
+        // adopt has happened.
+        watchers.awaitTx(1)
+
         assertEquals(
             0L, partitionState.tableCatalog.currentBlockIndex,
             "the incoming leader finished the block its predecessor left open"
         )
-        watchers.awaitTx(1)
         assertEquals(
             incoming, logProc.termFence.highestSeen,
             "the held records folded on replay, up to this leader's own claim"

--- a/dev/doc/block-gc.allium
+++ b/dev/doc/block-gc.allium
@@ -133,16 +133,14 @@ rule LeaderClosesBlockGc {
 --                          the `enabled` gate.
 
 rule LeaderFinishBlockSignalsBlockGc {
-    -- Auto-poke from the leader once a block upload completes. Bursts of block
+    -- Auto-poke from the leader once it has adopted a block. Bursts of block
     -- finishes coalesce because the signal channel is conflated.
-    -- See: LeaderLogProcessor.applyRecord (the BlockBoundary arm,
-    -- `blockGc.signal()`).
+    -- See: LeaderLogProcessor.closeBlock (`gc.signal()`).
     --
     -- The `enabled` gate lives inside the loop's `select` — `signal()` always
     -- enqueues, but the loop only listens to the signal channel when enabled.
     --
-    -- Chains from db.allium's LeaderUploadsBlockOnBoundary, i.e. once the upload
-    -- has completed — not when the boundary was cut.
+    -- Chains from db.allium's LeaderAdoptsOwnBlock, i.e. once the leader has read its own upload back and moved onto the next block — not when the boundary was cut.
     when: BlockGcSignalled()
     requires: block_gc.enabled
     requires: block_gc.is_running

--- a/dev/doc/db.allium
+++ b/dev/doc/db.allium
@@ -180,6 +180,11 @@ entity LogProcessor {
     --   Seeded from the persisted block boundary (table_catalog.boundary_term_id) so it survives restart.
     --   Scoped to the partition for its whole life rather than to a role — log-processor-lifecycle.allium's LeaderTerm carries why.
     --
+    -- pending_block: the block cut and not yet adopted, holding whatever arrived behind its boundary — absent unless one is in flight.
+    --   Whichever role is live holds it: a follower that read the boundary, or a leader that produced the block and is waiting to read its own confirmation back.
+    --   A block produced and not adopted MUST be handed to the role that replaces the one holding it (see TransitionToLeader, TransitionToFollower).
+    --   The adopt is what moves this node's catalog past the block, so the confirmation does not read as stale; dropped, it reaches a role with no block to match and stops the partition's tail.
+    --
     -- Transitions are driven by the transport's group subscription:
     --   transitionToLeader → TransitionToLeader (off the serialization point)
     --   demoteLeader       → TransitionToFollower (at the serialization point)
@@ -189,6 +194,7 @@ entity LogProcessor {
     mode: Leader | Follower
     latest_replica_msg_id: MessageId
     max_leader_term: Integer
+    pending_block: PendingBlock?
 }
 
 variant Leader : LogProcessor {
@@ -198,9 +204,9 @@ variant Leader : LogProcessor {
     -- and block garbage collectors.
     -- See: indexer/LeaderLogProcessor.kt, indexer/BlockCutter.kt
     --
-    -- A promotion's pending block is finished through this processor, before it reads its first source message.
+    -- A promotion's pending block is produced through this processor, before it reads its first source message, and adopted once this processor reads an upload of it back.
     --   - The boundary the outgoing leader cut is uploaded under the INCOMING term — see BlockCutter.
-    --   - The block is released once the upload returns, and the records the follower was holding replay behind it: each folds at its own position in the log and is applied where the fence admits it.
+    --   - The records the follower was holding drain at the adopt: each folds at its own position in the log and is applied where the fence admits it.
     --
     -- external_source is present iff the database has one configured; it makes this
     -- leader external-source-fed rather than client-driven (see the header).
@@ -212,8 +218,8 @@ variant Leader : LogProcessor {
     leader_term: Integer
 
     -- RESOLVE-side source watermark: the source-log position as of the last-resolved tx.
-    -- Stamped onto each replica record. Leads watchers.latest_source_msg_id, which only
-    -- advances on apply — see the header.
+    -- Stamped onto each replica record. Leads watchers.latest_source_msg_id, which advances only
+    -- on apply, and for a block's covered position only on the adopt — see the header.
     last_resolved_src_msg_id: MessageId
 
     -- The last non-null external-source token seen on the resolve side. Carried onto a
@@ -225,14 +231,13 @@ variant Leader : LogProcessor {
     -- txs). Seeded from live_index.block_row_count; reset when a boundary is injected.
     rows_since_block: Integer
 
-    -- A block cut is in progress: the BlockBoundary has been appended but its
-    -- BlockUploaded has not been produced. Resolution is PAUSED while true — the
-    -- source-log, external-source and GC arms are excluded from the select — so no tx
-    -- interleaves between the boundary and its upload, keeping the follower's bounded
-    -- pending-block buffer empty. See live-index.allium "Block cut".
+    -- A block cut is in progress: the BlockBoundary has been appended and its BlockUploaded has not been read back.
+    -- Resolution is PAUSED while true — the source-log, external-source and GC arms are excluded from the select — so no tx interleaves between the boundary and the adopt that closes its block, keeping the pending-block buffer empty.
+    -- True from promotion where the term inherits a block to produce, so such a term resolves nothing until it has adopted that block.
+    -- See live-index.allium "Block cut".
     block_in_progress: Boolean
 
-    -- This term's block cutter, constructed at promotion. The same one closes the block the
+    -- This term's block cutter, constructed at promotion. The same one produces the block the
     -- promotion inherited and every block this term goes on to fill.
     block_cutter: BlockCutter
 }
@@ -240,9 +245,7 @@ variant Leader : LogProcessor {
 variant Follower : LogProcessor {
     -- Subscribes to the replica log and is the SOLE replica-log consumer for its node.
     -- Feeds the shared live_index from replica messages, all of which are already durable.
-    -- Exposes pending_block state for handoff during leader transition.
     -- See: indexer/FollowerLogProcessor.kt
-    pending_block: PendingBlock?
 }
 
 entity TxResolver {
@@ -298,8 +301,13 @@ entity Watchers {
     --   sourceMsgId; if the token is non-null it overrides the tracked token
     --   (so restarts can read the latest resume point from the watcher).
     -- notifyMsg(srcMsgId): advances only sourceMsgId (for non-tx messages like
-    --   TriesAdded, BlockBoundary, BlockUploaded, and a NoOp carrying one).
+    --   TriesAdded, BlockUploaded, and a NoOp carrying one).
     -- notifyError(exception): transitions to Failed state; all subsequent awaits throw.
+    --
+    -- A block's covered source position is reported on the ADOPT, by whichever role adopts the block
+    -- (LeaderAdoptsOwnBlock, FollowerHandlesBlockUploaded): a node that has not recorded the block
+    -- claims none of the position it covers, so a caller that flushes a block and then awaits this
+    -- watermark is told of it once the flush is done.
     --
     -- See: api/log/Watchers.kt
     latest_tx_id: MessageId
@@ -310,19 +318,21 @@ entity Watchers {
     -- Monotonicity obligations enforced at runtime (temporal, not state properties):
     -- notifyTx must supply txId > latest_tx_id (strictly increasing)
     -- notifyTx and notifyMsg must supply srcMsgId >= latest_source_msg_id (non-decreasing)
-    --   >= not >: BlockBoundary can carry the same source msgId as the preceding
-    --   ResolvedTx when the block was triggered by the row gauge (no FlushBlock in between).
+    --   >= not >: the BlockUploaded closing a block can carry the same source msgId as the
+    --   preceding ResolvedTx when the block was triggered by the row gauge (no FlushBlock in between).
 }
 
 entity BlockCutter {
-    -- One per leader term: it fills a block, cuts it and uploads it — this term's own blocks, and the one a promotion inherited.
+    -- One per leader term: it fills a block, cuts it, produces it and adopts it — this term's own blocks, and the one a promotion inherited.
     --
-    -- Owns the block cycle, Filling → Cut → Uploading → Filling.
+    -- Owns the block cycle, Filling → Cut → Uploading → Filling, the last step driven by reading a BlockUploaded of the held block back.
     -- Filling carries the rows resolved into the open block, seeded at promotion from the rows already applied into it, so a term that inherits a partially-filled block cuts it where the previous leader would have.
-    -- Resolution is armed only while Filling, so nothing is resolved between a boundary and its upload.
+    -- Resolution is armed only while Filling, so nothing is resolved between a boundary and the adopt that closes its block.
     -- Leader.rows_since_block and Leader.block_in_progress are the coarser view this spec's rules take of that cycle.
     --
-    -- upload(boundaryMsgId, boundaryMessage):
+    -- A cut is two operations, a block PRODUCED on the boundary and ADOPTED on the confirmation coming back — which is how a follower reads the same pair of messages.
+    --
+    -- upload(pending_block) — produce the block its boundary cut:
     --   1. Finishes live index block (liveIndex.finishBlock), yielding L0 tries — one per
     --      table that took rows in this block, and none at all for a table that took none.
     --      A block cut with no transactions in it therefore writes no tries whatsoever
@@ -331,17 +341,30 @@ entity BlockCutter {
     --      table catalog knows — not only the tables from step 1. Block GC's per-table
     --      sweep depends on this (block-gc.allium, EveryTableBlockAtCurrentIndex)
     --   4. Builds and persists the block file — carrying this term, which is what seeds a
-    --      restarted log processor's fence
-    --   5. Refreshes the table catalog, then appends BlockUploaded to the replica log and awaits it.
-    --      BlockUploaded is durable before step 6 rolls the live index
-    --   6. Calls liveIndex.nextBlock()
-    --   7. Off this coroutine, and in this order: posts the L0 tries to the SOURCE log as
-    --      TriesAdded, then compactor.signalBlock(). Off-coroutine because the upload runs
+    --      restarted log processor's fence — and stamps the database's last-upload time
+    --   5. Appends BlockUploaded to the replica log and awaits it, directly rather than
+    --      through the append pump: this is the message the whole cluster closes the block
+    --      on, this node included, and a term ending in between drops whatever the pump
+    --      still holds
+    --   The block, its L0 tries and its boundary are held from here (LogProcessor.pending_block) until the adopt.
+    --   The catalog is not refreshed and the live index is not rolled here, so a term dying between the two operations leaves the block re-producible: its catalog has not moved past the block, and TableCatalog.buildBlock refuses a second attempt at an index the catalog already holds.
+    --
+    -- closeBlock(msg) — adopt the block msg confirms:
+    --   1. Refreshes the table catalog onto the block held from the produce
+    --   2. Calls liveIndex.nextBlock()
+    --   3. Off this coroutine, and in this order: posts the L0 tries to the SOURCE log as
+    --      TriesAdded, then compactor.signalBlock(). Off-coroutine because the adopt runs
     --      on the source log's sole consumer, so appending inline self-deadlocks when the
     --      source-log buffer saturates at a boundary.
+    --   Hands back the records held behind the boundary, which the caller applies once this has returned.
+    --   Nothing may apply a transaction between the produce's step 1 and step 2 here: the live tables have been snapshotted into L0 and are about to be cleared, so a tx applied in between is written nowhere.
+    --   The pending-block guard is what holds a record arriving in that window (see LeaderAppliesRecord), and the resolution pause is what keeps the buffer holding them small.
     --
-    -- The uploading term is this cutter's own, which is not always the boundary's: a promotion finishes the previous leader's pending block.
+    -- closes(msg) tests msg against the block held — block index, storage version and storage epoch, and never the term — the follower's test applied to whichever upload of that block arrives.
+    --
+    -- The producing term is this cutter's own, which is not always the boundary's: a promotion produces the previous leader's pending block.
     -- The BlockUploaded carries the term of whoever appends it, because a leader confirms a write only on reading it back at its own term.
+    -- Two terms can therefore produce one block index, where the term that cut the boundary also produced it before ending, and both uploads confirm the same block: one boundary over one prefix, covering one source position.
     --
     -- The upload timer and the last-upload-time gauge are the DATABASE's, registered once on the log processor, and report across every term.
     -- Each term's cutter is handed the gauge's backing state, because a Micrometer gauge keeps the state object it was registered with.
@@ -432,11 +455,11 @@ value TableEntry {
 
 value PendingBlock {
     -- Captures the state between BlockBoundary and BlockUploaded.
-    -- Held by the follower, which also buffers subsequent replica messages, up to max_buffered_records.
+    -- Held by whichever role is live, which also buffers subsequent replica messages, up to max_buffered_records.
     -- A buffered record is stored, and nothing else: it is neither folded into the term fence nor tested against it, because it has not been acted on.
-    -- It meets the fence when the block drains (FollowerHandlesBlockUploaded), or when a promotion inherits the block (TransitionToLeader).
+    -- It meets the fence when the block drains (FollowerHandlesBlockUploaded, LeaderAdoptsOwnBlock).
     -- Overflow is a fault (xtdb.indexer/follower-buffer-overflow) that the leader's block-cut pause keeps unreachable.
-    -- Passed from follower to transition processor on assignment.
+    -- Passed on at every role change, in both directions — see LogProcessor.pending_block.
     -- See: indexer/PendingBlock.kt
     boundary_msg_id: MessageId
     boundary_message: BlockBoundaryMessage
@@ -572,7 +595,7 @@ variant BlockBoundaryMessage : ReplicaMessage {
     -- The leader signals that a block boundary has been reached. Injected by the leader
     -- in RESOLUTION order, off the resolve-side row gauge (or on a FlushBlock CAS pass),
     -- so it lands after this block's txs and before the next block's.
-    -- Followers enter pending mode and buffer subsequent messages until BlockUploaded.
+    -- Whichever role reads it holds a pending block on it and buffers subsequent messages until the matching BlockUploaded; the leader that cut it also produces the block here.
     -- L0 tries are delivered in the subsequent BlockUploaded message (not separately).
     -- For external-source DBs, carries the ExternalSourceToken as of the boundary
     -- so it gets persisted in the Block on upload.
@@ -585,7 +608,7 @@ variant BlockBoundaryMessage : ReplicaMessage {
 variant BlockUploadedMessage : ReplicaMessage {
     -- Block has been written to the object store.
     -- Carries L0 tries so followers can update their trie catalogs.
-    -- Followers refresh catalogs and transition out of pending mode.
+    -- The role holding the block refreshes its catalogs on it and moves onto the next block.
     -- For external-source DBs, carries the ExternalSourceToken that was
     -- persisted with the block.
     -- See: log/proto/log.proto (BlockUploaded), api/log/ReplicaMessage.kt (BlockUploaded)
@@ -662,12 +685,15 @@ config {
 -- The high-water is the partition's, seeded from the last persisted block, so the fence survives restart.
 -- A discarded record still advances the consume position, so a transition catch-up can never hang on a fenced no-op.
 --
--- A record a follower holds behind an OPEN PENDING BLOCK is stored, and nothing else: it has not been acted on, so the fence has not heard of it.
--- Those records meet the fence when the block drains, each folding at its own position in the log — or, where a promotion inherits the block, as the incoming leader replays them (see TransitionToLeader).
--- So while a block is open the high-water stands at the term that cut the boundary, and the upload that closes the block reaches the follower with nothing folded ahead of it.
--- The block closes on the MATCH — block index, storage version and storage epoch — with the fence not consulted for that record at that point.
--- The closer's own term folds on the replay, behind the records it was holding and at the position it occupied in the log, where the drain may already have folded a higher one and the fence refuse it.
+-- A record held behind an OPEN PENDING BLOCK is stored, and nothing else: it has not been acted on, so the fence has not heard of it.
+-- This holds of a leader waiting on the block it produced as much as of a follower waiting on someone else's.
+-- Those records meet the fence when the block drains, each folding at its own position in the log.
+-- So while a block is open the high-water stands at the term that cut the boundary, and the upload that closes the block reaches the holding role with nothing folded ahead of it.
+-- The block closes on the MATCH — block index, storage version and storage epoch, and never the term — with the fence not consulted for that record at that point.
+-- So an upload written by a term the log has moved past closes the block a role is holding all the same.
+-- A follower's closer goes round again on the drain, behind the records it was holding and at the position it occupied in the log, where the drain may already have folded a higher term and the fence refuse it.
 -- Refusing it there costs nothing: the block is closed, and a refused record applies nothing.
+-- A leader's closer needs no second pass: it sits at or below this term, a higher one resigning the term ahead of the guard, and this term's claim folds no later than the drain, so the high-water already holds every term the closer carries.
 --
 -- The LEADER additionally tests against its OWN term on CONSUME-BACK (Raft's ReadIndex): it applies and acknowledges a write only once it has read that write back at that term.
 -- A HIGHER term read back means a newer leader has superseded it, so it RESIGNS without acknowledging its outstanding writes.
@@ -706,8 +732,11 @@ config {
 -- and the leader consumes the source log instead, so records in [follower-pos,
 -- replay_target) would otherwise be silently skipped.
 -- If the follower had a pending block (saw BlockBoundary but not BlockUploaded), the new
--- leader finishes the block via its BlockCutter — under its OWN term — before starting
--- source log consumption.
+-- leader produces the block via its BlockCutter — under its OWN term — before its term is published, and adopts it once that term's consume pump reads an upload of it back.
+-- That upload is this term's own, or the outgoing leader's where that term got one away before it ended: both confirm the same block, so the adopt takes whichever arrives first.
+-- The block stays held across the cutover, and the records the follower was holding drain at the adopt.
+-- Such a term resumes the source log at the last applied transaction, so it re-reads whatever the held boundary covered: the FlushBlock that triggered the cut, and nothing at all where the row gauge cut it (there the boundary carries the preceding transaction's position).
+-- Resolution is unarmed until the adopt, so the re-offered batch waits, and by the time the FlushBlock is re-resolved the adopt has advanced the current block index, so its CAS fails and it becomes a NoOp.
 
 -- == Staleness ==
 --
@@ -724,6 +753,8 @@ config {
 -- idempotency checks within the handler.
 --
 -- The term fence is a SEPARATE check, run first (see Fencing): a record the fence discards never reaches the staleness comparison.
+-- The pending-block guard runs ahead of both, so the upload that closes a held block is matched there rather than compared: the adopt is what advances that node's catalog past the block.
+-- A second upload of that index — two terms can produce one block — reaches the comparison with no block in flight, and is stale by it, on the leader (LeaderSkipsAdoptedBlockUpload) as on the follower.
 
 rule TransitionToLeader {
     -- db.allium's view of the transition: what it means for THIS database's pipeline.
@@ -778,28 +809,21 @@ rule TransitionToLeader {
             last_resolved_src_msg_id: watchers.latest_source_msg_id,
             last_resolved_ext_token: watchers.external_source_token,
             rows_since_block: live_index.block_row_count,
-            block_in_progress: false,
-            pending_block: null,
+            -- True where this term inherits a block to produce: resolution stays paused until it has adopted it.
+            block_in_progress: pending_block != null,
             block_cutter: BlockCutter.created()
         )
         TxResolver.created(
             latest_completed_tx: live_index.latest_completed_tx
         )
 
-        -- The new leader finishes the block the outgoing one left behind, before it reads a source message.
+        -- The new leader produces the block the outgoing one left behind, before it reads a source message.
         --   - The block's data is already in the live index (applied before BlockBoundary), but the block file was never persisted.
         --   - The BlockUploaded is appended under the INCOMING term, because a leader confirms a write only on reading it back at its own term (see BlockCutter).
-        --   - The upload and the replay are separate steps, with the block released between them.
-        --     Once the upload returns, this node's catalog is refreshed and its live index rolled, so the block is closed here and the transition stops carrying it.
-        --     A failure during the replay therefore re-opens a follower holding no block; one still holding it would match the BlockUploaded just appended and close the same block a second time.
-        --   - The replay is where the held records meet the fence: each folds at its own position in the log and is applied where the fence admits it, through this same leader, which uploads on a BlockBoundary among them rather than entering the follower's pending mode.
+        --   - The block stays held. This term adopts it — and drains the records the follower was holding — on reading that upload back (LeaderAdoptsOwnBlock), which is after the term below is published and its consume pump running.
+        --   - A term that ends in between hands the block on (TransitionToFollower, or the failure path here re-opening a follower), and the role that takes it closes it on the same message this term was waiting for.
         if pending_block != null:
-            log_processor.block_cutter.upload(
-                pending_block.boundary_msg_id,
-                pending_block.boundary_message
-            )
-            log_processor.pending_block = null
-            log_processor.replayHeldRecords(pending_block)
+            log_processor.block_cutter.upload(pending_block)
 
         log_processor.start(after_source: watchers.latest_source_msg_id, after_replica: replay_target)
 
@@ -829,9 +853,10 @@ rule TransitionToFollower {
         if tx_resolver != null:
             CloseResolver(tx_resolver)
 
-        -- The new follower carries no pending block.
-        -- Cancelling the leader leaves the boundary's apply incomplete, so that record is offered again and the follower opens the block itself.
-        -- It continues from the partition's replica position rather than being seeded with one: the tail spans the mode change.
+        -- A block this term produced and has not adopted is carried to the new follower, which closes it on the same message this term was waiting for.
+        -- It is read after the join, as a promotion reads the follower's: the term goes on applying records until then, and one of them may be the upload that closes this very block.
+        -- Cancelling the leader mid-boundary leaves no block here at all: that record's apply is incomplete, so it is offered again and the follower opens the block itself, as on any other boundary.
+        -- The follower continues from the partition's replica position rather than being seeded with one: the tail spans the mode change.
         log_processor.mode = Follower.created()
 }
 
@@ -1107,6 +1132,17 @@ rule LeaderAppliesRecord {
             -- or a routine leadership handover would surface to queries as a failed
             -- database (see ProcessingErrorHaltsNode).
             LeaderSuperseded(resolver: tx_resolver)
+        else if log_processor.pending_block != null:
+            -- Held, not fenced, ahead of the fence as on a follower: a record behind an open block has not been acted on, so folding it here would move the high-water past the term that cut the boundary, and the upload closing the block — written by that same term — would then be fenced away.
+            -- The upload this term is waiting for is matched here, on block index, storage version and storage epoch and not on term (BlockCutter.closes), so an upload of that block from a term the log has moved past closes it too.
+            if record.kind = BlockUploadedMessage
+               and record.block_index = log_processor.pending_block.boundary_message.block_index
+               and record.storage_version = storage_format.storage_version
+               and record.storage_epoch = storage_format.storage_epoch:
+                AdoptOwnBlock(record)
+            else:
+                log_processor.pending_block.buffered_records =
+                    log_processor.pending_block.buffered_records.append(record)
         else if record.term_id < log_processor.max_leader_term:
             -- The fence, applied here because this is where the leader acts on the record.
             -- Our own claim folded before the term opened, so the high-water is this leader's own
@@ -1159,14 +1195,10 @@ rule LeaderAppliesOwnTx {
 }
 
 rule LeaderUploadsBlockOnBoundary {
-    -- The leader reads its OWN BlockBoundary back. By log order the durable live index now
-    -- holds exactly this block's txs and no more — which is precisely what the block-cut
-    -- pause buys: nothing was resolved-and-applied between the boundary and here, so a
-    -- durable L0 block never contains rows from a later block.
+    -- The leader reads its OWN BlockBoundary back and PRODUCES the block: the cutter snapshots the index, uploads the files and appends BlockUploaded.
+    -- By log order the durable live index now holds exactly this block's txs and no more — which is precisely what the block-cut pause buys: nothing was resolved-and-applied between the boundary and here, so a durable L0 block never contains rows from a later block.
     --
-    -- The cutter snapshots the index, uploads the files, appends BlockUploaded and rolls
-    -- the index. Then the GCs are signalled (a block boundary is the only moment new
-    -- garbage can appear) and resolution RESUMES, picking up any stashed source batch.
+    -- The block is held from here, and the adopt — the catalog refresh, the index roll, the source watermark, the GC signals and the resolution resume — waits for an upload of the block to come back (LeaderAdoptsOwnBlock).
     when: ApplyOwnRecord(record)
     requires: record.kind = BlockBoundaryMessage
 
@@ -1175,37 +1207,59 @@ rule LeaderUploadsBlockOnBoundary {
             boundary_msg_id: record.msg_id,
             boundary_message: record
         )
-        log_processor.block_cutter.upload(record.msg_id, record)
-        log_processor.pending_block = null
+        log_processor.block_cutter.upload(log_processor.pending_block)
+}
 
-        -- The upload has returned, so this block's files are in object storage. Announcing
-        -- that as its own event is what lets an external source confirm its upstream
-        -- position without reaching into the cutter.
+rule LeaderAdoptsOwnBlock {
+    -- The leader reads a BlockUploaded confirming the block it holds and ADOPTS that block: the catalog is refreshed onto it, the live index rolls onto the next one, and the records held behind the boundary are applied.
+    -- The upload adopted is whichever of that block index reaches this term first, whichever term wrote it (BlockCutter.closes): both uploads confirm the same block, so adopting either is correct.
+    -- The other arrives with no block in flight, and is stale there (LeaderSkipsAdoptedBlockUpload).
+    -- The held records go back through the leader's own apply, so a boundary among them produces the next block there and the records behind that one are held again.
+    when: AdoptOwnBlock(record)
+
+    ensures:
+        log_processor.block_cutter.closeBlock(record)
+
+        -- The block is durable and this node is on it.
+        -- Announcing that as its own event is what lets an external source confirm its upstream position without reaching into the cutter.
         BlockBecameDurable(database, record.external_source_token)
 
         watchers.notifyMsg(record.latest_processed_msg_id)
 
+        -- A block boundary is the only moment new garbage can appear.
         BlockGcSignalled()
         TrieGcSignalled()
 
+        -- Resolution resumes, picking up any stashed source batch.
         log_processor.block_in_progress = false
         ResolutionResumed()
+
+        let buffered = log_processor.pending_block.buffered_records
+        log_processor.pending_block = null
+        for held in buffered:
+            log_processor.applyReplicaMessage(held)
+}
+
+rule LeaderSkipsAdoptedBlockUpload {
+    -- A BlockUploaded read back with no block in flight confirms a block this node has already adopted: the other upload of that index closed it, and the adopt moved the catalog past it.
+    -- It is skipped on block index, the staleness test every reader applies to a BlockUploaded (see Staleness).
+    -- An index the catalog has NOT reached is a fault: this node is holding no boundary for that block and has adopted no block at that index, which nothing explains.
+    when: ApplyOwnRecord(record)
+    requires: record.kind = BlockUploadedMessage
+    requires: record.block_index <= (table_catalog.current_block_index ?? -1)
 }
 
 rule LeaderAppliesOwnControlRecord {
     -- The leader's remaining own records need no work on apply — only the durable
     -- watermark advance, which is exactly what makes it lag resolution.
     --   TriesAdded / TriesDeleted: the trie catalog was already mutated on the resolve side.
-    --   BlockUploaded: our own, read back after the cutter's upload already rolled the index.
     --   NoOp: advances the watermark iff it carries one (a replay-target marker doesn't).
     when: ApplyOwnRecord(record)
-    requires: record.kind in {TriesAddedMessage, TriesDeletedMessage, BlockUploadedMessage, NoOpMessage}
+    requires: record.kind in {TriesAddedMessage, TriesDeletedMessage, NoOpMessage}
 
     ensures:
         if record.kind = TriesAddedMessage:
             watchers.notifyMsg(record.source_msg_id)
-        if record.kind = BlockUploadedMessage:
-            watchers.notifyMsg(record.latest_processed_msg_id)
         if record.kind = NoOpMessage and record.src_msg_id != null:
             watchers.notifyMsg(record.src_msg_id)
 }
@@ -1395,7 +1449,6 @@ rule HandleReplicaMessage {
                 -- Follower: enters pending mode. Subsequent messages (except the matching
                 -- BlockUploaded) are buffered by the pending block guard above.
                 log_processor.pending_block = PendingBlock(msg.msg_id, msg)
-                watchers.notifyMsg(msg.latest_processed_msg_id)
 
             if msg.kind = NoOpMessage and msg.src_msg_id != null:
                 watchers.notifyMsg(msg.src_msg_id)
@@ -1427,8 +1480,12 @@ rule FollowerHandlesBlockUploaded {
         live_index.nextBlock()
         CompactorSignalled()
 
+        -- The block's covered source position, ahead of the drain below: the held records carry later
+        -- positions, so behind them this one would go backwards (see Watchers' monotonicity obligations).
+        watchers.notifyMsg(msg.latest_processed_msg_id)
+
         -- Clear pending mode, then drain what the block was holding back through the dispatch above;
-        -- their typed notifications are what advance the watermarks.
+        -- their typed notifications are what advance the watermarks past this position.
         -- Each held record therefore folds at its own position in the log.
         let buffered = log_processor.pending_block.buffered_records
         log_processor.pending_block = null

--- a/dev/doc/gc.allium
+++ b/dev/doc/gc.allium
@@ -164,9 +164,8 @@ rule LeaderClosesTrieGc {
 
 -- Two channels feed the loop, each playing a different role:
 --
---   `signal()`:           fire-and-forget. Used by the leader once a block
---                         upload completes (db.allium:
---                         LeaderUploadsBlockOnBoundary). The channel is
+--   `signal()`:           fire-and-forget. Used by the leader once it has adopted
+--                         a block (db.allium: LeaderAdoptsOwnBlock). The channel is
 --                         conflated, so a burst of block boundaries coalesces
 --                         into one upcoming cycle. Tx processing never blocks on
 --                         GC progress — the first cycle after a long disabled
@@ -195,8 +194,7 @@ rule LeaderFinishBlockSignalsTrieGc {
     -- and only enqueues: it cannot re-enter the persister, so it cannot deadlock
     -- against the cycle it is scheduling.
     --
-    -- Chains from db.allium's LeaderUploadsBlockOnBoundary, i.e. once the upload
-    -- has completed — not when the boundary was cut.
+    -- Chains from db.allium's LeaderAdoptsOwnBlock, i.e. once the leader has read its own upload back and moved onto the next block — not when the boundary was cut.
     when: TrieGcSignalled()
     requires: trie_gc.enabled
     requires: trie_gc.is_running


### PR DESCRIPTION
The leader now adopts a block when it reads its own `BlockUploaded` back off the replica log, the way a follower always has, which closes a state a term dying mid-upload could not recover from: its catalog past a block whose upload never landed, and nothing left able to finish it. Doing it now because #6054 has just landed the leader-side restructuring that makes the two roles comparable at all — before it, the produce and the adopt were not separable objects.

## tl;dr

- **Both roles adopt a block on the same record**
  A follower closes a block on `BlockUploaded`. The leader did the whole close inline during its own `BlockBoundary` apply — files, append, catalog refresh, index roll — and then nothing at all on reading that message back. Now the boundary produces and holds the block, and the upload adopts it.

- **The old ordering left a hole a re-promotion falls into**
  `tableCatalog.refresh(block)` ran before the append was awaited, so a term ending in between put this node's catalog past a block that never became durable. Deferring the refresh is what keeps the block re-producible.

- **The widened window is held by the block-cut pause, which now carries two obligations**
  The follower's bounded pending-block buffer, as before, and — new — keeping anything from applying between `finishBlock` and `nextBlock()`, where the live tables have been snapshotted into L0 and are about to be cleared.

- **The leader becomes the last node to adopt a block rather than the first**
  By its own replica-log consumer lag. The source watermark moves with the adopt, on both roles, so a caller that flushes a block and awaits that watermark is still told once the flush is done.

## Problem

- **The two roles closed a block at different points, and only one of those was safe to interrupt**
  `FollowerLogProcessor.closeBlock` reads the block file, folds the tries, refreshes the catalog, rolls the live index and signals the compactor — all on reading `BlockUploaded`. `BlockCutter.uploadBlock` did the same adopt steps inline, during the apply of the boundary, having just written the files and appended the message itself; `LeaderLogProcessor`'s `BlockUploaded` branch then advanced a watermark and did nothing else.

- **Refresh-before-append is what makes a mid-upload death unrecoverable, and the trace is short**
  `refresh(block)` sets `currentBlockIndex` to N. The awaited append then fails, or the term is cancelled inside it. The apply never completes, so the partition's tail re-offers the boundary to the re-opened follower — which drops it as stale, `blockIndex <= currentBlockIndex` now being true. So `nextBlock()` never runs, the live index sits on a block it has already snapshotted into L0, and a promotion back to this node reaches `TableCatalog.buildBlock`'s `check(currentBlockIndex < blockIndex)` and hard-errors.

- **Queries stay correct throughout, which is why this has not been seen**
  `Snapshot.open` partitions live tables against the trie catalog's published L0 rather than against the table catalog (#5873), so the block's rows are served from exactly one side of the gap however long it lasts. The next block's cut also recovers the node. What does not recover is leadership returning to it in between.

- **`BlockCutter`'s own comment was reaching for this and could not get there**
  It read "unable to re-cut it because its own catalog has moved on", and argued from that for an awaited direct append. But the append can fail too — the ordering is what matters, not the awaiting.

## What changes

- **`BlockCutter` splits into produce and adopt**
  `upload(pendingBlock)` finishes the live-index block, registers the L0 tries, writes the per-table block files and the block file, and appends `BlockUploaded`. `closeBlock(msg)` refreshes the table catalog, rolls the live index, posts the L0s to the source log and signals the compactor, and hands back what was held. The `Uploading` state carries the built block and the added tries, because the adopt cannot recompute them once produce has passed.

- **The leader takes the follower's guard, in the follower's order**
  `applyReplicaMessage` is now own-term supersession check, then the pending-block hold, then the term fence, holding ahead of the fence for the follower's existing reason.

- **The guard is there for the drain, not for steady state**
  Nothing arrives between a boundary and its upload on a healthy leader — resolution is paused and the GC arm unarmed. But the held records drain at the adopt, back through the same apply, and a `BlockBoundary` among them opens the next block there; without the guard the records behind it would apply into a block already snapshotted. `LogProcessor.replayHeldRecords` is gone with it, and so is the `pendingBlock = null` between the promotion's upload and its replay, which existed only so a failure could not hand the block to a follower that would close it twice.

- **The handover is symmetric**
  `demoteLeader` reads the leader's pending block after `cancelAndJoin` and passes it to `openFollower`, mirroring what the promotion already did with the follower's — and the read follows the join for the same reason, since the term applies until then and one of those applies may be the adopt.

- **A block's covered source position is reported at the adopt, by whichever role adopts it**
  `BlockBoundary` no longer advances the source watermark on either role. On the leader that deletes the earlier of two notifies carrying the same value; on the follower it adds one to a `closeBlock` that never had any. Both halves are needed, because either role can adopt a block — a promotion adopts one the previous leader's boundary cut, a demotion hands a produced-but-unadopted one to a follower. Three callers flush a block and then await that watermark: `tu/flush-block!`, `Xtdb.flushBlock`, and `reset-compactor!`, which goes on to read both catalogs and delete compacted files.

- **Specs**
  `db.allium` moves `pending_block` onto the base `LogProcessor` entity, splits the cutter's contract, adds `LeaderAdoptsOwnBlock` and drops `BlockUploaded` from `LeaderAppliesOwnControlRecord`. `BlockBecameDurable` fires at the adopt, so `ExternalSourceLearnsDurableExtent` now gates on a block both durable and recorded. `log-processor-lifecycle.allium` gives `LeaderTerm` a `mid_block` carried through both transitions; `live-index.allium`'s resolution pause ends at the adopt.

## Consequences

- **`currentBlockIndex` and the source watermark both advance one replica round trip after the block file lands**
  Invisible to the resolve side: resolution resumes after the adopt either way, so the `FlushBlock` CAS reads the value it always did, and `BlockCutter.cut` is still structurally excluded from the window by `acceptingResolution`. The two moving together is what extends that to whoever *chooses* the CAS value, which is read from outside the term.

- **A promotion inside a held block resumes the source log one step earlier**
  `resumeAfterMsgId` and `TxResolver`'s seed both read that watermark, so such a term resumes at the last applied transaction and re-reads whatever the held boundary covered — the `FlushBlock` that triggered the cut, or nothing at all where the row gauge cut it. Resolution is unarmed until the adopt, so the re-offered batch waits, and by the time that `FlushBlock` re-resolves the adopt has advanced the block index, so its CAS fails and it lands as a `NoOp` (#5680).

- **Three things off the resolve side can see it, all within tolerance**
  healthz block-lag reads 1 during the window against a `<= 5` threshold, so nothing logs or 503s. `TableCatalog.latestBlock` emits later, which only holds an external source's upstream confirmation further back — the direction `ConfirmedPositionIsRecoverable` wants. The block GC waits one more cycle.

- **The `finishBlock` … `nextBlock()` exclusion is now an argument, not a lexical scope**
  It rests on `acceptingResolution` being false for the whole of `Uploading` — which unarms the source-log, ext-source and GC clauses — plus the fence, leaving only three things able to arrive: our own upload, a newer term (superseding before it applies), an older one (fenced, applying nothing). That is stated as an obligation in `db.allium` and `live-index.allium` rather than left to be re-derived.

- **`FollowerLogProcessor.processRecord`'s `error(...)` becomes reachable if the handover is ever dropped**
  It is an `IllegalStateException` on a replica tail that nothing restarts, so the failure mode is that the partition stops consuming for the life of the process. The handover is what keeps it unreachable, and it is now load-bearing in a way it was not.

## Out of scope

- **The other two eager applications**
  `SourceMessage.TriesAdded` and the trie GC's `TriesDeleted` are both mutated on the resolve side and re-applied nowhere. Moving them is near-mechanical once this has landed, and `TriesDeleted` additionally wants a FIFO of in-flight tasks so the GC's await still returns with the catalog updated.

- **Reshaping `PendingBlock` now that nothing is applied off the read-back**
  Its adopt-input half is empty — the `BlockUploaded` carries the block index and the tries, the block file is on storage, and the upload is already appended before a demotion can happen — so the demotion handover added here dissolves. Its hold buffer belongs on `LogProcessor`, which spans both roles and so needs no handover at all. Only the boundary message genuinely has to reach a promoting leader, `buildBlock` needing four fields only the reader of that record holds. Left for a follow-up, along with `PendingBlock`'s 1024-record overflow `Fault`, which stops a replica tail nothing restarts.

- **A node-wide bound on block-upload concurrency**
  `BlockCutter` derives its own 16-way `limitedParallelism` view per term per database, and such a view of `Dispatchers.IO` is elastic, so N databases flushing together permit 16×N in-flight `TableBlock.toByteArray()` buffers. Inherited from #6054, not introduced here.

- **Three pre-existing spec drifts, found while editing**
  `db.allium` still refers to a "transition processor" that no longer exists; `gc.allium` and `block-gc.allium` describe the GC auto-signal as coming "from finishBlock"; and `ExternalSourceLearnsDurableExtent` calls a `durableExtentAdvanced` surface the code does not have, exposing a `StateFlow` instead.

## Alternative approaches

- **Make a `BlockUploaded` with no pending block a legitimate close, instead of handing the block over**
  Well-defined — the block file is on storage, and the adopt needs nothing from the boundary — and safe precisely because the block-cut pause means a node in that window cannot have applied anything from the next block. It would turn a terminal assertion into a recovery and need no handover on the demotion path. It does not remove the need for one on the promotion path, though, because the held records must survive to the adopt.

- **Re-read the block file at the adopt, converging with the follower's call**
  Ruled out: `TableCatalog.refresh(block, metadata)` folds the metadata deltas that `tableCatalog.finishBlock` has already folded on the leader, so the leader cannot share the follower's call without double-counting row counts and HLL deltas. With the code convergence unavailable, the storage round trip bought nothing.

- **Queue the upload on the append pump like the boundary**
  Losing it is recoverable now — this node has not adopted the block either, so the next leader produces it again — so the pump would work. Awaiting keeps the window to the read-back alone and reports a failed append to the term, which leaves the boundary unapplied for the next role to pick up.

## Open questions

- **Should the two new `error(...)` sites be `err/fault` instead?**
  Both are unreachable-state assertions, and `IllegalStateException` and `Fault` take the same path through `runTerm`'s catch to `watchers.notifyError`, so there is no behavioural difference. They match their immediate neighbours — `BlockCutter.addRows` and `FollowerLogProcessor.processRecord` — against a literal reading of CODING.adoc's "new code should always use it".

- **Is a deterministic test of the demotion window worth building?**
  The pieces are pinned separately: producing leaves `pendingBlock` non-null, a follower seeded with an inherited block closes it on that upload, and `demoteLeader`'s hand-on is a single expression. The end-to-end interleaving is left to `LogProcessorSimTest`, which drives rebalances under a seeded scheduler at 100 iterations.

## Verification

`./gradlew test` — 2300 tests, 0 failures, across all nine modules that produce results. `./gradlew property-test` — 2648 tests, 0 failures, at 100 iterations, including `LogProcessorSimTest` (300), `NodeSimulationTest` (800) and `CompactorSimulationTest` (813). `allium check` reports the same diagnostics and no findings on all five edited specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
